### PR TITLE
docs: add gh auth device flow guide for agent environments

### DIFF
--- a/docs/discord-bot-howto.md
+++ b/docs/discord-bot-howto.md
@@ -104,3 +104,4 @@ The bot should create a thread and respond. After that, just type in the thread 
 - **Bot doesn't respond** — check that the channel ID is correct and the bot has permissions in that channel
 - **"Sent invalid authentication"** — the bot token is wrong or expired, reset it in the Developer Portal
 - **"Failed to start agent"** — kiro-cli isn't authenticated, run `kiro-cli login --use-device-flow` inside the container
+- **`gh` commands fail with 401** — the agent needs GitHub CLI authentication. See [gh auth device flow guide](gh-auth-device-flow.md) for how to authenticate in a headless container

--- a/docs/gh-auth-device-flow.md
+++ b/docs/gh-auth-device-flow.md
@@ -65,9 +65,11 @@ How it works:
 gh auth status
 ```
 
-## Steering / prompt snippet
+## Steering / prompt snippet (Kiro CLI only)
 
-To make your agent always handle `gh login` correctly, create `~/.kiro/steering/gh.md`:
+> **Note:** This section applies only to [Kiro CLI](https://kiro.dev) agents. Other agent backends (Claude Code, Codex, Gemini) have their own prompt/config mechanisms.
+
+To make your Kiro agent always handle `gh login` correctly, create `~/.kiro/steering/gh.md`:
 
 ```bash
 mkdir -p ~/.kiro/steering

--- a/docs/gh-auth-device-flow.md
+++ b/docs/gh-auth-device-flow.md
@@ -1,0 +1,77 @@
+# GitHub CLI Authentication in Agent Environments
+
+How to authenticate `gh` (GitHub CLI) when the agent runs in a headless container and the user may be on mobile.
+
+## Why `gh` auth matters
+
+`gh` is one of the most common tools agents use to interact with GitHub — reviewing PRs, creating issues, commenting, approving, merging, etc. Before the agent can do any of this, `gh` must be authenticated.
+
+## Challenges
+
+This isn't a typical `gh login` scenario. Three things make it tricky:
+
+1. **The agent runs in a K8s pod with no browser** — `gh auth login --web` can't open a browser, so device flow (code + URL) is the only option
+2. **The user might be on mobile, not at a desktop** — they're chatting via Discord on their phone, so the agent must send the URL and code as a clickable message
+3. **The user authorizes on their phone** — they tap the link, enter the code in mobile Safari/Chrome, and the agent's background process picks up the token automatically
+
+```
+┌───────────┐  "review PR #108"  ┌───────────┐  gh pr view  ┌───────────┐
+│  Discord   │──────────────────►│  OpenAB    │────────────►│  GitHub   │
+│  User      │                   │  + Agent   │◄────────────│  API      │
+└───────────┘                    └─────┬─────┘  401 🚫      └───────────┘
+                                       │
+                                       │ needs gh auth login first!
+                                       ▼
+                                 ┌───────────┐  device flow  ┌───────────┐
+                                 │  Agent     │─────────────►│  GitHub   │
+                                 │  (nohup)   │  code+URL    │  /login/  │
+                                 └─────┬─────┘◄─────────────│  device   │
+                                       │                     └─────┬─────┘
+                                       │ sends code+URL            │
+                                       ▼                           │
+                                 ┌───────────┐  authorize    ┌─────▼─────┐
+                                 │  Discord   │─────────────►│  Browser  │
+                                 │  User      │  enters code │  (mobile) │
+                                 └───────────┘               └───────────┘
+```
+
+## The problem with naive approaches
+
+`gh auth login --web` uses device flow: it prints a one-time code + URL, then polls GitHub until the user authorizes. In an agent environment the shell is synchronous — it blocks until the command finishes:
+
+| Approach | What happens |
+|---|---|
+| Run directly | Blocks forever. User never sees the code. |
+| `timeout N gh auth login -w` | Code appears only after timeout kills the process — token is never saved. |
+
+## Solution: `nohup` + background + read log
+
+```bash
+nohup gh auth login --hostname github.com --git-protocol https -p https -w > /tmp/gh-login.log 2>&1 &
+sleep 3 && cat /tmp/gh-login.log
+```
+
+How it works:
+1. `nohup ... &` runs `gh` in the background so the shell returns immediately
+2. `sleep 3 && cat` reads the log after `gh` has printed the code + URL
+3. The agent sends the code + URL to the user (via Discord)
+4. The user opens the link (even on mobile), enters the code
+5. `gh` detects the authorization and saves the token
+6. Done — `gh auth status` confirms login
+
+## Verify
+
+```bash
+gh auth status
+```
+
+## Steering / prompt snippet
+
+If you want your agent to always handle `gh login` correctly, add this to your agent's steering config:
+
+```
+When asked to "gh login", always use:
+nohup gh auth login --hostname github.com --git-protocol https -p https -w > /tmp/gh-login.log 2>&1 &
+sleep 3 && cat /tmp/gh-login.log
+Never use timeout. Always use nohup + background + read log.
+```

--- a/docs/gh-auth-device-flow.md
+++ b/docs/gh-auth-device-flow.md
@@ -67,11 +67,24 @@ gh auth status
 
 ## Steering / prompt snippet
 
-If you want your agent to always handle `gh login` correctly, add this to your agent's steering config:
+To make your agent always handle `gh login` correctly, create `~/.kiro/steering/gh.md`:
 
-```
-When asked to "gh login", always use:
+```bash
+mkdir -p ~/.kiro/steering
+cat > ~/.kiro/steering/gh.md << 'EOF'
+# GitHub CLI
+
+## Device Flow Login
+
+When asked to "gh login", always use nohup + background + read log:
+
+```bash
 nohup gh auth login --hostname github.com --git-protocol https -p https -w > /tmp/gh-login.log 2>&1 &
 sleep 3 && cat /tmp/gh-login.log
-Never use timeout. Always use nohup + background + read log.
 ```
+
+Never use `timeout`. The shell tool is synchronous — it blocks until the command finishes, so stdout won't be visible until then. `nohup` runs it in the background, `sleep 3 && cat` grabs the code immediately.
+EOF
+```
+
+Kiro CLI automatically picks up `~/.kiro/steering/*.md` files as persistent context, so the agent will remember this across all sessions.


### PR DESCRIPTION
Closes #173

## Summary

Adds a new doc `docs/gh-auth-device-flow.md` explaining how to authenticate `gh` CLI in agent environments (headless containers, mobile users).

## Challenges addressed

1. **Pod has no browser** — can't use `gh auth login --web` normally
2. **User might be on mobile** — agent must send clickable URL + code via Discord
3. **User authorizes on their phone** — background process picks up the token

## Changes

| File | Change |
|------|--------|
| `docs/gh-auth-device-flow.md` | New guide: challenges, why naive approaches fail, nohup solution, steering snippet |
| `docs/discord-bot-howto.md` | Added troubleshooting entry linking to the new guide |

## Why naive approaches don't work

| Approach | Result |
|---|---|
| Run directly | Blocks forever, user never sees the code |
| `timeout N` | Code appears only after timeout kills the process — token never saved |
| `nohup` + background + read log | ✅ Agent gets code immediately, gh polls in background |