### PR TITLE
feat: /close slash command to manually terminate a thread session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 config.toml
 *.swp
 .DS_Store
+sessions/

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -55,6 +55,15 @@ impl SessionPool {
             }
             warn!(thread_id, "stale connection, rebuilding");
             conns.remove(thread_id);
+            // Clear the old session directory so the replacement agent starts clean
+            let stale_dir = self.thread_dir(thread_id);
+            drop(conns);
+            match tokio::fs::remove_dir_all(&stale_dir).await {
+                Ok(_) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => warn!(thread_id, error = %e, "failed to remove stale session directory"),
+            }
+            conns = self.connections.write().await;
         }
 
         if conns.len() >= self.max_sessions {
@@ -100,20 +109,27 @@ impl SessionPool {
 
     pub async fn cleanup_idle(&self, ttl_secs: u64) {
         let cutoff = Instant::now() - std::time::Duration::from_secs(ttl_secs);
-        let mut conns = self.connections.write().await;
-        let stale: Vec<String> = conns
-            .iter()
-            .filter(|(_, c)| c.last_active < cutoff || !c.alive())
-            .map(|(k, _)| k.clone())
-            .collect();
-        for key in stale {
-            info!(thread_id = %key, "cleaning up idle session");
-            conns.remove(&key);
-            // Child process killed via kill_on_drop when AcpConnection drops
+        let dirs_to_remove: Vec<(String, PathBuf)>;
+        {
+            let mut conns = self.connections.write().await;
+            let stale: Vec<String> = conns
+                .iter()
+                .filter(|(_, c)| c.last_active < cutoff || !c.alive())
+                .map(|(k, _)| k.clone())
+                .collect();
+            dirs_to_remove = stale
+                .iter()
+                .map(|k| (k.clone(), self.thread_dir(k)))
+                .collect();
+            for key in &stale {
+                info!(thread_id = %key, "cleaning up idle session");
+                conns.remove(key);
+                // Child process killed via kill_on_drop when AcpConnection drops
+            }
+        } // write lock released before async I/O
 
-            // Clean up the per-thread working directory
-            let thread_dir = self.thread_dir(&key);
-            match tokio::fs::remove_dir_all(&thread_dir).await {
+        for (key, dir) in dirs_to_remove {
+            match tokio::fs::remove_dir_all(&dir).await {
                 Ok(_) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                 Err(e) => warn!(thread_id = %key, error = %e, "failed to remove session directory"),
@@ -122,18 +138,25 @@ impl SessionPool {
     }
 
     pub async fn shutdown(&self) {
-        let mut conns = self.connections.write().await;
-        let count = conns.len();
-        // Clean up per-thread session directories before dropping connections
-        for key in conns.keys().cloned().collect::<Vec<_>>() {
-            let dir = self.thread_dir(&key);
+        let dirs_to_remove: Vec<(String, PathBuf)>;
+        let count: usize;
+        {
+            let mut conns = self.connections.write().await;
+            count = conns.len();
+            dirs_to_remove = conns
+                .keys()
+                .map(|k| (k.clone(), self.thread_dir(k)))
+                .collect();
+            conns.clear(); // kill_on_drop handles process cleanup
+        } // write lock released before async I/O
+
+        for (key, dir) in dirs_to_remove {
             match tokio::fs::remove_dir_all(&dir).await {
                 Ok(_) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                 Err(e) => warn!(thread_id = %key, error = %e, "failed to remove session directory"),
             }
         }
-        conns.clear(); // kill_on_drop handles process cleanup
         info!(count, "pool shutdown complete");
     }
 }

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -22,7 +22,19 @@ impl SessionPool {
         }
     }
 
+    /// Build the per-thread working directory path.
+    fn thread_dir(&self, thread_id: &str) -> PathBuf {
+        [&self.config.working_dir, "sessions", thread_id]
+            .iter()
+            .collect()
+    }
+
     pub async fn get_or_create(&self, thread_id: &str) -> Result<()> {
+        // Validate thread_id to prevent path traversal — Discord snowflake IDs
+        // are numeric, so reject anything that isn't pure ASCII digits.
+        if !thread_id.chars().all(|c| c.is_ascii_digit()) {
+            return Err(anyhow!("invalid thread_id: {thread_id}"));
+        }
         // Check if alive connection exists
         {
             let conns = self.connections.read().await;
@@ -50,7 +62,7 @@ impl SessionPool {
         }
 
         // Create a per-thread working directory so concurrent sessions don't interfere
-        let thread_dir: PathBuf = [&self.config.working_dir, "sessions", thread_id].iter().collect();
+        let thread_dir = self.thread_dir(thread_id);
         tokio::fs::create_dir_all(&thread_dir).await?;
         let thread_dir_str = thread_dir.to_string_lossy().to_string();
 
@@ -100,11 +112,11 @@ impl SessionPool {
             // Child process killed via kill_on_drop when AcpConnection drops
 
             // Clean up the per-thread working directory
-            let thread_dir: PathBuf = [&self.config.working_dir, "sessions", &key].iter().collect();
-            if thread_dir.exists() {
-                if let Err(e) = tokio::fs::remove_dir_all(&thread_dir).await {
-                    warn!(thread_id = %key, error = %e, "failed to remove session directory");
-                }
+            let thread_dir = self.thread_dir(&key);
+            match tokio::fs::remove_dir_all(&thread_dir).await {
+                Ok(_) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => warn!(thread_id = %key, error = %e, "failed to remove session directory"),
             }
         }
     }
@@ -112,6 +124,15 @@ impl SessionPool {
     pub async fn shutdown(&self) {
         let mut conns = self.connections.write().await;
         let count = conns.len();
+        // Clean up per-thread session directories before dropping connections
+        for key in conns.keys().cloned().collect::<Vec<_>>() {
+            let dir = self.thread_dir(&key);
+            match tokio::fs::remove_dir_all(&dir).await {
+                Ok(_) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => warn!(thread_id = %key, error = %e, "failed to remove session directory"),
+            }
+        }
         conns.clear(); // kill_on_drop handles process cleanup
         info!(count, "pool shutdown complete");
     }

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -2,6 +2,7 @@ use crate::acp::connection::AcpConnection;
 use crate::config::AgentConfig;
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tracing::{info, warn};
@@ -48,16 +49,21 @@ impl SessionPool {
             return Err(anyhow!("pool exhausted ({} sessions)", self.max_sessions));
         }
 
+        // Create a per-thread working directory so concurrent sessions don't interfere
+        let thread_dir: PathBuf = [&self.config.working_dir, "sessions", thread_id].iter().collect();
+        tokio::fs::create_dir_all(&thread_dir).await?;
+        let thread_dir_str = thread_dir.to_string_lossy().to_string();
+
         let mut conn = AcpConnection::spawn(
             &self.config.command,
             &self.config.args,
-            &self.config.working_dir,
+            &thread_dir_str,
             &self.config.env,
         )
         .await?;
 
         conn.initialize().await?;
-        conn.session_new(&self.config.working_dir).await?;
+        conn.session_new(&thread_dir_str).await?;
 
         let is_rebuild = conns.contains_key(thread_id);
         if is_rebuild {
@@ -92,6 +98,14 @@ impl SessionPool {
             info!(thread_id = %key, "cleaning up idle session");
             conns.remove(&key);
             // Child process killed via kill_on_drop when AcpConnection drops
+
+            // Clean up the per-thread working directory
+            let thread_dir: PathBuf = [&self.config.working_dir, "sessions", &key].iter().collect();
+            if thread_dir.exists() {
+                if let Err(e) = tokio::fs::remove_dir_all(&thread_dir).await {
+                    warn!(thread_id = %key, error = %e, "failed to remove session directory");
+                }
+            }
         }
     }
 

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -137,6 +137,27 @@ impl SessionPool {
         }
     }
 
+    /// Manually close a session: kill the ACP process and clean up the working directory.
+    pub async fn close_session(&self, thread_id: &str) -> bool {
+        let removed = {
+            let mut conns = self.connections.write().await;
+            conns.remove(thread_id).is_some()
+            // Child process killed via kill_on_drop when AcpConnection drops
+        }; // write lock released before async I/O
+
+        let dir = self.thread_dir(thread_id);
+        match tokio::fs::remove_dir_all(&dir).await {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => warn!(thread_id, error = %e, "failed to remove session directory"),
+        }
+
+        if removed {
+            info!(thread_id, "session manually closed");
+        }
+        removed
+    }
+
     pub async fn shutdown(&self) {
         let dirs_to_remove: Vec<(String, PathBuf)>;
         let count: usize;

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -3,14 +3,16 @@ use crate::config::ReactionsConfig;
 use crate::format;
 use crate::reactions::StatusReactionController;
 use serenity::async_trait;
+use serenity::builder::{CreateCommand, CreateInteractionResponse, CreateInteractionResponseMessage};
+use serenity::model::application::Interaction;
 use serenity::model::channel::Message;
 use serenity::model::gateway::Ready;
-use serenity::model::id::{ChannelId, MessageId};
+use serenity::model::id::{ChannelId, GuildId, MessageId};
 use serenity::prelude::*;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::watch;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 pub struct Handler {
     pub pool: Arc<SessionPool>,
@@ -151,8 +153,56 @@ impl EventHandler for Handler {
         }
     }
 
-    async fn ready(&self, _ctx: Context, ready: Ready) {
+    async fn ready(&self, ctx: Context, ready: Ready) {
         info!(user = %ready.user.name, "discord bot connected");
+
+        // Register /close as a guild command (instant propagation, no global rate limits).
+        let command = CreateCommand::new("close")
+            .description("Close the current coding session and clean up the working directory");
+        for guild in &ready.guilds {
+            let guild_id = guild.id;
+            match guild_id.create_command(&ctx.http, command.clone()).await {
+                Ok(_) => info!(%guild_id, "registered /close guild command"),
+                Err(e) => warn!(%guild_id, error = %e, "failed to register /close guild command"),
+            }
+        }
+    }
+
+    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
+        let Interaction::Command(ref cmd) = interaction else {
+            return;
+        };
+        if cmd.data.name != "close" {
+            return;
+        }
+
+        let channel_id = cmd.channel_id;
+
+        // Only works inside threads
+        let in_thread = match channel_id.to_channel(&ctx.http).await {
+            Ok(serenity::model::channel::Channel::Guild(gc)) => gc.thread_metadata.is_some(),
+            _ => false,
+        };
+
+        let content = if in_thread {
+            let thread_key = channel_id.get().to_string();
+            if self.pool.close_session(&thread_key).await {
+                "✅ Session closed. Working directory cleaned up.".to_string()
+            } else {
+                "ℹ️ No active session in this thread.".to_string()
+            }
+        } else {
+            "⚠️ `/close` can only be used inside a thread.".to_string()
+        };
+
+        let response = CreateInteractionResponse::Message(
+            CreateInteractionResponseMessage::new()
+                .content(content)
+                .ephemeral(true),
+        );
+        if let Err(e) = cmd.create_response(&ctx.http, response).await {
+            error!(error = %e, "failed to respond to /close interaction");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a Discord slash command `/close` that lets users manually terminate a coding session inside a thread.

Closes #40
Depends on #41 (per-thread working directories)

## Changes

**`src/discord.rs`**:
- Register `/close` as a global slash command on `ready`
- Handle `InteractionCreate` events for the `/close` command
- Validates it's called inside a thread before closing

**`src/acp/pool.rs`**:
- Add `close_session(thread_id)` method that kills the ACP process and removes the per-thread working directory

## Design Decision: Slash Command vs Text Matching

Per @thepagent's feedback on #40, this uses **Discord slash commands** (`InteractionCreate` event) instead of text matching to avoid shadowing agent-side `/close` commands:

```
Text message "/close"  ──> forwarded to ACP agent (agent's command)
Slash command /close   ──> handled by broker (Discord interaction)
```

Zero collision between broker commands and agent commands.

## Behavior

- `/close` in a thread → kills session + cleans workdir → "\u2705 Session closed."
- `/close` with no active session → "\u2139\ufe0f No active session in this thread."
- `/close` outside a thread → "\u26a0\ufe0f Only works inside a thread."

## Testing

Compiled and verified against serenity 0.12 on EC2 (Ubuntu 24.04). Slash command registration and interaction handling tested locally.