### PR TITLE
fix: prevent Discord message fragmentation during streaming (fixes #81)

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -229,8 +229,8 @@ async fn stream_prompt(
                         if buf_rx.has_changed().unwrap_or(false) {
                             let content = buf_rx.borrow_and_update().clone();
                             if content != last_content {
-                                let display = if content.len() > 1900 {
-                                    let truncated = format::truncate_utf8(&content, 1900);
+                                let display = if content.chars().count() > 1900 {
+                                    let truncated = format::truncate_chars(&content, 1900);
                                     format!("{truncated}…")
                                 } else {
                                     content.clone()

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -217,31 +217,25 @@ async fn stream_prompt(
                 text_buf.push_str("⚠️ _Session expired, starting fresh..._\n\n");
             }
 
-            // Spawn edit-streaming task
+            // Spawn edit-streaming task — only edits the single message, never sends new ones.
+            // Long content is truncated during streaming; final multi-message split happens after.
             let edit_handle = {
                 let ctx = ctx.clone();
                 let mut buf_rx = buf_rx.clone();
                 tokio::spawn(async move {
                     let mut last_content = String::new();
-                    let mut current_edit_msg = msg_id;
                     loop {
                         tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
                         if buf_rx.has_changed().unwrap_or(false) {
                             let content = buf_rx.borrow_and_update().clone();
                             if content != last_content {
-                                if content.len() > 1900 {
-                                    let chunks = format::split_message(&content, 1900);
-                                    if let Some(first) = chunks.first() {
-                                        let _ = edit(&ctx, channel, current_edit_msg, first).await;
-                                    }
-                                    for chunk in chunks.iter().skip(1) {
-                                        if let Ok(new_msg) = channel.say(&ctx.http, chunk).await {
-                                            current_edit_msg = new_msg.id;
-                                        }
-                                    }
+                                let display = if content.len() > 1900 {
+                                    let truncated = format::truncate_utf8(&content, 1900);
+                                    format!("{truncated}…")
                                 } else {
-                                    let _ = edit(&ctx, channel, current_edit_msg, &content).await;
-                                }
+                                    content.clone()
+                                };
+                                let _ = edit(&ctx, channel, msg_id, &display).await;
                                 last_content = content;
                             }
                         }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,6 +1,7 @@
-/// Split text into chunks at line boundaries, each <= limit bytes (UTF-8 safe).
+/// Split text into chunks at line boundaries, each <= limit Unicode characters (UTF-8 safe).
+/// Discord's message limit counts Unicode characters, not bytes.
 pub fn split_message(text: &str, limit: usize) -> Vec<String> {
-    if text.len() <= limit {
+    if text.chars().count() <= limit {
         return vec![text.to_string()];
     }
 
@@ -8,8 +9,10 @@ pub fn split_message(text: &str, limit: usize) -> Vec<String> {
     let mut current = String::new();
 
     for line in text.split('\n') {
+        let line_chars = line.chars().count();
+        let current_chars = current.chars().count();
         // +1 for the newline
-        if !current.is_empty() && current.len() + line.len() + 1 > limit {
+        if !current.is_empty() && current_chars + line_chars + 1 > limit {
             chunks.push(current);
             current = String::new();
         }
@@ -17,9 +20,9 @@ pub fn split_message(text: &str, limit: usize) -> Vec<String> {
             current.push('\n');
         }
         // If a single line exceeds limit, hard-split on char boundaries
-        if line.len() > limit {
+        if line_chars > limit {
             for ch in line.chars() {
-                if current.len() + ch.len_utf8() > limit {
+                if current.chars().count() + 1 > limit {
                     chunks.push(current);
                     current = String::new();
                 }
@@ -35,14 +38,11 @@ pub fn split_message(text: &str, limit: usize) -> Vec<String> {
     chunks
 }
 
-/// Truncate a string to at most `limit` bytes on a char boundary.
-pub fn truncate_utf8(s: &str, limit: usize) -> &str {
-    if s.len() <= limit {
-        return s;
+/// Truncate a string to at most `limit` Unicode characters.
+/// Discord's message limit counts Unicode characters, not bytes.
+pub fn truncate_chars(s: &str, limit: usize) -> &str {
+    match s.char_indices().nth(limit) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
     }
-    let mut end = limit;
-    while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,4 +1,4 @@
-/// Split text into chunks at line boundaries, each <= limit chars.
+/// Split text into chunks at line boundaries, each <= limit bytes (UTF-8 safe).
 pub fn split_message(text: &str, limit: usize) -> Vec<String> {
     if text.len() <= limit {
         return vec![text.to_string()];
@@ -16,13 +16,14 @@ pub fn split_message(text: &str, limit: usize) -> Vec<String> {
         if !current.is_empty() {
             current.push('\n');
         }
-        // If a single line exceeds limit, hard-split it
+        // If a single line exceeds limit, hard-split on char boundaries
         if line.len() > limit {
-            for chunk in line.as_bytes().chunks(limit) {
-                if !current.is_empty() {
+            for ch in line.chars() {
+                if current.len() + ch.len_utf8() > limit {
                     chunks.push(current);
+                    current = String::new();
                 }
-                current = String::from_utf8_lossy(chunk).to_string();
+                current.push(ch);
             }
         } else {
             current.push_str(line);
@@ -32,4 +33,16 @@ pub fn split_message(text: &str, limit: usize) -> Vec<String> {
         chunks.push(current);
     }
     chunks
+}
+
+/// Truncate a string to at most `limit` bytes on a char boundary.
+pub fn truncate_utf8(s: &str, limit: usize) -> &str {
+    if s.len() <= limit {
+        return s;
+    }
+    let mut end = limit;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -7,29 +7,34 @@ pub fn split_message(text: &str, limit: usize) -> Vec<String> {
 
     let mut chunks = Vec::new();
     let mut current = String::new();
+    let mut current_len: usize = 0;
 
     for line in text.split('\n') {
         let line_chars = line.chars().count();
-        let current_chars = current.chars().count();
         // +1 for the newline
-        if !current.is_empty() && current_chars + line_chars + 1 > limit {
+        if !current.is_empty() && current_len + line_chars + 1 > limit {
             chunks.push(current);
             current = String::new();
+            current_len = 0;
         }
         if !current.is_empty() {
             current.push('\n');
+            current_len += 1;
         }
         // If a single line exceeds limit, hard-split on char boundaries
         if line_chars > limit {
             for ch in line.chars() {
-                if current.chars().count() + 1 > limit {
+                if current_len + 1 > limit {
                     chunks.push(current);
                     current = String::new();
+                    current_len = 0;
                 }
                 current.push(ch);
+                current_len += 1;
             }
         } else {
             current.push_str(line);
+            current_len += line_chars;
         }
     }
     if !current.is_empty() {


### PR DESCRIPTION
## Summary

Fixes #81 — long agent replies (>1900 chars) produce cascading duplicate messages in Discord.

This PR takes the same approach as the closed #82 (truncate during streaming, split only on final edit), but additionally fixes a UTF-8 boundary bug in `split_message()` that causes corrupted output for multi-byte content (Chinese, Japanese, emoji, etc.).

Aware of #53 which addresses the same streaming duplication alongside tool status tracking. This PR is intentionally scoped to message splitting only, keeping the change small and reviewable.

**Priority:** p2 — bug with workaround (short replies unaffected), consistent with #81 triage.

## Problem

```
User sends question ──► openab ──► AI agent streams response
                                        │
                          ┌──────────────┘
                          ▼
                 edit_handle loop (every 1.5s)
                          │
                          ▼  content > 1900 chars?
                 ┌────────────────────────────────────┐
                 │ split_message(&content, 1900)       │
                 │ edit(msg1, chunk[0])                 │
                 │ channel.say(chunk[1]) → NEW msg2    │
                 │ channel.say(chunk[2]) → NEW msg3    │
                 └────────────────────────────────────┘
                          │
                          ▼  next loop iteration, content grew
                 ┌────────────────────────────────────┐
                 │ split_message(&content, 1900)       │
                 │ edit(msg2, chunk[0])                 │  ← edits wrong msg
                 │ channel.say(chunk[1]) → NEW msg4    │  ← orphaned
                 │ channel.say(chunk[2]) → NEW msg5    │  ← orphaned
                 └────────────────────────────────────┘
                          │
                          ▼  stream ends, final edit runs
                 ┌────────────────────────────────────┐
                 │ split_message(&final, 2000)         │
                 │ edit(msg1, chunk[0])                 │
                 │ channel.say(chunk[1]) → NEW msg6    │  ← duplicate
                 │ channel.say(chunk[2]) → NEW msg7    │  ← duplicate
                 └────────────────────────────────────┘
                          │
                          ▼
                 Discord shows: msg1 msg2 msg3 msg4 msg5 msg6 msg7
                                      ^^^^ ^^^^ ^^^^ orphaned duplicates
```

Two independent code paths both call `channel.say()` for overflow chunks with no coordination. Each streaming loop iteration creates new orphaned messages that pile up.

## Fix

```
User sends question ──► openab ──► AI agent streams response
                                        │
                          ┌──────────────┘
                          ▼
                 edit_handle loop (every 1.5s)
                          │
                          ▼  content > 1900 chars?
                 ┌────────────────────────────────────┐
                 │ truncate_utf8(&content, 1900)       │
                 │ edit(msg1, truncated + "…")          │  ← always same msg
                 └────────────────────────────────────┘
                          │
                          ▼  next iteration, content grew
                 ┌────────────────────────────────────┐
                 │ truncate_utf8(&content, 1900)       │
                 │ edit(msg1, truncated + "…")          │  ← still same msg
                 └────────────────────────────────────┘
                          │
                          ▼  stream ends, final edit runs
                 ┌────────────────────────────────────┐
                 │ split_message(&final, 2000)         │
                 │ edit(msg1, chunk[0])                 │
                 │ channel.say(chunk[1]) → msg2        │  ← only now
                 │ channel.say(chunk[2]) → msg3        │  ← only now
                 └────────────────────────────────────┘
                          │
                          ▼
                 Discord shows: msg1 msg2 msg3
                                ✅ clean, no duplicates
```

**Streaming** = live preview in one message (truncated if long)
**Final edit** = authoritative delivery, split across messages if needed

## Additional fix: UTF-8 safe splitting

The existing `split_message()` hard-splits long lines with `as_bytes().chunks(limit)`, which can cut in the middle of a multi-byte UTF-8 character:

```rust
// Before — breaks UTF-8
for chunk in line.as_bytes().chunks(limit) {
    current = String::from_utf8_lossy(chunk).to_string();
    // "你好世" → "你好\xE4" + "\xB8\x96" → garbled
}

// After — splits on char boundaries
for ch in line.chars() {
    if current.len() + ch.len_utf8() > limit {
        chunks.push(current);
        current = String::new();
    }
    current.push(ch);
}
```

Also adds `truncate_utf8()` for safe truncation used by the streaming preview.

Neither #82 nor #53 addresses this UTF-8 boundary issue.

## Difference from #82 and #53

| | This PR | #82 (closed) | #53 (open) |
|---|---|---|---|
| Streaming truncate-only | ✅ | ✅ | ✅ |
| UTF-8 safe `split_message()` | ✅ | ❌ | ❌ |
| `truncate_utf8()` helper | ✅ | ❌ | ❌ |
| Tool status tracking fix | ❌ (out of scope) | ❌ | ✅ |
| Scope | message splitting only | message splitting only | message splitting + tool tracking |

This PR does not conflict with #53 — the changes are in non-overlapping code paths. If #53 lands first, this PR can be rebased cleanly on top.

## Files Changed

- `src/discord.rs` — streaming edit logic: truncate + edit single message, never `say()` mid-stream
- `src/format.rs` — `split_message()` char-boundary fix + new `truncate_utf8()`

## Testing — verified in production

1. **Built from source** on the deployment server (`cargo build --release`)
2. **Deployed and running** — the patched binary is currently serving a production Discord bot
3. **Verified with real users** — triggered long streaming responses (>2000 chars, CJK content) in Discord threads and observed:
   - ✅ Streaming phase: single message updates in-place with truncated preview, no new messages spawned
   - ✅ Final delivery: clean multi-message split, no duplicates, no orphaned fragments
   - ✅ UTF-8 integrity: Chinese characters display correctly at chunk boundaries, no corruption
   - ✅ Short responses (<1900 chars): behavior unchanged, no regression
4. **Before/after comparison:**

```
Before (duplicate fragments):
  [msg1: chunk1] [msg2: chunk2] [msg3: chunk2 again] [msg4: chunk3] [msg5: final chunk2] [msg6: final chunk3]
  → 6 messages, 3 are duplicates/orphans

After (clean delivery):
  [msg1: streaming preview…] → final: [msg1: chunk1] [msg2: chunk2] [msg3: chunk3]
  → 3 messages, zero duplicates
```

Built and deployed from source; verified against live Discord traffic with CJK and emoji content.
