### PR TITLE
refactor(pool): per-connection Arc<Mutex> to unblock concurrent sessions

### DIFF
--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -2,12 +2,13 @@ use crate::acp::connection::AcpConnection;
 use crate::config::AgentConfig;
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
-use tokio::sync::RwLock;
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
 use tokio::time::Instant;
 use tracing::{info, warn};
 
 pub struct SessionPool {
-    connections: RwLock<HashMap<String, AcpConnection>>,
+    connections: RwLock<HashMap<String, Arc<Mutex<AcpConnection>>>>,
     config: AgentConfig,
     max_sessions: usize,
 }
@@ -22,22 +23,22 @@ impl SessionPool {
     }
 
     pub async fn get_or_create(&self, thread_id: &str) -> Result<()> {
-        // Check if alive connection exists
+        // Fast path: alive connection exists — only the read lock is needed.
         {
             let conns = self.connections.read().await;
-            if let Some(conn) = conns.get(thread_id) {
-                if conn.alive() {
+            if let Some(conn_arc) = conns.get(thread_id) {
+                if conn_arc.lock().await.alive() {
                     return Ok(());
                 }
             }
         }
 
-        // Need to create or rebuild
+        // Slow path: create or rebuild.
         let mut conns = self.connections.write().await;
 
-        // Double-check after acquiring write lock
-        if let Some(conn) = conns.get(thread_id) {
-            if conn.alive() {
+        // Double-check after acquiring the write lock.
+        if let Some(conn_arc) = conns.get(thread_id) {
+            if conn_arc.lock().await.alive() {
                 return Ok(());
             }
             warn!(thread_id, "stale connection, rebuilding");
@@ -64,30 +65,59 @@ impl SessionPool {
             conn.session_reset = true;
         }
 
-        conns.insert(thread_id.to_string(), conn);
+        conns.insert(thread_id.to_string(), Arc::new(Mutex::new(conn)));
         Ok(())
     }
 
-    /// Get mutable access to a connection. Caller must have called get_or_create first.
+    /// Run `f` against a mutable connection reference. Only this connection's
+    /// per-session mutex is held for the callback's duration — the pool lock
+    /// is released immediately, so concurrent sessions are not blocked.
+    /// Caller must have called `get_or_create` first.
     pub async fn with_connection<F, R>(&self, thread_id: &str, f: F) -> Result<R>
     where
         F: FnOnce(&mut AcpConnection) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<R>> + Send + '_>>,
     {
-        let mut conns = self.connections.write().await;
-        let conn = conns
-            .get_mut(thread_id)
-            .ok_or_else(|| anyhow!("no connection for thread {thread_id}"))?;
-        f(conn).await
+        let conn_arc = {
+            let conns = self.connections.read().await;
+            conns
+                .get(thread_id)
+                .cloned()
+                .ok_or_else(|| anyhow!("no connection for thread {thread_id}"))?
+        };
+        let mut conn = conn_arc.lock().await;
+        f(&mut conn).await
     }
 
     pub async fn cleanup_idle(&self, ttl_secs: u64) {
         let cutoff = Instant::now() - std::time::Duration::from_secs(ttl_secs);
+
+        // Snapshot the Arcs under the read lock, then release it before
+        // awaiting any per-connection mutex. Otherwise a long-running
+        // `session_prompt` would block `cleanup_idle` on the connection
+        // mutex while it still held the pool write lock, re-introducing
+        // exactly the starvation this refactor is meant to eliminate.
+        let snapshot: Vec<(String, Arc<Mutex<AcpConnection>>)> = {
+            let conns = self.connections.read().await;
+            conns.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+        };
+
+        // Probe each connection under its own mutex. `try_lock` skips
+        // connections that are currently in use — they are by definition
+        // not idle, so there is nothing to clean up for them this round.
+        let mut stale = Vec::new();
+        for (key, conn_arc) in &snapshot {
+            let Ok(conn) = conn_arc.try_lock() else { continue };
+            if conn.last_active < cutoff || !conn.alive() {
+                stale.push(key.clone());
+            }
+        }
+
+        if stale.is_empty() {
+            return;
+        }
+
+        // Only now take the pool write lock to remove the stale entries.
         let mut conns = self.connections.write().await;
-        let stale: Vec<String> = conns
-            .iter()
-            .filter(|(_, c)| c.last_active < cutoff || !c.alive())
-            .map(|(k, _)| k.clone())
-            .collect();
         for key in stale {
             info!(thread_id = %key, "cleaning up idle session");
             conns.remove(&key);


### PR DESCRIPTION
## Problem

`SessionPool::with_connection` currently holds the pool's write lock for the entire callback duration. Because `stream_prompt` in `discord.rs` runs inside that callback and can take many seconds — or minutes — to drain an ACP turn, every other Discord thread is blocked from touching the pool while one session is streaming, even for `get_or_create` on a completely unrelated `thread_id` (which only needs the read lock).

In production on our fork (which runs a few dozen concurrent Discord threads against one broker), this manifests as:

- Long turns on one thread serialize every other thread's mention handling.
- `get_or_create` on a fresh thread can block for the duration of an unrelated streaming turn.
- Corresponds to #58 (pool write lock deadlock).

## Fix

Wrap each `AcpConnection` in `Arc<Mutex<_>>`:

- `with_connection` takes the pool's **read** lock only long enough to clone the Arc for the target `thread_id`, then releases it.
- It then locks **that specific connection's** mutex for the duration of the callback.
- Other sessions continue to stream concurrently.
- `get_or_create` on unrelated `thread_id`s is no longer blocked.
- Rebuilds still take the write lock briefly (correct — that's a structural change to the `HashMap`).

`cleanup_idle` is updated to follow the same rule on the cleanup path: snapshot the Arcs under the read lock, release it, then `try_lock` each connection individually. A connection that's currently in use is by definition not idle, so `try_lock` lets us skip it without ever awaiting on a per-connection mutex while holding the pool lock. The write lock is only re-acquired if there are stale entries to remove.

> **Note:** The `cleanup_idle` shape addresses the P1 review comment that Codex bot left on the original #77 — it pointed out that `cleanup_idle` grabbing the pool write lock and then awaiting `conn_arc.lock()` would re-introduce the exact starvation this refactor is meant to eliminate. The snapshot + `try_lock` pattern fixes that.

The `with_connection` signature is unchanged, so **no call sites need to be updated** — the fix is entirely internal to `pool.rs`. Diff is +51 / -21 in a single file.

## Why this approach

A few alternatives we considered:

1. **Leave it as one big `RwLock`, convert callers to read lock.** Doesn't work — callers need `&mut AcpConnection` to drive `session_prompt`, and a read lock can't hand out mutable refs.
2. **`DashMap<String, AcpConnection>`.** `DashMap`'s shard locks are synchronous, so we'd still need per-entry async coordination to let a callback hold exclusive access across `.await` points. Doesn't avoid the underlying need for a per-connection async mutex.
3. **Per-connection `Arc<Mutex<_>>` (this PR).** Minimal change, preserves the existing `with_connection` API, fixes the root cause (pool lock held during streaming). This matches the architecture discussed in #78 §2b.

## Scope

This PR is **only the locking change**. Previously bundled in #77 alongside notification-loop resilience, an alive-check safety net, and a startup cleanup routine — on reflection that was too much for a single review. Closing #77 and splitting into three focused PRs; this is the first.

**Next PRs** (to follow in order, from separate branches off `main`):

1. ✅ This PR — per-connection lock.
2. Notification loop resilience — `end_turn` can arrive before the final `agent_message_chunk` via `tokio::select!` racing; fix is a small drain window + empty-response fallback. Fixes #76.
3. Alive check + hard timeout — defensive safety net around `notification_loop` (30s alive check / 30min hard ceiling).

Supersedes #59 and #77. Closes #58.

## Testing

- Built clean against `main` (`0588893`, current tip).
- `cargo build --release` — no warnings or errors.
- Running on our fork in production for several weeks prior to the split (as part of #77) against bare-metal + Docker brokers with concurrent Discord threads — no deadlocks, no regressions in `get_or_create` latency.

Happy to add a focused test if you'd like — the behavioral change is subtle (a session that's streaming no longer blocks unrelated `get_or_create` calls), and a concurrent-access test with two tasks would make it visible.