### PR TITLE
fix: prevent duplicate messages for long replies (>1900 chars)

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -229,19 +229,17 @@ async fn stream_prompt(
                         if buf_rx.has_changed().unwrap_or(false) {
                             let content = buf_rx.borrow_and_update().clone();
                             if content != last_content {
-                                if content.len() > 1900 {
-                                    let chunks = format::split_message(&content, 1900);
-                                    if let Some(first) = chunks.first() {
-                                        let _ = edit(&ctx, channel, current_edit_msg, first).await;
-                                    }
-                                    for chunk in chunks.iter().skip(1) {
-                                        if let Ok(new_msg) = channel.say(&ctx.http, chunk).await {
-                                            current_edit_msg = new_msg.id;
-                                        }
-                                    }
+                                // During streaming, only edit the single message.
+                                // If content exceeds Discord's limit, truncate with
+                                // an indicator. The final edit after streaming ends
+                                // will handle proper multi-chunk splitting.
+                                let display = if content.len() > 1900 {
+                                    let truncated: String = content.chars().take(1880).collect();
+                                    format!("{truncated}\n\n_…(streaming)_")
                                 } else {
-                                    let _ = edit(&ctx, channel, current_edit_msg, &content).await;
-                                }
+                                    content.clone()
+                                };
+                                let _ = edit(&ctx, channel, current_edit_msg, &display).await;
                                 last_content = content;
                             }
                         }


### PR DESCRIPTION
## What

Fixes #81 — long agent replies (>1900 chars) produce cascading duplicate messages in Discord.

## The Problem

The edit-streaming task runs every 1.5s in a loop. Each iteration, if content exceeds 1900 chars, it splits into chunks and calls `say()` for each overflow chunk. But previous chunks are never cleaned up — they become orphaned messages.

```
  edit-streaming loop (every 1.5s)         final edit
  ─────────────────────────────────        ──────────

  Round 1: content grows to ~2500 chars
  ┌──────────┐ ┌──────────┐
  │ edit(C1) │ │ say(C2)  │
  └──────────┘ └──────────┘
  Discord: [msg1] [msg2]

  Round 2: content grows to ~3500 chars
               ┌──────────┐ ┌──────────┐ ┌──────────┐
               │ edit(C1)◄┘ │ say(C2)  │ │ say(C3)  │
               └──────────┘ └──────────┘ └──────────┘
  Discord: [msg1] [msg2*] [msg3] [msg4]
                   ▲ overwrites msg2, but msg2 old content
                     was already seen by users

  Round 3: content grows to ~4000 chars
                             ┌──────────┐ ┌──────────┐ ┌──────────┐
                             │ edit(C1)◄┘ │ say(C2)  │ │ say(C3)  │
                             └──────────┘ └──────────┘ └──────────┘
  Discord: [msg1] [msg2] [msg3] [msg4*] [msg5] [msg6]
                                 ▲ overwrites msg4

  Final edit (after stream ends):
  ┌──────────┐ ┌──────────┐ ┌──────────┐
  │ edit(C1) │ │ say(C2)  │ │ say(C3)  │
  └──────────┘ └──────────┘ └──────────┘
  Discord: [msg1*] [msg2] [msg3] [msg4] [msg5] [msg6] [msg7] [msg8]
            ▲ ok    ▲ orphan     ▲ orphan     ▲ orphan      ▲ ok
```

Each round of the streaming loop `say()`s new messages that pile up.
The user sees N chunks repeated again and again, then one final set.

## The Fix

The edit-streaming task now **never calls `say()`**. During streaming,
long content is truncated to 1880 chars with a `…(streaming)` indicator,
and only the single original message is `edit()`ed.

```
  edit-streaming loop (every 1.5s)         final edit
  ─────────────────────────────────        ──────────

  Round 1: content grows to ~2500 chars
  ┌─────────────────────────────┐
  │ edit(msg1, first 1880 chars │
  │         + "…(streaming)")   │
  └─────────────────────────────┘
  Discord: [msg1]  ← just one message, truncated preview

  Round 2: content grows to ~3500 chars
  ┌─────────────────────────────┐
  │ edit(msg1, first 1880 chars │
  │         + "…(streaming)")   │
  └─────────────────────────────┘
  Discord: [msg1]  ← still just one message, updated preview

  Round 3: content grows to ~4000 chars
  ┌─────────────────────────────┐
  │ edit(msg1, first 1880 chars │
  │         + "…(streaming)")   │
  └─────────────────────────────┘
  Discord: [msg1]  ← still just one message

  Final edit (after stream ends):
  ┌──────────┐ ┌──────────┐ ┌──────────┐
  │ edit(C1) │ │ say(C2)  │ │ say(C3)  │
  └──────────┘ └──────────┘ └──────────┘
  Discord: [msg1] [msg2] [msg3]  ← clean! only 3 messages
```

## Changes

- `src/discord.rs`: Replace chunk-and-say logic in edit-streaming task with truncate-and-edit