### PR TITLE
docs: use --set-string for Discord channel IDs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,24 +99,24 @@ helm repo update
 # Kiro CLI (default)
 helm install agent-broker agent-broker/agent-broker \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set discord.allowedChannels[0]="YOUR_CHANNEL_ID"
+  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID"
 
 # Codex
 helm install agent-broker agent-broker/agent-broker \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
+  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
   --set agent.preset=codex
 
 # Claude Code
 helm install agent-broker agent-broker/agent-broker \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
+  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
   --set agent.preset=claude
 
 # Gemini
 helm install agent-broker agent-broker/agent-broker \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
+  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
   --set agent.preset=gemini
 ```
 


### PR DESCRIPTION
Update all 4 Helm install examples in README to use `--set-string` for `discord.allowedChannels`.

Discord Snowflake IDs exceed float64 precision (>2^53). Using `--set` causes silent message ignoring due to scientific notation mangling. Configmap validation was already added in #64; this PR fixes the README examples.

Ref: #43