### PR TITLE
fix: detect and prevent Helm float64 mangling of Discord channel IDs (closes #43)

### DIFF
--- a/charts/agent-broker/templates/NOTES.txt
+++ b/charts/agent-broker/templates/NOTES.txt
@@ -1,5 +1,10 @@
 agent-broker {{ .Chart.AppVersion }} has been installed!
 
+⚠️  Discord channel IDs must be set with --set-string (not --set) to avoid float64 precision loss:
+
+  helm upgrade {{ .Release.Name }} agent-broker/agent-broker \
+    --set-string discord.allowedChannels[0]="<YOUR_CHANNEL_ID>"
+
 {{- if not .Values.discord.botToken }}
 
 ⚠️  No bot token was provided. Create the secret manually:

--- a/charts/agent-broker/templates/configmap.yaml
+++ b/charts/agent-broker/templates/configmap.yaml
@@ -8,6 +8,11 @@ data:
   config.toml: |
     [discord]
     bot_token = "${DISCORD_BOT_TOKEN}"
+    {{- range .Values.discord.allowedChannels }}
+    {{- if regexMatch "e\\+|E\\+" (toString .) }}
+    {{- fail (printf "discord.allowedChannels contains a mangled ID: %s — use --set-string instead of --set for channel IDs" (toString .)) }}
+    {{- end }}
+    {{- end }}
     allowed_channels = [{{ range $i, $ch := .Values.discord.allowedChannels }}{{ if $i }}, {{ end }}"{{ $ch }}"{{ end }}]
 
     [agent]

--- a/charts/agent-broker/values.yaml
+++ b/charts/agent-broker/values.yaml
@@ -17,6 +17,8 @@ persistence:
 
 discord:
   botToken: ""            # set via --set or external secret
+  # ⚠️ Use --set-string for channel IDs to avoid float64 precision loss:
+  #   helm install ... --set-string discord.allowedChannels[0]="<CHANNEL_ID>"
   allowedChannels:
     - "YOUR_CHANNEL_ID"
 


### PR DESCRIPTION
## Problem

Discord Snowflake IDs are 19-digit integers (> 2^53). Helm `--set` parses them as float64, losing precision and rendering them in scientific notation (e.g. `1.2345678901234568e+18`). This causes agent-broker to silently ignore all messages.

## Changes

### 1. `templates/configmap.yaml` — fail-fast validation
```yaml
{{- if regexMatch "e\\+|E\\+" (toString .) }}
{{- fail "discord.allowedChannels contains a mangled ID — use --set-string" }}
{{- end }}
```
If a channel ID contains scientific notation, `helm install/upgrade` fails immediately with a clear error message instead of silently deploying a broken config.

### 2. `templates/NOTES.txt` — post-install warning
Shows `--set-string` usage reminder on every install/upgrade.

### 3. `values.yaml` — inline comment
Documents the `--set-string` requirement next to `allowedChannels`.

## Before vs After

```
╔══════════════════════════════════════════════════════════════════════╗
║                      BEFORE (silent failure) 💀                      ║
╠══════════════════════════════════════════════════════════════════════╣
║                                                                      ║
║  User runs:                                                          ║
║  helm install ... --set discord.allowedChannels[0]=1234567890123456789
║                                                                      ║
║  ┌─────────────┐     ┌──────────────┐     ┌──────────────────┐       ║
║  │ Helm --set  │────▶│ float64 cast │────▶│ configmap.yaml   │       ║
║  │             │     │ precision 💥 │     │                  │       ║
║  └─────────────┘     └──────────────┘     │ allowed_channels │       ║
║                                           │ = ["1.23456789e+18"]     ║
║  1234567890123456789                      └────────┬─────────┘       ║
║  → 1.2345678901234568e+18                          │                 ║
║  → NEVER matches real ID                           ▼                 ║
║                                           ┌──────────────────┐       ║
║                                           │ agent-broker     │       ║
║                                           │ ignores ALL msgs │       ║
║                                           │ 🤷 no error log  │       ║
║                                           └──────────────────┘       ║
╠══════════════════════════════════════════════════════════════════════╣
║                      AFTER (fail fast) 🛡️                            ║
╠══════════════════════════════════════════════════════════════════════╣
║                                                                      ║
║  ❌ helm install ... --set discord.allowedChannels[0]=123...789       ║
║                                                                      ║
║  ┌─────────────┐     ┌──────────────┐     ┌──────────────────┐       ║
║  │ Helm --set  │────▶│ float64 cast │────▶│ configmap.yaml   │       ║
║  │             │     │ precision 💥 │     │ regexMatch "e+"  │       ║
║  └─────────────┘     └──────────────┘     │ ⛔ FAIL:         │       ║
║                                           │ "mangled ID,     │       ║
║                                           │  use --set-string"│      ║
║                                           └──────────────────┘       ║
║                                                                      ║
║  ✅ helm install ... --set-string discord.allowedChannels[0]="123..."
║                                                                      ║
║  ┌─────────────┐     ┌──────────────┐     ┌──────────────────┐       ║
║  │ --set-string│────▶│ kept as      │────▶│ configmap.yaml   │       ║
║  │             │     │ string ✅    │     │                  │       ║
║  └─────────────┘     └──────────────┘     │ allowed_channels │       ║
║                                           │ = ["123456789.."]│       ║
║                                           └────────┬─────────┘       ║
║                                                    ▼                 ║
║                                           ┌──────────────────┐       ║
║                                           │ agent-broker     │       ║
║                                           │ matches! ✅      │       ║
║                                           │ 🎉 msgs received │       ║
║                                           └──────────────────┘       ║
╚══════════════════════════════════════════════════════════════════════╝
```

## Testing

```bash
# This will now FAIL with a helpful error:
helm template test . --set discord.allowedChannels[0]=1234567890123456789

# This works correctly:
helm template test . --set-string discord.allowedChannels[0]="1234567890123456789"
```

Closes #43