### PR TITLE
chore: bump chart to 0.3.0

### DIFF
--- a/charts/agent-broker/Chart.yaml
+++ b/charts/agent-broker/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-broker
 description: Discord ↔ ACP coding CLI bridge (Kiro CLI, Claude Code, Codex, Gemini)
 type: application
-version: 0.2.1-beta.22
+version: 0.3.0
 appVersion: "afad7f9"


### PR DESCRIPTION
## 0.3.0 — Gemini CLI Support

### New Features

- **Gemini CLI backend** — Native ACP support via `gemini --acp`, no adapter needed
- **`agent.preset=gemini`** — One-line install with Google OAuth or `GEMINI_API_KEY`
- **Docker image** — `ghcr.io/thepagent/agent-broker-gemini` published to GHCR (amd64 + arm64)

### Install

```bash
helm install agent-broker agent-broker/agent-broker \
  --set discord.botToken="$DISCORD_BOT_TOKEN" \
  --set discord.allowedChannels[0]="CHANNEL_ID" \
  --set agent.preset=gemini
```

### Supported Backends

| Preset | CLI | Since |
|--------|-----|-------|
| (default) | Kiro CLI | 0.1.0 |
| `codex` | OpenAI Codex | 0.2.0 |
| `claude` | Claude Code | 0.2.0 |
| `gemini` | Gemini CLI | 0.3.0 |