### PR TITLE
chore: bump chart to 0.3.1-beta.1

### DIFF
--- a/charts/agent-broker/Chart.yaml
+++ b/charts/agent-broker/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-broker
 description: Discord ↔ ACP coding CLI bridge (Kiro CLI, Claude Code, Codex, Gemini)
 type: application
-version: 0.3.0
-appVersion: "afad7f9"
+version: 0.3.1-beta.1
+appVersion: "899c3d7"

--- a/charts/agent-broker/values.yaml
+++ b/charts/agent-broker/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/thepagent/agent-broker
-  tag: "afad7f9"
+  tag: "899c3d7"
   pullPolicy: IfNotPresent
 
 replicas: 1


### PR DESCRIPTION
## Changes since 0.3.0

- **#62** — Structured sender identity injection (`<sender_context>` JSON block)
- **#64** — Helm float64 channel ID fail-fast validation + `--set-string` warnings

## Version

```
version:    0.3.1-beta.1
appVersion: 899c3d7
```