### PR TITLE
chore: bump chart to 0.2.0

### DIFF
--- a/charts/agent-broker/Chart.yaml
+++ b/charts/agent-broker/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-broker
 description: Discord ↔ ACP coding CLI bridge (Kiro CLI, Claude Code, Codex, Gemini)
 type: application
-version: 0.1.12
+version: 0.2.0
 appVersion: "7a6fe69"


### PR DESCRIPTION
## 0.2.0 — Codex & Claude Code Support

### New Features

- **Codex backend** — Use OpenAI Codex via [`@zed-industries/codex-acp`](https://github.com/zed-industries/codex-acp) adapter
- **Claude Code backend** — Use Anthropic Claude Code via [`@agentclientprotocol/claude-agent-acp`](https://github.com/agentclientprotocol/claude-agent-acp) adapter
- **`agent.preset`** — One-line backend selection: `--set agent.preset=codex` or `--set agent.preset=claude`
- **Separate Docker images** — `agent-broker-codex` and `agent-broker-claude` published to GHCR alongside the default `agent-broker` (kiro-cli)
- **Dynamic NOTES.txt** — Auth instructions adapt to the selected backend

### Breaking Changes

- **PVC mount changed** — Now mounts entire `/home/agent` instead of individual subPaths (`dot-kiro`, `kiro-cli-data`). Existing kiro-cli users may need to re-authenticate after upgrade.

### Install

```bash
helm repo add agent-broker https://thepagent.github.io/agent-broker
helm install agent-broker agent-broker/agent-broker \
  --set discord.botToken="$DISCORD_BOT_TOKEN" \
  --set discord.allowedChannels[0]="CHANNEL_ID" \
  --set agent.preset=codex   # or claude, or omit for kiro-cli
```