### PR TITLE
fix: keep Cargo.toml at stable version on main

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -42,7 +42,7 @@ jobs:
           if [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
           else
-            CURRENT=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+            CURRENT=$(grep '^version:' charts/openab/Chart.yaml | awk '{print $2}')
             BASE="${CURRENT%%-*}"
             IFS='.' read -r major minor patch <<< "$BASE"
             case "${{ inputs.bump }}" in
@@ -55,15 +55,19 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "::notice::Release version: ${VERSION}"
 
-      - uses: dtolnay/rust-toolchain@stable
+          # Determine stable version (strip pre-release suffix)
+          STABLE="${VERSION%%-*}"
+          echo "stable=${STABLE}" >> "$GITHUB_OUTPUT"
 
       - name: Update version files
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          sed -i "s/^version = .*/version = \"${VERSION}\"/" Cargo.toml
+          STABLE="${{ steps.version.outputs.stable }}"
+          # Chart.yaml always gets the full version (beta or stable)
           sed -i "s/^version: .*/version: ${VERSION}/" charts/openab/Chart.yaml
           sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" charts/openab/Chart.yaml
-          cargo generate-lockfile
+          # Cargo.toml only gets stable version (main stays clean)
+          sed -i "s/^version = .*/version = \"${STABLE}\"/" Cargo.toml
 
       - name: Create release PR
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openab"
-version = "0.6.4-beta.1"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openab"
-version = "0.6.4-beta.1"
+version = "0.6.4"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
`Cargo.toml` on main should always reflect the stable version, not pre-release suffixes like `-beta.x`.

### Changes
- `Cargo.toml`: `0.6.4-beta.1` → `0.6.4` (stable)
- `release-pr.yml`:
  - Version source changed from `Cargo.toml` to `Chart.yaml`
  - Beta releases only update `Chart.yaml`; `Cargo.toml` only gets the stable version
  - Removed `rust-toolchain` and `cargo generate-lockfile` (no longer needed)