### PR TITLE
fix: empty allowed_channels denies all channels (secure by default)

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -1,5 +1,6 @@
 [discord]
 bot_token = "${DISCORD_BOT_TOKEN}"
+# Required: at least one channel ID. Empty list = bot will not respond to any messages.
 allowed_channels = ["1234567890"]
 
 [agent]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -28,8 +28,7 @@ impl EventHandler for Handler {
         let bot_id = ctx.cache.current_user().id;
 
         let channel_id = msg.channel_id.get();
-        let in_allowed_channel =
-            self.allowed_channels.is_empty() || self.allowed_channels.contains(&channel_id);
+        let in_allowed_channel = self.allowed_channels.contains(&channel_id);
 
         let is_mentioned = msg.mentions_user_id(bot_id)
             || msg.content.contains(&format!("<@{}>", bot_id))
@@ -172,6 +171,9 @@ impl EventHandler for Handler {
 
     async fn ready(&self, _ctx: Context, ready: Ready) {
         info!(user = %ready.user.name, "discord bot connected");
+        if self.allowed_channels.is_empty() {
+            tracing::warn!("allowed_channels is empty — bot will NOT respond to any messages. Configure allowed_channels in config.toml.");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implements **Option A** from #91: empty `allowed_channels` now means the bot will **not respond to any messages** (secure by default).

## Changes

### `src/discord.rs`
- Removed `self.allowed_channels.is_empty() ||` from the channel check — empty set now denies all
- Added startup warning log in `ready()` when `allowed_channels` is empty:
  ```
  WARN: allowed_channels is empty — bot will NOT respond to any messages. Configure allowed_channels in config.toml.
  ```

### `config.toml.example`
- Added comment: `# Required: at least one channel ID. Empty list = bot will not respond to any messages.`

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `allowed_channels = []` | ✅ Responds in ALL channels | ❌ Responds in NO channels + warning log |
| `allowed_channels = ["123"]` | ✅ Responds in channel 123 | ✅ Responds in channel 123 (unchanged) |
| Thread in allowed channel | ✅ Works | ✅ Works (unchanged) |

## Breaking Change

Users who intentionally left `allowed_channels` empty to allow all channels will need to explicitly list their channel IDs. This is a one-line config change.

Closes #91
