### PR TITLE
feat: team mode — silent buffering, @mention replies, deadlock fix + Mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,47 @@ graph LR
 - **ACP protocol** — JSON-RPC over stdio with tool call, thinking, and permission auto-reply support
 - **Kubernetes-ready** — Dockerfile + k8s manifests with PVC for auth persistence
 
+## Chat Modes
+
+### Personal (default)
+Best for single-user or private bot usage.
+
+```mermaid
+flowchart LR
+    U([User]) -->|"any message in #general"| AB[agent-broker]
+    AB -->|auto-creates topic| T[Forum Topic]
+    T -->|all messages| AB
+    AB -->|replies directly| T
+```
+
+### Team
+Best for community / multi-user group chats.
+
+```mermaid
+flowchart LR
+    U([User]) -->|"plain text in #general"| AB[agent-broker]
+    AB -->|"silent 👀 buffer"| K[kiro-cli]
+
+    U -->|"@botname in #general"| AB
+    AB -->|reply in-place| U
+
+    U -->|"!kiro prompt"| AB
+    AB -->|creates topic| T[Forum Topic]
+
+    T -->|plain text| AB
+    AB -->|"silent 👀 buffer"| K
+
+    T -->|"@botname in topic"| AB
+    AB -->|replies in topic| T
+```
+
+Switch in `config.toml`:
+```toml
+[telegram]
+mode = "team"                  # or "personal"
+topic_creator_id = 123456789   # team only: restrict !kiro to this user ID
+```
+
 ## Session Lifecycle
 
 ```mermaid
@@ -104,26 +145,7 @@ cargo build --release
 
 ### 6. Use
 
-**Personal mode** (default) — single user / private bot:
-- Send any message in `#general` → bot auto-creates a topic and responds
-- Follow-up messages in the same topic continue the conversation
-
-**Team mode** — community / multi-user group:
-
-| Where | What you send | Result |
-|---|---|---|
-| `#general` | plain message | Kiro listens silently 👀, buffers context |
-| `#general` | `@botname` | Kiro replies in-place (no topic created) |
-| `#general` | `!kiro <prompt>` | Creates a new topic |
-| topic | plain message | Kiro listens silently 👀, buffers context |
-| topic | `@botname` | Kiro replies directly |
-
-Switch modes in `config.toml`:
-```toml
-[telegram]
-mode = "team"              # or "personal"
-topic_creator_id = 123456789  # team only: who can run !kiro
-```
+Send messages in the forum group. See [Chat Modes](#chat-modes) for full personal vs team behavior.
 
 Bot commands (send in any topic):
 - `!status` — show session state and last active time


### PR DESCRIPTION
# PR: Telegram adapter + session lifecycle with memory compaction

## Summary

Ports agent-broker from Discord to Telegram and adds full session lifecycle management: idle eviction, resume, and memory compaction so the agent remembers context across session boundaries.

## Changes

### 1. Telegram Adapter (`src/telegram.rs`) — replaces `discord.rs`

- Uses `teloxide` instead of `serenity`
- Telegram forum supergroup topics map 1:1 to sessions (one topic = one conversation)
- General topic always spawns a new topic to keep the main channel clean
- Auto-renames new topics with a Kiro-generated title after first response
- Emoji reactions as live status on the user's message: `👀 → 🤔 → 🔥/👨‍💻/⚡ → 👍 / 😱`
- Auth via `allowed_users` (Telegram user IDs) in `config.toml`
- Bot commands: `!stop`, `!restart`, `!status`

Session key strategy:
```
DM chat      → <chat_id>
Group chat   → <chat_id>:<user_id>
Forum topic  → <chat_id>:<thread_id>
```

### 2. Session Lifecycle (`src/acp/pool.rs`)

```
User message arrives
        │
        ▼
get_or_create(thread_id)
        │
        ├─ alive session? ──────────────────────────────► use it
        │
        └─ no session / dead
                │
                ▼
           spawn kiro-cli acp
                │
                ├─ prev session_id exists?
                │       │
                │       ├─ YES → session/load ──► ✅ full resume
                │       │
                │       └─ NO  → session/new  ──► fresh start
                │
                └─ pending_context? ──► prepend to first prompt
                                              (memory compaction injection)
        │
        ▼
stream_prompt ──► is_streaming = true, update last_active
        │
        ▼
prompt_done ──► is_streaming = false, update last_active
        │
        ▼
cleanup_idle (every 15 min)
        │
        ├─ is_streaming? ──► skip (never evict mid-response)
        │
        └─ idle > 2hr? ──► compact → evict → notify user
```

### 3. Memory Compaction (`src/acp/pool.rs` + `src/acp/connection.rs`)

Kiro CLI ACP does not support `--resume` and does not replay conversation history on `session/load` — every new session is a cold start regardless of the session ID passed. To work around this limitation, agent-broker implements memory compaction:

> Before evicting an idle session, the broker sends a summarization prompt to the still-live agent, stores the summary, and injects it as context into the first prompt of the next session. The agent answers with full context without needing native resume support.

```
Session idle > TTL
        │
        ▼
cleanup_idle sends compaction prompt (lock released — no deadlock):
  "Summarize this conversation in 3rd person, capturing all key
   facts about the user and topics discussed. Be concise."
        │
        ▼
Summary stored in SessionPool.summaries[thread_id]
        │
        ▼
Session evicted, acp_session_id saved in prev_session_ids
        │
Next message to same thread
        │
        ▼
get_or_create → session/new → conn.pending_context = summary
        │
        ▼
session_prompt prepends context to first real user prompt:
  "[Context from previous session]: <summary>\n\n<user message>"
        │
        ▼
Agent answers with full context ✅
```

No extra round-trip — context is injected inline with the first prompt.

### 4. Config

`[discord]` → `[telegram]`:

```toml
[telegram]
bot_token = "${TELEGRAM_BOT_TOKEN}"
allowed_users = [123456789]          # Telegram user ID allowlist

[pool]
max_sessions = 10
```

TTL constants in `src/telegram.rs`:
```rust
const CLEANUP_INTERVAL_SECS: u64 = 900;   // run cleanup every 15 min
const SESSION_TTL_SECS: u64 = 7200;       // evict after 2hr idle
```

## Testing

**Alice test** (memory compaction verification):
1. Send: *"Hi I'm Alice. I love blue flowers."*
2. Wait for eviction notification (⏱ ~2hr, or lower TTL for testing)
3. Send: *"Who am I?"* and *"What color flower do I love?"*
4. Expected: agent answers correctly from compacted summary ✅

**Tested with:** kiro-cli 1.29.3, `session/load` always fails with `-32603` (kiro does not persist history) → compaction path is the active resume mechanism.

## What's Not In This PR

- Discord support is fully removed (replacement, not addition)
- `docs/telegram-bot-howto.md` not yet written (see setup guide in README)
