### PR TITLE
fix: CI appVersion mismatch + Helm OCI namespace collision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,33 +189,34 @@ jobs:
           fi
           echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve image SHA
+        id: image-sha
+        run: |
+          # Use the commit SHA that triggered this build — this is the SHA
+          # that merge-manifests tagged the Docker image with (type=sha,prefix=).
+          # We capture it here explicitly so it survives the bump commit.
+          IMAGE_SHA="${{ github.sha }}"
+          IMAGE_SHA="${IMAGE_SHA:0:7}"
+          echo "sha=${IMAGE_SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Update Chart.yaml and values.yaml
         run: |
-          SHORT_SHA="${{ github.sha }}"
-          SHORT_SHA="${SHORT_SHA:0:7}"
+          IMAGE_SHA="${{ steps.image-sha.outputs.sha }}"
           sed -i "s/^version: .*/version: ${{ steps.bump.outputs.new_version }}/" charts/agent-broker/Chart.yaml
-          sed -i "s/^appVersion: .*/appVersion: \"${SHORT_SHA}\"/" charts/agent-broker/Chart.yaml
+          sed -i "s/^appVersion: .*/appVersion: \"${IMAGE_SHA}\"/" charts/agent-broker/Chart.yaml
           sed -i "s|repository: .*|repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}|" charts/agent-broker/values.yaml
-          sed -i "s/tag: .*/tag: \"${SHORT_SHA}\"/" charts/agent-broker/values.yaml
+          sed -i "s/tag: .*/tag: \"${IMAGE_SHA}\"/" charts/agent-broker/values.yaml
 
-      - name: Create bump PR
+      - name: Push chart bump directly to main
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION="${{ steps.bump.outputs.new_version }}"
-          BRANCH="chore/chart-${VERSION}"
+          IMAGE_SHA="${{ steps.image-sha.outputs.sha }}"
           git config user.name "openclaw-helm-bot[bot]"
           git config user.email "3185992+openclaw-helm-bot[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
           git add charts/agent-broker/Chart.yaml charts/agent-broker/values.yaml
-          git commit -m "chore: bump chart to ${VERSION}"
-          git push origin "$BRANCH"
-          if [[ "$VERSION" == *-beta* ]]; then
-            LABEL="beta"
-          else
-            LABEL="stable"
-          fi
-          gh pr create \
-            --title "chore: bump chart to ${VERSION}" \
-            --body "Auto-generated chart version bump (${LABEL}) for image \`${{ github.sha }}\`." \
-            --base main --head "$BRANCH"
+          git commit -m "chore: bump chart to ${VERSION} [skip ci]
+
+          image: ${IMAGE_SHA}"
+          git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           NAME=$(grep '^name:' ${CHART}/Chart.yaml | awk '{print $2}')
           VERSION=$(grep '^version:' ${CHART}/Chart.yaml | awk '{print $2}')
           helm package ${CHART}
-          helm push ${NAME}-${VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}
+          helm push ${NAME}-${VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
 
       - name: Append OCI install instructions to release notes
         env:
@@ -85,7 +85,7 @@ jobs:
 
           ### OCI Registry
           \`\`\`bash
-          helm install agent-broker oci://ghcr.io/${OWNER}/agent-broker --version ${VERSION}
+          helm install agent-broker oci://ghcr.io/${OWNER}/charts/agent-broker --version ${VERSION}
           \`\`\`
           EOF
 


### PR DESCRIPTION
## Problem

Two CI design flaws caused 0.3.1-beta.1 deployment to fail (see #66):

1. **appVersion points to non-existent image** — bump-chart created a PR to update Chart.yaml; when merged, the new commit SHA had no corresponding Docker image
2. **Helm chart and Docker image pushed to same GHCR repo** — `helm push` to `oci://ghcr.io/thepagent` collided with Docker images at `ghcr.io/thepagent/agent-broker`

## Changes

### build.yml
- `bump-chart` now pushes directly to main with `[skip ci]` instead of creating a PR
- Explicitly captures image SHA from the build commit, ensuring appVersion always matches an existing image

### release.yml
- `helm push` now targets `oci://ghcr.io/<owner>/charts` instead of `oci://ghcr.io/<owner>`
- Updated OCI install instructions in release notes accordingly

## Impact

- No more manual `--set image.tag=` override needed
- `helm install` default image tag is always correct
- OCI install path changes to `oci://ghcr.io/thepagent/charts/agent-broker`

Fixes #66