### PR TITLE
fix: per-connection locking to prevent cross-session deadlock during long prompts

### DIFF
--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -2,12 +2,13 @@ use crate::acp::connection::AcpConnection;
 use crate::config::AgentConfig;
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
-use tokio::sync::RwLock;
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
 use tokio::time::Instant;
 use tracing::{info, warn};
 
 pub struct SessionPool {
-    connections: RwLock<HashMap<String, AcpConnection>>,
+    connections: RwLock<HashMap<String, Arc<Mutex<AcpConnection>>>>,
     config: AgentConfig,
     max_sessions: usize,
 }
@@ -22,24 +23,27 @@ impl SessionPool {
     }
 
     pub async fn get_or_create(&self, thread_id: &str) -> Result<()> {
-        // Check if alive connection exists
+        // Check if alive connection exists (read lock only)
         {
             let conns = self.connections.read().await;
-            if let Some(conn) = conns.get(thread_id) {
+            if let Some(conn_arc) = conns.get(thread_id) {
+                let conn = conn_arc.lock().await;
                 if conn.alive() {
                     return Ok(());
                 }
             }
         }
 
-        // Need to create or rebuild
+        // Need to create or rebuild (write lock)
         let mut conns = self.connections.write().await;
 
         // Double-check after acquiring write lock
-        if let Some(conn) = conns.get(thread_id) {
+        if let Some(conn_arc) = conns.get(thread_id) {
+            let conn = conn_arc.lock().await;
             if conn.alive() {
                 return Ok(());
             }
+            drop(conn);
             warn!(thread_id, "stale connection, rebuilding");
             conns.remove(thread_id);
         }
@@ -64,41 +68,42 @@ impl SessionPool {
             conn.session_reset = true;
         }
 
-        conns.insert(thread_id.to_string(), conn);
+        conns.insert(thread_id.to_string(), Arc::new(Mutex::new(conn)));
         Ok(())
     }
 
-    /// Get mutable access to a connection. Caller must have called get_or_create first.
-    pub async fn with_connection<F, R>(&self, thread_id: &str, f: F) -> Result<R>
-    where
-        F: FnOnce(&mut AcpConnection) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<R>> + Send + '_>>,
-    {
-        let mut conns = self.connections.write().await;
-        let conn = conns
-            .get_mut(thread_id)
-            .ok_or_else(|| anyhow!("no connection for thread {thread_id}"))?;
-        f(conn).await
+    /// Get a shared reference to a connection's lock.
+    /// The pool RwLock is only held briefly for the lookup (read lock).
+    /// The caller then locks only their own connection — other sessions
+    /// remain fully accessible.
+    pub async fn get_connection(&self, thread_id: &str) -> Result<Arc<Mutex<AcpConnection>>> {
+        let conns = self.connections.read().await;
+        conns
+            .get(thread_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("no connection for thread {thread_id}"))
     }
 
     pub async fn cleanup_idle(&self, ttl_secs: u64) {
         let cutoff = Instant::now() - std::time::Duration::from_secs(ttl_secs);
         let mut conns = self.connections.write().await;
-        let stale: Vec<String> = conns
-            .iter()
-            .filter(|(_, c)| c.last_active < cutoff || !c.alive())
-            .map(|(k, _)| k.clone())
-            .collect();
+        let mut stale = Vec::new();
+        for (key, conn_arc) in conns.iter() {
+            let conn = conn_arc.lock().await;
+            if conn.last_active < cutoff || !conn.alive() {
+                stale.push(key.clone());
+            }
+        }
         for key in stale {
             info!(thread_id = %key, "cleaning up idle session");
             conns.remove(&key);
-            // Child process killed via kill_on_drop when AcpConnection drops
         }
     }
 
     pub async fn shutdown(&self) {
         let mut conns = self.connections.write().await;
         let count = conns.len();
-        conns.clear(); // kill_on_drop handles process cleanup
+        conns.clear();
         info!(count, "pool shutdown complete");
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -169,133 +169,145 @@ async fn stream_prompt(
     msg_id: MessageId,
     reactions: Arc<StatusReactionController>,
 ) -> anyhow::Result<()> {
-    let prompt = prompt.to_string();
-    let reactions = reactions.clone();
+    // Get per-connection lock — does NOT hold the pool lock during streaming.
+    // Other sessions remain fully accessible.
+    let conn_arc = pool.get_connection(thread_key).await?;
+    let mut conn = conn_arc.lock().await;
 
-    pool.with_connection(thread_key, |conn| {
-        let prompt = prompt.clone();
+    let reset = conn.session_reset;
+    conn.session_reset = false;
+
+    let (mut rx, _) = conn.session_prompt(prompt).await?;
+    reactions.set_thinking().await;
+
+    let initial = if reset {
+        "⚠️ _Session expired, starting fresh..._\n\n...".to_string()
+    } else {
+        "...".to_string()
+    };
+    let (buf_tx, buf_rx) = watch::channel(initial);
+
+    let mut text_buf = String::new();
+    let mut tool_lines: Vec<String> = Vec::new();
+    let current_msg_id = msg_id;
+
+    if reset {
+        text_buf.push_str("⚠️ _Session expired, starting fresh..._\n\n");
+    }
+
+    // Spawn edit-streaming task
+    let edit_handle = {
         let ctx = ctx.clone();
-        let reactions = reactions.clone();
-        Box::pin(async move {
-            let reset = conn.session_reset;
-            conn.session_reset = false;
-
-            let (mut rx, _) = conn.session_prompt(&prompt).await?;
-            reactions.set_thinking().await;
-
-            let initial = if reset {
-                "⚠️ _Session expired, starting fresh..._\n\n...".to_string()
-            } else {
-                "...".to_string()
-            };
-            let (buf_tx, buf_rx) = watch::channel(initial);
-
-            let mut text_buf = String::new();
-            let mut tool_lines: Vec<String> = Vec::new();
-            let current_msg_id = msg_id;
-
-            if reset {
-                text_buf.push_str("⚠️ _Session expired, starting fresh..._\n\n");
-            }
-
-            // Spawn edit-streaming task
-            let edit_handle = {
-                let ctx = ctx.clone();
-                let mut buf_rx = buf_rx.clone();
-                tokio::spawn(async move {
-                    let mut last_content = String::new();
-                    let mut current_edit_msg = msg_id;
-                    loop {
-                        tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
-                        if buf_rx.has_changed().unwrap_or(false) {
-                            let content = buf_rx.borrow_and_update().clone();
-                            if content != last_content {
-                                if content.len() > 1900 {
-                                    let chunks = format::split_message(&content, 1900);
-                                    if let Some(first) = chunks.first() {
-                                        let _ = edit(&ctx, channel, current_edit_msg, first).await;
-                                    }
-                                    for chunk in chunks.iter().skip(1) {
-                                        if let Ok(new_msg) = channel.say(&ctx.http, chunk).await {
-                                            current_edit_msg = new_msg.id;
-                                        }
-                                    }
-                                } else {
-                                    let _ = edit(&ctx, channel, current_edit_msg, &content).await;
-                                }
-                                last_content = content;
+        let mut buf_rx = buf_rx.clone();
+        tokio::spawn(async move {
+            let mut last_content = String::new();
+            let mut current_edit_msg = msg_id;
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+                if buf_rx.has_changed().unwrap_or(false) {
+                    let content = buf_rx.borrow_and_update().clone();
+                    if content != last_content {
+                        if content.len() > 1900 {
+                            let chunks = format::split_message(&content, 1900);
+                            if let Some(first) = chunks.first() {
+                                let _ = edit(&ctx, channel, current_edit_msg, first).await;
                             }
+                            for chunk in chunks.iter().skip(1) {
+                                if let Ok(new_msg) = channel.say(&ctx.http, chunk).await {
+                                    current_edit_msg = new_msg.id;
+                                }
+                            }
+                        } else {
+                            let _ = edit(&ctx, channel, current_edit_msg, &content).await;
                         }
-                        if buf_rx.has_changed().is_err() {
-                            break;
-                        }
+                        last_content = content;
                     }
-                })
-            };
-
-            // Process ACP notifications
-            let mut got_first_text = false;
-            while let Some(notification) = rx.recv().await {
-                if notification.id.is_some() {
+                }
+                if buf_rx.has_changed().is_err() {
                     break;
                 }
-
-                if let Some(event) = classify_notification(&notification) {
-                    match event {
-                        AcpEvent::Text(t) => {
-                            if !got_first_text {
-                                got_first_text = true;
-                                // Reaction: back to thinking after tools
-                            }
-                            text_buf.push_str(&t);
-                            let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
-                        }
-                        AcpEvent::Thinking => {
-                            reactions.set_thinking().await;
-                        }
-                        AcpEvent::ToolStart { title, .. } if !title.is_empty() => {
-                            reactions.set_tool(&title).await;
-                            tool_lines.push(format!("🔧 `{title}`..."));
-                            let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
-                        }
-                        AcpEvent::ToolDone { title, status, .. } => {
-                            reactions.set_thinking().await;
-                            let icon = if status == "completed" { "✅" } else { "❌" };
-                            if let Some(line) = tool_lines.iter_mut().rev().find(|l| l.contains(&title)) {
-                                *line = format!("{icon} `{title}`");
-                            }
-                            let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
-                        }
-                        _ => {}
-                    }
-                }
             }
-
-            conn.prompt_done().await;
-            drop(buf_tx);
-            let _ = edit_handle.await;
-
-            // Final edit
-            let final_content = compose_display(&tool_lines, &text_buf);
-            let final_content = if final_content.is_empty() {
-                "_(no response)_".to_string()
-            } else {
-                final_content
-            };
-
-            let chunks = format::split_message(&final_content, 2000);
-            for (i, chunk) in chunks.iter().enumerate() {
-                if i == 0 {
-                    let _ = edit(&ctx, channel, current_msg_id, chunk).await;
-                } else {
-                    let _ = channel.say(&ctx.http, chunk).await;
-                }
-            }
-
-            Ok(())
         })
-    })
-    .await
+    };
+
+    // Process ACP notifications.
+    // Instead of blocking forever on rx.recv(), periodically check if the
+    // agent process is still alive. Long tool calls (e.g. flutter test,
+    // git clone) send no notifications for minutes — that's normal as long
+    // as the process is running. Only break if the process has died.
+    let mut got_first_text = false;
+    loop {
+        let notification = tokio::select! {
+            msg = rx.recv() => match msg {
+                Some(n) => n,
+                None => break,
+            },
+            _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                if !conn.alive() {
+                    tracing::warn!("agent process died during prompt");
+                    break;
+                }
+                continue;
+            }
+        };
+
+        if notification.id.is_some() {
+            break;
+        }
+
+        if let Some(event) = classify_notification(&notification) {
+            match event {
+                AcpEvent::Text(t) => {
+                    if !got_first_text {
+                        got_first_text = true;
+                    }
+                    text_buf.push_str(&t);
+                    let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
+                }
+                AcpEvent::Thinking => {
+                    reactions.set_thinking().await;
+                }
+                AcpEvent::ToolStart { title, .. } if !title.is_empty() => {
+                    reactions.set_tool(&title).await;
+                    tool_lines.push(format!("🔧 `{title}`..."));
+                    let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
+                }
+                AcpEvent::ToolDone { title, status, .. } => {
+                    reactions.set_thinking().await;
+                    let icon = if status == "completed" { "✅" } else { "❌" };
+                    if let Some(line) = tool_lines.iter_mut().rev().find(|l| l.contains(&title)) {
+                        *line = format!("{icon} `{title}`");
+                    }
+                    let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    conn.prompt_done().await;
+    drop(conn); // release per-connection lock immediately
+    drop(buf_tx);
+    let _ = edit_handle.await;
+
+    // Final edit
+    let final_content = compose_display(&tool_lines, &text_buf);
+    let final_content = if final_content.is_empty() {
+        "_(no response)_".to_string()
+    } else {
+        final_content
+    };
+
+    let chunks = format::split_message(&final_content, 2000);
+    for (i, chunk) in chunks.iter().enumerate() {
+        if i == 0 {
+            let _ = edit(&ctx, channel, current_msg_id, chunk).await;
+        } else {
+            let _ = channel.say(&ctx.http, chunk).await;
+        }
+    }
+
+    Ok(())
 }
 
 fn compose_display(tool_lines: &[String], text: &str) -> String {


### PR DESCRIPTION
## Problem

`SessionPool::with_connection()` acquires a **global write lock** on the connections HashMap and holds it for the entire duration of `stream_prompt()` — which can run for minutes during long tool calls (flutter build, test suites, git operations).

One busy session blocks **all** other sessions, cleanup tasks, and new session creation. The entire broker becomes unresponsive.

### Reproduction

1. Open Thread A, ask the agent to run a long command (e.g., `flutter build linux`)
2. While Thread A is busy, open Thread B and send any message
3. Thread B hangs indefinitely — `get_or_create` waits for the write lock

### Root cause

`HashMap::get_mut` requires `&mut self`, forcing a write lock on the entire map to access one connection. The lock is held inside `with_connection` for the full streaming duration:

```rust
pub async fn with_connection(&self, thread_id: &str, f: F) -> Result<R> {
    let mut conns = self.connections.write().await;  // global write lock
    let conn = conns.get_mut(thread_id)?;
    f(conn).await  // held for minutes
}
```

## Solution

### Per-connection locking

Replace `HashMap<String, AcpConnection>` with `HashMap<String, Arc<Mutex<AcpConnection>>>`.

The pool `RwLock` is now only held briefly for lookups (read lock, milliseconds). Each connection has its own `Mutex`, so sessions operate independently:

```rust
pub async fn get_connection(&self, thread_id: &str) -> Result<Arc<Mutex<AcpConnection>>> {
    let conns = self.connections.read().await;  // brief read lock
    conns.get(thread_id).cloned()
        .ok_or_else(|| anyhow!("no connection"))
}

// Caller:
let conn_arc = pool.get_connection(thread_key).await?;
let mut conn = conn_arc.lock().await;  // only locks THIS connection
```

### Alive check instead of unbounded blocking

The notification loop (`while let rx.recv().await`) blocks forever if the prompt response is never received. This is dangerous because the per-connection lock is held during this time.

Replace with a `tokio::select!` that checks process liveness every 30 seconds:

```rust
loop {
    tokio::select! {
        msg = rx.recv() => { /* process notification */ },
        _ = tokio::time::sleep(Duration::from_secs(30)) => {
            if !conn.alive() {
                warn!("agent process died during prompt");
                break;
            }
            continue; // alive → keep waiting
        }
    }
}
```

This correctly handles:
- Long tool calls (process alive → wait indefinitely) ✅
- Process crash (process dead → break in ≤30s) ✅
- No false timeouts on legitimate long operations ✅

### Why Arc\<Mutex\> over alternatives

| Alternative | Problem |
|------------|---------|
| Increase timeout / add idle timeout | Doesn't fix cross-session blocking; false timeouts on long tool calls |
| Checkout pattern (remove from map, use, return) | Connection lost on panic; can't detect "checked out" state for future prompt queueing |
| Keep `with_connection` but use `RwLock` per connection | Unnecessary complexity — `Mutex` is correct for exclusive access |
| **`Arc<Mutex<AcpConnection>>`** | Standard connection pool pattern; correct granularity; enables future prompt queueing via `try_lock()` |

The `Arc<Mutex>` approach also naturally supports future enhancements: callers can use `try_lock()` to detect busy connections and queue prompts via ACP's `promptQueueing` capability instead of blocking.

## Changes

| File | Lines | What |
|------|-------|------|
| `pool.rs` | +54/-43 | `Arc<Mutex<AcpConnection>>` storage; `get_connection()` returns `Arc` clone via brief read lock; remove `with_connection()` |
| `discord.rs` | +100/-94 | `stream_prompt()` uses `get_connection()` + per-connection lock; `tokio::select!` alive check loop; explicit `drop(conn)` after `prompt_done()` |

## Testing

Tested with `claude-agent-acp` backend, two concurrent sessions:
- Thread A running `flutter build linux` (5+ minutes) — Thread B responds normally ✅
- Thread A running long `Agent` subagent task — Thread B creates new session and responds ✅
- Status API responsive while sessions are busy ✅
- Process crash detected within 30 seconds ✅

Closes #58