### PR TITLE
fix: detect float64-mangled Discord channel IDs in Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,24 +99,24 @@ helm repo update
 # Kiro CLI (default)
 helm install agent-broker agent-broker/agent-broker \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set discord.allowedChannels[0]="YOUR_CHANNEL_ID"
+  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID"
 
 # Codex
 helm install agent-broker agent-broker/agent-broker \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
+  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
   --set agent.preset=codex
 
 # Claude Code
 helm install agent-broker agent-broker/agent-broker \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
+  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
   --set agent.preset=claude
 
 # Gemini
 helm install agent-broker agent-broker/agent-broker \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
+  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
   --set agent.preset=gemini
 ```
 

--- a/charts/agent-broker/templates/NOTES.txt
+++ b/charts/agent-broker/templates/NOTES.txt
@@ -48,3 +48,12 @@ Authenticate your agent CLI (first time only) — refer to your CLI's documentat
 Then restart the pod:
 
   kubectl rollout restart deployment/{{ include "agent-broker.fullname" . }}
+
+
+⚠️  Discord channel IDs are large integers (>2^53). Always use --set-string:
+
+  helm install agent-broker agent-broker/agent-broker \
+    --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID"
+
+  Using --set (without -string) causes float64 precision loss and the bot
+  will silently ignore all messages.

--- a/charts/agent-broker/templates/configmap.yaml
+++ b/charts/agent-broker/templates/configmap.yaml
@@ -8,6 +8,12 @@ data:
   config.toml: |
     [discord]
     bot_token = "${DISCORD_BOT_TOKEN}"
+    {{- /* Validate channel IDs are not mangled by float64 precision loss */ -}}
+    {{- range .Values.discord.allowedChannels }}
+    {{- if contains "e+" (toString .) }}
+    {{- fail (printf "discord.allowedChannels contains scientific notation '%s' — use --set-string discord.allowedChannels[0]=YOUR_CHANNEL_ID" (toString .)) }}
+    {{- end }}
+    {{- end }}
     allowed_channels = [{{ range $i, $ch := .Values.discord.allowedChannels }}{{ if $i }}, {{ end }}"{{ $ch }}"{{ end }}]
 
     [agent]


### PR DESCRIPTION
Discord Snowflake IDs exceed float64 precision (>2^53). When users pass channel IDs via `--set` instead of `--set-string`, Helm converts them to scientific notation (e.g. `1.486e+18`), causing the bot to silently ignore all messages.

## Changes

- **configmap.yaml**: Add template validation that fails early if any channel ID contains `e+` (scientific notation)
- **README.md**: Update all 4 Helm install examples to use `--set-string` for `discord.allowedChannels`
- **NOTES.txt**: Add warning about `--set-string` requirement

## Testing

```bash
# This now fails with a clear error message:
helm template agent-broker agent-broker/agent-broker \
  --set discord.allowedChannels[0]="1234567890123456789"

# This works correctly:
helm template agent-broker agent-broker/agent-broker \
  --set-string discord.allowedChannels[0]="1234567890123456789"
```

Fixes #43