### PR TITLE
fix: replace .unwrap() with .expect() on infallible calls

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -145,7 +145,7 @@ impl Default for ReactionTiming {
 // --- loading ---
 
 fn expand_env_vars(raw: &str) -> String {
-    let re = Regex::new(r"\$\{(\w+)\}").unwrap();
+    let re = Regex::new(r"\$\{(\w+)\}").expect("env var regex literal is valid");
     re.replace_all(raw, |caps: &regex::Captures| {
         std::env::var(&caps[1]).unwrap_or_default()
     })

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -115,7 +115,8 @@ impl EventHandler for Handler {
         });
         let prompt_with_sender = format!(
             "<sender_context>\n{}\n</sender_context>\n\n{}",
-            serde_json::to_string(&sender_ctx).unwrap(),
+            serde_json::to_string(&sender_ctx)
+                .expect("sender_ctx is built from a serde_json::json! literal and cannot fail to serialize"),
             prompt
         );
 
@@ -500,7 +501,7 @@ fn compose_display(tool_lines: &[String], text: &str) -> String {
 }
 
 static MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r"<@[!&]?\d+>").unwrap()
+    regex::Regex::new(r"<@[!&]?\d+>").expect("mention regex literal is valid")
 });
 
 fn strip_mention(content: &str) -> String {
@@ -509,7 +510,8 @@ fn strip_mention(content: &str) -> String {
 
 fn shorten_thread_name(prompt: &str) -> String {
     // Shorten GitHub URLs: https://github.com/owner/repo/issues/123 → owner/repo#123
-    let re = regex::Regex::new(r"https?://github\.com/([^/]+/[^/]+)/(issues|pull)/(\d+)").unwrap();
+    let re = regex::Regex::new(r"https?://github\.com/([^/]+/[^/]+)/(issues|pull)/(\d+)")
+        .expect("github url regex literal is valid");
     let shortened = re.replace_all(prompt, "$1#$3");
     let name: String = shortened.chars().take(40).collect();
     if name.len() < shortened.len() {


### PR DESCRIPTION
# Description
  Replace four `.unwrap()` calls with `.expect("...")` so the panic message documents the invariant.

  ## Changes
  - `src/config.rs` — `expand_env_vars` regex literal
  - `src/discord.rs` — `sender_ctx` JSON serialization, `strip_mention` regex, `shorten_thread_name` GitHub URL regex

  ## Rationale
  All four call sites are infallible in practice (regex literals known at compile time, and a `serde_json::Value` built from a `json!` macro). `.expect("reason")` is the conventional form
  for "should never panic" — if it ever does fire, the message points at the violated invariant.
    `.unwrap_or_else()` is not suitable here because there is no meaningful fallback value for an invalid regex or a failed serialization — the program cannot continue correctly, so a panic
  with a descriptive message is the right behavior.