### PR TITLE
feat: add OpenCode as ACP agent backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
           - { suffix: "-claude", dockerfile: "Dockerfile.claude", artifact: "claude" }
           - { suffix: "-gemini", dockerfile: "Dockerfile.gemini", artifact: "gemini" }
           - { suffix: "-copilot", dockerfile: "Dockerfile.copilot", artifact: "copilot" }
+          - { suffix: "-opencode", dockerfile: "Dockerfile.opencode", artifact: "opencode" }
         platform:
           - { os: linux/amd64, runner: ubuntu-latest }
           - { os: linux/arm64, runner: ubuntu-24.04-arm }
@@ -131,6 +132,7 @@ jobs:
           - { suffix: "-claude", artifact: "claude" }
           - { suffix: "-gemini", artifact: "gemini" }
           - { suffix: "-copilot", artifact: "copilot" }
+          - { suffix: "-opencode", artifact: "opencode" }
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -179,6 +181,7 @@ jobs:
           - { suffix: "-claude" }
           - { suffix: "-gemini" }
           - { suffix: "-copilot" }
+          - { suffix: "-opencode" }
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -18,6 +18,7 @@ jobs:
           - { dockerfile: Dockerfile.codex, suffix: "-codex", agent: "codex-acp", agent_args: "" }
           - { dockerfile: Dockerfile.gemini, suffix: "-gemini", agent: "gemini", agent_args: "--acp" }
           - { dockerfile: Dockerfile.copilot, suffix: "-copilot", agent: "copilot", agent_args: "--acp" }
+          - { dockerfile: Dockerfile.opencode, suffix: "-opencode", agent: "opencode", agent_args: "acp" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -1,0 +1,48 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+# node:22-bookworm-slim mirrors the base image used by Dockerfile.claude,
+# Dockerfile.codex, and Dockerfile.gemini, keeping the project on a single
+# consistent runtime base.
+#
+# opencode is published to npm as `opencode-ai`; the npm package is a thin
+# postinstall wrapper (~9 KB) that downloads the same pre-compiled binary
+# used by the official install script, so `npm install -g` and
+# `curl | bash` are equivalent in the end result.
+#
+# Version is pinned for reproducible builds.
+# opencode releases very frequently (often daily); bump this version via
+# a dedicated PR when a new release is needed.
+#
+# Note: opencode does not publish SHA256 checksums for its releases,
+# so checksum verification is not possible at this time.
+FROM node:22-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+
+# Install opencode
+RUN npm install -g opencode-ai@1.4.3 --retry 3
+
+# Install gh CLI (matches Dockerfile.claude / Dockerfile.gemini / Dockerfile.codex)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/node
+WORKDIR /home/node
+
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENTRYPOINT ["openab"]
+CMD ["/etc/openab/config.toml"]

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -45,4 +45,4 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["openab"]
-CMD ["/etc/openab/config.toml"]
+CMD ["run", "/etc/openab/config.toml"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenAB — Open Agent Broker
 
-A lightweight, secure, cloud-native ACP harness that bridges Discord and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, Copilot CLI, etc.) over stdio JSON-RPC — delivering the next-generation development experience.
+A lightweight, secure, cloud-native ACP harness that bridges Discord and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, etc.) over stdio JSON-RPC — delivering the next-generation development experience.
 
 🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://discord.gg/YNksK9M6)** 🎉
 
