### PR TITLE
fix: use toolCallId for tool status tracking, prevent duplicate messages on long responses

### DIFF
--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -60,8 +60,8 @@ impl std::fmt::Display for JsonRpcError {
 pub enum AcpEvent {
     Text(String),
     Thinking,
-    ToolStart { title: String },
-    ToolDone { title: String, status: String },
+    ToolStart { id: String, title: String },
+    ToolDone { id: String, title: String, status: String },
     Status,
 }
 
@@ -79,16 +79,18 @@ pub fn classify_notification(msg: &JsonRpcMessage) -> Option<AcpEvent> {
             Some(AcpEvent::Thinking)
         }
         "tool_call" => {
+            let id = update.get("toolCallId").and_then(|v| v.as_str()).unwrap_or("").to_string();
             let title = update.get("title").and_then(|v| v.as_str()).unwrap_or("").to_string();
-            Some(AcpEvent::ToolStart { title })
+            Some(AcpEvent::ToolStart { id, title })
         }
         "tool_call_update" => {
+            let id = update.get("toolCallId").and_then(|v| v.as_str()).unwrap_or("").to_string();
             let title = update.get("title").and_then(|v| v.as_str()).unwrap_or("").to_string();
             let status = update.get("status").and_then(|v| v.as_str()).unwrap_or("").to_string();
             if status == "completed" || status == "failed" {
-                Some(AcpEvent::ToolDone { title, status })
+                Some(AcpEvent::ToolDone { id, title, status })
             } else {
-                Some(AcpEvent::ToolStart { title })
+                Some(AcpEvent::ToolStart { id, title })
             }
         }
         "plan" => Some(AcpEvent::Status),

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -215,7 +215,8 @@ async fn stream_prompt(
                                 // Truncate if over Discord's limit — the final edit handles
                                 // proper multi-message splitting after streaming completes.
                                 let display = if content.len() > 1900 {
-                                    format!("{}…", &content[..1900])
+                                    let end = content.floor_char_boundary(1900);
+                                    format!("{}…", &content[..end])
                                 } else {
                                     content.clone()
                                 };

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -192,6 +192,7 @@ async fn stream_prompt(
 
             let mut text_buf = String::new();
             let mut tool_lines: Vec<String> = Vec::new();
+            let mut tool_ids: Vec<String> = Vec::new();
             let current_msg_id = msg_id;
 
             if reset {
@@ -210,19 +211,15 @@ async fn stream_prompt(
                         if buf_rx.has_changed().unwrap_or(false) {
                             let content = buf_rx.borrow_and_update().clone();
                             if content != last_content {
-                                if content.len() > 1900 {
-                                    let chunks = format::split_message(&content, 1900);
-                                    if let Some(first) = chunks.first() {
-                                        let _ = edit(&ctx, channel, current_edit_msg, first).await;
-                                    }
-                                    for chunk in chunks.iter().skip(1) {
-                                        if let Ok(new_msg) = channel.say(&ctx.http, chunk).await {
-                                            current_edit_msg = new_msg.id;
-                                        }
-                                    }
+                                // During streaming, only edit the single placeholder message.
+                                // Truncate if over Discord's limit — the final edit handles
+                                // proper multi-message splitting after streaming completes.
+                                let display = if content.len() > 1900 {
+                                    format!("{}…", &content[..1900])
                                 } else {
-                                    let _ = edit(&ctx, channel, current_edit_msg, &content).await;
-                                }
+                                    content.clone()
+                                };
+                                let _ = edit(&ctx, channel, current_edit_msg, &display).await;
                                 last_content = content;
                             }
                         }
@@ -253,16 +250,27 @@ async fn stream_prompt(
                         AcpEvent::Thinking => {
                             reactions.set_thinking().await;
                         }
-                        AcpEvent::ToolStart { title, .. } if !title.is_empty() => {
+                        AcpEvent::ToolStart { id, title, .. } if !title.is_empty() => {
                             reactions.set_tool(&title).await;
+                            tool_ids.push(id);
                             tool_lines.push(format!("🔧 `{title}`..."));
                             let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
                         }
-                        AcpEvent::ToolDone { title, status, .. } => {
+                        AcpEvent::ToolDone { id, title, status, .. } => {
                             reactions.set_thinking().await;
                             let icon = if status == "completed" { "✅" } else { "❌" };
-                            if let Some(line) = tool_lines.iter_mut().rev().find(|l| l.contains(&title)) {
-                                *line = format!("{icon} `{title}`");
+                            // Match by toolCallId instead of title text.
+                            // On match, swap the icon but keep the original ToolStart title,
+                            // since ToolDone often returns a different or empty title.
+                            let idx = tool_ids.iter().rposition(|tid| !tid.is_empty() && tid == &id);
+                            if let Some(i) = idx {
+                                let kept_title = tool_lines[i]
+                                    .split('`').nth(1)
+                                    .unwrap_or(&title);
+                                tool_lines[i] = format!("{icon} `{kept_title}`");
+                            } else if !title.is_empty() {
+                                tool_ids.push(id);
+                                tool_lines.push(format!("{icon} `{title}`"));
                             }
                             let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
                         }

--- a/src/format.rs
+++ b/src/format.rs
@@ -18,11 +18,14 @@ pub fn split_message(text: &str, limit: usize) -> Vec<String> {
         }
         // If a single line exceeds limit, hard-split it
         if line.len() > limit {
-            for chunk in line.as_bytes().chunks(limit) {
+            let mut pos = 0;
+            while pos < line.len() {
+                let end = line.floor_char_boundary((pos + limit).min(line.len()));
                 if !current.is_empty() {
                     chunks.push(current);
                 }
-                current = String::from_utf8_lossy(chunk).to_string();
+                current = line[pos..end].to_string();
+                pos = end;
             }
         } else {
             current.push_str(line);


### PR DESCRIPTION
## Problem

Two related display bugs in the Discord output pipeline, both stemming from the same architectural gap: tool call events lack stable identity tracking, and the streaming/final-edit lifecycle creates orphaned messages.

### Bug 1: tool status lines show wrong or empty titles

When using Claude Code (via `claude-agent-acp`), the ACP protocol's `tool_call` (start) and `tool_call_update` (done) events frequently carry **different `title` values** for the same tool invocation:

- Read tool starts as `"Read CLAUDE.md"`, completes as `"Read File"`
- Bash tool starts as `"find /workspace -name '*.py'"`, completes as `"Terminal"`
- Subagent child tools often complete with an **empty title**

The current matching logic (`tool_lines.find(|l| l.contains(&title))`) fails to correlate these, producing:

```
✅ ``         ← empty: ToolDone title was empty, no match found
✅ ``         ← empty: same issue
🔧 `Read CLAUDE.md`...  ← stale: ToolDone had different title, never matched
```

### Bug 2: long responses appear duplicated in Discord

When agent output exceeds ~1900 characters, the response is posted **2-3 times**:

```
[tool status lines]
[agent response text]       ← from streaming overflow (channel.say)
[tool status lines]         ← duplicated
[agent response text]       ← from final edit overflow (channel.say again)
```

**Root cause**: the edit-streaming task (1.5s interval) calls `channel.say()` to create overflow messages when content exceeds 1900 chars. These message IDs are tracked only inside the spawned task. The final edit uses the *original* message ID and creates its own overflow — the streaming messages are never cleaned up.

## Solution

### Fix 1: match tool calls by toolCallId

Every ACP `tool_call` and `tool_call_update` notification carries a unique `toolCallId` field. This PR extracts it and uses it as the matching key instead of title text.

On `ToolDone`, we find the corresponding `ToolStart` line by ID and swap only the icon, **preserving the original title** from the start event — which always has the most descriptive text.

```
Before: ToolStart("Read CLAUDE.md") → ToolDone("Read File") → no match → broken
After:  ToolStart(id=abc, "Read CLAUDE.md") → ToolDone(id=abc, "") → match → ✅ Read CLAUDE.md
```

### Fix 2: streaming edits a single message, no overflow

During streaming, only edit the single placeholder message. If content exceeds 1900 chars, truncate with "…" — this is a live preview, not the final output. The final edit (after streaming completes) handles proper multi-message splitting via `channel.say()`.

This cleanly separates responsibilities:
- **Streaming** = live preview in one message (truncated if needed)
- **Final edit** = authoritative delivery, split across messages if needed

No orphaned messages, no duplication.

### Alternatives considered

**For tool matching:**
- Keep title matching but normalize titles → fragile, depends on CLI-specific title formats
- Match by index (last pending tool) → breaks with parallel tool calls

**For duplicate messages:**
- Share message IDs between streaming task and final edit via `Arc<Mutex<Vec<MessageId>>>` → adds complexity and potential race conditions
- Delete streaming overflow messages before final edit → fragile, depends on Discord API timing
- **Truncate during streaming, let final edit handle splitting** ← chosen, simplest, zero race conditions

## Changes

| File | Lines | What |
|------|-------|------|
| `protocol.rs` | +7/-5 | Add `id` field to `ToolStart`/`ToolDone`, extract `toolCallId` |
| `discord.rs` | +24/-16 | Track `tool_ids` parallel to `tool_lines`, match by ID; simplify streaming to single-message edit with truncation |

## Testing

Tested with `claude-agent-acp` backend:
- Tool status lines now correctly show titles for all tool types (Read, Bash, Edit, Agent subagents)
- Long responses (>2000 chars with 30+ tool calls) display once, not duplicated
- Streaming preview works normally for responses under 1900 chars