### PR TITLE
Update CODEOWNERS from @thepagent to @openabdev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Default code owner for all files
-* @thepagent
+* @openabdev
 
 # Explicitly protect the CODEOWNERS file itself. While the wildcard above
 # already covers it, this ensures ownership is preserved even if more
 # specific patterns are added later (CODEOWNERS uses last-match-wins).
-/.github/CODEOWNERS @thepagent
+/.github/CODEOWNERS @openabdev


### PR DESCRIPTION
##### Summary
- Update `.github/CODEOWNERS` to reflect the org migration from `thepagent` to `openabdev`

##### Changes
- Replace `@thepagent` → `@openabdev` in default code owner (line 2)
- Replace `@thepagent` → `@openabdev` in CODEOWNERS file protection rule (line 7)

##### Context
After migrating the repository from `thepagent/agent-broker` to `openabdev/openab`, the CODEOWNERS file still references the old `@thepagent` GitHub handle. This is the last remaining reference to the old org name in the codebase.