### PR TITLE
docs: add Spec-Kit SDD skill and integration guide

### DIFF
--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,0 +1,13 @@
+# Skills
+
+此目錄存放 agent-agnostic 的 Skill 定義檔。
+
+每個 `.md` 檔案定義一個可被 AI agent 執行的工作流程。使用者根據自己的 agent 類型，將檔案複製到對應路徑即可啟用。
+
+各 agent 的安裝方式請參考 [speckit-integration.md](../speckit-integration.md)。
+
+## 目前可用的 Skills
+
+| 檔案 | 用途 |
+|---|---|
+| `speckit-sdd.md` | 使用 GitHub Spec-Kit 進行 Spec-Driven Development |

--- a/docs/skills/speckit-sdd.md
+++ b/docs/skills/speckit-sdd.md
@@ -1,0 +1,114 @@
+---
+name: speckit-sdd
+description: 使用 Spec-Kit 進行 Spec-Driven Development (SDD) 的完整流程。當使用者提到「SDD」、「spec-kit」、「寫規格」、「specify」、「建立 spec」時使用。
+---
+
+# Skill: Spec-Driven Development with Spec-Kit
+
+當使用者要求進行 Spec-Driven Development 時，依照以下流程執行。
+
+## 觸發條件
+
+使用者提到以下意圖時啟動：
+- 「用 spec-kit」、「SDD」、「spec-driven」
+- 「寫規格」、「建立 spec」、「specify」
+- 「/speckit.constitution」、「/speckit.specify」、「/speckit.plan」、「/speckit.tasks」、「/speckit.implement」
+- 「幫我規劃這個功能」、「先寫 spec 再實作」
+
+## 前置確認
+
+1. 確認 `specify` CLI 可用：`specify --version`
+   - 如果不存在，提示使用者安裝：`uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@v0.6.0`
+2. 確認專案是否已初始化 spec-kit：檢查 `.specify/` 目錄是否存在
+   - 不存在 → 進入 Phase 0
+   - 已存在 → 詢問使用者要從哪個 Phase 開始
+
+## 執行流程
+
+### Phase 0：初始化（Init）
+
+只在專案尚未初始化時執行。
+
+```bash
+specify init . --ai <agent>
+```
+
+這會建立 `.specify/` 目錄結構。
+
+### Phase 1：憲法（Constitution）
+
+建立專案的核心原則與開發準則。
+
+1. 詢問使用者專案的核心價值觀，例如：
+   - 程式碼品質標準
+   - 測試要求
+   - 效能要求
+   - 安全性考量
+2. 執行：`specify constitution`（或手動建立 `.specify/constitution.md`）
+3. 向使用者確認產出的原則是否正確
+
+### Phase 2：規格（Specify）
+
+描述要建構的功能。
+
+1. 詢問使用者：「你想要建構什麼？專注在 what 和 why，不用管技術細節。」
+2. 執行：`specify specify "<使用者描述>"`（或手動建立 `.specify/spec.md`）
+3. 產出的 spec 應包含：
+   - 功能描述
+   - 使用者情境
+   - 成功標準
+   - 邊界條件
+4. 向使用者確認 spec 內容
+
+### Phase 3：計畫（Plan）
+
+根據 spec 產生技術實作計畫。
+
+1. 詢問使用者技術偏好：
+   - 使用的框架 / 語言
+   - 架構風格
+   - 任何限制條件
+2. 執行：`specify plan "<技術指引>"`（或手動建立 `.specify/plan.md`）
+3. 產出的 plan 應包含：
+   - 技術架構
+   - 檔案結構
+   - 依賴套件
+   - 實作策略
+4. 向使用者確認 plan 內容
+
+### Phase 4：任務拆解（Tasks）
+
+將 plan 拆成可執行的任務清單。
+
+1. 執行：`specify tasks`（或手動建立 `.specify/tasks.md`）
+2. 每個 task 應該是：
+   - 獨立可完成的
+   - 有明確的完成標準
+   - 按依賴順序排列
+3. 向使用者確認任務清單
+
+### Phase 5：實作（Implement）
+
+逐一執行任務。
+
+1. 執行：`specify implement`（或按照 tasks.md 逐一手動實作）
+2. 每完成一個 task：
+   - 告知使用者進度
+   - 如果遇到問題，暫停並詢問
+3. 全部完成後，摘要所有改動
+
+## 單一 Phase 執行
+
+使用者可以只要求執行特定 phase，例如：
+- 「幫我寫 spec」→ 只跑 Phase 2
+- 「幫我拆 tasks」→ 只跑 Phase 4
+- 「直接實作」→ 只跑 Phase 5（前提是前面的 phase 已完成）
+
+如果前置 phase 的產出不存在（例如要跑 plan 但沒有 spec），先提醒使用者需要先完成前面的步驟。
+
+## 注意事項
+
+- 每個 phase 結束都要跟使用者確認，不要自動跳到下一個
+- spec 和 plan 的內容要存到 `.specify/` 目錄下
+- 如果使用者對產出不滿意，可以重跑該 phase
+- `specify` CLI 不可用時，手動建立對應的 markdown 檔案也可以達到同樣效果

