### PR TITLE
fix: remove hardcoded image.tag to use Chart.AppVersion

### DIFF
--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: ghcr.io/openabdev/openab
   # tag defaults to .Chart.AppVersion
-  tag: "94253a5"
+  tag: ""
   pullPolicy: IfNotPresent
 
 podSecurityContext:


### PR DESCRIPTION
## Summary

Set `image.tag` to an empty string in `charts/openab/values.yaml` so the Helm template falls back to `.Chart.AppVersion`.

## Root Cause

`image.tag` was hardcoded to a commit hash (`94253a5`), which prevented `helm upgrade` from picking up the `appVersion` defined in `Chart.yaml`. Deployed pods ran an outdated binary as a result.

## Fix

```yaml
image:
  tag: ""
```

The existing template logic in `_helpers.tpl`:
```
{{- $tag := default .ctx.Chart.AppVersion .ctx.Values.image.tag }}
```
will now correctly resolve to the chart's `appVersion` (`0.7.0-beta.1`).

Closes #235