### PR TITLE
fix(discord): reuse existing starter threads

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -12,6 +12,8 @@ use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::{error, info};
 
+const THREAD_EXISTS_MSG: &str = "A thread has already been created for this message";
+
 pub struct Handler {
     pub pool: Arc<SessionPool>,
     pub allowed_channels: HashSet<u64>,
@@ -390,9 +392,7 @@ async fn get_or_create_thread(ctx: &Context, msg: &Message, prompt: &str) -> any
 
     match thread {
         Ok(thread) => Ok(thread.id.get()),
-        Err(err) if err.to_string().contains("A thread has already been created for this message") => {
-            Ok(msg.id.get())
-        }
+        Err(err) if err.to_string().contains(THREAD_EXISTS_MSG) => Ok(msg.id.get()),
         Err(err) => Err(err.into()),
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -3,7 +3,7 @@ use crate::config::ReactionsConfig;
 use crate::format;
 use crate::reactions::StatusReactionController;
 use serenity::async_trait;
-use serenity::model::channel::{Message, ReactionType};
+use serenity::model::channel::{Message, MessageFlags, ReactionType};
 use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, MessageId};
 use serenity::prelude::*;
@@ -364,6 +364,18 @@ async fn get_or_create_thread(ctx: &Context, msg: &Message, prompt: &str) -> any
         }
     }
 
+    // Discord surfaces the starter thread on the message payload when available.
+    // For message-based threads, the thread id also matches the starter message id.
+    if let Some(thread) = &msg.thread {
+        return Ok(thread.id.get());
+    }
+    if msg
+        .flags
+        .is_some_and(|flags| flags.contains(MessageFlags::HAS_THREAD))
+    {
+        return Ok(msg.id.get());
+    }
+
     let thread_name = shorten_thread_name(prompt);
 
     let thread = msg
@@ -374,7 +386,13 @@ async fn get_or_create_thread(ctx: &Context, msg: &Message, prompt: &str) -> any
             serenity::builder::CreateThread::new(thread_name)
                 .auto_archive_duration(serenity::model::channel::AutoArchiveDuration::OneDay),
         )
-        .await?;
+        .await;
 
-    Ok(thread.id.get())
+    match thread {
+        Ok(thread) => Ok(thread.id.get()),
+        Err(err) if err.to_string().contains("A thread has already been created for this message") => {
+            Ok(msg.id.get())
+        }
+        Err(err) => Err(err.into()),
+    }
 }


### PR DESCRIPTION
## Summary

Fix Discord message handling when a starter thread already exists for the triggering message.

This makes `get_or_create_thread()` resilient instead of treating Discord's existing-thread response as a fatal error.

Closes #189

## Root cause

The previous implementation always called `create_thread_from_message(...)` for non-thread messages.

If Discord had already created a starter thread for that message, the API returned:

`A thread has already been created for this message`

OpenAB logged the error and returned early, so the prompt was dropped even though a valid thread already existed.

## Changes

- import `MessageFlags`
- reuse `msg.thread` when Discord includes the starter thread on the message payload
- reuse `msg.id` when `MessageFlags::HAS_THREAD` is present
- treat Discord's `A thread has already been created for this message` response as a recoverable case and fall back to the existing starter thread id

## Validation

- reproduced the production failure from logs on 2026-04-10
- built locally with `cargo build`
- deployed the patched binary on the production host
- restarted `openab.service`
- confirmed the service came back healthy and connected after restart

## Why this approach

For message-based starter threads, Discord uses the starter message id as the thread id. That means the correct recovery path is to reuse the existing thread instead of failing the request.