--- a/docs/skills/speckit-sdd.md
+++ b/docs/skills/speckit-sdd.md
@@ -1,6 +1,10 @@
 ---
 name: speckit-sdd
 description: 使用 Spec-Kit 進行 Spec-Driven Development (SDD) 的完整流程。當使用者提到「SDD」、「spec-kit」、「寫規格」、「specify」、「建立 spec」時使用。
+compatibility: >
+  此 frontmatter 使用 YAML 格式，與 Kiro CLI (.kiro/skills/*/SKILL.md) 和
+  Codex (codex-skills/*/SKILL.md) 原生相容。Claude Code (.claude/commands/) 會忽略
+  未知的 frontmatter key。Gemini CLI 需轉為 TOML 格式，參見 docs/speckit-integration.md。
 ---
 
 # Skill: Spec-Driven Development with Spec-Kit

--- a/docs/speckit-integration.md
+++ b/docs/speckit-integration.md
@@ -32,6 +32,8 @@ specify --version
 ```
 
 > 如果希望每次部署都自帶，可以把上述步驟加到 Dockerfile 裡。
+>
+> 上述指令 pin 在 `v0.6.0`，請至 [spec-kit releases](https://github.com/github/spec-kit/releases) 確認最新版本。
 
 ### 2. 安裝 SDD Skill / Command
 
@@ -60,7 +62,31 @@ cp docs/skills/speckit-sdd.md codex-skills/speckit-sdd/SKILL.md
 
 #### Gemini CLI
 
-需要轉成 TOML 格式，或直接將內容貼入 `.gemini/commands/speckit.sdd.toml` 的 `prompt` 欄位。
+```bash
+mkdir -p .gemini/commands
+```
+
+建立 `.gemini/commands/speckit.sdd.toml`：
+
+```toml
+description = "使用 Spec-Kit 進行 Spec-Driven Development (SDD) 的完整流程"
+
+prompt = """
+當使用者要求進行 Spec-Driven Development 時，依照以下流程執行。
+
+觸發條件：使用者提到「SDD」、「spec-kit」、「寫規格」、「specify」等意圖時啟動。
+
+Phase 0: Init        → specify init . --ai gemini（建立 .specify/ 目錄）
+Phase 1: Constitution → specify constitution（建立專案原則）
+Phase 2: Specify      → specify specify "<描述>"（撰寫功能規格）
+Phase 3: Plan         → specify plan "<技術指引>"（產生技術實作計畫）
+Phase 4: Tasks        → specify tasks（拆解為可執行任務）
+Phase 5: Implement    → specify implement（逐一實作任務）
+
+每個 phase 結束都要跟使用者確認，不要自動跳到下一個。
+如果 specify CLI 不可用，手動建立 .specify/ 下的 markdown 檔案也可以。
+"""
+```
 
 ### 3. 初始化 Spec-Kit 專案（可選）
 

--- a/docs/speckit-integration.md
+++ b/docs/speckit-integration.md
@@ -1,0 +1,99 @@
+# Spec-Driven Development (SDD) with OpenAB
+
+透過 [GitHub Spec Kit](https://github.com/github/spec-kit) 在 Discord 上執行 Spec-Driven Development 流程。不需要修改任何 OpenAB 程式碼，只需要設定 Skill / Command 檔案。
+
+## 前置需求
+
+- 一個正在運行的 OpenAB 實例（任何 agent 皆可）
+- Agent 的 working directory 有寫入權限
+
+## 設定步驟
+
+### 1. 安裝 specify CLI（在 Pod 內）
+
+進入 OpenAB 的 Pod：
+
+```bash
+kubectl exec -it <pod-name> -- bash
+```
+
+安裝 `uv` 和 `specify-cli`：
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@v0.6.0
+```
+
+驗證安裝：
+
+```bash
+specify --version
+```
+
+> 如果希望每次部署都自帶，可以把上述步驟加到 Dockerfile 裡。
+
+### 2. 安裝 SDD Skill / Command
+
+SDD 流程定義在 `docs/skills/speckit-sdd.md`。根據你使用的 agent，將它放到對應位置：
+
+#### Kiro CLI
+
+```bash
+mkdir -p .kiro/skills/speckit-sdd
+cp docs/skills/speckit-sdd.md .kiro/skills/speckit-sdd/SKILL.md
+```
+
+#### Claude Code
+
+```bash
+mkdir -p .claude/commands
+cp docs/skills/speckit-sdd.md .claude/commands/speckit-sdd.md
+```
+
+#### Codex
+
+```bash
+mkdir -p codex-skills/speckit-sdd
+cp docs/skills/speckit-sdd.md codex-skills/speckit-sdd/SKILL.md
+```
+
+#### Gemini CLI
+
+需要轉成 TOML 格式，或直接將內容貼入 `.gemini/commands/speckit.sdd.toml` 的 `prompt` 欄位。
+
+### 3. 初始化 Spec-Kit 專案（可選）
+
+在 working directory 下執行：
+
+```bash
+specify init . --ai <agent-name>
+```
+
+這會建立 `.specify/` 目錄結構。也可以跳過這步，讓 agent 在 Discord 對話中自動初始化。
+
+## 使用方式
+
+在 Discord 中 mention bot，用自然語言觸發 SDD 流程：
+
+| 你說的話 | Agent 會做什麼 |
+|---|---|
+| `用 spec-kit 幫我規劃一個 photo app` | 從 Phase 1 開始跑完整 SDD |
+| `幫我寫 spec：一個照片管理工具` | 只跑 specify phase |
+| `幫我拆 tasks` | 只跑 tasks phase |
+| `SDD` | 詢問你要做什麼，然後開始 |
+
+每個 phase 結束後 agent 會暫停確認，不會自動跳到下一步。
+
+## SDD 流程概覽
+
+```
+Phase 0: Init        → specify init（建立 .specify/ 目錄）
+Phase 1: Constitution → 建立專案原則
+Phase 2: Specify      → 撰寫功能規格
+Phase 3: Plan         → 產生技術實作計畫
+Phase 4: Tasks        → 拆解為可執行任務
+Phase 5: Implement    → 逐一實作任務
+```
+
+所有產出存放在 `.specify/` 目錄下，agent 在後續對話中會自動讀取這些檔案作為上下文。


### PR DESCRIPTION
## What

Add documentation and a reusable skill definition for running [Spec-Driven Development (SDD)](https://github.com/github/spec-kit) workflows through OpenAB — no code changes required.

## Files

- `docs/skills/speckit-sdd.md` — Agent-agnostic SDD workflow definition (Phase 0–5: init → constitution → specify → plan → tasks → implement)
- `docs/speckit-integration.md` — Setup guide for new users, with per-agent install instructions (Kiro CLI, Claude Code, Codex, Gemini CLI)

## How it works

Users copy the skill file to their agent's expected path (e.g. `.kiro/skills/`, `.claude/commands/`, `codex-skills/`), and the agent picks it up automatically. No OpenAB code modifications needed — it's purely a docs/skill addition.

## Usage

Once set up, users trigger SDD from Discord with natural language:

```
@bot 用 spec-kit 幫我規劃一個 photo app
@bot 幫我寫 spec
@bot SDD
```

Ref openabdev/openab#184