@@ -17,7 +17,7 @@ A lightweight, secure, cloud-native ACP harness that bridges Discord and any [Ag
 
 ## Features
 
-- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, Copilot CLI via config
+- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI via config
 - **@mention trigger** — mention the bot in an allowed channel to start a conversation
 - **Thread-based multi-turn** — auto-creates threads; no @mention needed for follow-ups
 - **Edit-streaming** — live-updates the Discord message every 1.5s as tokens arrive
@@ -68,6 +68,7 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 | Claude Code | `claude-agent-acp` | [@agentclientprotocol/claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp) | [docs/claude-code.md](docs/claude-code.md) |
 | Codex | `codex-acp` | [@zed-industries/codex-acp](https://github.com/zed-industries/codex-acp) | [docs/codex.md](docs/codex.md) |
 | Gemini | `gemini --acp` | Native | [docs/gemini.md](docs/gemini.md) |
+| OpenCode | `opencode acp` | Native | [docs/opencode.md](docs/opencode.md) |
 | Copilot CLI ⚠️ | `copilot --acp --stdio` | Native | [docs/copilot.md](docs/copilot.md) |
 
 > 🔧 Running multiple agents? See [docs/multi-agent.md](docs/multi-agent.md)

--- a/charts/openab/Chart.yaml
+++ b/charts/openab/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openab
-description: Discord ↔ ACP coding CLI bridge (Kiro CLI, Claude Code, Codex, Gemini)
+description: A lightweight, secure, cloud-native ACP harness that bridges Discord and any ACP-compatible coding CLI.
 type: application
 version: 0.7.5
 appVersion: "0.7.5"

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -53,6 +53,33 @@ agents:
     #   tolerations: []
     #   affinity: {}
     #   image: "ghcr.io/openabdev/openab-claude:latest"
+    # opencode:
+    #   command: opencode
+    #   args:
+    #     - acp
+    #   discord:
+    #     botToken: ""
+    #     allowedChannels:
+    #       - "YOUR_CHANNEL_ID"
+    #     allowedUsers: []
+    #     allowBotMessages: "off"
+    #     trustedBotIds: []
+    #   workingDir: /home/node
+    #   env: {}
+    #   envFrom: []
+    #   pool:
+    #     maxSessions: 10
+    #     sessionTtlHours: 24
+    #   reactions:
+    #     enabled: true
+    #     removeAfterReply: false
+    #   persistence:
+    #     enabled: true
+    #     storageClass: ""
+    #     size: 1Gi
+    #   agentsMd: ""
+    #   resources: {}
+    #   image: "ghcr.io/openabdev/openab-opencode:latest"
     image: ""
     command: kiro-cli
     args:

--- a/config.toml.example
+++ b/config.toml.example
@@ -35,6 +35,15 @@ working_dir = "/home/agent"
 # working_dir = "/home/agent"
 # env = {}  # Auth via: kubectl exec -it <pod> -- gh auth login -p https -w
 
+# [agent]
+# command = "opencode"
+# args = ["acp"]
+# working_dir = "/home/node"
+# # Note: opencode handles tool authorization internally and never emits
+# # session/request_permission — all tools run without user confirmation,
+# # equivalent to --trust-all-tools on other backends.
+# # Run `opencode auth login` once before starting openab.
+
 [pool]
 max_sessions = 10
 session_ttl_hours = 24

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -1,0 +1,52 @@
+# OpenCode
+
+OpenCode supports ACP natively via the `acp` subcommand — no adapter needed.
+
+## Docker Image
+
+```bash
+docker build -f Dockerfile.opencode -t openab-opencode:latest .
+```
+
+The image installs `opencode-ai` globally via npm on `node:22-bookworm-slim`.
+
+## Helm Install
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.opencode.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.opencode.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.opencode.image=ghcr.io/openabdev/openab-opencode:latest \
+  --set agents.opencode.command=opencode \
+  --set 'agents.opencode.args={acp}' \
+  --set agents.opencode.workingDir=/home/node
+```
+
+> Set `agents.kiro.enabled=false` to disable the default Kiro agent.
+
+## Manual config.toml
+
+```toml
+[agent]
+command = "opencode"
+args = ["acp"]
+working_dir = "/home/node"
+```
+
+## Authentication
+
+```bash
+kubectl exec -it deployment/openab-opencode -- opencode auth login
+```
+
+Follow the browser OAuth flow, then restart the pod:
+
+```bash
+kubectl rollout restart deployment/openab-opencode
+```
+
+## Notes
+
+- **Tool authorization**: OpenCode handles tool authorization internally and never emits `session/request_permission` — all tools run without user confirmation, equivalent to `--trust-all-tools` on other backends.
+- **Frequent releases**: OpenCode releases very frequently (often daily). The pinned version in `Dockerfile.opencode` should be bumped via a dedicated PR when an update is needed.


### PR DESCRIPTION
## Summary

Add [OpenCode](https://opencode.ai) as a first-class ACP agent backend alongside Kiro CLI, Claude Code, Codex, and Gemini.

OpenCode ships native ACP support via `opencode acp` — pure stdio JSON-RPC, zero adapter layer required. Integration is **configuration-only**: no changes to `src/`.

```
Discord mention
      │
      ▼
openab (Rust)
      │  spawn("opencode", ["acp"])
      ▼
opencode acp                        ← native ACP, stdio JSON-RPC
      │
      ├─ initialize                 → agentInfo: { name: "OpenCode", version: "1.4.3" }
      ├─ session/new                → sessionId
      └─ session/prompt             → session/update stream → stopReason: end_turn
```

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1493098567445778605

## Changes

| File | Change | Description |
|---|---|---|
| `config.toml.example` | MOD | Add commented `opencode` `[agent]` block |
| `Dockerfile.opencode` | NEW | Multi-stage build: installs opencode via npm on node:22-bookworm-slim |
| `README.md` | MOD | Add opencode to description, features list, and backend table |
| `docs/opencode.md` | NEW | Per-agent guide: Docker, Helm, Manual config, Authentication, Notes |

No changes to `src/acp/` — the existing ACP implementation is fully compatible as-is.

## Protocol compatibility — what we verified

OpenCode's ACP implementation has two strict requirements that differ from other backends. Both are already handled correctly by the existing `connection.rs`:

**1. `protocolVersion` must be integer `1`, not string `"2024-11-05"`**

Sending the string form returns:
```
{"error": {"code": -32602, "message": "Invalid params",
  "data": {"protocolVersion": {"_errors": ["Invalid input: expected number, received string"]}}}}
```
`connection.rs` line 210 already sends `"protocolVersion": 1` (integer). ✅

**2. `session/new` requires a `cwd` field**

Omitting `cwd` returns:
```
{"error": {"code": -32602, "message": "Invalid params",
  "data": {"cwd": {"_errors": ["Invalid input: expected string, received undefined"]}}}}
```
`connection.rs` line 230 already sends `"cwd": cwd`. ✅

**3. `session/request_permission` is never emitted**

OpenCode handles tool authorization internally. The existing auto-reply logic in `connection.rs` is not triggered and has no side effects — tools run without any user confirmation prompt, equivalent to `--trust-all-tools` on other backends.

Full verified exchange against opencode v1.4.3:
```
→ initialize  { protocolVersion: 1, clientInfo: { name: "openab", version: "0.1.0" } }
← { agentInfo: { name: "OpenCode", version: "1.4.3" }, protocolVersion: 1,
    agentCapabilities: { loadSession: true, mcpCapabilities: { http: true, sse: true }, ... } }

→ session/new  { cwd: "/root", mcpServers: [] }
← { sessionId: "ses_27de700e2ffePDjkWSR2DR2jV5" }

→ session/prompt  { sessionId, prompt: [{ type: "text", text: "..." }] }
← session/update  { type: "agent_message_chunk", ... }
← session/update  { type: "agent_thought_chunk", ... }
← session/update  { type: "usage_update", ... }
← stopReason: "end_turn"
```

## Live test

Tested end-to-end on openab **v0.7.1** + opencode **v1.4.3** via Discord:

```
[INFO] spawning agent  cmd="opencode" args=["acp"] cwd="/root"
[INFO] initialized     agent="OpenCode"
[INFO] session created session_id=ses_27de700e2ffePDjkWSR2DR2jV5
```

Multi-turn conversations stable. Streaming reactions (👀→🤔→🔥→🆗) functioning correctly.

## Auth

Run once in the deployment environment before starting openab:

```bash
opencode auth login
```

OpenCode supports 75+ providers (Anthropic, OpenAI, OpenRouter, GitHub Copilot, local models, etc.) — whichever is configured in `~/.config/opencode/opencode.json` is used at runtime. No env var required by openab.