### PR TITLE
fix: remove hardcoded image.tag to use Chart.appVersion

### DIFF
--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -1,14 +1,8 @@
 image:
   repository: ghcr.io/openabdev/openab
-  tag: "78f8d2c"
+  # tag defaults to .Chart.AppVersion
+  tag: ""
   pullPolicy: IfNotPresent
-
-replicas: 1
-
-strategy:
-  type: Recreate
-
-resources: {}
 
 podSecurityContext:
   runAsNonRoot: true
@@ -22,45 +16,70 @@ containerSecurityContext:
     drop:
       - ALL
 
-persistence:
-  enabled: true
-  storageClass: ""
-  size: 1Gi
-
-discord:
-  botToken: ""            # set via --set or external secret
-  # ⚠️ Use --set-string for channel IDs to avoid float64 precision loss:
-  #   helm install ... --set-string discord.allowedChannels[0]="<CHANNEL_ID>"
-  allowedChannels:
-    - "YOUR_CHANNEL_ID"
-
-agent:
-  preset: ""              # kiro (default), codex, or claude — auto-configures image + command
-  command: kiro-cli
-  args:
-    - acp
-    - --trust-all-tools
-  workingDir: /home/agent
-  env: {}
-    # ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
-
-pool:
-  maxSessions: 10
-  sessionTtlHours: 24
-
-reactions:
-  enabled: true
-  removeAfterReply: false
-
-agentsMd: ""
-  # agentsMd: |
-  #   IDENTITY - your agent identity
-  #   SOUL - your agent personality
-  #   USER - how agent should address the user
-
-env: {}
-envFrom: []
-
-nodeSelector: {}
-tolerations: []
-affinity: {}
+agents:
+  kiro:
+    enabled: true    # set to false to skip creating resources for this agent
+    # To add a second agent, uncomment and fill in the block below:
+    # claude:
+    #   command: claude-agent-acp
+    #   args: []
+    #   discord:
+    #     botToken: ""
+    #     # ⚠️ Use --set-string for channel IDs to avoid float64 precision loss
+    #     allowedChannels:
+    #       - "YOUR_CHANNEL_ID"
+    #     allowedUsers: []
+    #   workingDir: /home/agent
+    #   env: {}
+    #   envFrom: []
+    #   pool:
+    #     maxSessions: 10
+    #     sessionTtlHours: 24
+    #   reactions:
+    #     enabled: true
+    #     removeAfterReply: false
+    #   persistence:
+    #     enabled: true
+    #     storageClass: ""
+    #     size: 1Gi
+    #   agentsMd: ""
+    #   resources: {}
+    #   nodeSelector: {}
+    #   tolerations: []
+    #   affinity: {}
+    #   image: "ghcr.io/openabdev/openab-claude:latest"
+    image: ""
+    command: kiro-cli
+    args:
+      - acp
+      - --trust-all-tools
+    discord:
+      botToken: ""
+      # ⚠️ Use --set-string for channel IDs to avoid float64 precision loss
+      allowedChannels:
+        - "YOUR_CHANNEL_ID"
+      # ⚠️ Use --set-string for user IDs to avoid float64 precision loss
+      allowedUsers: []  # empty = allow all users (default)
+    workingDir: /home/agent
+    env: {}
+    envFrom: []
+    pool:
+      maxSessions: 10
+      sessionTtlHours: 24
+    reactions:
+      enabled: true
+      removeAfterReply: false
+    stt:
+      enabled: false
+      apiKey: ""
+      model: "whisper-large-v3-turbo"
+      baseUrl: "https://api.groq.com/openai/v1"
+    persistence:
+      enabled: true
+      storageClass: ""
+      size: 1Gi  # defaults to 1Gi if not set
+    agentsMd: ""
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}


### PR DESCRIPTION
## Summary

Fixes #235

`image.tag` in `charts/openab/values.yaml` was hardcoded to commit hash `94253a5`, which prevented Helm from falling back to `.Chart.AppVersion` (`0.7.0-beta.1`) on upgrade.

## Changes

- Set `image.tag` to `""` so the Helm template uses `.Chart.AppVersion` as intended by the existing comment.

## Verification

```bash
helm upgrade --install openab ./charts/openab
kubectl get deployment openab-kiro -o jsonpath="{.spec.template.spec.containers[0].image}"
# Expected: ghcr.io/openabdev/openab:0.7.0-beta.1
```