### PR TITLE
fix: use PR for chart bump instead of direct push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,21 +175,19 @@ jobs:
           sed -i "s|repository: .*|repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}|" charts/agent-broker/values.yaml
           sed -i "s/tag: .*/tag: \"${SHORT_SHA}\"/" charts/agent-broker/values.yaml
 
-      - name: Commit and push
+      - name: Create release PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          BRANCH="chore/release-chart-${{ steps.bump.outputs.new_version }}"
           git config user.name "openclaw-helm-bot[bot]"
           git config user.email "3185992+openclaw-helm-bot[bot]@users.noreply.github.com"
-          git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}
+          git checkout -b "$BRANCH"
           git add charts/agent-broker/Chart.yaml charts/agent-broker/values.yaml
           git commit -m "chore: release chart ${{ steps.bump.outputs.new_version }}"
-          git pull --rebase
-          git push
-
-      - name: Trigger chart release
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh workflow run release.yml --repo ${{ github.repository }}
+          git push origin "$BRANCH"
+          gh pr create --title "chore: release chart ${{ steps.bump.outputs.new_version }}" \
+            --body "Auto-generated chart version bump." \
+            --base main --head "$BRANCH" --repo ${{ github.repository }}
+          gh pr merge "$BRANCH" --squash --auto --repo ${{ github.repository }}
 


### PR DESCRIPTION
Ruleset bypass doesn't work for app tokens on user-owned repos. Switch to creating a PR with auto-merge instead.