### PR TITLE
feat: track context window usage 

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,67 @@
+# GitHub Copilot Code Review Instructions
+
+## Review Philosophy
+- Only comment when you have HIGH CONFIDENCE (>80%) that an issue exists
+- Be concise: one sentence per comment when possible
+- Focus on actionable feedback, not observations
+- Silence is preferred over noisy false positives
+
+## Project Context
+- **OpenAB**: A lightweight ACP (Agent Client Protocol) harness bridging Discord ↔ any ACP-compatible coding CLI over stdio JSON-RPC
+- **Language**: Rust 2021 edition, single binary
+- **Async runtime**: tokio (full features)
+- **Discord**: serenity 0.12 (gateway + cache)
+- **Error handling**: `anyhow::Result` everywhere, no `unwrap()` in production paths
+- **Serialization**: serde + serde_json for ACP JSON-RPC, toml for config
+- **Key modules**: `acp/connection.rs` (ACP stdio bridge), `acp/pool.rs` (session pool), `discord.rs` (Discord event handler), `config.rs` (TOML config), `usage.rs` (pluggable quota runners), `reactions.rs` (emoji reactions), `stt.rs` (speech-to-text)
+
+## Priority Areas (Review These)
+
+### Correctness
+- Logic errors that could cause panics or incorrect behavior
+- ACP JSON-RPC protocol violations (wrong method names, missing fields, incorrect response routing)
+- Race conditions in async code (especially in the reader loop and session pool)
+- Resource leaks (child processes not killed, channels not closed)
+- Off-by-one in timeout calculations
+- Incorrect error propagation — `unwrap()` in non-test code is always a bug
+
+### Concurrency & Safety
+- Multiple atomic fields updated independently — document if readers may see mixed snapshots
+- `Mutex` held across `.await` points (potential deadlock)
+- Session pool lock scope — `RwLock` held during I/O can stall all sessions
+- Child process lifecycle — `kill_on_drop` must be set, zombie processes must not accumulate
+
+### ACP Protocol
+- `session/request_permission` must always get a response (auto-allow or forwarded)
+- `session/update` notifications must not be consumed — forward to subscriber after capture
+- `usage_update`, `available_commands_update`, `tool_call`, `agent_message_chunk` must be classified correctly
+- Timeout values: initialize=90s, session/new=120s, others=30s (Gemini cold-start is slow)
+
+### Discord API
+- Messages >2000 chars will be rejected — truncate or split
+- Slash command registration is per-guild, max 100 per bot
+- Autocomplete responses must return within 3s (no heavy I/O)
+- Ephemeral messages for errors, regular messages for results
+
+### Config & Deployment
+- `config.toml` fields must have sensible defaults — missing `[usage]` section should not crash
+- Environment variable expansion via `${VAR}` must handle missing vars gracefully
+- Agent `env` map is passed to child processes — sensitive values should not be logged
+
+## CI Pipeline (Do Not Flag These)
+- `cargo fmt --check` — formatting is enforced by CI
+- `cargo clippy --all-targets -- -D warnings` — lint warnings are enforced by CI
+- `cargo test` — test failures are caught by CI
+
+## Skip These (Low Value)
+- Style/formatting — CI handles via rustfmt
+- Clippy warnings — CI handles
+- Minor naming suggestions unless truly confusing
+- Suggestions to add comments for self-documenting code
+- Logging level suggestions unless security-relevant
+- Import ordering
+
+## Response Format
+1. State the problem (1 sentence)
+2. Why it matters (1 sentence, only if not obvious)
+3. Suggested fix (code snippet or specific action)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,7 @@
 - `session/request_permission` must always get a response (auto-allow or forwarded)
 - `session/update` notifications must not be consumed — forward to subscriber after capture
 - `usage_update`, `available_commands_update`, `tool_call`, `agent_message_chunk` must be classified correctly
