### PR TITLE
fix: mount agentsMd at all preset discovery filenames

### DIFF
--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -78,6 +78,12 @@ spec:
             - name: config
               mountPath: {{ $cfg.workingDir | default "/home/agent" }}/AGENTS.md
               subPath: AGENTS.md
+            - name: config
+              mountPath: {{ $cfg.workingDir | default "/home/agent" }}/CLAUDE.md
+              subPath: AGENTS.md
+            - name: config
+              mountPath: {{ $cfg.workingDir | default "/home/agent" }}/GEMINI.md
+              subPath: AGENTS.md
             {{- end }}
       {{- with $cfg.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Summary

`agentsMd` content was mounted only at `AGENTS.md`, which works for the `kiro` and `codex` presets but is silently ignored by `claude` (expects `CLAUDE.md`) and `gemini` (expects `GEMINI.md`).

This PR mounts the same configmap key (`AGENTS.md`) at all three discovery filenames:
- `AGENTS.md` (kiro, codex)
- `CLAUDE.md` (claude)
- `GEMINI.md` (gemini)

No change to the configmap — just additional volumeMount entries in the deployment template.

## Details

Implements **Option 2** from the issue discussion (mount to all three filenames). This is the simplest approach: zero preset-awareness needed in helpers, fully backward compatible, and the slight storage redundancy is negligible since it's the same configmap key.

Fixes #134