### PR TITLE
helm: add first-class STT config to chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A lightweight, secure, cloud-native ACP harness that bridges Discord and any [Ag
 - **Session pool** — one CLI process per thread, auto-managed lifecycle
 - **ACP protocol** — JSON-RPC over stdio with tool call, thinking, and permission auto-reply support
 - **Kubernetes-ready** — Dockerfile + k8s manifests with PVC for auth persistence
+- **Voice message STT** — auto-transcribes Discord voice messages via Groq, OpenAI, or local Whisper server ([docs/stt.md](docs/stt.md))
 
 ## Quick Start
 

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -40,6 +40,14 @@ data:
     [reactions]
     enabled = {{ ($cfg.reactions).enabled | default true }}
     remove_after_reply = {{ ($cfg.reactions).removeAfterReply | default false }}
+    {{- if ($cfg.stt).enabled }}
+
+    [stt]
+    enabled = true
+    api_key = "${STT_API_KEY}"
+    model = "{{ ($cfg.stt).model | default "whisper-large-v3-turbo" }}"
+    base_url = "{{ ($cfg.stt).baseUrl | default "https://api.groq.com/openai/v1" }}"
+    {{- end }}
   {{- if $cfg.agentsMd }}
   AGENTS.md: |
     {{- $cfg.agentsMd | nindent 4 }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -41,6 +41,9 @@ data:
     enabled = {{ ($cfg.reactions).enabled | default true }}
     remove_after_reply = {{ ($cfg.reactions).removeAfterReply | default false }}
     {{- if ($cfg.stt).enabled }}
+    {{- if not ($cfg.stt).apiKey }}
+    {{ fail (printf "agents.%s.stt.apiKey is required when stt.enabled=true" $name) }}
+    {{- end }}
 
     [stt]
     enabled = true

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -45,6 +45,13 @@ spec:
                   name: {{ include "openab.agentFullname" $d }}
                   key: discord-bot-token
             {{- end }}
+            {{- if and ($cfg.stt).enabled ($cfg.stt).apiKey }}
+            - name: STT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $d }}
+                  key: stt-api-key
+            {{- end }}
             - name: HOME
               value: {{ $cfg.workingDir | default "/home/agent" }}
             {{- range $k, $v := $cfg.env }}

--- a/charts/openab/templates/secret.yaml
+++ b/charts/openab/templates/secret.yaml
@@ -14,6 +14,9 @@ metadata:
 type: Opaque
 data:
   discord-bot-token: {{ $cfg.discord.botToken | b64enc | quote }}
+  {{- if and ($cfg.stt).enabled ($cfg.stt).apiKey }}
+  stt-api-key: {{ $cfg.stt.apiKey | b64enc | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -69,6 +69,11 @@ agents:
     reactions:
       enabled: true
       removeAfterReply: false
+    stt:
+      enabled: false
+      apiKey: ""
+      model: "whisper-large-v3-turbo"
+      baseUrl: "https://api.groq.com/openai/v1"
     persistence:
       enabled: true
       storageClass: ""

--- a/docs/stt.md
+++ b/docs/stt.md
@@ -125,6 +125,26 @@ base_url = "http://192.168.1.100:8080/v1"
 
 - **Ollama** — does not expose an `/audio/transcriptions` endpoint.
 
+## Helm Chart (Kubernetes)
+
+When deploying via the openab Helm chart, STT is a first-class config block — no manual configmap patching needed:
+
+```bash
+helm upgrade openab openab/openab \
+  --set agents.kiro.stt.enabled=true \
+  --set agents.kiro.stt.apiKey=gsk_xxx
+```
+
+The API key is stored in a K8s Secret and injected as an env var (never in plaintext in the configmap). You can also customize model and endpoint:
+
+```bash
+helm upgrade openab openab/openab \
+  --set agents.kiro.stt.enabled=true \
+  --set agents.kiro.stt.apiKey=gsk_xxx \
+  --set agents.kiro.stt.model=whisper-large-v3-turbo \
+  --set agents.kiro.stt.baseUrl=https://api.groq.com/openai/v1
+```
+
 ## Disabling STT
 
 Omit the `[stt]` section entirely, or set:


### PR DESCRIPTION
## Summary

Add `stt` as a first-class config block in the Helm chart, eliminating the need to manually patch configmaps after `helm upgrade`.

Closes #227

## Before (manual patching required)

```bash
helm upgrade openab openab/openab --set agents.kiro.env.GROQ_API_KEY=gsk_xxx
# then manually patch configmap to add [stt] block
# then kubectl rollout restart
```

## After (single command)

```bash
helm upgrade openab openab/openab \
  --set agents.kiro.stt.enabled=true \
  --set agents.kiro.stt.apiKey=gsk_xxx
```

## Changes

| File | Change |
|---|---|
| `values.yaml` | Add `stt` defaults (enabled, apiKey, model, baseUrl) |
| `configmap.yaml` | Render `[stt]` section when enabled, using `${STT_API_KEY}` env var |
| `secret.yaml` | Store `apiKey` in K8s Secret (same pattern as `discord.botToken`) |
| `deployment.yaml` | Inject `STT_API_KEY` env var from Secret |

## Design

Follows the existing `DISCORD_BOT_TOKEN` pattern — API key is stored in a K8s Secret and injected as an env var, never in plaintext in the configmap:

```
values.yaml          Secret              Deployment env        ConfigMap
stt.apiKey ────► stt-api-key ────► STT_API_KEY ────► ${STT_API_KEY}
```

All STT fields are optional. When `stt.enabled` is false (default), no STT resources are rendered.