### PR TITLE
build(docker): update codex-acp to 0.11.1 and add runtime utilities

### DIFF
--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -8,10 +8,10 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
-RUN npm install -g @zed-industries/codex-acp@0.9.5 @openai/codex --retry 3
+RUN npm install -g @zed-industries/codex-acp@0.11.1 @openai/codex --retry 3
 
 # Install gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
- Upgrade @zed-industries/codex-acp from 0.9.5 to 0.11.1.
- Install procps and ripgrep in the runtime stage to support improved process monitoring (health check) and search capabilities (rg) within the container.