### PR TITLE
fix: align Cargo.toml version to 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openab"
-version = "0.6.0"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openab"
-version = "0.6.0"
+version = "0.6.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Cargo.toml was at 0.6.0 while Chart.yaml is 0.6.3. This caused release-pr.yml to calculate the wrong next version (0.6.1-beta.1 instead of 0.6.4-beta.1).