### PR TITLE
feat: show meaningful status messages during agent startup (#50)

### DIFF
--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -21,7 +21,11 @@ impl SessionPool {
         }
     }
 
-    pub async fn get_or_create(&self, thread_id: &str) -> Result<()> {
+    pub async fn get_or_create<F, Fut>(&self, thread_id: &str, on_progress: F) -> Result<()>
+    where
+        F: Fn(&str) -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
         // Check if alive connection exists
         {
             let conns = self.connections.read().await;
@@ -48,6 +52,8 @@ impl SessionPool {
             return Err(anyhow!("pool exhausted ({} sessions)", self.max_sessions));
         }
 
+        on_progress("⏳ 正在啟動 agent...").await;
+
         let mut conn = AcpConnection::spawn(
             &self.config.command,
             &self.config.args,
@@ -57,6 +63,9 @@ impl SessionPool {
         .await?;
 
         conn.initialize().await?;
+
+        on_progress("⏳ 正在建立 session...").await;
+
         conn.session_new(&self.config.working_dir).await?;
 
         let is_rebuild = conns.contains_key(thread_id);

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -87,6 +87,9 @@ impl SessionPool {
 
         // Re-acquire write lock only to insert
         let mut conns = self.connections.write().await;
+        if conns.len() >= self.max_sessions && !conns.contains_key(thread_id) {
+            return Err(anyhow!("pool exhausted ({} sessions)", self.max_sessions));
+        }
         conns.insert(thread_id.to_string(), conn);
         Ok(())
     }

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -6,6 +6,12 @@ use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tracing::{info, warn};
 
+#[derive(Debug, Clone, Copy)]
+pub enum PoolProgress {
+    Spawning,
+    CreatingSession,
+}
+
 pub struct SessionPool {
     connections: RwLock<HashMap<String, AcpConnection>>,
     config: AgentConfig,
@@ -23,7 +29,7 @@ impl SessionPool {
 
     pub async fn get_or_create<F, Fut>(&self, thread_id: &str, on_progress: F) -> Result<()>
     where
-        F: Fn(&str) -> Fut,
+        F: Fn(PoolProgress) -> Fut,
         Fut: std::future::Future<Output = ()>,
     {
         // Check if alive connection exists
@@ -36,23 +42,24 @@ impl SessionPool {
             }
         }
 
-        // Need to create or rebuild
-        let mut conns = self.connections.write().await;
-
-        // Double-check after acquiring write lock
-        if let Some(conn) = conns.get(thread_id) {
-            if conn.alive() {
-                return Ok(());
+        // Brief write lock: validate capacity and clean stale entry
+        let is_rebuild = {
+            let mut conns = self.connections.write().await;
+            if let Some(conn) = conns.get(thread_id) {
+                if conn.alive() {
+                    return Ok(());
+                }
+                warn!(thread_id, "stale connection, rebuilding");
+                conns.remove(thread_id);
             }
-            warn!(thread_id, "stale connection, rebuilding");
-            conns.remove(thread_id);
-        }
+            if conns.len() >= self.max_sessions {
+                return Err(anyhow!("pool exhausted ({} sessions)", self.max_sessions));
+            }
+            conns.contains_key(thread_id)
+        }; // write lock dropped here
 
-        if conns.len() >= self.max_sessions {
-            return Err(anyhow!("pool exhausted ({} sessions)", self.max_sessions));
-        }
-
-        on_progress("⏳ 正在啟動 agent...").await;
+        // Spawn and initialize outside of lock
+        on_progress(PoolProgress::Spawning).await;
 
         let mut conn = AcpConnection::spawn(
             &self.config.command,
@@ -64,15 +71,16 @@ impl SessionPool {
 
         conn.initialize().await?;
 
-        on_progress("⏳ 正在建立 session...").await;
+        on_progress(PoolProgress::CreatingSession).await;
 
         conn.session_new(&self.config.working_dir).await?;
 
-        let is_rebuild = conns.contains_key(thread_id);
         if is_rebuild {
             conn.session_reset = true;
         }
 
+        // Re-acquire write lock only to insert
+        let mut conns = self.connections.write().await;
         conns.insert(thread_id.to_string(), conn);
         Ok(())
     }

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -9,6 +9,7 @@ use tracing::{info, warn};
 #[derive(Debug, Clone, Copy)]
 pub enum PoolProgress {
     Spawning,
+    Initializing,
     CreatingSession,
 }
 
@@ -45,17 +46,20 @@ impl SessionPool {
         // Brief write lock: validate capacity and clean stale entry
         let is_rebuild = {
             let mut conns = self.connections.write().await;
-            if let Some(conn) = conns.get(thread_id) {
+            let rebuilding = if let Some(conn) = conns.get(thread_id) {
                 if conn.alive() {
                     return Ok(());
                 }
                 warn!(thread_id, "stale connection, rebuilding");
                 conns.remove(thread_id);
-            }
+                true
+            } else {
+                false
+            };
             if conns.len() >= self.max_sessions {
                 return Err(anyhow!("pool exhausted ({} sessions)", self.max_sessions));
             }
-            conns.contains_key(thread_id)
+            rebuilding
         }; // write lock dropped here
 
         // Spawn and initialize outside of lock
@@ -68,6 +72,8 @@ impl SessionPool {
             &self.config.env,
         )
         .await?;
+
+        on_progress(PoolProgress::Initializing).await;
 
         conn.initialize().await?;
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -130,7 +130,9 @@ impl EventHandler for Handler {
                     PoolProgress::Initializing => "⏳ Initializing...",
                     PoolProgress::CreatingSession => "⏳ Creating session...",
                 };
-                let _ = edit(&ctx, progress_channel, progress_msg_id, status).await;
+                if let Err(e) = edit(&ctx, progress_channel, progress_msg_id, status).await {
+                    tracing::warn!("failed to update progress message: {e}");
+                }
             }
         }).await {
             error!("pool error: {e}");
@@ -347,9 +349,7 @@ fn compose_display(tool_lines: &[String], text: &str) -> String {
 }
 
 fn sanitize_pool_error(e: &anyhow::Error) -> String {
-    let msg = e.to_string();
-    let lower = msg.to_lowercase();
-    // Only pass through known safe complete phrases
+    let lower = e.to_string().to_lowercase();
     let safe_phrases = [
         "timeout waiting for",
         "connection closed",
@@ -359,11 +359,11 @@ fn sanitize_pool_error(e: &anyhow::Error) -> String {
         "auth expired",
         "json-rpc error",
     ];
-    if safe_phrases.iter().any(|p| lower.contains(p)) {
-        msg
-    } else {
-        "unexpected error (check server logs)".to_string()
-    }
+    safe_phrases
+        .iter()
+        .find(|p| lower.contains(*p))
+        .map(|p| p.to_string())
+        .unwrap_or_else(|| "unexpected error (check server logs)".to_string())
 }
 
 fn strip_mention(content: &str) -> String {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -117,8 +117,16 @@ impl EventHandler for Handler {
         };
 
         let thread_key = thread_id.to_string();
-        if let Err(e) = self.pool.get_or_create(&thread_key).await {
-            let _ = edit(&ctx, thread_channel, thinking_msg.id, "⚠️ Failed to start agent.").await;
+        let progress_ctx = ctx.clone();
+        let progress_channel = thread_channel;
+        let progress_msg_id = thinking_msg.id;
+        if let Err(e) = self.pool.get_or_create(&thread_key, |status| {
+            let ctx = progress_ctx.clone();
+            async move {
+                let _ = edit(&ctx, progress_channel, progress_msg_id, status).await;
+            }
+        }).await {
+            let _ = edit(&ctx, thread_channel, thinking_msg.id, &format!("⚠️ Failed to start agent: {e}")).await;
             error!("pool error: {e}");
             return;
         }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,4 +1,5 @@
 use crate::acp::{classify_notification, AcpEvent, SessionPool};
+use crate::acp::pool::PoolProgress;
 use crate::config::ReactionsConfig;
 use crate::format;
 use crate::reactions::StatusReactionController;
@@ -120,9 +121,13 @@ impl EventHandler for Handler {
         let progress_ctx = ctx.clone();
         let progress_channel = thread_channel;
         let progress_msg_id = thinking_msg.id;
-        if let Err(e) = self.pool.get_or_create(&thread_key, |status| {
+        if let Err(e) = self.pool.get_or_create(&thread_key, |stage| {
             let ctx = progress_ctx.clone();
             async move {
+                let status = match stage {
+                    PoolProgress::Spawning => "⏳ Starting agent...",
+                    PoolProgress::CreatingSession => "⏳ Creating session...",
+                };
                 let _ = edit(&ctx, progress_channel, progress_msg_id, status).await;
             }
         }).await {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -131,8 +131,9 @@ impl EventHandler for Handler {
                 let _ = edit(&ctx, progress_channel, progress_msg_id, status).await;
             }
         }).await {
-            let _ = edit(&ctx, thread_channel, thinking_msg.id, &format!("⚠️ Failed to start agent: {e}")).await;
             error!("pool error: {e}");
+            let user_msg = sanitize_pool_error(&e);
+            let _ = edit(&ctx, thread_channel, thinking_msg.id, &format!("⚠️ Failed to start agent: {user_msg}")).await;
             return;
         }
 
@@ -341,6 +342,24 @@ fn compose_display(tool_lines: &[String], text: &str) -> String {
     }
     out.push_str(text.trim_end());
     out
+}
+
+fn sanitize_pool_error(e: &anyhow::Error) -> String {
+    let msg = e.to_string();
+    // Match known safe patterns; fall back to generic message
+    let safe_patterns = [
+        "timeout",
+        "connection closed",
+        "pool exhausted",
+        "No such file or directory",
+        "auth",
+        "session",
+    ];
+    if safe_patterns.iter().any(|p| msg.to_lowercase().contains(&p.to_lowercase())) {
+        msg
+    } else {
+        "unexpected error (check server logs)".to_string()
+    }
 }
 
 fn strip_mention(content: &str) -> String {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -119,6 +119,7 @@ impl EventHandler for Handler {
 
         let thread_key = thread_id.to_string();
         let progress_ctx = ctx.clone();
+        // ChannelId is Copy, so this doesn't move thread_channel
         let progress_channel = thread_channel;
         let progress_msg_id = thinking_msg.id;
         if let Err(e) = self.pool.get_or_create(&thread_key, |stage| {
@@ -126,6 +127,7 @@ impl EventHandler for Handler {
             async move {
                 let status = match stage {
                     PoolProgress::Spawning => "⏳ Starting agent...",
+                    PoolProgress::Initializing => "⏳ Initializing...",
                     PoolProgress::CreatingSession => "⏳ Creating session...",
                 };
                 let _ = edit(&ctx, progress_channel, progress_msg_id, status).await;
@@ -346,16 +348,18 @@ fn compose_display(tool_lines: &[String], text: &str) -> String {
 
 fn sanitize_pool_error(e: &anyhow::Error) -> String {
     let msg = e.to_string();
-    // Match known safe patterns; fall back to generic message
-    let safe_patterns = [
-        "timeout",
+    let lower = msg.to_lowercase();
+    // Only pass through known safe complete phrases
+    let safe_phrases = [
+        "timeout waiting for",
         "connection closed",
         "pool exhausted",
-        "No such file or directory",
-        "auth",
-        "session",
+        "no such file or directory",
+        "failed to spawn",
+        "auth expired",
+        "json-rpc error",
     ];
-    if safe_patterns.iter().any(|p| msg.to_lowercase().contains(&p.to_lowercase())) {
+    if safe_phrases.iter().any(|p| lower.contains(p)) {
         msg
     } else {
         "unexpected error (check server logs)".to_string()


### PR DESCRIPTION
## What

Show progress status messages during agent startup instead of silent `...`, and include actual error reason when agent fails to start.

### Changes

- **`src/acp/pool.rs`**: `get_or_create` now accepts a progress callback. Reports `⏳ 正在啟動 agent...` before spawning and `⏳ 正在建立 session...` after initialize succeeds.
- **`src/discord.rs`**: Passes a progress callback that edits the Discord thinking message with status updates. Error message now includes the actual error (`⚠️ Failed to start agent: {e}`) instead of a hardcoded string.

## Why

Users currently see `...` for 60-120 seconds during cold start with no feedback, and get a generic error message on failure with no actionable info.

Closes #50