### PR TITLE
fix: prevent duplicate Discord messages for long content

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -223,25 +223,22 @@ async fn stream_prompt(
                 let mut buf_rx = buf_rx.clone();
                 tokio::spawn(async move {
                     let mut last_content = String::new();
-                    let mut current_edit_msg = msg_id;
+                    let current_edit_msg = msg_id;
                     loop {
                         tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
                         if buf_rx.has_changed().unwrap_or(false) {
                             let content = buf_rx.borrow_and_update().clone();
                             if content != last_content {
-                                if content.len() > 1900 {
-                                    let chunks = format::split_message(&content, 1900);
-                                    if let Some(first) = chunks.first() {
-                                        let _ = edit(&ctx, channel, current_edit_msg, first).await;
-                                    }
-                                    for chunk in chunks.iter().skip(1) {
-                                        if let Ok(new_msg) = channel.say(&ctx.http, chunk).await {
-                                            current_edit_msg = new_msg.id;
-                                        }
-                                    }
+                                // During streaming, only edit the single placeholder message.
+                                // If content exceeds 1900 chars, truncate with ellipsis —
+                                // this is a live preview, not the final output.
+                                // The final edit after streaming handles proper multi-message splitting.
+                                let display = if content.len() > 1900 {
+                                    format!("{}…", &content[..1900])
                                 } else {
-                                    let _ = edit(&ctx, channel, current_edit_msg, &content).await;
-                                }
+                                    content.clone()
+                                };
+                                let _ = edit(&ctx, channel, current_edit_msg, &display).await;
                                 last_content = content;
                             }
                         }


### PR DESCRIPTION
## Summary

- During edit-streaming, the `>1900 char` code path split content into chunks and called `channel.say()` for each overflow chunk, creating new Discord messages
- The final edit after streaming also split and called `channel.say()` for overflow chunks -- both paths ran independently, producing duplicate messages
- Fix: during streaming, truncate content over 1900 chars with an ellipsis and only edit the single placeholder message. The final edit handles proper multi-message splitting after streaming completes.

## Test plan

- [ ] Trigger an agent reply exceeding 1900 chars (e.g., multi-tool-call response with long analysis)
- [ ] Verify only one set of chunked messages appears in Discord (no duplicates)
- [ ] Verify the streaming preview shows truncated content with ellipsis for long responses
- [ ] Verify the final output is correctly split across multiple messages when needed

Fixes #81