### PR TITLE
fix: use PR + auto-merge for chart bump (branch protection)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,16 +207,23 @@ jobs:
           sed -i "s|repository: .*|repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}|" charts/agent-broker/values.yaml
           sed -i "s/tag: .*/tag: \"${IMAGE_SHA}\"/" charts/agent-broker/values.yaml
 
-      - name: Push chart bump directly to main
+      - name: Create and auto-merge bump PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION="${{ steps.bump.outputs.new_version }}"
           IMAGE_SHA="${{ steps.image-sha.outputs.sha }}"
+          BRANCH="chore/chart-${VERSION}"
           git config user.name "openclaw-helm-bot[bot]"
           git config user.email "3185992+openclaw-helm-bot[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add charts/agent-broker/Chart.yaml charts/agent-broker/values.yaml
-          git commit -m "chore: bump chart to ${VERSION} [skip ci]
+          git commit -m "chore: bump chart to ${VERSION}
 
           image: ${IMAGE_SHA}"
-          git push origin main
+          git push origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --title "chore: bump chart to ${VERSION}" \
+            --body "Auto-generated chart version bump for image \`${IMAGE_SHA}\`." \
+            --base main --head "$BRANCH")
+          gh pr merge "$PR_URL" --squash --auto --delete-branch


### PR DESCRIPTION
Follow-up to #67 — direct push to main is blocked by branch protection rules (`GH013: Changes must be made through a pull request`).

## Change

Replace `git push origin main` with PR creation + `gh pr merge --squash --auto --delete-branch`. This:

- Respects branch protection rules
- Auto-merges immediately (no manual intervention)
- appVersion still uses the correct image SHA from the build (via `image-sha` step from #67)

## Note on appVersion after merge

The auto-merged PR will create a new merge commit, but the Chart.yaml inside it will contain the correct image SHA (captured during the build). The merge commit SHA itself is irrelevant — what matters is the `appVersion` field value, which points to the actual Docker image tag.

Follows up on #66