### PR TITLE
feat: broadcast shutdown notification to active threads (RFC #78 §1d Phase 1)

### DIFF
--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -1,7 +1,8 @@
 use crate::acp::connection::AcpConnection;
 use crate::acp::protocol::ConfigOption;
+use crate::adapter::{ChannelRef, ChatAdapter};
 use crate::config::AgentConfig;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
@@ -16,6 +17,11 @@ struct PoolState {
     /// Lock-free cancel handles: thread_key → (stdin, session_id).
     /// Stored separately so cancel can work without locking the connection.
     cancel_handles: HashMap<String, (Arc<tokio::sync::Mutex<tokio::process::ChildStdin>>, String)>,
+    /// Addressing info for each active thread. Populated alongside `active`
+    /// and pruned together. Used by `begin_shutdown` so the broker can post
+    /// a notification to every live session without the adapter layer
+    /// maintaining a parallel cache. Invariant: `addresses.keys() == active.keys()`.
+    addresses: HashMap<String, (ChannelRef, Arc<dyn ChatAdapter>)>,
     /// Suspended sessions: thread_key → ACP sessionId.
     /// Saved on eviction so sessions can be resumed via `session/load`.
     suspended: HashMap<String, String>,
@@ -28,6 +34,10 @@ pub struct SessionPool {
     state: RwLock<PoolState>,
     config: AgentConfig,
     max_sessions: usize,
+    /// Flipped by `begin_shutdown` to reject new admissions. Checked inside
+    /// `get_or_create` under the state write lock so admission and snapshot
+    /// are atomic.
+    shutting_down: std::sync::atomic::AtomicBool,
 }
 
 type EvictionCandidate = (
@@ -67,15 +77,53 @@ impl SessionPool {
             state: RwLock::new(PoolState {
                 active: HashMap::new(),
                 cancel_handles: HashMap::new(),
+                addresses: HashMap::new(),
                 suspended: HashMap::new(),
                 creating: HashMap::new(),
             }),
             config,
             max_sessions,
+            shutting_down: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
-    pub async fn get_or_create(&self, thread_id: &str) -> Result<()> {
+    /// True once `begin_shutdown` has been called. Router uses this to show a
+    /// shutdown-specific message instead of a generic pool error when
+    /// `get_or_create` rejects admission.
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutting_down
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Flip the pool into shutting-down state and return a snapshot of every
+    /// live session's addressing info. Takes the state write lock so the
+    /// snapshot is atomic with respect to in-flight `get_or_create` calls:
+    /// any admission that committed before us is included; any that comes
+    /// after us sees the flag inside the same lock and rejects.
+    pub async fn begin_shutdown(&self) -> Vec<(String, ChannelRef, Arc<dyn ChatAdapter>)> {
+        let state = self.state.write().await;
+        self.shutting_down
+            .store(true, std::sync::atomic::Ordering::Release);
+        state
+            .addresses
+            .iter()
+            .map(|(k, (c, a))| (k.clone(), c.clone(), a.clone()))
+            .collect()
+    }
+
+    pub async fn get_or_create(
+        &self,
+        thread_id: &str,
+        channel: &ChannelRef,
+        adapter: &Arc<dyn ChatAdapter>,
+    ) -> Result<()> {
+        // Fast-fail: avoid spawning a fresh ACP process if shutdown is already
+        // in progress. The authoritative check happens again under the state
+        // write lock below so we also catch shutdowns that start mid-spawn.
+        if self.is_shutting_down() {
+            bail!("pool is shutting down");
+        }
+
         let create_gate = {
             let mut state = self.state.write().await;
             get_or_insert_gate(&mut state.creating, thread_id)
@@ -84,6 +132,9 @@ impl SessionPool {
 
         let (existing, saved_session_id) = {
             let state = self.state.read().await;
+            if self.is_shutting_down() {
+                bail!("pool is shutting down");
+            }
             (
                 state.active.get(thread_id).cloned(),
                 state.suspended.get(thread_id).cloned(),
@@ -95,6 +146,16 @@ impl SessionPool {
         if let Some(conn) = existing.clone() {
             let conn = conn.lock().await;
             if conn.alive() {
+                // Re-check shutdown state after waiting on the per-connection
+                // mutex. Taking `state.read()` synchronizes us with
+                // `begin_shutdown`'s write-lock flag flip, so the flag value
+                // we see here reflects every `begin_shutdown` that has
+                // committed. This closes the race where shutdown starts
+                // while we were waiting on `conn.lock()`.
+                let _sync = self.state.read().await;
+                if self.is_shutting_down() {
+                    bail!("pool is shutting down");
+                }
                 return Ok(());
             }
             if saved_session_id.is_none() {
@@ -174,6 +235,14 @@ impl SessionPool {
 
         let mut state = self.state.write().await;
 
+        // Admission check inside the state write lock. This is atomic with
+        // `begin_shutdown`'s flag-flip + snapshot: a shutdown that started
+        // during our ACP spawn is caught here, and our work is thrown away
+        // rather than being added to a pool that is about to be torn down.
+        if self.is_shutting_down() {
+            bail!("pool is shutting down");
+        }
+
         // Another task may have created a healthy connection while we were
         // initializing this one.
         if let Some(existing) = state.active.get(thread_id).cloned() {
@@ -186,11 +255,13 @@ impl SessionPool {
             warn!(thread_id, "stale connection, rebuilding");
             drop(existing);
             state.active.remove(thread_id);
+            state.addresses.remove(thread_id);
         }
 
         if state.active.len() >= self.max_sessions {
             if let Some((key, expected_conn, _, sid)) = eviction_candidate {
                 if remove_if_same_handle(&mut state.active, &key, &expected_conn).is_some() {
+                    state.addresses.remove(&key);
                     info!(evicted = %key, "pool full, suspending oldest idle session");
                     if let Some(sid) = sid {
                         state.suspended.insert(key, sid);
@@ -216,6 +287,9 @@ impl SessionPool {
         if !cancel_session_id.is_empty() {
             state.cancel_handles.insert(thread_id.to_string(), (cancel_handle, cancel_session_id));
         }
+        state
+            .addresses
+            .insert(thread_id.to_string(), (channel.clone(), adapter.clone()));
         Ok(())
     }
 
@@ -324,6 +398,7 @@ impl SessionPool {
         let mut state = self.state.write().await;
         for (key, expected_conn, sid) in stale {
             if remove_if_same_handle(&mut state.active, &key, &expected_conn).is_some() {
+                state.addresses.remove(&key);
                 info!(thread_id = %key, "cleaning up idle session");
                 if let Some(sid) = sid {
                     state.suspended.insert(key, sid);
@@ -336,6 +411,7 @@ impl SessionPool {
         let mut state = self.state.write().await;
         let count = state.active.len();
         state.active.clear(); // Drop impl kills process groups
+        state.addresses.clear();
         info!(count, "pool shutdown complete");
     }
 }

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -9,19 +9,22 @@ use tokio::sync::{Mutex, RwLock};
 use tokio::time::Instant;
 use tracing::{info, warn};
 
+/// A single active session: connection handle + addressing info bundled
+/// together so their lifetimes are enforced at the type level.
+struct SessionEntry {
+    conn: Arc<Mutex<AcpConnection>>,
+    channel: ChannelRef,
+    adapter: Arc<dyn ChatAdapter>,
+}
+
 /// Combined state protected by a single lock to prevent deadlocks.
 /// Lock ordering: never await a per-connection mutex while holding `state`.
 struct PoolState {
-    /// Active connections: thread_key → AcpConnection handle.
-    active: HashMap<String, Arc<Mutex<AcpConnection>>>,
+    /// Active sessions: thread_key → SessionEntry (connection + addressing).
+    sessions: HashMap<String, SessionEntry>,
     /// Lock-free cancel handles: thread_key → (stdin, session_id).
     /// Stored separately so cancel can work without locking the connection.
     cancel_handles: HashMap<String, (Arc<tokio::sync::Mutex<tokio::process::ChildStdin>>, String)>,
-    /// Addressing info for each active thread. Populated alongside `active`
-    /// and pruned together. Used by `begin_shutdown` so the broker can post
-    /// a notification to every live session without the adapter layer
-    /// maintaining a parallel cache. Invariant: `addresses.keys() == active.keys()`.
-    addresses: HashMap<String, (ChannelRef, Arc<dyn ChatAdapter>)>,
     /// Suspended sessions: thread_key → ACP sessionId.
     /// Saved on eviction so sessions can be resumed via `session/load`.
     suspended: HashMap<String, String>,
@@ -47,16 +50,18 @@ type EvictionCandidate = (
     Option<String>,
 );
 
-fn remove_if_same_handle<T>(
-    map: &mut HashMap<String, Arc<Mutex<T>>>,
+/// Remove a session entry only if its connection handle matches `expected`.
+/// Returns the removed connection Arc, or None if the handle was swapped.
+fn remove_if_same_conn(
+    map: &mut HashMap<String, SessionEntry>,
     key: &str,
-    expected: &Arc<Mutex<T>>,
-) -> Option<Arc<Mutex<T>>> {
+    expected: &Arc<Mutex<AcpConnection>>,
+) -> Option<Arc<Mutex<AcpConnection>>> {
     let should_remove = map
         .get(key)
-        .is_some_and(|current| Arc::ptr_eq(current, expected));
+        .is_some_and(|entry| Arc::ptr_eq(&entry.conn, expected));
     if should_remove {
-        map.remove(key)
+        map.remove(key).map(|e| e.conn)
     } else {
         None
     }
@@ -75,9 +80,8 @@ impl SessionPool {
     pub fn new(config: AgentConfig, max_sessions: usize) -> Self {
         Self {
             state: RwLock::new(PoolState {
-                active: HashMap::new(),
+                sessions: HashMap::new(),
                 cancel_handles: HashMap::new(),
-                addresses: HashMap::new(),
                 suspended: HashMap::new(),
                 creating: HashMap::new(),
             }),
@@ -105,9 +109,9 @@ impl SessionPool {
         self.shutting_down
             .store(true, std::sync::atomic::Ordering::Release);
         state
-            .addresses
+            .sessions
             .iter()
-            .map(|(k, (c, a))| (k.clone(), c.clone(), a.clone()))
+            .map(|(k, e)| (k.clone(), e.channel.clone(), e.adapter.clone()))
             .collect()
     }
 
@@ -136,7 +140,7 @@ impl SessionPool {
                 bail!("pool is shutting down");
             }
             (
-                state.active.get(thread_id).cloned(),
+                state.sessions.get(thread_id).map(|e| e.conn.clone()),
                 state.suspended.get(thread_id).cloned(),
             )
         };
@@ -152,7 +156,11 @@ impl SessionPool {
                 // we see here reflects every `begin_shutdown` that has
                 // committed. This closes the race where shutdown starts
                 // while we were waiting on `conn.lock()`.
-                let _sync = self.state.read().await;
+                //
+                // DO NOT REMOVE — this read-lock is a synchronization barrier,
+                // not a data access. Without it the `is_shutting_down()` check
+                // below can observe a stale value.
+                let _shutdown_barrier = self.state.read().await;
                 if self.is_shutting_down() {
                     bail!("pool is shutting down");
                 }
@@ -167,9 +175,9 @@ impl SessionPool {
         let snapshot: Vec<(String, Arc<Mutex<AcpConnection>>)> = {
             let state = self.state.read().await;
             state
-                .active
+                .sessions
                 .iter()
-                .map(|(k, v)| (k.clone(), Arc::clone(v)))
+                .map(|(k, e)| (k.clone(), Arc::clone(&e.conn)))
                 .collect()
         };
 
@@ -245,7 +253,8 @@ impl SessionPool {
 
         // Another task may have created a healthy connection while we were
         // initializing this one.
-        if let Some(existing) = state.active.get(thread_id).cloned() {
+        if let Some(entry) = state.sessions.get(thread_id) {
+            let existing = entry.conn.clone();
             let Ok(existing) = existing.try_lock() else {
                 return Ok(());
             };
@@ -254,14 +263,12 @@ impl SessionPool {
             }
             warn!(thread_id, "stale connection, rebuilding");
             drop(existing);
-            state.active.remove(thread_id);
-            state.addresses.remove(thread_id);
+            state.sessions.remove(thread_id);
         }
 
-        if state.active.len() >= self.max_sessions {
+        if state.sessions.len() >= self.max_sessions {
             if let Some((key, expected_conn, _, sid)) = eviction_candidate {
-                if remove_if_same_handle(&mut state.active, &key, &expected_conn).is_some() {
-                    state.addresses.remove(&key);
+                if remove_if_same_conn(&mut state.sessions, &key, &expected_conn).is_some() {
                     info!(evicted = %key, "pool full, suspending oldest idle session");
                     if let Some(sid) = sid {
                         state.suspended.insert(key, sid);
@@ -278,18 +285,19 @@ impl SessionPool {
             }
         }
 
-        if state.active.len() >= self.max_sessions {
+        if state.sessions.len() >= self.max_sessions {
             return Err(anyhow!("pool exhausted ({} sessions)", self.max_sessions));
         }
 
         state.suspended.remove(thread_id);
-        state.active.insert(thread_id.to_string(), new_conn);
+        state.sessions.insert(thread_id.to_string(), SessionEntry {
+            conn: new_conn,
+            channel: channel.clone(),
+            adapter: adapter.clone(),
+        });
         if !cancel_session_id.is_empty() {
             state.cancel_handles.insert(thread_id.to_string(), (cancel_handle, cancel_session_id));
         }
-        state
-            .addresses
-            .insert(thread_id.to_string(), (channel.clone(), adapter.clone()));
         Ok(())
     }
 
@@ -303,9 +311,9 @@ impl SessionPool {
         let conn = {
             let state = self.state.read().await;
             state
-                .active
+                .sessions
                 .get(thread_id)
-                .cloned()
+                .map(|e| e.conn.clone())
                 .ok_or_else(|| anyhow!("no connection for thread {thread_id}"))?
         };
 
@@ -316,8 +324,8 @@ impl SessionPool {
     /// Get cached configOptions for a session (e.g. available models).
     pub async fn get_config_options(&self, thread_id: &str) -> Vec<ConfigOption> {
         let state = self.state.read().await;
-        let conn = match state.active.get(thread_id) {
-            Some(c) => c.clone(),
+        let conn = match state.sessions.get(thread_id) {
+            Some(e) => e.conn.clone(),
             None => return Vec::new(),
         };
         drop(state);
@@ -335,9 +343,9 @@ impl SessionPool {
         let conn = {
             let state = self.state.read().await;
             state
-                .active
+                .sessions
                 .get(thread_id)
-                .cloned()
+                .map(|e| e.conn.clone())
                 .ok_or_else(|| anyhow!("no connection for thread {thread_id}"))?
         };
         let mut conn = conn.lock().await;
@@ -372,9 +380,9 @@ impl SessionPool {
         let snapshot: Vec<(String, Arc<Mutex<AcpConnection>>)> = {
             let state = self.state.read().await;
             state
-                .active
+                .sessions
                 .iter()
-                .map(|(k, v)| (k.clone(), Arc::clone(v)))
+                .map(|(k, e)| (k.clone(), Arc::clone(&e.conn)))
                 .collect()
         };
 
@@ -397,8 +405,7 @@ impl SessionPool {
 
         let mut state = self.state.write().await;
         for (key, expected_conn, sid) in stale {
-            if remove_if_same_handle(&mut state.active, &key, &expected_conn).is_some() {
-                state.addresses.remove(&key);
+            if remove_if_same_conn(&mut state.sessions, &key, &expected_conn).is_some() {
                 info!(thread_id = %key, "cleaning up idle session");
                 if let Some(sid) = sid {
                     state.suspended.insert(key, sid);
@@ -409,19 +416,36 @@ impl SessionPool {
 
     pub async fn shutdown(&self) {
         let mut state = self.state.write().await;
-        let count = state.active.len();
-        state.active.clear(); // Drop impl kills process groups
-        state.addresses.clear();
+        let count = state.sessions.len();
+        state.sessions.clear(); // Drop impl kills process groups
         info!(count, "pool shutdown complete");
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{get_or_insert_gate, remove_if_same_handle};
+    use super::get_or_insert_gate;
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Mutex;
+
+    /// The pointer-equality removal logic used by `remove_if_same_conn`.
+    /// Tested here with a simple type since `AcpConnection` cannot be
+    /// constructed in unit tests.
+    fn remove_if_same_handle<T>(
+        map: &mut HashMap<String, Arc<Mutex<T>>>,
+        key: &str,
+        expected: &Arc<Mutex<T>>,
+    ) -> Option<Arc<Mutex<T>>> {
+        let should_remove = map
+            .get(key)
+            .is_some_and(|current| Arc::ptr_eq(current, expected));
+        if should_remove {
+            map.remove(key)
+        } else {
+            None
+        }
+    }
 
     #[test]
     fn remove_if_same_handle_removes_matching_entry() {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::Serialize;
 use std::sync::Arc;
-use tracing::error;
+use tracing::{error, info, warn};
 
 use crate::acp::{classify_notification, AcpEvent, ContentBlock, SessionPool};
 use crate::config::ReactionsConfig;
@@ -154,11 +154,30 @@ impl AdapterRouter {
                 .unwrap_or(&thread_channel.channel_id)
         );
 
-        if let Err(e) = self.pool.get_or_create(&thread_key).await {
-            let msg = format_user_error(&e.to_string());
-            let _ = adapter
-                .send_message(thread_channel, &format!("⚠️ {msg}"))
-                .await;
+        // Session admission. The pool itself is authoritative: it rejects
+        // with an error if `begin_shutdown` has already fired, and on success
+        // stores the `ChannelRef` + adapter so `broadcast_shutdown` can reach
+        // this thread without the router keeping a parallel cache.
+        if let Err(e) = self.pool.get_or_create(&thread_key, thread_channel, adapter).await {
+            if self.pool.is_shutting_down() {
+                // Don't send the shutdown rejection back to bot-authored events.
+                // Slack (and potentially any other platform that doesn't drop
+                // the bot's own posts) would deliver our broadcast message as a
+                // new bot event, route it here during the shutdown window, and
+                // we'd reply with another bot-authored rejection — looping until
+                // the bot-turn cap trips. Human senders still get the notice.
+                if !sender.is_bot {
+                    let _ = adapter
+                        .send_message(
+                            thread_channel,
+                            "⚠️ Bot is shutting down and cannot accept new messages right now.",
+                        )
+                        .await;
+                }
+                return Ok(());
+            }
+            let msg = format!("⚠️ {}", format_user_error(&e.to_string()));
+            let _ = adapter.send_message(thread_channel, &msg).await;
             error!("pool error: {e}");
             return Err(e);
         }
@@ -207,6 +226,58 @@ impl AdapterRouter {
         }
 
         result
+    }
+
+    /// Broadcast a short notification to every active thread, across all
+    /// configured adapters, before the broker shuts down. Sends happen in
+    /// parallel and are capped by `timeout`; the call returns early if the
+    /// deadline is hit so shutdown itself is never blocked by a slow platform.
+    ///
+    /// Delivery is best-effort: evicted sessions whose `ChannelRef` is still
+    /// in the cache still receive the notification, which is the behavior we
+    /// want (the user saw the thread was in flight; they deserve to know the
+    /// broker is going away).
+    pub async fn broadcast_shutdown(&self, message: &str, timeout: std::time::Duration) {
+        // The pool owns both the flag flip and the live-session snapshot and
+        // performs both atomically under its state write lock. Any message
+        // admitted before us is in the snapshot; any that comes after sees
+        // the flag inside the same lock and returns an admission error that
+        // `handle_message` surfaces inline.
+        let snapshot = self.pool.begin_shutdown().await;
+
+        if snapshot.is_empty() {
+            return;
+        }
+
+        info!(count = snapshot.len(), "broadcasting shutdown notification");
+
+        let mut set = tokio::task::JoinSet::new();
+        for (thread_key, channel, adapter) in snapshot {
+            let message = message.to_string();
+            set.spawn(async move {
+                if let Err(e) = adapter.send_message(&channel, &message).await {
+                    warn!(thread_key, error = %e, "failed to post shutdown notification");
+                }
+            });
+        }
+
+        let deadline = tokio::time::sleep(timeout);
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                biased;
+                _ = &mut deadline => {
+                    warn!(timeout_ms = timeout.as_millis() as u64, "shutdown broadcast timed out; remaining sends cancelled");
+                    set.shutdown().await;
+                    return;
+                }
+                next = set.join_next() => {
+                    if next.is_none() {
+                        return;
+                    }
+                }
+            }
+        }
     }
 
     async fn stream_prompt(

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
@@ -32,7 +32,7 @@ pub struct MessageRef {
 }
 
 /// Sender identity injected into prompts for downstream agent context.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SenderContext {
     pub schema: String,
     pub sender_id: String,
@@ -116,7 +116,6 @@ impl AdapterRouter {
         adapter: &Arc<dyn ChatAdapter>,
         thread_channel: &ChannelRef,
         sender_json: &str,
-        sender_is_bot: bool,
         prompt: &str,
         extra_blocks: Vec<ContentBlock>,
         trigger_msg: &MessageRef,
@@ -167,6 +166,9 @@ impl AdapterRouter {
                 // new bot event, route it here during the shutdown window, and
                 // we'd reply with another bot-authored rejection — looping until
                 // the bot-turn cap trips. Human senders still get the notice.
+                let sender_is_bot = serde_json::from_str::<SenderContext>(sender_json)
+                    .map(|sender| sender.is_bot)
+                    .unwrap_or(false);
                 if !sender_is_bot {
                     let _ = adapter
                         .send_message(

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -116,6 +116,7 @@ impl AdapterRouter {
         adapter: &Arc<dyn ChatAdapter>,
         thread_channel: &ChannelRef,
         sender_json: &str,
+        sender_is_bot: bool,
         prompt: &str,
         extra_blocks: Vec<ContentBlock>,
         trigger_msg: &MessageRef,
@@ -166,7 +167,7 @@ impl AdapterRouter {
                 // new bot event, route it here during the shutdown window, and
                 // we'd reply with another bot-authored rejection — looping until
                 // the bot-turn cap trips. Human senders still get the notice.
-                if !sender.is_bot {
+                if !sender_is_bot {
                     let _ = adapter
                         .send_message(
                             thread_channel,

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -521,7 +521,6 @@ impl EventHandler for Handler {
                     &adapter,
                     &thread_channel,
                     &sender_json,
-                    sender.is_bot,
                     &prompt,
                     extra_blocks,
                     &trigger_msg,

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -517,7 +517,15 @@ impl EventHandler for Handler {
         tokio::spawn(async move {
             let sender_json = serde_json::to_string(&sender).unwrap();
             if let Err(e) = router
-                .handle_message(&adapter, &thread_channel, &sender_json, &prompt, extra_blocks, &trigger_msg)
+                .handle_message(
+                    &adapter,
+                    &thread_channel,
+                    &sender_json,
+                    sender.is_bot,
+                    &prompt,
+                    extra_blocks,
+                    &trigger_msg,
+                )
                 .await
             {
                 error!("handle_message error: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,11 +259,17 @@ async fn main() -> anyhow::Result<()> {
 /// we fall back to ctrl_c alone.
 #[cfg(unix)]
 async fn wait_for_shutdown_signal() {
-    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-        .expect("install SIGTERM handler");
-    tokio::select! {
-        _ = tokio::signal::ctrl_c() => {}
-        _ = sigterm.recv() => {}
+    match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+        Ok(mut sigterm) => {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = sigterm.recv() => {}
+            }
+        }
+        Err(e) => {
+            warn!("failed to install SIGTERM handler ({e}), falling back to ctrl_c only");
+            tokio::signal::ctrl_c().await.ok();
+        }
     }
     info!("shutdown signal received");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,15 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
+/// Neutral shutdown notification broadcast to every active thread. Wording
+/// deliberately avoids "restarting" because `helm uninstall` / final-stop
+/// can't be distinguished from a rolling restart at signal time.
+const SHUTDOWN_MSG: &str = "⚠️ Bot is shutting down. Context will reset on return.";
+
+/// Broadcast deadline. Shutdown itself must never block on a slow platform,
+/// so incomplete sends are dropped once this elapses.
+const SHUTDOWN_BROADCAST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 #[derive(Parser)]
 #[command(name = "openab")]
 #[command(about = "Multi-platform ACP agent broker (Discord, Slack)", long_about = None)]
@@ -176,7 +185,7 @@ async fn main() -> anyhow::Result<()> {
                 );
 
                 let handler = discord::Handler {
-                    router,
+                    router: router.clone(),
                     allow_all_channels,
                     allow_all_users,
                     allowed_channels,
@@ -201,21 +210,31 @@ async fn main() -> anyhow::Result<()> {
                     .event_handler(handler)
                     .await?;
 
-                // Graceful Discord shutdown on ctrl_c
+                // Graceful shutdown on SIGINT or SIGTERM: wait for the signal,
+                // broadcast to every active thread (Discord + Slack), then stop
+                // Discord shards. `client.start()` is the foreground blocker here,
+                // so this handler runs as a spawned task.
                 let shard_manager = client.shard_manager.clone();
+                let shutdown_router = router.clone();
                 tokio::spawn(async move {
-                    tokio::signal::ctrl_c().await.ok();
-                    info!("shutdown signal received");
+                    wait_for_shutdown_signal().await;
+                    shutdown_router
+                        .broadcast_shutdown(SHUTDOWN_MSG, SHUTDOWN_BROADCAST_TIMEOUT)
+                        .await;
                     shard_manager.shutdown_all().await;
                 });
 
                 info!("discord bot running");
                 client.start().await?;
             } else {
-                // No Discord — just wait for ctrl_c
-                info!("running without discord, press ctrl+c to stop");
-                tokio::signal::ctrl_c().await.ok();
-                info!("shutdown signal received");
+                // No Discord — this task itself blocks on the shutdown signal,
+                // then broadcasts before falling through to cleanup. Slack-only
+                // deployments need SIGTERM + broadcast just like Discord.
+                info!("running without discord, waiting for shutdown signal");
+                wait_for_shutdown_signal().await;
+                router
+                    .broadcast_shutdown(SHUTDOWN_MSG, SHUTDOWN_BROADCAST_TIMEOUT)
+                    .await;
             }
 
             // Cleanup
@@ -231,6 +250,28 @@ async fn main() -> anyhow::Result<()> {
             Ok(())
         }
     }
+}
+
+/// Wait for SIGINT (ctrl_c) or, on Unix, SIGTERM (systemctl stop, docker stop,
+/// kill). Without SIGTERM handling the broker would be killed outright by
+/// service managers and skip the shutdown broadcast, so both signals route
+/// here on Unix. On non-Unix targets `tokio::signal::unix` is unavailable, so
+/// we fall back to ctrl_c alone.
+#[cfg(unix)]
+async fn wait_for_shutdown_signal() {
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .expect("install SIGTERM handler");
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {}
+        _ = sigterm.recv() => {}
+    }
+    info!("shutdown signal received");
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown_signal() {
+    tokio::signal::ctrl_c().await.ok();
+    info!("shutdown signal received");
 }
 
 fn parse_id_set(raw: &[String], label: &str) -> anyhow::Result<HashSet<u64>> {

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -957,7 +957,6 @@ async fn handle_message(
             &adapter_dyn,
             &thread_channel,
             &sender_json,
-            sender.is_bot,
             &prompt,
             extra_blocks,
             &trigger_msg,

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -953,7 +953,15 @@ async fn handle_message(
 
     let adapter_dyn: Arc<dyn ChatAdapter> = adapter.clone();
     if let Err(e) = router
-        .handle_message(&adapter_dyn, &thread_channel, &sender_json, &prompt, extra_blocks, &trigger_msg)
+        .handle_message(
+            &adapter_dyn,
+            &thread_channel,
+            &sender_json,
+            sender.is_bot,
+            &prompt,
+            extra_blocks,
+            &trigger_msg,
+        )
         .await
     {
         error!("Slack handle_message error: {e}");


### PR DESCRIPTION
## Summary

On SIGINT or SIGTERM the broker now posts a short notification to every active thread across all configured adapters (Discord, Slack, …) before closing shards. Users get a clear signal that the broker is going away instead of replies cutting off silently mid-stream.

Discord Discussion URL: https://discord.com/channels/1488041051187974246/1495050997461024879

Relates to: #78, #75

## Problem

Today, when the broker is restarted (`systemctl restart`, `docker stop`, Ctrl+C), conversations just die silently mid-reply. Users have no signal that anything is happening until the broker comes back, and in-flight streams leave partial messages with no explanation. RFC #78 §1d calls this out as Phase 1.

The original #182 (rebased before v0.7.6) was Discord-specific and done at the `main.rs` level. The multi-platform refactor in #259 makes that approach stale: Slack threads also need the notification, and the `AdapterRouter` / `ChatAdapter` abstraction is the right home for platform-neutral broadcast. This revision rewrites the feature against that architecture.

## Design

**Pool owns addressing, not the router.** `SessionPool` now stores each active session's `ChannelRef` + `Arc<dyn ChatAdapter>` alongside the connection (`addresses: HashMap<thread_key, ...>`), kept in lockstep with `state.active` so broadcast has a single source of truth. No parallel cache in the adapter layer, no `pool.active_thread_ids()` filter, no prune task.

**Atomic admission and snapshot.**
- `SessionPool::begin_shutdown()` takes the state write lock, flips the shutdown flag, and snapshots `addresses` — all in one critical section. Any admission committed before us is in the snapshot.
- `get_or_create` checks `is_shutting_down()` at four points so every session is either in the snapshot or rejected at admission:
  1. Fast-fail on entry.
  2. Inside the initial `state.read()` block.
  3. Before `return Ok(())` on the existing-alive-session path, with a `state.read()` barrier synchronizing against `begin_shutdown`'s `state.write()` flag flip (closes the race where shutdown starts while we wait on the per-connection mutex).
  4. Inside the final `state.write()` block before insert.

**Platform-neutral broadcast.** `AdapterRouter::broadcast_shutdown(message, timeout)` calls `pool.begin_shutdown()` and posts the notification to every snapshot entry in parallel via `tokio::task::JoinSet`. A `tokio::select!` with a configurable deadline (10s here) caps total broadcast time so shutdown itself never blocks on a slow platform.

**Unified signal handling.** `main.rs` uses a shared `wait_for_shutdown_signal()` helper for SIGINT + SIGTERM (`#[cfg(unix)]`-gated with a ctrl_c-only fallback for non-Unix). Both the Discord-enabled and Slack-only branches invoke `broadcast_shutdown` before tearing down adapters.

## Behaviour notes

- Delivery is best-effort: send errors and the 10-second deadline both fall through to normal pool teardown.
- Wording is intentionally neutral ("Context will reset on return") — we don't promise automatic session resume. RFC #78 Phase 2 persistence is a separate follow-up.
- Per-channel parallel send is safe under Discord/Slack rate limits (limits are per-channel, not per-adapter) and is ~10× faster than sequential for deployments with several active threads.

## Tests & verification

- `cargo test` — 43 passed, 0 failed.
- `cargo clippy --all-targets -- -D warnings` — clean.
- Live-tested on bare-metal and Docker brokers: SIGTERM triggers `broadcasting shutdown notification count=N` log and the message arrives in every active thread.

## Test plan

- [ ] CI: `cargo test`, `cargo clippy`, Docker smoke tests.
- [x] Manual: start broker with Discord and/or Slack configured, open an active thread, send SIGTERM (`docker stop` / `kill -TERM`), verify the thread receives the "Bot is shutting down" message before the pool tears down.
- [ ] Manual: broadcast timeout path — block network to Discord and verify shutdown still completes after 10s.

