### PR TITLE
feat: add NetworkPolicy, ServiceAccount & harden .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,12 @@
 config.toml
 *.swp
 .DS_Store
+
+# Secrets — never commit real credentials
+.env
+.env.*
+*.pem
+*.key
+**/secrets/
+kubeconfig
+kubeconfig.*

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -25,6 +25,9 @@ spec:
       labels:
         {{- include "openab.selectorLabels" $d | nindent 8 }}
     spec:
+      {{- if $.Values.serviceAccount.create }}
+      serviceAccountName: {{ include "openab.agentFullname" $d }}
+      {{- end }}
       {{- with $.Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/openab/templates/networkpolicy.yaml
+++ b/charts/openab/templates/networkpolicy.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- range $name, $cfg := .Values.agents }}
+{{- if ne (include "openab.agentEnabled" $cfg) "false" }}
+{{- $d := dict "ctx" $ "agent" $name "cfg" $cfg }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "openab.agentFullname" $d }}
+  labels:
+    {{- include "openab.labels" $d | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openab.selectorLabels" $d | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+    - ports:
+        - port: 53
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openab/templates/serviceaccount.yaml
+++ b/charts/openab/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+{{- range $name, $cfg := .Values.agents }}
+{{- if ne (include "openab.agentEnabled" $cfg) "false" }}
+{{- $d := dict "ctx" $ "agent" $name "cfg" $cfg }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openab.agentFullname" $d }}
+  labels:
+    {{- include "openab.labels" $d | nindent 4 }}
+automountServiceAccountToken: false
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -1,3 +1,9 @@
+networkPolicy:
+  enabled: true
+
+serviceAccount:
+  create: true
+
 image:
   repository: ghcr.io/openabdev/openab
   # tag defaults to .Chart.AppVersion


### PR DESCRIPTION
## What

Add Kubernetes security hardening to the Helm chart:

### NetworkPolicy
- Block **all ingress** — OpenAB is outbound-only (Discord WebSocket), no pod or external traffic should reach it
- Restrict **egress** to only 443/TCP (Discord Gateway/API) and 53/TCP+UDP (DNS)

### ServiceAccount
- Dedicated SA per agent with `automountServiceAccountToken: false`
- Prevents attackers from using K8s API tokens if they gain shell access

### .gitignore
- Add patterns for `.env`, `*.pem`, `*.key`, `secrets/`, `kubeconfig` to prevent accidental credential commits

## Changes
- `charts/openab/templates/networkpolicy.yaml` — new
- `charts/openab/templates/serviceaccount.yaml` — new
- `charts/openab/templates/deployment.yaml` — add `serviceAccountName`
- `charts/openab/values.yaml` — add `networkPolicy.enabled` and `serviceAccount.create` toggles (default: true)
- `.gitignore` — add security-related patterns

## Toggles
Both features are **enabled by default** and can be disabled:
```yaml
networkPolicy:
  enabled: false
serviceAccount:
  create: false
```