### PR TITLE
fix(discord): react 🎤 on voice messages when STT is disabled

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -16,7 +16,7 @@ use serenity::prelude::*;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::watch;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Hard cap on consecutive bot messages (from any other bot) in a
 /// channel or thread. When this many recent messages are all from
@@ -205,6 +205,7 @@ impl EventHandler for Handler {
         });
 
         // Process attachments: route by content type (audio → STT, image → encode)
+        let mut audio_skipped = false;
         if !msg.attachments.is_empty() {
             for attachment in &msg.attachments {
                 if is_audio_attachment(attachment) {
@@ -216,12 +217,22 @@ impl EventHandler for Handler {
                             });
                         }
                     } else {
-                        debug!(filename = %attachment.filename, "skipping audio attachment (STT disabled)");
+                        warn!(filename = %attachment.filename, "skipping audio attachment (STT disabled)");
+                        audio_skipped = true;
                     }
                 } else if let Some(content_block) = download_and_encode_image(attachment).await {
                     debug!(url = %attachment.url, filename = %attachment.filename, "adding image attachment");
                     content_blocks.push(content_block);
                 }
+            }
+        }
+
+        // If audio was skipped, react with 🎤 so the user knows their voice message was noticed
+        if audio_skipped {
+            let _ = msg.react(&ctx.http, ReactionType::Unicode("🎤".into())).await;
+            // Voice-only message: no text and only the sender_context block → early return
+            if prompt.is_empty() && content_blocks.len() == 1 {
+                return;
             }
         }
 


### PR DESCRIPTION
## Summary

When STT is not configured, voice messages were silently dropped — no reaction, no reply. Users thought the bot was broken.

Closes #251

## Changes

| File | Change | Lines |
|---|---|---|
| `src/discord.rs` | Add `warn` import, track `audio_skipped`, react 🎤, early return | +13, -2 |

## What it does

1. **Track skipped audio** — `audio_skipped` bool set when an audio attachment is encountered with STT disabled
2. **Upgrade log level** — `debug!()` → `warn!()` so operators see it in production logs
3. **React 🎤** — on the original message, consistent with existing 🚫 pattern for denied users
4. **Early return for voice-only** — if `prompt.is_empty()` and only the sender_context block exists in `content_blocks`, bail out instead of sending an empty prompt to the agent
5. **Mixed messages still work** — text + voice → process text, react 🎤 to signal audio was ignored

## Behavior matrix

| Message type | STT enabled | STT disabled (after this PR) |
|---|---|---|
| Voice only | Transcribe → process | React 🎤 → early return ✅ |
| Voice + text | Transcribe → process all | React 🎤 → process text only ✅ |
| Voice + image | Transcribe → process all | React 🎤 → process image only ✅ |
| Text only | Process | Process (unchanged) |

## Related

- #224 — feat: support voice message STT (design issue)
- PR #225 — feat: support voice message STT (implementation, merged)
- #251 — this bug report