-- Timeout values: initialize=90s, session/new=120s, others=30s (Gemini cold-start is slow)
+- Timeout values: session/new=120s, all other methods (including initialize)=30s
 
 ### Discord API
 - Messages >2000 chars will be rejected — truncate or split

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -53,6 +53,7 @@ pub struct AcpConnection {
     pub last_active: Instant,
     pub session_reset: bool,
     /// Context window usage from the latest `usage_update` ACP notification.
+    /// A value of 0 means no `usage_update` has been received yet (unknown).
     pub context_used: Arc<std::sync::atomic::AtomicU64>,
     pub context_size: Arc<std::sync::atomic::AtomicU64>,
     _reader_handle: JoinHandle<()>,

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -142,12 +142,15 @@ impl AcpConnection {
                             .and_then(|p| p.get("update"))
                         {
                             if upd.get("sessionUpdate").and_then(|v| v.as_str()) == Some("usage_update") {
-                                if let Some(used) = upd.get("used").and_then(|v| v.as_u64()) {
-                                    ctx_used.store(used, Ordering::Relaxed);
-                                }
-                                if let Some(size) = upd.get("size").and_then(|v| v.as_u64()) {
-                                    ctx_size.store(size, Ordering::Relaxed);
-                                }
+                                let used = upd.get("used")
+                                    .and_then(|v| v.as_u64())
+                                    .unwrap_or(0);
+                                ctx_used.store(used, Ordering::Relaxed);
+
+                                let size = upd.get("size")
+                                    .and_then(|v| v.as_u64())
+                                    .unwrap_or(0);
+                                ctx_size.store(size, Ordering::Relaxed);
                             }
                         }
                     }

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -150,8 +150,10 @@ impl AcpConnection {
                     if let Some(crate::acp::protocol::AcpEvent::UsageUpdate { used, size }) =
                         crate::acp::protocol::classify_notification(&msg)
                     {
-                        ctx_used.store(used, Ordering::Relaxed);
+                        // Store size before used so readers that check
+                        // `context_size == 0` as "no data yet" see size first.
                         ctx_size.store(size, Ordering::Relaxed);
+                        ctx_used.store(used, Ordering::Relaxed);
                     }
 
                     // Response (has id) → resolve pending AND forward to subscriber

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -52,6 +52,9 @@ pub struct AcpConnection {
     pub acp_session_id: Option<String>,
     pub last_active: Instant,
     pub session_reset: bool,
+    /// Context window usage from the latest `usage_update` ACP notification.
+    pub context_used: Arc<std::sync::atomic::AtomicU64>,
+    pub context_size: Arc<std::sync::atomic::AtomicU64>,
     _reader_handle: JoinHandle<()>,
 }
 
@@ -86,11 +89,15 @@ impl AcpConnection {
             Arc::new(Mutex::new(HashMap::new()));
         let notify_tx: Arc<Mutex<Option<mpsc::UnboundedSender<JsonRpcMessage>>>> =
             Arc::new(Mutex::new(None));
+        let context_used = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let context_size = Arc::new(std::sync::atomic::AtomicU64::new(0));
 
         let reader_handle = {
             let pending = pending.clone();
             let notify_tx = notify_tx.clone();
             let stdin_clone = stdin.clone();
+            let ctx_used = context_used.clone();
+            let ctx_size = context_size.clone();
             tokio::spawn(async move {
                 let mut reader = BufReader::new(stdout);
                 let mut line = String::new();
@@ -127,6 +134,22 @@ impl AcpConnection {
                             }
                         }
                         continue;
+                    }
+
+                    // Capture usage_update for context window tracking
+                    if msg.method.as_deref() == Some("session/update") {
+                        if let Some(upd) = msg.params.as_ref()
+                            .and_then(|p| p.get("update"))
+                        {
+                            if upd.get("sessionUpdate").and_then(|v| v.as_str()) == Some("usage_update") {
+                                if let Some(used) = upd.get("used").and_then(|v| v.as_u64()) {
+                                    ctx_used.store(used, Ordering::Relaxed);
+                                }
+                                if let Some(size) = upd.get("size").and_then(|v| v.as_u64()) {
+                                    ctx_size.store(size, Ordering::Relaxed);
+                                }
+                            }
+                        }
                     }
 
                     // Response (has id) → resolve pending AND forward to subscriber
@@ -186,6 +209,8 @@ impl AcpConnection {
             acp_session_id: None,
             last_active: Instant::now(),
             session_reset: false,
+            context_used,
+            context_size,
             _reader_handle: reader_handle,
         })
     }

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -55,6 +55,11 @@ pub struct AcpConnection {
     /// Context window usage from the latest `usage_update` ACP notification.
     /// `context_used` may legitimately be 0 (e.g., new or empty context).
     /// Treat `context_size == 0` as meaning no `usage_update` has been received yet.
+    ///
+    /// **Consistency note:** These two fields are updated via separate relaxed
+    /// atomic stores, so readers may observe a mixed snapshot (e.g., new `used`
+    /// with old `size`). This is acceptable for best-effort display purposes;
+    /// any consumer requiring a consistent pair should use the snapshot helper.
     pub context_used: Arc<std::sync::atomic::AtomicU64>,
     pub context_size: Arc<std::sync::atomic::AtomicU64>,
     _reader_handle: JoinHandle<()>,

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -57,9 +57,10 @@ pub struct AcpConnection {
     /// Treat `context_size == 0` as meaning no `usage_update` has been received yet.
     ///
     /// **Consistency note:** These two fields are updated via separate relaxed
-    /// atomic stores, so readers may observe a mixed snapshot (e.g., new `used`
-    /// with old `size`). This is acceptable for best-effort display purposes;
-    /// any consumer requiring a consistent pair should use the snapshot helper.
+    /// atomic stores, so readers may observe a mixed pair (e.g., new `used`
+    /// with old `size`). This is acceptable for best-effort display purposes.
+    /// Code that requires a coordinated view of both values must use additional
+    /// synchronization instead of reading these atomics independently.
     pub context_used: Arc<std::sync::atomic::AtomicU64>,
     pub context_size: Arc<std::sync::atomic::AtomicU64>,
     _reader_handle: JoinHandle<()>,

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -136,23 +136,14 @@ impl AcpConnection {
                         continue;
                     }
 
-                    // Capture usage_update for context window tracking
-                    if msg.method.as_deref() == Some("session/update") {
-                        if let Some(upd) = msg.params.as_ref()
-                            .and_then(|p| p.get("update"))
-                        {
-                            if upd.get("sessionUpdate").and_then(|v| v.as_str()) == Some("usage_update") {
-                                let used = upd.get("used")
-                                    .and_then(|v| v.as_u64())
-                                    .unwrap_or(0);
-                                ctx_used.store(used, Ordering::Relaxed);
-
-                                let size = upd.get("size")
-                                    .and_then(|v| v.as_u64())
-                                    .unwrap_or(0);
-                                ctx_size.store(size, Ordering::Relaxed);
-                            }
-                        }
+                    // Capture usage_update for context window tracking.
+                    // Reuses the shared classify_notification parser so the
+                    // logic stays in one place (protocol.rs).
+                    if let Some(crate::acp::protocol::AcpEvent::UsageUpdate { used, size }) =
+                        crate::acp::protocol::classify_notification(&msg)
+                    {
+                        ctx_used.store(used, Ordering::Relaxed);
+                        ctx_size.store(size, Ordering::Relaxed);
                     }
 
                     // Response (has id) → resolve pending AND forward to subscriber

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -53,7 +53,8 @@ pub struct AcpConnection {
     pub last_active: Instant,
     pub session_reset: bool,
     /// Context window usage from the latest `usage_update` ACP notification.
-    /// A value of 0 means no `usage_update` has been received yet (unknown).
+    /// `context_used` may legitimately be 0 (e.g., new or empty context).
+    /// Treat `context_size == 0` as meaning no `usage_update` has been received yet.
     pub context_used: Arc<std::sync::atomic::AtomicU64>,
     pub context_size: Arc<std::sync::atomic::AtomicU64>,
     _reader_handle: JoinHandle<()>,

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -107,8 +107,8 @@ pub fn classify_notification(msg: &JsonRpcMessage) -> Option<AcpEvent> {
         }
         "plan" => Some(AcpEvent::Status),
         "usage_update" => {
-            let used = update.get("used").and_then(|v| v.as_u64()).unwrap_or(0);
-            let size = update.get("size").and_then(|v| v.as_u64()).unwrap_or(0);
+            let used = update.get("used").and_then(|v| v.as_u64())?;
+            let size = update.get("size").and_then(|v| v.as_u64())?;
             Some(AcpEvent::UsageUpdate { used, size })
         }
         _ => None,

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -63,6 +63,7 @@ pub enum AcpEvent {
     ToolStart { id: String, title: String },
     ToolDone { id: String, title: String, status: String },
     Status,
+    UsageUpdate { used: u64, size: u64 },
 }
 
 pub fn classify_notification(msg: &JsonRpcMessage) -> Option<AcpEvent> {
@@ -105,6 +106,11 @@ pub fn classify_notification(msg: &JsonRpcMessage) -> Option<AcpEvent> {
             }
         }
         "plan" => Some(AcpEvent::Status),
+        "usage_update" => {
+            let used = update.get("used").and_then(|v| v.as_u64()).unwrap_or(0);
+            let size = update.get("size").and_then(|v| v.as_u64()).unwrap_or(0);
+            Some(AcpEvent::UsageUpdate { used, size })
+        }
         _ => None,
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -641,7 +641,7 @@ fn format_context_footer(ctx_used: u64, ctx_size: u64) -> Option<String> {
         return None;
     }
     let pct = ((ctx_used as u128 * 100 + ctx_size as u128 / 2) / ctx_size as u128).min(100) as u64;
-    Some(format!("-# 📊 {ctx_used}/{ctx_size} tokens ({pct}%)"))
+    Some(format!("-# 📊 Context: {ctx_used}/{ctx_size} tokens ({pct}%)"))
 }
 
 /// Flatten a tool-call title into a single line that's safe to render
@@ -829,9 +829,8 @@ mod tests {
     #[test]
     fn context_footer_normal_percentage() {
         let footer = format_context_footer(31434, 1_000_000).unwrap();
-        assert!(footer.contains("31434/1000000"));
+        assert!(footer.contains("Context: 31434/1000000"));
         assert!(footer.contains("3%"));
-        // No leading newline — callers add it
         assert!(!footer.starts_with('\n'));
     }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -600,7 +600,7 @@ async fn stream_prompt(
                 // Append context footer to the last chunk if it fits (char count, not bytes).
                 let content = if i == last_idx {
                     if let Some(ref footer) = ctx_footer {
-                        if chunk.chars().count() + footer.chars().count() < 2000 {
+                        if chunk.chars().count() + footer.chars().count() <= 2000 {
                             format!("{chunk}{footer}")
                         } else {
                             chunk.to_string()
@@ -620,8 +620,9 @@ async fn stream_prompt(
             // If footer didn't fit in the last chunk, send as a separate message.
             if let Some(ref footer) = ctx_footer {
                 let last_chunk = chunks.last().map(|c| c.as_str()).unwrap_or("");
-                if last_chunk.chars().count() + footer.chars().count() >= 2000 {
-                    let _ = channel.say(&ctx.http, footer).await;
+                if last_chunk.chars().count() + footer.chars().count() > 2000 {
+                    let standalone = footer.trim_start_matches('\n');
+                    let _ = channel.say(&ctx.http, standalone).await;
                 }
             }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -589,24 +589,25 @@ async fn stream_prompt(
                 final_content
             };
 
-            // Build context usage footer (empty string if no data).
+            // Build context usage footer.
             let ctx_size = conn.context_size.load(std::sync::atomic::Ordering::Relaxed);
-            let ctx_footer = if ctx_size > 0 {
-                let ctx_used = conn.context_used.load(std::sync::atomic::Ordering::Relaxed);
-                let pct = (ctx_used as f64 / ctx_size as f64 * 100.0).round() as u64;
-                format!("\n-# 📊 {ctx_used}/{ctx_size} tokens ({pct}%)")
-            } else {
-                String::new()
-            };
+            let ctx_used = conn.context_used.load(std::sync::atomic::Ordering::Relaxed);
+            let ctx_footer = format_context_footer(ctx_used, ctx_size);
 
             let chunks = format::split_message(&final_content, 2000);
             let last_idx = chunks.len().saturating_sub(1);
             for (i, chunk) in chunks.iter().enumerate() {
-                // Append context footer to the last chunk if it fits.
-                let content = if i == last_idx && !ctx_footer.is_empty()
-                    && chunk.len() + ctx_footer.len() < 2000
-                {
-                    format!("{chunk}{ctx_footer}")
+                // Append context footer to the last chunk if it fits (char count, not bytes).
+                let content = if i == last_idx {
+                    if let Some(ref footer) = ctx_footer {
+                        if chunk.chars().count() + footer.chars().count() < 2000 {
+                            format!("{chunk}{footer}")
+                        } else {
+                            chunk.to_string()
+                        }
+                    } else {
+                        chunk.to_string()
+                    }
                 } else {
                     chunk.to_string()
                 };
@@ -616,11 +617,29 @@ async fn stream_prompt(
                     let _ = channel.say(&ctx.http, &content).await;
                 }
             }
+            // If footer didn't fit in the last chunk, send as a separate message.
+            if let Some(ref footer) = ctx_footer {
+                let last_chunk = chunks.last().map(|c| c.as_str()).unwrap_or("");
+                if last_chunk.chars().count() + footer.chars().count() >= 2000 {
+                    let _ = channel.say(&ctx.http, footer).await;
+                }
+            }
 
             Ok(())
         })
     })
     .await
+}
+
+/// Format a context usage footer for Discord messages.
+/// Returns `None` when `ctx_size == 0` (no `usage_update` received yet).
+/// The percentage is clamped to 100 to handle `used > size` edge cases.
+fn format_context_footer(ctx_used: u64, ctx_size: u64) -> Option<String> {
+    if ctx_size == 0 {
+        return None;
+    }
+    let pct = ((ctx_used as u128 * 100 + ctx_size as u128 / 2) / ctx_size as u128).min(100) as u64;
+    Some(format!("\n-# 📊 {ctx_used}/{ctx_size} tokens ({pct}%)"))
 }
 
 /// Flatten a tool-call title into a single line that's safe to render
@@ -797,5 +816,31 @@ mod tests {
     fn invalid_data_returns_error() {
         let garbage = vec![0x00, 0x01, 0x02, 0x03];
         assert!(resize_and_compress(&garbage).is_err());
+    }
+
+    #[test]
+    fn context_footer_none_when_size_zero() {
+        assert!(format_context_footer(0, 0).is_none());
+        assert!(format_context_footer(500, 0).is_none());
+    }
+
+    #[test]
+    fn context_footer_normal_percentage() {
+        let footer = format_context_footer(31434, 1_000_000).unwrap();
+        assert!(footer.contains("31434/1000000"));
+        assert!(footer.contains("3%"));
+    }
+
+    #[test]
+    fn context_footer_clamps_over_100() {
+        // used > size should clamp to 100%
+        let footer = format_context_footer(1_200_000, 1_000_000).unwrap();
+        assert!(footer.contains("100%"));
+    }
+
+    #[test]
+    fn context_footer_100_percent() {
+        let footer = format_context_footer(1_000_000, 1_000_000).unwrap();
+        assert!(footer.contains("100%"));
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -590,11 +590,13 @@ async fn stream_prompt(
             };
 
             // Append context window usage footer if available.
+            // Skip when the message is already near the 2000-char Discord limit
+            // to avoid the footer splitting into a separate message.
             let ctx_size = conn.context_size.load(std::sync::atomic::Ordering::Relaxed);
-            let final_content = if ctx_size > 0 {
+            let final_content = if ctx_size > 0 && final_content.len() < 1900 {
                 let ctx_used = conn.context_used.load(std::sync::atomic::Ordering::Relaxed);
                 let pct = (ctx_used as f64 / ctx_size as f64 * 100.0).round() as u64;
-                format!("{final_content}\n-# 📊 Context: {ctx_used}/{ctx_size} tokens ({pct}%)")
+                format!("{final_content}\n-# 📊 {ctx_used}/{ctx_size} tokens ({pct}%)")
             } else {
                 final_content
             };

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -598,10 +598,11 @@ async fn stream_prompt(
             let last_idx = chunks.len().saturating_sub(1);
             for (i, chunk) in chunks.iter().enumerate() {
                 // Append context footer to the last chunk if it fits (char count, not bytes).
+                // +1 accounts for the '\n' separator between chunk and footer.
                 let content = if i == last_idx {
                     if let Some(ref footer) = ctx_footer {
-                        if chunk.chars().count() + footer.chars().count() <= 2000 {
-                            format!("{chunk}{footer}")
+                        if chunk.chars().count() + 1 + footer.chars().count() <= 2000 {
+                            format!("{chunk}\n{footer}")
                         } else {
                             chunk.to_string()
                         }
@@ -620,9 +621,8 @@ async fn stream_prompt(
             // If footer didn't fit in the last chunk, send as a separate message.
             if let Some(ref footer) = ctx_footer {
                 let last_chunk = chunks.last().map(|c| c.as_str()).unwrap_or("");
-                if last_chunk.chars().count() + footer.chars().count() > 2000 {
-                    let standalone = footer.trim_start_matches('\n');
-                    let _ = channel.say(&ctx.http, standalone).await;
+                if last_chunk.chars().count() + 1 + footer.chars().count() > 2000 {
+                    let _ = channel.say(&ctx.http, footer).await;
                 }
             }
 
@@ -635,12 +635,13 @@ async fn stream_prompt(
 /// Format a context usage footer for Discord messages.
 /// Returns `None` when `ctx_size == 0` (no `usage_update` received yet).
 /// The percentage is clamped to 100 to handle `used > size` edge cases.
+/// The returned string does NOT include a leading newline — callers add it as needed.
 fn format_context_footer(ctx_used: u64, ctx_size: u64) -> Option<String> {
     if ctx_size == 0 {
         return None;
     }
     let pct = ((ctx_used as u128 * 100 + ctx_size as u128 / 2) / ctx_size as u128).min(100) as u64;
-    Some(format!("\n-# 📊 {ctx_used}/{ctx_size} tokens ({pct}%)"))
+    Some(format!("-# 📊 {ctx_used}/{ctx_size} tokens ({pct}%)"))
 }
 
 /// Flatten a tool-call title into a single line that's safe to render
@@ -830,6 +831,8 @@ mod tests {
         let footer = format_context_footer(31434, 1_000_000).unwrap();
         assert!(footer.contains("31434/1000000"));
         assert!(footer.contains("3%"));
+        // No leading newline — callers add it
+        assert!(!footer.starts_with('\n'));
     }
 
     #[test]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -589,6 +589,16 @@ async fn stream_prompt(
                 final_content
             };
 
+            // Append context window usage footer if available.
+            let ctx_size = conn.context_size.load(std::sync::atomic::Ordering::Relaxed);
+            let final_content = if ctx_size > 0 {
+                let ctx_used = conn.context_used.load(std::sync::atomic::Ordering::Relaxed);
+                let pct = (ctx_used as f64 / ctx_size as f64 * 100.0).round() as u64;
+                format!("{final_content}\n-# 📊 Context: {ctx_used}/{ctx_size} tokens ({pct}%)")
+            } else {
+                final_content
+            };
+
             let chunks = format::split_message(&final_content, 2000);
             for (i, chunk) in chunks.iter().enumerate() {
                 if i == 0 {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -589,24 +589,31 @@ async fn stream_prompt(
                 final_content
             };
 
-            // Append context window usage footer if available.
-            // Skip when the message is already near the 2000-char Discord limit
-            // to avoid the footer splitting into a separate message.
+            // Build context usage footer (empty string if no data).
             let ctx_size = conn.context_size.load(std::sync::atomic::Ordering::Relaxed);
-            let final_content = if ctx_size > 0 && final_content.len() < 1900 {
+            let ctx_footer = if ctx_size > 0 {
                 let ctx_used = conn.context_used.load(std::sync::atomic::Ordering::Relaxed);
                 let pct = (ctx_used as f64 / ctx_size as f64 * 100.0).round() as u64;
-                format!("{final_content}\n-# 📊 {ctx_used}/{ctx_size} tokens ({pct}%)")
+                format!("\n-# 📊 {ctx_used}/{ctx_size} tokens ({pct}%)")
             } else {
-                final_content
+                String::new()
             };
 
             let chunks = format::split_message(&final_content, 2000);
+            let last_idx = chunks.len().saturating_sub(1);
             for (i, chunk) in chunks.iter().enumerate() {
-                if i == 0 {
-                    let _ = edit(&ctx, channel, current_msg_id, chunk).await;
+                // Append context footer to the last chunk if it fits.
+                let content = if i == last_idx && !ctx_footer.is_empty()
+                    && chunk.len() + ctx_footer.len() < 2000
+                {
+                    format!("{chunk}{ctx_footer}")
                 } else {
-                    let _ = channel.say(&ctx.http, chunk).await;
+                    chunk.to_string()
+                };
+                if i == 0 {
+                    let _ = edit(&ctx, channel, current_msg_id, &content).await;
+                } else {
+                    let _ = channel.say(&ctx.http, &content).await;
                 }
             }
 


### PR DESCRIPTION
## Summary

Track ACP context window usage from `usage_update` session notifications and display it in Discord after each prompt response. Also adds project-specific Copilot code review instructions.

## Changes

| File | Change | Description |
|---|---|---|
| `src/acp/protocol.rs` | MOD | Add `UsageUpdate { used, size }` variant to `AcpEvent`; parse via `?` — returns `None` if either field is missing |
| `src/acp/connection.rs` | MOD | Add `context_used`/`context_size` `AtomicU64` fields; capture values from `usage_update` via shared `classify_notification` parser |
| `src/discord.rs` | MOD | Append context usage footer after each prompt response; extracted `format_context_footer()` helper with 4 unit tests |
| `.github/copilot-instructions.md` | NEW | 67 lines — review philosophy, ACP/concurrency/Discord priority areas, CI-aware skip list |

## How it works

```
Agent prompt response
       |
       v
  ACP notification: session/update { sessionUpdate: "usage_update", used: 31434, size: 1000000 }
       |
       v
  classify_notification() -> Some(UsageUpdate { used: 31434, size: 1000000 })
       |
       v
  reader loop: ctx_size.store(1000000, Relaxed)   // size first — reduces sentinel race
               ctx_used.store(31434, Relaxed)
       |
       v
  stream_prompt() finishes -> format_context_footer(31434, 1000000)
       |
       v
  Discord message footer:
  -# 📊 Context: 31434/1000000 tokens (3%)
```

## Discord display

After each agent response, a small footer line appears:

> -# 📊 Context: 31434/1000000 tokens (3%)

- Uses Discord's `-#` small text syntax (renders as subdued footer)
- Only shown when `context_size > 0` (at least one `usage_update` received)
- If footer doesn't fit in the last chunk (<= 2000 chars), sent as a separate message
- No impact on backends that don't emit `usage_update` (e.g. Copilot)

## Design decisions

- **`context_size == 0` means unknown** — `context_used` can legitimately be 0 (empty context), so `context_size` is the sentinel
- **`?` instead of `unwrap_or(0)`** — missing fields -> `None` -> counters unchanged (no silent clobbering)
- **Reuses `classify_notification`** — parsing logic stays in `protocol.rs`, reader loop delegates
- **`Ordering::Relaxed`** — sufficient for best-effort metric counters; `size` stored before `used` to reduce sentinel race
- **`format_context_footer()` helper** — pure function, separately testable; percentage clamped to 100 via `u128` integer math
- **`chars().count()` for Discord limit** — Discord's 2000 limit is character-based, not byte-based
- **Footer as standalone message** — when last chunk is too full, footer sent as its own message (never silently dropped)

## Tests

4 new unit tests for `format_context_footer`:
- `context_footer_none_when_size_zero` — returns `None` when size is 0
- `context_footer_normal_percentage` — correct format with "Context:" label
- `context_footer_clamps_over_100` — `used > size` clamped to 100%
- `context_footer_100_percent` — exact 100% boundary

## Copilot instructions

The `.github/copilot-instructions.md` teaches Copilot's automated PR reviewer about OpenAB-specific concerns:

- ACP protocol correctness (JSON-RPC routing, notification forwarding, timeout values)
- Concurrency safety (atomic fields, Mutex across `.await`, session pool lock scope)
- Discord API constraints (2000 char limit, 3s autocomplete deadline)
- Skip CI-covered checks (rustfmt, clippy, tests) to reduce noise
- `>80%` confidence threshold