### PR TITLE
docs: add PR review steering guide

### DIFF
--- a/docs/steering/pr-review.md
+++ b/docs/steering/pr-review.md
@@ -6,7 +6,7 @@ When reviewing a PR, always address these four questions:
 
 1. **他解決什麼問題或需求** — 這個 PR 要解決什麼痛點或滿足什麼需求？用白話說明背景。
 2. **他用什麼方式解決** — 具體的技術做法、架構設計、關鍵實作細節。
-3. **他考慮過其他方式嗎** — 從 PR 描述、討論、commit history 中找出被考慮過但沒採用的替代方案，以及為什麼被否決。
+3. **他考慮過其他方式嗎** — PR 描述中是否說明了為什麼選擇這個方式而非其他替代方案？如果沒有，建議作者補充。
 4. **這是目前最好的方式嗎** — 評估現有做法是否最佳，指出可以改進的地方和潛在風險。
 
 ## Severity Levels
@@ -41,12 +41,12 @@ A 4000×2000 landscape image gets squashed into 1200×1200.
 
 ### Fix
 
-​```rust
+```rust
 let ratio = f64::from(IMAGE_MAX_DIMENSION_PX) / f64::max(w, h);
 let new_w = (f64::from(w) * ratio) as u32;
 let new_h = (f64::from(h) * ratio) as u32;
 img.resize(new_w, new_h, image::imageops::FilterType::Lanczos3)
-​```
+```
 ```
 
 ## Self-Review Checklist (before opening PR)
@@ -64,3 +64,13 @@ Authors should check these before requesting review:
 - **Classify severity** — not everything is a blocker; use 🔴🟡🟢 so the author knows what to prioritize
 - **Acknowledge good work** — if something is well done, say so
 - **One round if possible** — batch all feedback in one review pass to avoid back-and-forth
+
+## Output Format — Traffic Light
+
+After the review, structure the output using this format:
+
+🟢 **INFO** — Things that look good, patterns followed correctly, positive observations.
+
+🟡 **NIT** — Minor suggestions, documentation improvements, nice-to-haves. Not blockers.
+
+🔴 **SUGGESTED CHANGES** — Significant concerns, DX footguns, missing pieces that should be addressed. Frame as suggestions for maintainers to consider (we are triagers, not maintainers).

--- a/docs/steering/pr-review.md
+++ b/docs/steering/pr-review.md
@@ -16,7 +16,7 @@ Use emoji + color to classify each review comment:
 | Level | Emoji | Meaning | Action Required |
 |-------|-------|---------|-----------------|
 | 🔴 Critical | `## 🔴 Critical:` | Correctness bug, security issue, data loss risk | Must fix before merge |
-| 🟡 Minor | `## 🟡 Minor:` | Style inconsistency, missing defense-in-depth, non-blocking improvement | Should fix, doesn't block merge |
+| 🟡 Minor | `## 🟡 Minor:` | Style inconsistency, missing defense-in-depth, non-blocking improvement | Should fix, not really a blocker but nice to have |
 | 🟢 Info | `## 🟢 Info:` | Knowledge sharing, future consideration, design tradeoff note | No action needed |
 
 ## Comment Format

