### PR TITLE
docs: update gh-pages README for 0.6.1 multi-agent chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,44 @@ agents:
         - "YOUR_CLAUDE_CHANNEL_ID"
 ```
 
+## All Four Agents Example (values.yaml)
+
+```yaml
+agents:
+  kiro:
+    discord:
+      botToken: ""
+      allowedChannels:
+        - "KIRO_CHANNEL_ID"
+  claude:
+    image: ghcr.io/openabdev/openab-claude:78f8d2c
+    command: claude-agent-acp
+    workingDir: /home/node
+    discord:
+      botToken: ""
+      allowedChannels:
+        - "CLAUDE_CHANNEL_ID"
+  codex:
+    image: ghcr.io/openabdev/openab-codex:78f8d2c
+    command: codex-acp
+    workingDir: /home/node
+    discord:
+      botToken: ""
+      allowedChannels:
+        - "CODEX_CHANNEL_ID"
+  gemini:
+    image: ghcr.io/openabdev/openab-gemini:78f8d2c
+    command: gemini
+    args: ["--acp"]
+    workingDir: /home/node
+    discord:
+      botToken: ""
+      allowedChannels:
+        - "GEMINI_CHANNEL_ID"
+    env:
+      GEMINI_API_KEY: "${GEMINI_API_KEY}"
+```
+
 ## Post-Install: Authenticate
 
 Each agent requires a one-time auth. The PVC persists tokens across pod restarts.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ helm install openab openab/openab \
 helm install openab openab/openab \
   --set agents.kiro.enabled=false \
   --set agents.codex.command=codex-acp \
+  --set agents.codex.image=ghcr.io/openabdev/openab-codex:78f8d2c \
+  --set agents.codex.workingDir=/home/node \
   --set agents.codex.discord.botToken="$DISCORD_BOT_TOKEN" \
   --set-string 'agents.codex.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
 
@@ -57,6 +59,8 @@ helm install openab openab/openab \
   --set agents.kiro.enabled=false \
   --set agents.gemini.command=gemini \
   --set 'agents.gemini.args={--acp}' \
+  --set agents.gemini.image=ghcr.io/openabdev/openab-gemini:78f8d2c \
+  --set agents.gemini.workingDir=/home/node \
   --set agents.gemini.discord.botToken="$DISCORD_BOT_TOKEN" \
   --set-string 'agents.gemini.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
 ```

--- a/README.md
+++ b/README.md
@@ -31,29 +31,37 @@ helm install openab openab/openab \
 
 > ⚠️ Always use `--set-string` for channel IDs to avoid float64 precision loss.
 
+## Single Agent (non-default)
+
+To deploy only Claude Code (or any non-default agent), disable the default `kiro` agent with `enabled: false`:
+
+```bash
+# Claude Code only (disable default kiro)
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.claude.command=claude-agent-acp \
+  --set agents.claude.image=ghcr.io/openabdev/openab-claude:78f8d2c \
+  --set agents.claude.workingDir=/home/node \
+  --set agents.claude.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.claude.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
+```
+
+> **Why `enabled: false`?** Helm deep-merges values — adding `agents.claude` does **not** remove the default `agents.kiro`. Without `enabled: false`, a broken kiro agent (no token, placeholder channel) would be deployed alongside claude.
+
 ## Multi-Agent
 
 One Helm release can run multiple agents simultaneously — each gets its own Deployment, ConfigMap, Secret, and PVC.
 
 ```bash
-# Codex
+# Kiro + Claude in one release
 helm install openab openab/openab \
-  --set agents.codex.command=codex-acp \
-  --set agents.codex.discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set-string 'agents.codex.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
-
-# Claude Code
-helm install openab openab/openab \
+  --set agents.kiro.discord.botToken="$KIRO_BOT_TOKEN" \
+  --set-string 'agents.kiro.discord.allowedChannels[0]=KIRO_CHANNEL_ID' \
   --set agents.claude.command=claude-agent-acp \
-  --set agents.claude.discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set-string 'agents.claude.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
-
-# Gemini
-helm install openab openab/openab \
-  --set agents.gemini.command=gemini \
-  --set 'agents.gemini.args[0]=--acp' \
-  --set agents.gemini.discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set-string 'agents.gemini.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
+  --set agents.claude.image=ghcr.io/openabdev/openab-claude:78f8d2c \
+  --set agents.claude.workingDir=/home/node \
+  --set agents.claude.discord.botToken="$CLAUDE_BOT_TOKEN" \
+  --set-string 'agents.claude.discord.allowedChannels[0]=CLAUDE_CHANNEL_ID'
 ```
 
 ## Upgrade
