### PR TITLE
feat: add agent.preset for simplified install UX

### DIFF
--- a/charts/agent-broker/templates/NOTES.txt
+++ b/charts/agent-broker/templates/NOTES.txt
@@ -8,17 +8,18 @@ agent-broker {{ .Chart.AppVersion }} has been installed!
     --from-literal=discord-bot-token="YOUR_TOKEN"
 {{- end }}
 
-{{- if eq .Values.agent.command "kiro-cli" }}
+{{- $cmd := include "agent-broker.agent.command" . | trim }}
+{{- if eq $cmd "kiro-cli" }}
 
 Authenticate kiro-cli (first time only):
 
   kubectl exec -it deployment/{{ include "agent-broker.fullname" . }} -- kiro-cli login --use-device-flow
-{{- else if eq .Values.agent.command "codex-acp" }}
+{{- else if eq $cmd "codex-acp" }}
 
 Authenticate Codex (first time only):
 
   kubectl exec -it deployment/{{ include "agent-broker.fullname" . }} -- codex login --device-auth
-{{- else if eq .Values.agent.command "claude-agent-acp" }}
+{{- else if eq $cmd "claude-agent-acp" }}
 
 Authenticate Claude Code (first time only):
 

--- a/charts/agent-broker/templates/_helpers.tpl
+++ b/charts/agent-broker/templates/_helpers.tpl
@@ -32,3 +32,41 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "agent-broker.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Resolve agent preset → image repository
+*/}}
+{{- define "agent-broker.image.repository" -}}
+{{- if .Values.agent.preset }}
+  {{- if eq .Values.agent.preset "codex" }}ghcr.io/thepagent/agent-broker-codex
+  {{- else if eq .Values.agent.preset "claude" }}ghcr.io/thepagent/agent-broker-claude
+  {{- else }}{{ .Values.image.repository }}
+  {{- end }}
+{{- else }}{{ .Values.image.repository }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve agent preset → command
+*/}}
+{{- define "agent-broker.agent.command" -}}
+{{- if .Values.agent.preset }}
+  {{- if eq .Values.agent.preset "codex" }}codex-acp
+  {{- else if eq .Values.agent.preset "claude" }}claude-agent-acp
+  {{- else }}{{ .Values.agent.command }}
+  {{- end }}
+{{- else }}{{ .Values.agent.command }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve agent preset → args
+*/}}
+{{- define "agent-broker.agent.args" -}}
+{{- if .Values.agent.preset }}
+  {{- if or (eq .Values.agent.preset "codex") (eq .Values.agent.preset "claude") }}[]
+  {{- else }}{{ .Values.agent.args | toJson }}
+  {{- end }}
+{{- else }}{{ .Values.agent.args | toJson }}
+{{- end }}
+{{- end }}

--- a/charts/agent-broker/templates/configmap.yaml
+++ b/charts/agent-broker/templates/configmap.yaml
@@ -11,8 +11,8 @@ data:
     allowed_channels = [{{ range $i, $ch := .Values.discord.allowedChannels }}{{ if $i }}, {{ end }}"{{ $ch }}"{{ end }}]
 
     [agent]
-    command = "{{ .Values.agent.command }}"
-    args = [{{ range $i, $a := .Values.agent.args }}{{ if $i }}, {{ end }}"{{ $a }}"{{ end }}]
+    command = "{{ include "agent-broker.agent.command" . | trim }}"
+    args = {{ include "agent-broker.agent.args" . | trim }}
     working_dir = "{{ .Values.agent.workingDir }}"
     {{- if .Values.agent.env }}
     env = { {{ range $k, $v := .Values.agent.env }}{{ $k }} = "{{ $v }}", {{ end }} }

--- a/charts/agent-broker/templates/deployment.yaml
+++ b/charts/agent-broker/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: agent-broker
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "agent-broker.image.repository" . | trim }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: DISCORD_BOT_TOKEN

--- a/charts/agent-broker/values.yaml
+++ b/charts/agent-broker/values.yaml
@@ -21,6 +21,7 @@ discord:
     - "YOUR_CHANNEL_ID"
 
 agent:
+  preset: ""              # kiro (default), codex, or claude — auto-configures image + command
   command: kiro-cli
   args:
     - acp


### PR DESCRIPTION
## Summary

Add `agent.preset` value that auto-configures image + command, reducing install to:

```bash
helm install agent-broker agent-broker/agent-broker \
  --set discord.botToken="$DISCORD_BOT_TOKEN" \
  --set discord.allowedChannels[0]="CHANNEL_ID" \
  --set agent.preset=codex
```

## Presets

| Preset | Image | Command |
|--------|-------|---------|
| (empty/default) | `agent-broker` | `kiro-cli acp --trust-all-tools` |
| `codex` | `agent-broker-codex` | `codex-acp` |
| `claude` | `agent-broker-claude` | `claude-agent-acp` |

## Changes

- `_helpers.tpl` — 3 new helpers to resolve preset → image, command, args
- `deployment.yaml` — use `agent-broker.image.repository` helper
- `configmap.yaml` — use `agent-broker.agent.command` and `agent-broker.agent.args` helpers
- `NOTES.txt` — resolve command from preset for auth hints
- `values.yaml` — add `agent.preset: ""`

## Tested

```
helm template --set agent.preset=codex  → image: agent-broker-codex, command: codex-acp, args: []
helm template --set agent.preset=claude → image: agent-broker-claude, command: claude-agent-acp, args: []
helm template (no preset)              → image: agent-broker, command: kiro-cli, args: [acp, --trust-all-tools]
```

Closes #25