### PR TITLE
fix: pull --rebase before push in bump-chart

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,7 @@ jobs:
           git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}
           git add charts/agent-broker/Chart.yaml charts/agent-broker/values.yaml
           git commit -m "chore: release chart ${{ steps.bump.outputs.new_version }}"
+          git pull --rebase
           git push
 
       - name: Trigger chart release


### PR DESCRIPTION
Fixes non-fast-forward rejection when main moves during the build.