@@ -71,6 +79,7 @@ Each agent is configured under `agents.<name>`:
 | `image.repository` | `ghcr.io/openabdev/openab` | Default container image repository |
 | `image.tag` | `""` (uses appVersion) | Default image tag, defaults to Chart appVersion |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `agents.<name>.enabled` | `true` | Set to `false` to skip creating resources for this agent |
 | `agents.<name>.image` | `""` | Override full image reference (e.g. `ghcr.io/openabdev/openab-claude:latest`), defaults to `image.repository:appVersion` |
 | `agents.<name>.command` | `kiro-cli` | CLI command to run as agent |
 | `agents.<name>.args` | `["acp", "--trust-all-tools"]` | Arguments passed to the agent CLI |
@@ -103,21 +112,37 @@ agents:
         - "YOUR_CHANNEL_ID"
 ```
 
+## Claude Only Example (values.yaml)
+
+```yaml
+agents:
+  kiro:
+    enabled: false
+  claude:
+    image: ghcr.io/openabdev/openab-claude:78f8d2c
+    command: claude-agent-acp
+    workingDir: /home/node
+    discord:
+      botToken: ""  # set via --set or external secret
+      allowedChannels:
+        - "YOUR_CHANNEL_ID"
+```
+
 ## Multi-Agent Example (values.yaml)
 
 ```yaml
 agents:
   kiro:
     discord:
-      botToken: "${DISCORD_BOT_TOKEN}"
+      botToken: ""  # set via --set or external secret
       allowedChannels:
         - "YOUR_KIRO_CHANNEL_ID"
   claude:
-    image: ghcr.io/openabdev/openab-claude:latest
+    image: ghcr.io/openabdev/openab-claude:78f8d2c
     command: claude-agent-acp
     workingDir: /home/node
     discord:
-      botToken: "${DISCORD_BOT_TOKEN}"
+      botToken: ""  # set via --set or external secret
       allowedChannels:
         - "YOUR_CLAUDE_CHANNEL_ID"
 ```

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ helm install openab openab/openab \
 
 ## Single Agent (non-default)
 
-To deploy only Claude Code (or any non-default agent), disable the default `kiro` agent with `enabled: false`:
+To deploy only one non-default agent, disable the default `kiro` with `enabled: false`:
 
 ```bash
-# Claude Code only (disable default kiro)
+# Claude Code only
 helm install openab openab/openab \
   --set agents.kiro.enabled=false \
   --set agents.claude.command=claude-agent-acp \
@@ -44,9 +44,24 @@ helm install openab openab/openab \
   --set agents.claude.workingDir=/home/node \
   --set agents.claude.discord.botToken="$DISCORD_BOT_TOKEN" \
   --set-string 'agents.claude.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
+
+# Codex only
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.codex.command=codex-acp \
+  --set agents.codex.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.codex.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
+
+# Gemini only
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.gemini.command=gemini \
+  --set 'agents.gemini.args={--acp}' \
+  --set agents.gemini.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.gemini.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
 ```
 
-> **Why `enabled: false`?** Helm deep-merges values — adding `agents.claude` does **not** remove the default `agents.kiro`. Without `enabled: false`, a broken kiro agent (no token, placeholder channel) would be deployed alongside claude.
+> **Why `enabled: false`?** Helm deep-merges values — adding `agents.claude` does **not** remove the default `agents.kiro`. Without `enabled: false`, a broken kiro agent (no token, placeholder channel) would be deployed alongside your agent.
 
 ## Multi-Agent
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,41 @@ agents:
         - "YOUR_CHANNEL_ID"
 ```
 
+## Codex Only Example (values.yaml)
+
+```yaml
+agents:
+  kiro:
+    enabled: false
+  codex:
+    image: ghcr.io/openabdev/openab-codex:78f8d2c
+    command: codex-acp
+    workingDir: /home/node
+    discord:
+      botToken: ""  # set via --set or external secret
+      allowedChannels:
+        - "YOUR_CHANNEL_ID"
+```
+
+## Gemini Only Example (values.yaml)
+
+```yaml
+agents:
+  kiro:
+    enabled: false
+  gemini:
+    image: ghcr.io/openabdev/openab-gemini:78f8d2c
+    command: gemini
+    args: ["--acp"]
+    workingDir: /home/node
+    discord:
+      botToken: ""  # set via --set or external secret
+      allowedChannels:
+        - "YOUR_CHANNEL_ID"
+    env:
+      GEMINI_API_KEY: "${GEMINI_API_KEY}"
+```
+
 ## Multi-Agent Example (values.yaml)
 
 ```yaml


### PR DESCRIPTION
##### Summary
- Update gh-pages README to match the 0.6.1 multi-agent Helm chart structure
- Add `agents.<name>.enabled` flag to values reference table
- Add "Claude only" deployment scenario with `agents.kiro.enabled: false`
- Update multi-agent examples with correct `image` / `workingDir` values
- Explain Helm deep-merge behavior and why `enabled: false` is needed to disable the default kiro agent