### PR TITLE
docs: add issue triage guide

### DIFF
--- a/docs/steering/triage.md
+++ b/docs/steering/triage.md
@@ -1,0 +1,50 @@
+# Issue Triage Guide for openabdev/openab
+
+## Steps
+
+1. **Confirm type** — ensure one of: `bug`, `feature`, `guidance`
+2. **Verify claims** — be skeptical; find source code or official docs to confirm before accepting a bug report as valid
+3. **Set priority** — add exactly one:
+   - `p0` 🔴 Critical — drop everything
+   - `p1` 🟠 High — address this sprint
+   - `p2` 🟡 Medium — planned work
+   - `p3` 🟤 Low — nice to have
+4. **Remove `needs-triage`** — triage complete
+
+## Priority Guidelines
+
+| Priority | Criteria |
+|----------|----------|
+| p0 | Security vulnerability, data loss, entire system down |
+| p1 | Major feature broken for a class of users (e.g. all Claude Code / Cursor users) |
+| p2 | Bug with workaround, or planned feature work |
+| p3 | Minor improvement, cosmetic, nice to have |
+
+## Response Template
+
+- **Issue at a Glance** — always include an ASCII diagram showing the flow and where things break
+- Acknowledge the issue by investigating the relevant source code or official docs
+- Confirm root cause or ask clarifying questions
+- Link relevant spec/doc references when available
+- Invite PR or state next steps
+- **Draft response for human approval before posting to the issue comment**
+
+## Issue at a Glance Example
+
+```
+Discord User ──► openab ──► Claude Code / Cursor agent
+                   │
+                   ▼
+          session/request_permission
+          (agent asks: "can I run this tool?")
+                   │
+                   ▼
+          openab auto-reply (WRONG shape):
+          ┌─────────────────────────────────┐
+          │ { "optionId": "allow_always" }  │  ← flat, no wrapper
+          └─────────────────────────────────┘
+                   │
+                   ▼
+          SDK cannot find `outcome` field
+          → treats as REFUSAL ❌
+```


### PR DESCRIPTION
OpenAB is built AI-first and AI-native. This steering doc is how our team actually triages issues day-to-day — using OpenAB itself. By dogfooding our own tool, we continuously improve the workflow and automate what we can. We're sharing this process transparently so the community can see how we work and contribute to making it better.

OpenAB 從第一天起就是 AI-first、AI-native。這份 steering doc 就是我們團隊每天用 OpenAB 本身來 triage issues 的實際流程。透過 dogfooding 自己打造的工具，我們持續改進工作流程、盡可能自動化。我們公開分享這個流程，讓社群看到我們怎麼運作，也歡迎一起讓它變得更好。

---

This PR publishes our issue triage process to `docs/steering/triage.md` for community transparency.

## What's included

- Triage steps: confirm type → verify claims → set priority → remove `needs-triage`
- Priority guidelines (p0–p3)
- Response template with **Issue at a Glance** ASCII diagram requirement
- Emphasis on verifying claims against source code / official docs before confirming bugs
- Human approval required before posting responses