### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default code owner for all files
+* @thepagent
+
+# Explicitly protect the CODEOWNERS file itself. While the wildcard above
+# already covers it, this ensures ownership is preserved even if more
+# specific patterns are added later (CODEOWNERS uses last-match-wins).
+/.github/CODEOWNERS @thepagent


### PR DESCRIPTION
Define `@thepagent` as code owner for all files. Combined with the ruleset update (require code owner review + 2 approvals), all PRs to main will require approval from `@thepagent`.

```
* @thepagent
/.github/CODEOWNERS @thepagent
```