--- a/docs/steering/pr-review.md
+++ b/docs/steering/pr-review.md
@@ -1,0 +1,57 @@
+# PR Review Guide for openabdev/openab
+
+## Severity Levels
+
+Use emoji + color to classify each review comment:
+
+| Level | Emoji | Meaning | Action Required |
+|-------|-------|---------|-----------------|
+| 🔴 Critical | `## 🔴 Critical:` | Correctness bug, security issue, data loss risk | Must fix before merge |
+| 🟡 Minor | `## 🟡 Minor:` | Style inconsistency, missing defense-in-depth, non-blocking improvement | Should fix, doesn't block merge |
+| 🟢 Info | `## 🟢 Info:` | Knowledge sharing, future consideration, design tradeoff note | No action needed |
+
+## Comment Format
+
+Each review comment should include:
+
+1. **What's wrong** — describe the issue clearly
+2. **Where** — file path and line number
+3. **Why it matters** — what breaks or what risk it introduces
+4. **Fix** — provide a concrete code suggestion
+
+### Example (from PR #210)
+
+```
+## 🔴 Critical: resize() distorts aspect ratio
+
+**File:** `src/discord.rs`, line ~320
+
+`image::Image::resize(w, h, filter)` resizes the image to the exact
+given dimensions — it does not preserve aspect ratio automatically.
+A 4000×2000 landscape image gets squashed into 1200×1200.
+
+### Fix
+
+​```rust
+let ratio = f64::from(IMAGE_MAX_DIMENSION_PX) / f64::max(w, h);
+let new_w = (f64::from(w) * ratio) as u32;
+let new_h = (f64::from(h) * ratio) as u32;
+img.resize(new_w, new_h, image::imageops::FilterType::Lanczos3)
+​```
+```
+
+## Self-Review Checklist (before opening PR)
+
+Authors should check these before requesting review:
+
+- [ ] **API behavior verified** — read the docs for any new library/function used
+- [ ] **Safety checks preserved** — if refactoring, confirm all original validation/security checks are still present
+- [ ] **Code style consistent** — logging, error handling, naming match the existing codebase
+- [ ] **Tests test the right thing** — assertions reflect actual expected behavior, not just "passes"
+
+## Review Etiquette
+
+- **Be specific** — "this is wrong" is not helpful; show what's wrong and how to fix it
+- **Classify severity** — not everything is a blocker; use 🔴🟡🟢 so the author knows what to prioritize
+- **Acknowledge good work** — if something is well done, say so
+- **One round if possible** — batch all feedback in one review pass to avoid back-and-forth

--- a/docs/steering/pr-review.md
+++ b/docs/steering/pr-review.md
@@ -1,5 +1,14 @@
 # PR Review Guide for openabdev/openab
 
+## Review Framework
+
+When reviewing a PR, always address these four questions:
+
+1. **他解決什麼問題或需求** — 這個 PR 要解決什麼痛點或滿足什麼需求？用白話說明背景。
+2. **他用什麼方式解決** — 具體的技術做法、架構設計、關鍵實作細節。
+3. **他考慮過其他方式嗎** — 從 PR 描述、討論、commit history 中找出被考慮過但沒採用的替代方案，以及為什麼被否決。
+4. **這是目前最好的方式嗎** — 評估現有做法是否最佳，指出可以改進的地方和潛在風險。
+
 ## Severity Levels
 
 Use emoji + color to classify each review comment:

--- a/docs/steering/pr-review.md
+++ b/docs/steering/pr-review.md
@@ -4,10 +4,10 @@
 
 When reviewing a PR, always address these four questions:
 
-1. **他解決什麼問題或需求** — 這個 PR 要解決什麼痛點或滿足什麼需求？用白話說明背景。
-2. **他用什麼方式解決** — 具體的技術做法、架構設計、關鍵實作細節。
-3. **他考慮過其他方式嗎** — PR 描述中是否說明了為什麼選擇這個方式而非其他替代方案？如果沒有，建議作者補充。
-4. **這是目前最好的方式嗎** — 評估現有做法是否最佳，指出可以改進的地方和潛在風險。
+1. **What problem does it solve** — What pain point or requirement does this PR address? Explain the background in plain language.
+2. **How does it solve it** — The specific technical approach, architecture decisions, and key implementation details.
+3. **Were alternatives considered** — Does the PR description explain why this approach was chosen over alternatives? If not, suggest the author clarify.
+4. **Is this the best approach** — Evaluate whether the current approach is optimal. Point out areas for improvement and potential risks.
 
 ## Severity Levels
 


### PR DESCRIPTION
## Background

During PR #210, @the3mi demonstrated an excellent review style using severity levels (🔴🟡🟢) with concrete fix suggestions. This was effective enough that we want to codify it as a team standard.

## What's added

`docs/steering/pr-review.md` — covers:

- **Severity levels**: 🔴 Critical (must fix) / 🟡 Minor (should fix) / 🟢 Info (no action)
- **Comment format**: what's wrong → where → why it matters → fix (with code)
- **Self-review checklist**: API docs checked, safety checks preserved, style consistent, tests correct
- **Review etiquette**: be specific, classify severity, batch feedback in one pass

## Example

Uses the actual aspect ratio bug from PR #210 as the reference example.

Credit to @the3mi for the review format 🦞