### PR TITLE
feat: add agent.preset for simplified install UX

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -37,10 +37,21 @@ impl EventHandler for Handler {
 
         let in_thread = if !in_allowed_channel {
             match msg.channel_id.to_channel(&ctx.http).await {
-                Ok(serenity::model::channel::Channel::Guild(gc)) => gc
-                    .parent_id
-                    .map_or(false, |pid| self.allowed_channels.contains(&pid.get())),
-                _ => false,
+                Ok(serenity::model::channel::Channel::Guild(gc)) => {
+                    let result = gc
+                        .parent_id
+                        .map_or(false, |pid| self.allowed_channels.contains(&pid.get()));
+                    tracing::debug!(channel_id = %msg.channel_id, parent_id = ?gc.parent_id, result, "thread check");
+                    result
+                }
+                Ok(other) => {
+                    tracing::debug!(channel_id = %msg.channel_id, kind = ?other, "not a guild channel");
+                    false
+                }
+                Err(e) => {
+                    tracing::debug!(channel_id = %msg.channel_id, error = %e, "to_channel failed");
+                    false
+                }
             }
         } else {
             false


### PR DESCRIPTION
## Summary

Add `agent.preset` value that auto-configures image + command, reducing install to:

```bash
helm install agent-broker agent-broker/agent-broker \
  --set discord.botToken="$DISCORD_BOT_TOKEN" \
  --set discord.allowedChannels[0]="CHANNEL_ID" \
  --set agent.preset=codex
```

## Presets

| Preset | Image | Command |
|--------|-------|---------|
| (empty/default) | `agent-broker` | `kiro-cli acp --trust-all-tools` |
| `codex` | `agent-broker-codex` | `codex-acp` |
| `claude` | `agent-broker-claude` | `claude-agent-acp` |

## Changes

- `_helpers.tpl` — 3 new helpers to resolve preset → image, command, args
- `deployment.yaml` — use `agent-broker.image.repository` helper
- `configmap.yaml` — use `agent-broker.agent.command` and `agent-broker.agent.args` helpers
- `NOTES.txt` — resolve command from preset for auth hints
- `values.yaml` — add `agent.preset: ""`

## Tested

```
helm template --set agent.preset=codex  → image: agent-broker-codex, command: codex-acp, args: []
helm template --set agent.preset=claude → image: agent-broker-claude, command: claude-agent-acp, args: []
helm template (no preset)              → image: agent-broker, command: kiro-cli, args: [acp, --trust-all-tools]
```

Closes #25