### PR TITLE
chore: update bot identity to openab-app[bot]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,8 +214,8 @@ jobs:
           VERSION="${{ steps.bump.outputs.new_version }}"
           IMAGE_SHA="${{ steps.image-sha.outputs.sha }}"
           BRANCH="chore/chart-${VERSION}"
-          git config user.name "openclaw-helm-bot[bot]"
-          git config user.email "3185992+openclaw-helm-bot[bot]@users.noreply.github.com"
+          git config user.name "openab-app[bot]"
+          git config user.email "274185012+openab-app[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add charts/openab/Chart.yaml charts/openab/values.yaml
           git commit -m "chore: bump chart to ${VERSION}


### PR DESCRIPTION
Update git commit author in build.yml from `openclaw-helm-bot[bot]` to `openab-app[bot]` (ID 274185012) to match the new GitHub App.