### PR TITLE
docs: add GitHub webhook integration and token setup guides

### DIFF
--- a/docs/github-token-setup.md
+++ b/docs/github-token-setup.md
@@ -39,29 +39,34 @@ Use `envFrom` in your Helm values to inject the token as `GH_TOKEN`:
 envFrom:
   - secretRef:
       name: gh-token-secret
-
-env:
-  GH_TOKEN: ""   # or use envFrom above
 ```
 
-Or pass it directly during install:
+> **Recommended**: Use `envFrom` with a separate secret so the token doesn't appear in shell history or Helm release metadata.
+
+As a fallback, you can pass it directly during install — but note this exposes the token in shell history:
 
 ```bash
 helm install openab openab/openab \
   --set env.GH_TOKEN="<YOUR_GITHUB_TOKEN>"
 ```
 
-> **Recommended**: Use `envFrom` with a separate secret rather than `--set`, so the token doesn't appear in shell history.
-
 The `gh` CLI automatically picks up `GH_TOKEN` — no additional auth setup needed.
 
 ## 4. Install `gh` CLI in the Agent Container
 
-Ensure `gh` is available in your Dockerfile:
+Ensure `gh` is available in your Dockerfile. Note: `gh` is not in the default Debian repos — you need to add the GitHub CLI apt repository first:
 
 ```dockerfile
