### PR TITLE
docs: quote indexed Helm keys for zsh users

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Swap backends using the `agent.preset` Helm value or manual config. Tested backe
 
 ### Helm Install (recommended)
 
+If you use `zsh`, quote indexed Helm keys like `'discord.allowedChannels[0]=...'` to avoid shell globbing.
+
 ```bash
 helm repo add openab https://openabdev.github.io/openab
 helm repo update
@@ -99,24 +101,24 @@ helm repo update
 # Kiro CLI (default)
 helm install openab openab/openab \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID"
+  --set-string 'discord.allowedChannels[0]=YOUR_CHANNEL_ID'
 
 # Codex
 helm install openab openab/openab \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
+  --set-string 'discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agent.preset=codex
 
 # Claude Code
 helm install openab openab/openab \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
+  --set-string 'discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agent.preset=claude
 
 # Gemini
 helm install openab openab/openab \
   --set discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set-string discord.allowedChannels[0]="YOUR_CHANNEL_ID" \
+  --set-string 'discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agent.preset=gemini
 ```
 

--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -2,8 +2,10 @@ openab {{ .Chart.AppVersion }} has been installed!
 
 ⚠️  Discord channel IDs must be set with --set-string (not --set) to avoid float64 precision loss:
 
+⚠️  In zsh, quote indexed keys to avoid shell globbing:
+
   helm upgrade {{ .Release.Name }} openab/openab \
-    --set-string discord.allowedChannels[0]="<YOUR_CHANNEL_ID>"
+    --set-string 'discord.allowedChannels[0]=<YOUR_CHANNEL_ID>'
 
 {{- if not .Values.discord.botToken }}
 

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -30,7 +30,8 @@ persistence:
 discord:
   botToken: ""            # set via --set or external secret
   # ⚠️ Use --set-string for channel IDs to avoid float64 precision loss:
-  #   helm install ... --set-string discord.allowedChannels[0]="<CHANNEL_ID>"
+  #   zsh users should quote indexed keys to avoid shell globbing:
+  #   helm install ... --set-string 'discord.allowedChannels[0]=<CHANNEL_ID>'
   allowedChannels:
     - "YOUR_CHANNEL_ID"
 


### PR DESCRIPTION
## Summary
Quote indexed `--set-string` Helm examples and add a short zsh note so macOS users do not hit shell globbing before Helm runs.

## Problem
Indexed Helm keys like `discord.allowedChannels[0]` are valid, but unquoted examples fail in `zsh` with `no matches found` because square brackets are treated as glob patterns.

## Changes
- Quote indexed `--set-string` examples in the README Helm install section
- Add the same guidance to the chart NOTES output
- Update the chart values comment to show the zsh-safe form

## Why This Scope
This is a docs-only change. The chart behavior is already correct once the indexed keys are quoted, so there is no template or runtime bug to fix.

## Validation
- Reproduced the failure in `zsh` with unquoted indexed keys
- Confirmed the quoted form installs successfully via Helm
