### PR TITLE
perf: cache dependency build layer in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@
 FROM rust:1-bookworm AS builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
 COPY src/ src/
-RUN cargo build --release
+RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim


### PR DESCRIPTION
Splits the build into two stages: first build deps with a dummy main.rs (cached), then build the actual source. Subsequent builds only recompile the app code, not all 100+ crates.