### PR TITLE
feat: allow bots to trigger without mention

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,8 +20,6 @@ pub struct DiscordConfig {
     pub allowed_channels: Vec<String>,
     #[serde(default)]
     pub allowed_users: Vec<String>,
-    #[serde(default)]
-    pub monitored_bot_ids: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,8 @@ pub struct DiscordConfig {
     pub allowed_channels: Vec<String>,
     #[serde(default)]
     pub allowed_users: Vec<String>,
+    #[serde(default)]
+    pub allow_bot_trigger: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,10 @@ pub struct DiscordConfig {
     pub allowed_channels: Vec<String>,
     #[serde(default)]
     pub allowed_users: Vec<String>,
+    #[serde(default)]
+    pub monitored_bot_ids: Vec<String>,
+    #[serde(default)]
+    pub auto_respond_from_bots: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,8 +22,6 @@ pub struct DiscordConfig {
     pub allowed_users: Vec<String>,
     #[serde(default)]
     pub monitored_bot_ids: Vec<String>,
-    #[serde(default)]
-    pub auto_respond_from_bots: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -19,11 +19,17 @@ pub struct Handler {
     pub allowed_channels: HashSet<u64>,
     pub allowed_users: HashSet<u64>,
     pub reactions_config: ReactionsConfig,
+    pub allow_bot_trigger: bool,
 }
 
 #[async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
+        // Skip bot messages unless allow_bot_trigger is enabled
+        if msg.author.bot && !self.allow_bot_trigger {
+            return;
+        }
+
         let bot_id = ctx.cache.current_user().id;
 
         let channel_id = msg.channel_id.get();

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -19,20 +19,11 @@ pub struct Handler {
     pub allowed_channels: HashSet<u64>,
     pub allowed_users: HashSet<u64>,
     pub reactions_config: ReactionsConfig,
-    pub monitored_bot_ids: HashSet<u64>,
 }
 
 #[async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
-        // Check if message is from a monitored bot (allows auto-response without mention)
-        let is_monitored_bot = msg.author.bot && self.monitored_bot_ids.contains(&msg.author.id.get());
-
-        // Skip bot messages unless from a monitored bot
-        if msg.author.bot && !is_monitored_bot {
-            return;
-        }
-
         let bot_id = ctx.cache.current_user().id;
 
         let channel_id = msg.channel_id.get();
@@ -68,8 +59,7 @@ impl EventHandler for Handler {
         if !in_allowed_channel && !in_thread {
             return;
         }
-        // Require mention unless in thread or from a monitored bot
-        if !in_thread && !is_mentioned && !is_monitored_bot {
+        if !in_thread && !is_mentioned {
             return;
         }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -19,12 +19,20 @@ pub struct Handler {
     pub allowed_channels: HashSet<u64>,
     pub allowed_users: HashSet<u64>,
     pub reactions_config: ReactionsConfig,
+    pub monitored_bot_ids: HashSet<u64>,
+    pub auto_respond_from_bots: bool,
 }
 
 #[async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
-        if msg.author.bot {
+        // Allow monitored bots to trigger without mention only when feature is enabled
+        let is_monitored_bot = self.auto_respond_from_bots
+            && msg.author.bot
+            && self.monitored_bot_ids.contains(&msg.author.id.get());
+
+        // Skip bot messages unless from a monitored bot (when feature is enabled)
+        if msg.author.bot && !is_monitored_bot {
             return;
         }
 
@@ -63,7 +71,8 @@ impl EventHandler for Handler {
         if !in_allowed_channel && !in_thread {
             return;
         }
-        if !in_thread && !is_mentioned {
+        // Require mention unless in thread or from a monitored bot
+        if !in_thread && !is_mentioned && !is_monitored_bot {
             return;
         }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -20,18 +20,15 @@ pub struct Handler {
     pub allowed_users: HashSet<u64>,
     pub reactions_config: ReactionsConfig,
     pub monitored_bot_ids: HashSet<u64>,
-    pub auto_respond_from_bots: bool,
 }
 
 #[async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
-        // Allow monitored bots to trigger without mention only when feature is enabled
-        let is_monitored_bot = self.auto_respond_from_bots
-            && msg.author.bot
-            && self.monitored_bot_ids.contains(&msg.author.id.get());
+        // Check if message is from a monitored bot (allows auto-response without mention)
+        let is_monitored_bot = msg.author.bot && self.monitored_bot_ids.contains(&msg.author.id.get());
 
-        // Skip bot messages unless from a monitored bot (when feature is enabled)
+        // Skip bot messages unless from a monitored bot
         if msg.author.bot && !is_monitored_bot {
             return;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,13 +40,15 @@ async fn main() -> anyhow::Result<()> {
 
     let allowed_channels = parse_id_set(&cfg.discord.allowed_channels, "allowed_channels")?;
     let allowed_users = parse_id_set(&cfg.discord.allowed_users, "allowed_users")?;
-    info!(channels = allowed_channels.len(), users = allowed_users.len(), "parsed allowlists");
+    let allow_bot_trigger = cfg.discord.allow_bot_trigger;
+    info!(channels = allowed_channels.len(), users = allowed_users.len(), allow_bot_trigger, "parsed allowlists");
 
     let handler = discord::Handler {
         pool: pool.clone(),
         allowed_channels,
         allowed_users,
         reactions_config: cfg.reactions,
+        allow_bot_trigger,
     };
 
     let intents = GatewayIntents::GUILD_MESSAGES

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,15 +40,13 @@ async fn main() -> anyhow::Result<()> {
 
     let allowed_channels = parse_id_set(&cfg.discord.allowed_channels, "allowed_channels")?;
     let allowed_users = parse_id_set(&cfg.discord.allowed_users, "allowed_users")?;
-    let monitored_bot_ids = parse_id_set(&cfg.discord.monitored_bot_ids, "monitored_bot_ids")?;
-    info!(channels = allowed_channels.len(), users = allowed_users.len(), monitored_bots = monitored_bot_ids.len(), "parsed allowlists");
+    info!(channels = allowed_channels.len(), users = allowed_users.len(), "parsed allowlists");
 
     let handler = discord::Handler {
         pool: pool.clone(),
         allowed_channels,
         allowed_users,
         reactions_config: cfg.reactions,
-        monitored_bot_ids,
     };
 
     let intents = GatewayIntents::GUILD_MESSAGES

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,7 @@ async fn main() -> anyhow::Result<()> {
     let allowed_channels = parse_id_set(&cfg.discord.allowed_channels, "allowed_channels")?;
     let allowed_users = parse_id_set(&cfg.discord.allowed_users, "allowed_users")?;
     let monitored_bot_ids = parse_id_set(&cfg.discord.monitored_bot_ids, "monitored_bot_ids")?;
-    let auto_respond_from_bots = cfg.discord.auto_respond_from_bots;
-    info!(channels = allowed_channels.len(), users = allowed_users.len(), monitored_bots = monitored_bot_ids.len(), auto_respond = auto_respond_from_bots, "parsed allowlists");
+    info!(channels = allowed_channels.len(), users = allowed_users.len(), monitored_bots = monitored_bot_ids.len(), "parsed allowlists");
 
     let handler = discord::Handler {
         pool: pool.clone(),
@@ -50,7 +49,6 @@ async fn main() -> anyhow::Result<()> {
         allowed_users,
         reactions_config: cfg.reactions,
         monitored_bot_ids,
-        auto_respond_from_bots,
     };
 
     let intents = GatewayIntents::GUILD_MESSAGES

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,13 +40,17 @@ async fn main() -> anyhow::Result<()> {
 
     let allowed_channels = parse_id_set(&cfg.discord.allowed_channels, "allowed_channels")?;
     let allowed_users = parse_id_set(&cfg.discord.allowed_users, "allowed_users")?;
-    info!(channels = allowed_channels.len(), users = allowed_users.len(), "parsed allowlists");
+    let monitored_bot_ids = parse_id_set(&cfg.discord.monitored_bot_ids, "monitored_bot_ids")?;
+    let auto_respond_from_bots = cfg.discord.auto_respond_from_bots;
+    info!(channels = allowed_channels.len(), users = allowed_users.len(), monitored_bots = monitored_bot_ids.len(), auto_respond = auto_respond_from_bots, "parsed allowlists");
 
     let handler = discord::Handler {
         pool: pool.clone(),
         allowed_channels,
         allowed_users,
         reactions_config: cfg.reactions,
+        monitored_bot_ids,
+        auto_respond_from_bots,
     };
 
     let intents = GatewayIntents::GUILD_MESSAGES


### PR DESCRIPTION
## Summary

Remove bot-skip logic. Any bot message in an allowed channel can now trigger a response without needing a mention.

## Changes

- `src/discord.rs` — remove `if msg.author.bot { return; }` block
- `src/config.rs` — remove unused `monitored_bot_ids` field
- `src/main.rs` — remove `monitored_bot_ids` parsing