### PR TITLE
refactor: remove duplicate LazyLock import in src/discord.rs

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -12,7 +12,6 @@ use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, MessageId};
 use serenity::prelude::*;
 use std::collections::HashSet;
-use std::sync::LazyLock;
 use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::{debug, error, info};


### PR DESCRIPTION
- The `std::sync::LazyLock` was imported twice in the same file.
- This change removes the redundant import while keeping the necessary one.