### PR TITLE
feat: add allowed_bots_from config for bot-to-bot messaging

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -24,6 +24,12 @@ data:
     {{- end }}
     {{- end }}
     allowed_users = {{ $cfg.discord.allowedUsers | default list | toJson }}
+    {{- range $cfg.discord.allowedBotsFrom }}
+    {{- if regexMatch "e\\+|E\\+" (toString .) }}
+    {{- fail (printf "discord.allowedBotsFrom contains a mangled ID: %s — use --set-string instead of --set for bot IDs" (toString .)) }}
+    {{- end }}
+    {{- end }}
+    allowed_bots_from = {{ $cfg.discord.allowedBotsFrom | default list | toJson }}
 
     [agent]
     command = "{{ $cfg.command }}"

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -60,6 +60,8 @@ agents:
         - "YOUR_CHANNEL_ID"
       # ⚠️ Use --set-string for user IDs to avoid float64 precision loss
       allowedUsers: []  # empty = allow all users (default)
+      # ⚠️ Use --set-string for bot IDs to avoid float64 precision loss
+      allowedBotsFrom: []  # bot user IDs to accept messages from (default: reject all bots)
     workingDir: /home/agent
     env: {}
     envFrom: []

--- a/config.toml.example
+++ b/config.toml.example
@@ -2,6 +2,7 @@
 bot_token = "${DISCORD_BOT_TOKEN}"
 allowed_channels = ["1234567890"]
 # allowed_users = ["<YOUR_DISCORD_USER_ID>"]  # empty or omitted = allow all users
+# allowed_bots_from = ["<DISPATCHER_BOT_ID>"]  # bot user IDs to accept messages from (default: reject all bots)
 
 [agent]
 command = "kiro-cli"

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,10 @@ pub struct DiscordConfig {
     pub allowed_channels: Vec<String>,
     #[serde(default)]
     pub allowed_users: Vec<String>,
+    /// Bot user IDs whose messages should be accepted instead of ignored.
+    /// When empty (default), all bot messages are rejected.
+    #[serde(default)]
+    pub allowed_bots_from: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -31,6 +31,7 @@ pub struct Handler {
     pub pool: Arc<SessionPool>,
     pub allowed_channels: HashSet<u64>,
     pub allowed_users: HashSet<u64>,
+    pub allowed_bots_from: HashSet<u64>,
     pub reactions_config: ReactionsConfig,
     pub stt_config: SttConfig,
 }
@@ -38,11 +39,23 @@ pub struct Handler {
 #[async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
-        if msg.author.bot {
-            return;
-        }
-
         let bot_id = ctx.cache.current_user().id;
+
+        if msg.author.bot {
+            // Never process our own messages (self-loop guard)
+            if msg.author.id == bot_id {
+                return;
+            }
+            // Only accept messages from explicitly allowed bots
+            if !self.allowed_bots_from.contains(&msg.author.id.get()) {
+                return;
+            }
+            debug!(
+                author_id = %msg.author.id,
+                author_name = %msg.author.name,
+                "accepted message from allowed bot"
+            );
+        }
 
         let channel_id = msg.channel_id.get();
         let in_allowed_channel =

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,8 @@ async fn main() -> anyhow::Result<()> {
 
     let allowed_channels = parse_id_set(&cfg.discord.allowed_channels, "allowed_channels")?;
     let allowed_users = parse_id_set(&cfg.discord.allowed_users, "allowed_users")?;
-    info!(channels = allowed_channels.len(), users = allowed_users.len(), "parsed allowlists");
+    let allowed_bots_from = parse_id_set(&cfg.discord.allowed_bots_from, "allowed_bots_from")?;
+    info!(channels = allowed_channels.len(), users = allowed_users.len(), bots = allowed_bots_from.len(), "parsed allowlists");
 
     // Resolve STT config before constructing handler (auto-detect mutates cfg.stt)
     if cfg.stt.enabled {
@@ -63,6 +64,7 @@ async fn main() -> anyhow::Result<()> {
         pool: pool.clone(),
         allowed_channels,
         allowed_users,
+        allowed_bots_from,
         reactions_config: cfg.reactions,
         stt_config: cfg.stt.clone(),
     };


### PR DESCRIPTION
## Summary

- Add `allowed_bots_from` to `[discord]` config: a list of bot user IDs whose messages should be accepted instead of ignored
- Self-loop guard ensures an agent never processes its own messages, even if misconfigured
- Default behavior is unchanged — when the list is empty, all bot messages are rejected (same as today)
- Helm chart updated with `discord.allowedBotsFrom` + ID validation (same pattern as existing `allowedChannels`/`allowedUsers`)

Closes #243

## Details

In multi-agent architectures, a dispatcher bot creates threads and @mentions specific openab worker agents to route tasks. Currently `discord.rs` hard-rejects all bot messages (`msg.author.bot → return`), making this pattern impossible.

The fix introduces a targeted allowlist rather than a blanket "accept all bots" flag:

```toml
[discord]
allowed_bots_from = ["123456789012345678"]
```

Logic in `discord.rs`:

```rust
if msg.author.bot {
    if msg.author.id == bot_id { return; }          // self-loop guard
    if !self.allowed_bots_from.contains(&id) { return; }  // allowlist check
}
```

### Files changed

| File | Change |
|------|--------|
| `src/config.rs` | Add `allowed_bots_from: Vec<String>` to `DiscordConfig` |
| `src/discord.rs` | Replace hard reject with self-loop guard + allowlist check |
| `src/main.rs` | Parse + wire `allowed_bots_from` to Handler |
| `config.toml.example` | Document new option |
| `charts/openab/values.yaml` | Add `discord.allowedBotsFrom` |
| `charts/openab/templates/configmap.yaml` | Template + ID validation |

## Test plan

- [ ] `cargo check` passes ✅ (verified locally)
- [ ] Default config (no `allowed_bots_from`): all bot messages rejected — same as before
- [ ] With `allowed_bots_from = ["<bot_id>"]`: messages from that bot are processed
- [ ] Self-loop: agent's own messages are always rejected regardless of allowlist
- [ ] Helm: `helm template` with `allowedBotsFrom: ["123"]` renders correct TOML