### PR TITLE
fix: disambiguate CI artifact names for multi-variant builds

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -37,10 +37,21 @@ impl EventHandler for Handler {
 
         let in_thread = if !in_allowed_channel {
             match msg.channel_id.to_channel(&ctx.http).await {
-                Ok(serenity::model::channel::Channel::Guild(gc)) => gc
-                    .parent_id
-                    .map_or(false, |pid| self.allowed_channels.contains(&pid.get())),
-                _ => false,
+                Ok(serenity::model::channel::Channel::Guild(gc)) => {
+                    let result = gc
+                        .parent_id
+                        .map_or(false, |pid| self.allowed_channels.contains(&pid.get()));
+                    tracing::debug!(channel_id = %msg.channel_id, parent_id = ?gc.parent_id, result, "thread check");
+                    result
+                }
+                Ok(other) => {
+                    tracing::debug!(channel_id = %msg.channel_id, kind = ?other, "not a guild channel");
+                    false
+                }
+                Err(e) => {
+                    tracing::debug!(channel_id = %msg.channel_id, error = %e, "to_channel failed");
+                    false
+                }
             }
         } else {
             false


### PR DESCRIPTION
The default variant (empty suffix) produced artifact names like `digests-ubuntu-latest`, which collided with the download pattern for other variants. This caused `merge-manifests` to try merging digests from wrong variants, resulting in "not found" errors.

Fix: use explicit `artifact` keys (`default`, `codex`, `claude`) instead of suffix-based naming.

Fixes the Build & Release failure from #20 merge.