### PR TITLE
fix: remove trailing comma in TOML inline table

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
     args = {{ if $cfg.args }}{{ $cfg.args | toJson }}{{ else }}[]{{ end }}
     working_dir = "{{ $cfg.workingDir | default "/home/agent" }}"
     {{- if $cfg.env }}
-    env = { {{ range $k, $v := $cfg.env }}{{ $k }} = "{{ $v }}", {{ end }} }
+    env = { {{ $first := true }}{{ range $k, $v := $cfg.env }}{{ if not $first }}, {{ end }}{{ $k }} = "{{ $v }}"{{ $first = false }}{{ end }} }
     {{- end }}
 
     [pool]


### PR DESCRIPTION
Fixes #195

## Problem

The Go template `range` loop in `configmap.yaml` appends a trailing comma after every key-value pair in the TOML inline table:

```toml
env = { GH_TOKEN = "xxx",  }
```

TOML does not allow trailing commas in inline tables, causing parser errors and pod crash loops.

## Fix

Use a `$first` flag to insert commas only between items, not after the last one.

```diff
- env = { {{ range $k, $v := $cfg.env }}{{ $k }} = "{{ $v }}", {{ end }} }
+ env = { {{ $first := true }}{{ range $k, $v := $cfg.env }}{{ if not $first }}, {{ end }}{{ $k }} = "{{ $v }}"{{ $first = false }}{{ end }} }
```