### PR TITLE
fix: remove hardcoded image.tag to use Chart.AppVersion

### DIFF
--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/openabdev/openab
-  tag: "78f8d2c"
+  tag: ""
   pullPolicy: IfNotPresent
 
 replicas: 1


### PR DESCRIPTION
## Summary

Remove the hardcoded `image.tag: "78f8d2c"` in `charts/openab/values.yaml` and set it to an empty string so the Helm template falls back to `.Chart.AppVersion`.

## Root Cause

The `image.tag` was hardcoded to a commit hash, which prevented `helm upgrade` from picking up the `appVersion` defined in `Chart.yaml`. This caused deployed pods to run an outdated binary.

## Fix

Set `image.tag` to `""` so the existing template logic (`default .ctx.Chart.AppVersion .ctx.Values.image.tag`) correctly resolves to the chart's `appVersion`.

Closes #235