### PR TITLE
fix: role-mention only matches bot's own roles (with guild_create cache)

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -11,6 +11,7 @@ use std::sync::LazyLock;
 use serenity::async_trait;
 use serenity::model::channel::{Message, ReactionType};
 use serenity::model::gateway::Ready;
+use serenity::model::guild::Guild;
 use serenity::model::id::{ChannelId, MessageId};
 use serenity::prelude::*;
 use std::collections::HashSet;
@@ -33,6 +34,10 @@ pub struct Handler {
     pub allowed_users: HashSet<u64>,
     pub reactions_config: ReactionsConfig,
     pub stt_config: SttConfig,
+    /// Cached bot role IDs across all guilds. Populated from `guild_create` events
+    /// (not `ready`, which only has `UnavailableGuild` stubs for larger guilds).
+    /// Discord Role IDs are globally unique, so a flat set is safe.
+    pub bot_role_ids: Arc<tokio::sync::RwLock<HashSet<u64>>>,
 }
 
 #[async_trait]
@@ -48,9 +53,20 @@ impl EventHandler for Handler {
         let in_allowed_channel =
             self.allowed_channels.is_empty() || self.allowed_channels.contains(&channel_id);
 
-        let is_mentioned = msg.mentions_user_id(bot_id)
-            || msg.content.contains(&format!("<@{}>", bot_id))
-            || msg.mention_roles.iter().any(|r| msg.content.contains(&format!("<@&{}>", r)));
+        // Check direct user mention
+        let is_user_mentioned = msg.mentions_user_id(bot_id)
+            || msg.content.contains(&format!("<@{}>", bot_id));
+
+        // Check role mention — only match THIS bot's cached roles, not all roles
+        // in the message (prevents cross-bot triggering in multi-bot guilds).
+        let is_role_mentioned = if !msg.mention_roles.is_empty() {
+            let cached_roles = self.bot_role_ids.read().await;
+            msg.mention_roles.iter().any(|r| cached_roles.contains(&r.get()))
+        } else {
+            false
+        };
+
+        let is_mentioned = is_user_mentioned || is_role_mentioned;
 
         let in_thread = if !in_allowed_channel {
             match msg.channel_id.to_channel(&ctx.http).await {
@@ -237,7 +253,27 @@ impl EventHandler for Handler {
     }
 
     async fn ready(&self, _ctx: Context, ready: Ready) {
-        info!(user = %ready.user.name, "discord bot connected");
+        info!(user = %ready.user.name, guilds = ready.guilds.len(), "discord bot connected");
+        // Role cache is populated by guild_create events (fired after ready),
+        // which have complete guild data even for larger guilds.
+    }
+
+    /// Fired per guild after ready. Guild data is complete here (unlike ready.guilds
+    /// which only has UnavailableGuild stubs for larger guilds).
+    async fn guild_create(&self, ctx: Context, guild: Guild, _is_new: Option<bool>) {
+        let bot_id = ctx.cache.current_user().id;
+        match guild.id.member(&ctx.http, bot_id).await {
+            Ok(member) => {
+                let mut roles = self.bot_role_ids.write().await;
+                for role in &member.roles {
+                    roles.insert(role.get());
+                }
+                info!(guild_id = %guild.id, role_count = member.roles.len(), "cached bot roles from guild_create");
+            }
+            Err(e) => {
+                tracing::warn!(guild_id = %guild.id, error = %e, "failed to cache bot roles in guild_create");
+            }
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ async fn main() -> anyhow::Result<()> {
         allowed_users,
         reactions_config: cfg.reactions,
         stt_config: cfg.stt.clone(),
+        bot_role_ids: Arc::new(tokio::sync::RwLock::new(HashSet::new())),
     };
 
     let intents = GatewayIntents::GUILD_MESSAGES


### PR DESCRIPTION
## Summary

- Fix role-mention detection to only match roles assigned to the receiving bot, preventing cross-triggers in multi-bot guilds
- Cache the bot's own role IDs from `guild_create` events (not `ready`) in a `RwLock<HashSet>` — zero per-message API calls
- Early-exit when `msg.mention_roles` is empty (skip cache read entirely)

Closes #245

## Details

**Bug**: `msg.mention_roles.iter().any(|r| msg.content.contains(...))` triggers on _any_ role mentioned in the message, not just the bot's own roles. In a guild with bots A (role X) and B (role Y), mentioning role Y incorrectly wakes up bot A.

**Fix**: replace string matching with a set intersection against the bot's cached roles:

```rust
let is_role_mentioned = if !msg.mention_roles.is_empty() {
    let cached_roles = self.bot_role_ids.read().await;
    msg.mention_roles.iter().any(|r| cached_roles.contains(&r.get()))
} else {
    false
};
```

**Technical notes**:

1. **Why `guild_create` instead of `ready`?** `ready.guilds` contains `UnavailableGuild` stubs. Guild member data may not be available yet, particularly for larger guilds, causing `.member()` lookups to 404. `guild_create` fires per guild after `ready` with complete data.

2. **Global `HashSet` vs per-guild `HashMap`**: We use a flat `HashSet<u64>` for the cache. Discord Role IDs are globally unique and `msg.mention_roles` only contains roles valid for the current guild, so a flat cache is safe and keeps lookups simple.

3. **Known limitation**: If a role is added to the bot while it is running, it won't be recognized until restart. A `guild_member_update` handler could keep the cache hot if dynamic role assignment becomes a requested feature.

### Files changed

| File | Change |
|------|--------|
| `src/discord.rs` | Add `bot_role_ids: Arc<RwLock<HashSet<u64>>>` to Handler; replace string-match with cache lookup; add `guild_create` handler to populate cache |
| `src/main.rs` | Initialize empty `bot_role_ids` cache |

## Test plan

- [ ] `cargo check` passes ✅ (verified locally)
- [ ] Single-bot guild: role mention still triggers the bot
- [ ] Multi-bot guild: role-mentioning bot A's role does NOT trigger bot B
- [ ] Bot has no guild roles: role mention does not trigger the bot
- [ ] Large guild: role cache populates correctly via `guild_create`
- [ ] No role mentions in message: early-exit, no cache read