### PR TITLE
docs: recommend faster Gemini model for CLI startup

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -22,6 +22,7 @@ working_dir = "/home/agent"
 
 # [agent]
 # command = "gemini"
+# args = ["--acp", "--model", "gemini-3.1-flash-lite-preview"]
 # args = ["--acp"]
 # working_dir = "/home/agent"
 # env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }


### PR DESCRIPTION
Fix issue #176: Update example config to recommend gemini-3.1-flash-lite-preview for faster startup and response latency in interactive chat usage.