### PR TITLE
fix: drop --auto from chart bump PR merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,4 +226,4 @@ jobs:
             --title "chore: bump chart to ${VERSION}" \
             --body "Auto-generated chart version bump for image \`${IMAGE_SHA}\`." \
             --base main --head "$BRANCH")
-          gh pr merge "$PR_URL" --squash --auto --delete-branch
+          gh pr merge "$PR_URL" --squash --delete-branch


### PR DESCRIPTION
The `--auto` flag waits for reviews that never come on bot PRs. Direct merge works because `openab-app` is a bypass actor on the branch ruleset.

Closes #121