### PR TITLE
chore: add MIT LICENSE file and license metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "openab"
 version = "0.7.8"
 edition = "2021"
+license = "MIT"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
# Description
* README declares MIT but the repo had no LICENSE file and Cargo.toml was missing the license field.