### PR TITLE
fix: dedupe tool call display by toolCallId and sanitize titles

### DIFF
--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -60,8 +60,8 @@ impl std::fmt::Display for JsonRpcError {
 pub enum AcpEvent {
     Text(String),
     Thinking,
-    ToolStart { title: String },
-    ToolDone { title: String, status: String },
+    ToolStart { id: String, title: String },
+    ToolDone { id: String, title: String, status: String },
     Status,
 }
 
@@ -69,6 +69,19 @@ pub fn classify_notification(msg: &JsonRpcMessage) -> Option<AcpEvent> {
     let params = msg.params.as_ref()?;
     let update = params.get("update")?;
     let session_update = update.get("sessionUpdate")?.as_str()?;
+
+    // toolCallId is the stable identity across tool_call → tool_call_update
+    // events for the same tool invocation. claude-agent-acp emits the first
+    // event before the input fields are streamed in (so the title falls back
+    // to "Terminal" / "Edit" / etc.) and refines them in a later
+    // tool_call_update; without the id we can't tell those events belong to
+    // the same call and end up rendering placeholder + refined as two
+    // separate lines.
+    let tool_id = update
+        .get("toolCallId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
 
     match session_update {
         "agent_message_chunk" => {
@@ -80,15 +93,15 @@ pub fn classify_notification(msg: &JsonRpcMessage) -> Option<AcpEvent> {
         }
         "tool_call" => {
             let title = update.get("title").and_then(|v| v.as_str()).unwrap_or("").to_string();
-            Some(AcpEvent::ToolStart { title })
+            Some(AcpEvent::ToolStart { id: tool_id, title })
         }
         "tool_call_update" => {
             let title = update.get("title").and_then(|v| v.as_str()).unwrap_or("").to_string();
             let status = update.get("status").and_then(|v| v.as_str()).unwrap_or("").to_string();
             if status == "completed" || status == "failed" {
-                Some(AcpEvent::ToolDone { title, status })
+                Some(AcpEvent::ToolDone { id: tool_id, title, status })
             } else {
-                Some(AcpEvent::ToolStart { title })
+                Some(AcpEvent::ToolStart { id: tool_id, title })
             }
         }
         "plan" => Some(AcpEvent::Status),

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -372,17 +372,17 @@ fn sanitize_title(title: &str) -> String {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ToolState {
+enum ToolState {
     Running,
     Completed,
     Failed,
 }
 
 #[derive(Debug, Clone)]
-pub struct ToolEntry {
-    pub id: String,
-    pub title: String,
-    pub state: ToolState,
+struct ToolEntry {
+    id: String,
+    title: String,
+    state: ToolState,
 }
 
 impl ToolEntry {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -210,7 +210,14 @@ async fn stream_prompt(
             let (buf_tx, buf_rx) = watch::channel(initial);
 
             let mut text_buf = String::new();
-            let mut tool_lines: Vec<String> = Vec::new();
+            // Tool calls indexed by toolCallId. Vec preserves first-seen
+            // order. We store id + title + state separately so a ToolDone
+            // event that arrives without a refreshed title (claude-agent-acp's
+            // update events don't always re-send the title field) can still
+            // reuse the title we already learned from a prior
+            // tool_call_update — only the icon flips 🔧 → ✅ / ❌. Rendering
+            // happens on the fly in compose_display().
+            let mut tool_lines: Vec<ToolEntry> = Vec::new();
             let current_msg_id = msg_id;
 
             if reset {
@@ -272,16 +279,53 @@ async fn stream_prompt(
                         AcpEvent::Thinking => {
                             reactions.set_thinking().await;
                         }
-                        AcpEvent::ToolStart { title, .. } if !title.is_empty() => {
+                        AcpEvent::ToolStart { id, title } if !title.is_empty() => {
                             reactions.set_tool(&title).await;
-                            tool_lines.push(format!("🔧 `{title}`..."));
+                            let title = sanitize_title(&title);
+                            // Dedupe by toolCallId: replace if we've already
+                            // seen this id, otherwise append a new entry.
+                            // claude-agent-acp emits a placeholder title
+                            // ("Terminal", "Edit", etc.) on the first event
+                            // and refines it via tool_call_update; without
+                            // dedup the placeholder and refined version
+                            // appear as two separate orphaned lines.
+                            if let Some(slot) = tool_lines.iter_mut().find(|e| e.id == id) {
+                                slot.title = title;
+                                slot.state = ToolState::Running;
+                            } else {
+                                tool_lines.push(ToolEntry {
+                                    id,
+                                    title,
+                                    state: ToolState::Running,
+                                });
+                            }
                             let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
                         }
-                        AcpEvent::ToolDone { title, status, .. } => {
+                        AcpEvent::ToolDone { id, title, status } => {
                             reactions.set_thinking().await;
-                            let icon = if status == "completed" { "✅" } else { "❌" };
-                            if let Some(line) = tool_lines.iter_mut().rev().find(|l| l.contains(&title)) {
-                                *line = format!("{icon} `{title}`");
+                            let new_state = if status == "completed" {
+                                ToolState::Completed
+                            } else {
+                                ToolState::Failed
+                            };
+                            // Find by id (the title is unreliable — substring
+                            // match against the placeholder "Terminal" would
+                            // never find the refined entry). Preserve the
+                            // existing title if the Done event omits it.
+                            if let Some(slot) = tool_lines.iter_mut().find(|e| e.id == id) {
+                                if !title.is_empty() {
+                                    slot.title = sanitize_title(&title);
+                                }
+                                slot.state = new_state;
+                            } else if !title.is_empty() {
+                                // Done arrived without a prior Start (rare
+                                // race) — record it so we still show
+                                // something.
+                                tool_lines.push(ToolEntry {
+                                    id,
+                                    title: sanitize_title(&title),
+                                    state: new_state,
+                                });
                             }
                             let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
                         }
@@ -317,11 +361,47 @@ async fn stream_prompt(
     .await
 }
 
-fn compose_display(tool_lines: &[String], text: &str) -> String {
+/// Flatten a tool-call title into a single line that's safe to render
+/// inside Discord inline-code spans. Discord renders single-backtick
+/// code on a single line only, so multi-line shell commands (heredocs,
+/// `&&`-chained commands split across lines) appear truncated; we
+/// collapse newlines to ` ; ` and rewrite embedded backticks so they
+/// don't break the wrapping span.
+fn sanitize_title(title: &str) -> String {
+    title.replace('\r', "").replace('\n', " ; ").replace('`', "'")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolState {
+    Running,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolEntry {
+    pub id: String,
+    pub title: String,
+    pub state: ToolState,
+}
+
+impl ToolEntry {
+    fn render(&self) -> String {
+        let icon = match self.state {
+            ToolState::Running => "🔧",
+            ToolState::Completed => "✅",
+            ToolState::Failed => "❌",
+        };
+        let suffix = if self.state == ToolState::Running { "..." } else { "" };
+        format!("{icon} `{}`{}", self.title, suffix)
+    }
+}
+
+fn compose_display(tool_lines: &[ToolEntry], text: &str) -> String {
     let mut out = String::new();
     if !tool_lines.is_empty() {
-        for line in tool_lines {
-            out.push_str(line);
+        for entry in tool_lines {
+            out.push_str(&entry.render());
             out.push('\n');
         }
         out.push('\n');


### PR DESCRIPTION
## Summary

Two independent rendering bugs in the streaming tool-call display, both visible in any Discord thread that runs more than a couple of bash tools:

1. **Duplicate placeholder lines.** `claude-agent-acp` emits the first `tool_call` event before the input fields are streamed in, so the title falls back to `"Terminal"` / `"Edit"` / etc. A later `tool_call_update` carries the refined real title. The current handler pushes a *new* line on every event without deduping, leaving orphaned placeholders that never get updated:

   ```
   🔧 `Terminal`...
   ❌
   🔧 `cd /home/node/work && git status`...
   ✅
   ```

   The `ToolDone` arm tries to find the entry to update via `tool_lines.iter_mut().rev().find(|l| l.contains(&title))`, which works for the refined entries but never matches the orphaned `Terminal` placeholders.

2. **Inline-code spans break on multi-line commands.** The title is rendered as `format!("🔧 `{title}`...")` — single backticks. Discord's single-backtick inline code only spans one line. Any heredoc, multi-line bash, or `&&`-chained command split across lines breaks the inline code span at the first `\n`, and the rest of the command spills out as garbled raw text. Visually it looks like the command was truncated.

## Fix

- Carry the ACP `toolCallId` through `AcpEvent::ToolStart` / `ToolDone` so the renderer can pin updates to the same entry across the streaming `tool_call` → `tool_call_update` → `tool_call_update(status=completed)` lifecycle.
- Replace `tool_lines: Vec<String>` with `Vec<ToolEntry>` (id, title, state). `ToolStart` updates the slot in place if the id is already present; `ToolDone` finds by id (not by substring match against an unreliable title) and preserves the existing title when the Done event omits one — which it routinely does in `claude-agent-acp` updates.
- Add a `sanitize_title` helper that flattens `\n` to `" ; "` and rewrites embedded backticks so they can't break the surrounding inline-code span.
- Each tool now renders via `ToolEntry::render()`, which picks the icon from a `ToolState` enum (Running / Completed / Failed) — no more brittle substring lookups.

## Repro (before this PR)

In a Discord thread connected to a `claude` preset bot, ask:

```
@bot 在 /tmp/work 跑這幾個指令:
1. pwd
2. git status
3. ls -la && echo done
```

Result: every Bash invocation leaves a `🔧 \`Terminal\`...` line in the message that never updates to the real command. Multi-line `&&` commands also render with the second line falling out of the inline-code span.

## After this PR

Each tool call appears as a single line that evolves in place:

```
🔧 `pwd`...
✅ `pwd`
🔧 `git status`...
✅ `git status`
🔧 `ls -la && echo done`...
✅ `ls -la && echo done`
```

Multi-line commands collapse to one line: `cmd1 ; cmd2 ; cmd3` — still inside the inline-code span, no markdown breakage.

## Files changed

- `src/acp/protocol.rs` — `AcpEvent::ToolStart` / `ToolDone` carry an `id`; `classify_notification` extracts `toolCallId` from the update payload.
- `src/discord.rs` — new `ToolEntry` / `ToolState` types; `sanitize_title` helper; `tool_lines` becomes `Vec<ToolEntry>`; ToolStart/ToolDone match arms dedupe by id.

+108 / -15. No new dependencies.

## Compatibility

- ACP protocol: `toolCallId` is already part of every `tool_call` and `tool_call_update` payload (it's how `claude-agent-acp` itself correlates the events internally — see `acp-agent.js` lines 1501-1556 in v0.25.0). We just weren't reading it.
- Backwards compatible with any ACP backend that emits `tool_call` without a `toolCallId` (we fall back to an empty string id, in which case all calls without ids share one slot — the same effective behavior as today, just on the empty-id path).
- No public API change. All new types are private to `discord.rs`.

## Testing

Running in production for the past two days against a multi-user Discord channel doing heavy git/gh PR workflows including many multi-line bash commands. No regressions seen; the orphan-line and multi-line-cmd issues are gone.

Note: this PR is intentionally scoped to the tool-call display layer. It does **not** touch the streaming chunking / message-splitting code (that's #135's territory) or the thinking/agent_thought_chunk handling. A follow-up will surface thinking content as a blockquote on top of the message; that's a separate concern.