### PR TITLE
chore: release 0.6.1

### DIFF
--- a/charts/openab/Chart.yaml
+++ b/charts/openab/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openab
 description: Discord ↔ ACP coding CLI bridge (Kiro CLI, Claude Code, Codex, Gemini)
 type: application
-version: 0.6.1-beta.1
-appVersion: "52ac30a"
+version: 0.6.1
+appVersion: "f490584"


### PR DESCRIPTION
Stable release 0.6.1

## Changes since 0.6.0

- **fix(helm): per-agent image as string, fallback to appVersion, persistence.size default 1Gi** (#145) @neilkuan
- **docs: update README for 0.6.0 agents map chart** (#144)

Chart version: `0.6.1`
App version: `f490584`