### PR TITLE
feat: structured sender identity injection (Phase 1+2 of #61)

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -86,13 +86,13 @@ impl EventHandler for Handler {
             "channel_id": msg.channel_id.to_string(),
             "is_bot": msg.author.bot,
         });
-        let prompt = format!(
+        let prompt_with_sender = format!(
             "<sender_context>\n{}\n</sender_context>\n\n{}",
             serde_json::to_string(&sender_ctx).unwrap(),
             prompt
         );
 
-        tracing::debug!(prompt = %prompt, in_thread, "processing");
+        tracing::debug!(prompt = %prompt_with_sender, in_thread, "processing");
 
         let thread_id = if in_thread {
             msg.channel_id.get()
@@ -138,7 +138,7 @@ impl EventHandler for Handler {
         let result = stream_prompt(
             &self.pool,
             &thread_key,
-            &prompt,
+            &prompt_with_sender,
             &ctx,
             thread_channel,
             thinking_msg.id,


### PR DESCRIPTION
## Summary

Inject Discord sender identity into the prompt so downstream coding CLIs can identify who sent each message. Implements Phase 1 + Phase 2 of #61.

## What the CLI receives

```
<sender_context>
{"schema":"agent-broker.sender.v1","sender_id":"<user_id>","sender_name":"<username>","display_name":"<nickname>","channel":"discord","channel_id":"<channel_id>","is_bot":false}
</sender_context>

hello
```

## Field Design (inspired by OpenClaw, simplified)

| Field | Why | Source |
|---|---|---|
| `schema` | Version control — future format changes won't break consumers | Fixed `agent-broker.sender.v1` |
| `sender_id` | Core — CLI matches this against local ID mapping to identify users | `msg.author.id` |
| `sender_name` | Stable Discord username | `msg.author.name` |
| `display_name` | Human-readable server nickname, fallback to username | `msg.member.nick` → `msg.author.name` |
| `channel` | Source platform — extensible for Slack/Telegram later | Fixed `discord` |
| `channel_id` | Which channel the message came from | `msg.channel_id` |
| `is_bot` | CLI can distinguish human vs bot messages | `msg.author.bot` |

**Intentionally left out:** `tag` (deprecated discriminators), `e164` (phone-only), `label` (CLI can compose), PluralKit, trusted/untrusted separation.

## Changes

`src/discord.rs` — after `strip_mention` and empty-check, build a `serde_json::json!` object with sender fields and wrap it in `<sender_context>` XML tags.

## Design

- **Schema versioned** (`agent-broker.sender.v1`) for forward compatibility
- **XML tag wrapping** — LLM-based CLIs parse it natively
- **Backward compatible** — CLIs that don't recognize the tag just see extra text
- **Extensible** — add fields later without breaking existing consumers
- **No protocol changes** — only `discord.rs` modified, ACP layer untouched

## Before vs After

```
╔═══════════════════════════════════════════════════════════════╗
║                      BEFORE 👻                                ║
╠═══════════════════════════════════════════════════════════════╣
║  Discord              agent-broker              CLI           ║
║  ┌────────┐          ┌────────────┐          ┌────────┐      ║
║  │ User A │─"hello"─▶│ strip only │─"hello"─▶│ Who?   │      ║
║  │ id,name│          │ ❌ dropped  │          │ 🤷     │      ║
║  └────────┘          └────────────┘          └────────┘      ║
╠═══════════════════════════════════════════════════════════════╣
║                      AFTER  👁️                                ║
╠═══════════════════════════════════════════════════════════════╣
║  Discord              agent-broker              CLI           ║
║  ┌────────┐          ┌────────────┐          ┌────────┐      ║
║  │ User A │─"hello"─▶│ + sender   │─prompt──▶│ User A!│      ║
║  │ id,name│          │   context   │          │ ✅     │      ║
║  └────────┘          │ ✅ injected │          └────────┘      ║
║                      └────────────┘                          ║
╚═══════════════════════════════════════════════════════════════╝
```

Closes #61 (Phase 1+2)