-RUN apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl gpg && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && apt-get install -y gh && \
+    rm -rf /var/lib/apt/lists/*
 ```
+
+See the [official install docs](https://github.com/cli/cli/blob/trunk/docs/install_linux.md) for other methods.
 
 ## 5. Verify
 

--- a/docs/github-token-setup.md
+++ b/docs/github-token-setup.md
@@ -1,0 +1,94 @@
+# GitHub Token Setup for Agents
+
+Step-by-step guide to give your agent secure access to GitHub via `gh` CLI.
+
+## Overview
+
+Agents sometimes need to interact with GitHub — push branches, open PRs, comment on issues. The recommended approach is to store a GitHub fine-grained personal access token in a Kubernetes secret and inject it via the Helm chart's `envFrom`.
+
+## 1. Create a Fine-Grained Personal Access Token
+
+1. Go to [GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens](https://github.com/settings/tokens?type=beta)
+2. Click **Generate new token**
+3. Configure:
+   - **Token name**: e.g. `openab-masami`
+   - **Expiration**: set a reasonable expiry (e.g. 90 days)
+   - **Repository access**: select only the repos the agent needs
+   - **Permissions**:
+     - Contents: Read and write (push branches)
+     - Pull requests: Read and write (create/comment on PRs)
+     - Issues: Read and write (comment on issues)
+     - Workflows: Read and write (if the agent needs to modify workflows)
+4. Click **Generate token** and copy it immediately
+
+## 2. Store the Token in a Kubernetes Secret
+
+Create a dedicated secret for the GitHub token:
+
+```bash
+kubectl create secret generic gh-token-secret \
+  --from-literal=gh-token="<YOUR_GITHUB_TOKEN>"
+```
+
+## 3. Inject via Helm Chart
+
+Use `envFrom` in your Helm values to inject the token as `GH_TOKEN`:
+
+```yaml
+# values.yaml
+envFrom:
+  - secretRef:
+      name: gh-token-secret
+
+env:
+  GH_TOKEN: ""   # or use envFrom above
+```
+
+Or pass it directly during install:
+
+```bash
+helm install openab openab/openab \
+  --set env.GH_TOKEN="<YOUR_GITHUB_TOKEN>"
+```
+
+> **Recommended**: Use `envFrom` with a separate secret rather than `--set`, so the token doesn't appear in shell history.
+
+The `gh` CLI automatically picks up `GH_TOKEN` — no additional auth setup needed.
+
+## 4. Install `gh` CLI in the Agent Container
+
+Ensure `gh` is available in your Dockerfile:
+
+```dockerfile
+RUN apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
+```
+
+## 5. Verify
+
+Once the agent pod is running:
+
+```bash
+# Check auth status
+gh auth status
+
+# Should show:
+# ✓ Logged in to github.com as your-agent-user (GH_TOKEN)
+```
+
+The agent can now run `gh` commands: `gh pr create`, `gh issue comment`, `gh repo fork`, etc.
+
+## Security Best Practices
+
+- **Fine-grained tokens only** — avoid classic tokens; fine-grained tokens limit access to specific repos and permissions
+- **Least privilege** — only grant the permissions the agent actually needs
+- **Set expiration** — rotate tokens regularly; don't use non-expiring tokens
+- **One token per agent** — if you run multiple agents, give each its own token with its own GitHub account
+- **Never log tokens** — ensure your agent doesn't echo `$GH_TOKEN` in responses or logs
+- **Dedicated GitHub account** — create a bot account (e.g. `masami-agent`) rather than using a personal account
+
+## Troubleshooting
+
+- **`gh auth status` fails** — check that `GH_TOKEN` env var is set: `echo ${GH_TOKEN:+exists}`
+- **Permission denied on push** — the token's repo access doesn't include the target repo, or write permission is missing
+- **403 on PR create** — the token needs Pull requests: Read and write permission
+- **Token expired** — generate a new one and update the k8s secret

--- a/docs/github-webhook-integration.md
+++ b/docs/github-webhook-integration.md
@@ -1,0 +1,113 @@
+# GitHub Webhook to Discord — Agent Trigger Pattern
+
+## Overview
+
+OpenAB only listens to Discord events. It does not accept external webhooks directly. To trigger agents from GitHub events (PR, Issue, etc.), we route through Discord as the single entry point.
+
+## Architecture
+
+```
+GitHub (PR/Issue event)
+  → GitHub Actions workflow
+    → Discord Webhook (formatted message to channel)
+      → OpenAB detects message
+        → Routes to target agent
+          → Agent performs action (review, comment, notify)
+```
+
+## Setup
+
+### 1. Discord Webhook
+
+Create a webhook in your Discord server for the target channel/topic:
+- Server Settings → Integrations → Webhooks → New Webhook
+- Copy the webhook URL
+
+### 2. GitHub Secret
+
+Add the webhook URL as a repository secret:
+- Repo → Settings → Secrets and variables → Actions
+- Name: `DISCORD_WEBHOOK_URL`
+- Value: the webhook URL from step 1
+
+### 3. GitHub Actions Workflow
+
+Add `.github/workflows/notify-discord.yml` to your repo:
+
+```yaml
+name: Notify Discord
+
+on:
+  pull_request:
+    types: [opened, reopened]
+  issues:
+    types: [opened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            TITLE="${{ github.event.pull_request.title }}"
+            URL="${{ github.event.pull_request.html_url }}"
+            AUTHOR="${{ github.event.pull_request.user.login }}"
+            NUM="${{ github.event.pull_request.number }}"
+            TYPE="pr_opened"
+            LABEL="PR #${NUM}"
+          else
+            TITLE="${{ github.event.issue.title }}"
+            URL="${{ github.event.issue.html_url }}"
+            AUTHOR="${{ github.event.issue.user.login }}"
+            NUM="${{ github.event.issue.number }}"
+            TYPE="issue_opened"
+            LABEL="Issue #${NUM}"
+          fi
+
+          curl -s -H "Content-Type: application/json" \
+            -d "{\"content\":\"[GH-EVENT] repo:${{ github.repository }} action:${TYPE} ${LABEL}\\n**${TITLE}**\\nby ${AUTHOR}\\n${URL}\"}" \
+            "$DISCORD_WEBHOOK_URL"
+```
+
+## Message Format Convention
+
+Messages use a structured prefix so OpenAB can identify GitHub events:
+
+```
+[GH-EVENT] repo:{owner/repo} action:{event_type} {PR/Issue} #{number}
+**{title}**
+by {author}
+{url}
+```
+
+Example:
+```
+[GH-EVENT] repo:openabdev/openab action:pr_opened PR #42
+**Add webhook integration docs**
+by obrutjack
+https://github.com/openabdev/openab/pull/42
+```
+
+## Open Questions
+
+- **Bot message handling**: Does OpenAB currently ignore messages from bots/webhooks? If so, webhook sources need to be allowlisted.
+- **Routing**: How does OpenAB determine which agent handles a `[GH-EVENT]` message?
+- **Loop prevention**: If an agent replies in the same channel, could it re-trigger events? Recommend using a dedicated channel and filtering by `[GH-EVENT]` prefix only.
+
+## Best Practices
+
+- Use a dedicated channel or thread for webhook events
+- Stick to the `[GH-EVENT]` prefix convention for all GitHub-sourced messages
+- Validate webhook sources on the Discord side (restrict channel permissions)
+- Avoid agents posting back to the same webhook channel to prevent loops
+- Start minimal (PR + Issue notifications), expand as needed
+
+## Future Considerations
+
+- Extend pattern to other sources: Jira, Slack, PagerDuty, etc.
+- Agent-to-agent invocation during review workflows
+- Event filtering and deduplication at the OpenAB level
+- Richer payloads using Discord embeds instead of plain text

--- a/docs/github-webhook-integration.md
+++ b/docs/github-webhook-integration.md
@@ -67,9 +67,10 @@ jobs:
             LABEL="Issue #${NUM}"
           fi
 
-          curl -s -H "Content-Type: application/json" \
-            -d "{\"content\":\"[GH-EVENT] repo:${{ github.repository }} action:${TYPE} ${LABEL}\\n**${TITLE}**\\nby ${AUTHOR}\\n${URL}\"}" \
-            "$DISCORD_WEBHOOK_URL"
+          MSG="[GH-EVENT] repo:${{ github.repository }} action:${TYPE} ${LABEL}"
+          MSG="${MSG}\n**${TITLE}**\nby ${AUTHOR}\n${URL}"
+          PAYLOAD=$(printf '%s' "$MSG" | jq -Rs '{content: .}')
+          curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"
 ```
 
 ## Message Format Convention
@@ -93,7 +94,7 @@ https://github.com/openabdev/openab/pull/42
 
 ## Open Questions
 
-- **Bot message handling**: Does OpenAB currently ignore messages from bots/webhooks? If so, webhook sources need to be allowlisted.
+- **Bot message handling**: Does OpenAB currently ignore messages from bots/webhooks? If so, webhook sources need to be allowlisted. Note: OpenAB uses `allowed_channels` and `allowed_users` in `config.toml` for filtering — webhook messages come from a bot user, so the bot's user ID may need to be added to `allowed_users`, or the filtering logic would need a `[GH-EVENT]` prefix check.
 - **Routing**: How does OpenAB determine which agent handles a `[GH-EVENT]` message?
 - **Loop prevention**: If an agent replies in the same channel, could it re-trigger events? Recommend using a dedicated channel and filtering by `[GH-EVENT]` prefix only.
 

--- a/docs/github-webhook-integration.md
+++ b/docs/github-webhook-integration.md
@@ -1,5 +1,10 @@
 # GitHub Webhook to Discord — Agent Trigger Pattern
 
+> **Note:** This documents a v1 workaround using GitHub Actions + Discord webhooks.
+> The target architecture (v2+) is the [Custom Gateway](adr/custom-gateway.md) with a
+> native GitHub adapter, which provides direct webhook reception, HMAC validation,
+> and richer event context. See [ADR: Custom Gateway — Section 5](adr/custom-gateway.md#5-what-this-enables-beyond-chat) for the GitHub integration example.
+
 ## Overview
 
 OpenAB only listens to Discord events. It does not accept external webhooks directly. To trigger agents from GitHub events (PR, Issue, etc.), we route through Discord as the single entry point.


### PR DESCRIPTION
## Summary

Adds two documentation files for GitHub → Discord → OpenAB integration.

Replaces PR thepagent/agent-broker#85 (closed — project moved to openabdev/openab).

## Changes

### `docs/github-webhook-integration.md`
- Architecture: GitHub → GitHub Actions → Discord Webhook → OpenAB → Agent
- Setup guide (Discord webhook, GitHub secret, workflow example)
- Message format convention (`[GH-EVENT]` prefix)
- Open questions, best practices, future considerations

### `docs/github-token-setup.md`
- Fine-grained token creation and permission guide
- K8s secret + Helm `envFrom` injection (no chart template changes needed)
- Security best practices and troubleshooting

## Doc-only PR
No code or infra changes. Workflow implementation will be a separate PR after open questions are resolved.