### PR TITLE
feat: add Discord notification workflow for PR and Issue events

### DIFF
--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -1,0 +1,35 @@
+name: Notify Discord
+
+on:
+  pull_request:
+    types: [opened, reopened]
+  issues:
+    types: [opened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            TITLE="${{ github.event.pull_request.title }}"
+            URL="${{ github.event.pull_request.html_url }}"
+            AUTHOR="${{ github.event.pull_request.user.login }}"
+            NUM="${{ github.event.pull_request.number }}"
+            TYPE="pr_opened"
+            LABEL="PR #${NUM}"
+          else
+            TITLE="${{ github.event.issue.title }}"
+            URL="${{ github.event.issue.html_url }}"
+            AUTHOR="${{ github.event.issue.user.login }}"
+            NUM="${{ github.event.issue.number }}"
+            TYPE="issue_opened"
+            LABEL="Issue #${NUM}"
+          fi
+
+          curl -s -H "Content-Type: application/json" \
+            -d "{\"content\":\"[GH-EVENT] repo:${{ github.repository }} action:${TYPE} ${LABEL}\\n**${TITLE}**\\nby ${AUTHOR}\\n${URL}\"}" \
+            "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -13,23 +13,37 @@ jobs:
       - name: Send to Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            TITLE="${{ github.event.pull_request.title }}"
-            URL="${{ github.event.pull_request.html_url }}"
-            AUTHOR="${{ github.event.pull_request.user.login }}"
-            NUM="${{ github.event.pull_request.number }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            TITLE="$PR_TITLE"
+            URL="$PR_URL"
+            AUTHOR="$PR_AUTHOR"
+            NUM="$PR_NUMBER"
             TYPE="pr_opened"
             LABEL="PR #${NUM}"
           else
-            TITLE="${{ github.event.issue.title }}"
-            URL="${{ github.event.issue.html_url }}"
-            AUTHOR="${{ github.event.issue.user.login }}"
-            NUM="${{ github.event.issue.number }}"
+            TITLE="$ISSUE_TITLE"
+            URL="$ISSUE_URL"
+            AUTHOR="$ISSUE_AUTHOR"
+            NUM="$ISSUE_NUMBER"
             TYPE="issue_opened"
             LABEL="Issue #${NUM}"
           fi
 
-          curl -s -H "Content-Type: application/json" \
-            -d "{\"content\":\"[GH-EVENT] repo:${{ github.repository }} action:${TYPE} ${LABEL}\\n**${TITLE}**\\nby ${AUTHOR}\\n${URL}\"}" \
-            "$DISCORD_WEBHOOK_URL"
+          PAYLOAD=$(jq -n \
+            --arg content "[GH-EVENT] repo:${REPO} action:${TYPE} ${LABEL}
+**${TITLE}**
+by ${AUTHOR}
+${URL}" \
+            '{"content": $content}')
+          curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -14,6 +14,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -31,14 +32,14 @@ jobs:
             URL="$PR_URL"
             AUTHOR="$PR_AUTHOR"
             NUM="$PR_NUMBER"
-            TYPE="pr_opened"
+            TYPE="pr_${EVENT_ACTION}"
             LABEL="PR #${NUM}"
           else
             TITLE="$ISSUE_TITLE"
             URL="$ISSUE_URL"
             AUTHOR="$ISSUE_AUTHOR"
             NUM="$ISSUE_NUMBER"
-            TYPE="issue_opened"
+            TYPE="issue_${EVENT_ACTION}"
             LABEL="Issue #${NUM}"
           fi
 

--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, reopened]
   issues:
-    types: [opened]
+    types: [opened, reopened]
 
 jobs:
   notify:
@@ -24,6 +24,8 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
+          [ -z "$DISCORD_WEBHOOK_URL" ] && { echo "::warning::DISCORD_WEBHOOK_URL not set"; exit 0; }
+
           if [ "$EVENT_NAME" = "pull_request" ]; then
             TITLE="$PR_TITLE"
             URL="$PR_URL"
@@ -46,4 +48,4 @@ jobs:
 by ${AUTHOR}
 ${URL}" \
             '{"content": $content}')
-          curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"
+          curl --fail-with-body -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"

--- a/docs/github-webhook-integration.md
+++ b/docs/github-webhook-integration.md
@@ -46,7 +46,7 @@ on:
   pull_request:
     types: [opened, reopened]
   issues:
-    types: [opened]
+    types: [opened, reopened]
 
 jobs:
   notify:
@@ -55,27 +55,43 @@ jobs:
       - name: Send to Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            TITLE="${{ github.event.pull_request.title }}"
-            URL="${{ github.event.pull_request.html_url }}"
-            AUTHOR="${{ github.event.pull_request.user.login }}"
-            NUM="${{ github.event.pull_request.number }}"
-            TYPE="pr_opened"
+          [ -z "$DISCORD_WEBHOOK_URL" ] && { echo "::warning::DISCORD_WEBHOOK_URL not set"; exit 0; }
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            TITLE="$PR_TITLE"
+            URL="$PR_URL"
+            AUTHOR="$PR_AUTHOR"
+            NUM="$PR_NUMBER"
+            TYPE="pr_${EVENT_ACTION}"
             LABEL="PR #${NUM}"
           else
-            TITLE="${{ github.event.issue.title }}"
-            URL="${{ github.event.issue.html_url }}"
-            AUTHOR="${{ github.event.issue.user.login }}"
-            NUM="${{ github.event.issue.number }}"
-            TYPE="issue_opened"
+            TITLE="$ISSUE_TITLE"
+            URL="$ISSUE_URL"
+            AUTHOR="$ISSUE_AUTHOR"
+            NUM="$ISSUE_NUMBER"
+            TYPE="issue_${EVENT_ACTION}"
             LABEL="Issue #${NUM}"
           fi
 
-          MSG="[GH-EVENT] repo:${{ github.repository }} action:${TYPE} ${LABEL}"
-          MSG="${MSG}\n**${TITLE}**\nby ${AUTHOR}\n${URL}"
-          PAYLOAD=$(printf '%s' "$MSG" | jq -Rs '{content: .}')
-          curl -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"
+          PAYLOAD=$(jq -n \
+            --arg content "[GH-EVENT] repo:${REPO} action:${TYPE} ${LABEL}
+**${TITLE}**
+by ${AUTHOR}
+${URL}" \
+            '{"content": $content}')
+          curl --fail-with-body -s -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"
 ```
 
 ## Message Format Convention
@@ -88,6 +104,8 @@ Messages use a structured prefix so OpenAB can identify GitHub events:
 by {author}
 {url}
 ```
+
+Supported `event_type` values: `pr_opened`, `pr_reopened`, `issue_opened`, `issue_reopened`
 
 Example:
 ```


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that sends notifications to Discord when PRs or Issues are opened.

This is the implementation counterpart to the docs in PR #105.

Discord Discussion URL: https://discordapp.com/channels/1491295327620169908/1497824478879809676/1497825205538652170

## What it does

- Triggers on `pull_request` (opened/reopened) and `issues` (opened/reopened)
- Sends a structured `[GH-EVENT]` message to Discord via `$DISCORD_WEBHOOK_URL` secret
- Message format follows the convention defined in `docs/github-webhook-integration.md`

## Requirements

- `DISCORD_WEBHOOK_URL` must be set as a repository secret

## Example output

```
[GH-EVENT] repo:openabdev/openab action:pr_opened PR #105
**docs: add GitHub webhook integration and token setup guides**
by masami-agent
https://github.com/openabdev/openab/pull/105
```
