### PR TITLE
feat: add tool_display config to control tool call visibility in Discord

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openab"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -40,6 +40,7 @@ data:
     [reactions]
     enabled = {{ ($cfg.reactions).enabled | default true }}
     remove_after_reply = {{ ($cfg.reactions).removeAfterReply | default false }}
+    tool_display = "{{ ($cfg.reactions).toolDisplay | default "compact" }}"
     {{- if ($cfg.stt).enabled }}
     {{- if not ($cfg.stt).apiKey }}
     {{ fail (printf "agents.%s.stt.apiKey is required when stt.enabled=true" $name) }}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -69,6 +69,7 @@ agents:
     reactions:
       enabled: true
       removeAfterReply: false
+      toolDisplay: "compact"   # full | compact | none
     stt:
       enabled: false
       apiKey: ""

--- a/config.toml.example
+++ b/config.toml.example
@@ -33,6 +33,7 @@ session_ttl_hours = 24
 [reactions]
 enabled = true
 remove_after_reply = false
+tool_display = "compact"   # full (complete command) | compact (name only) | none (hide tool lines)
 
 [reactions.emojis]
 queued = "👀"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -20,3 +20,4 @@ data:
     [reactions]
     enabled = true
     remove_after_reply = false
+    tool_display = "compact"   # full (complete command) | compact (name only) | none (hide tool lines)

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,3 +200,33 @@ pub fn load_config(path: &Path) -> anyhow::Result<Config> {
         .map_err(|e| anyhow::anyhow!("failed to parse {}: {e}", path.display()))?;
     Ok(config)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_display_deserializes_all_modes() {
+        let toml_full: ReactionsConfig = toml::from_str(r#"tool_display = "full""#).unwrap();
+        assert_eq!(toml_full.tool_display, ToolDisplay::Full);
+
+        let toml_compact: ReactionsConfig = toml::from_str(r#"tool_display = "compact""#).unwrap();
+        assert_eq!(toml_compact.tool_display, ToolDisplay::Compact);
+
+        let toml_none: ReactionsConfig = toml::from_str(r#"tool_display = "none""#).unwrap();
+        assert_eq!(toml_none.tool_display, ToolDisplay::None);
+    }
+
+    #[test]
+    fn tool_display_defaults_to_compact() {
+        // Empty config → all defaults, including tool_display = compact
+        let config: ReactionsConfig = toml::from_str("").unwrap();
+        assert_eq!(config.tool_display, ToolDisplay::Compact);
+    }
+
+    #[test]
+    fn tool_display_rejects_invalid_value() {
+        let result: Result<ReactionsConfig, _> = toml::from_str(r#"tool_display = "abbreviated""#);
+        assert!(result.is_err(), "invalid tool_display value must be rejected");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,15 @@ pub struct PoolConfig {
     pub session_ttl_hours: u64,
 }
 
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolDisplay {
+    Full,
+    #[default]
+    Compact,
+    None,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ReactionsConfig {
     #[serde(default = "default_true")]
@@ -79,6 +88,8 @@ pub struct ReactionsConfig {
     pub emojis: ReactionEmojis,
     #[serde(default)]
     pub timing: ReactionTiming,
+    #[serde(default)]
+    pub tool_display: ToolDisplay,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -147,6 +158,7 @@ impl Default for ReactionsConfig {
             remove_after_reply: false,
             emojis: ReactionEmojis::default(),
             timing: ReactionTiming::default(),
+            tool_display: ToolDisplay::default(),
         }
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,5 +1,5 @@
 use crate::acp::{classify_notification, AcpEvent, ContentBlock, SessionPool};
-use crate::config::{ReactionsConfig, SttConfig};
+use crate::config::{ReactionsConfig, SttConfig, ToolDisplay};
 use crate::error_display::{format_coded_error, format_user_error};
 use crate::format;
 use crate::reactions::StatusReactionController;
@@ -614,6 +614,12 @@ fn sanitize_title(title: &str) -> String {
     title.replace('\r', "").replace('\n', " ; ").replace('`', "'")
 }
 
+/// For `ToolDisplay::Compact` mode: return the segment before the first `:`
+/// trimmed. Falls back to the whole title if there is no colon.
+fn compact_title(title: &str) -> String {
+    title.split(':').next().unwrap_or(title).trim().to_string()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ToolState {
     Running,
@@ -778,5 +784,14 @@ mod tests {
     fn invalid_data_returns_error() {
         let garbage = vec![0x00, 0x01, 0x02, 0x03];
         assert!(resize_and_compress(&garbage).is_err());
+    }
+
+    #[test]
+    fn compact_title_strips_after_colon() {
+        assert_eq!(compact_title("Running: curl -s url"), "Running");
+        assert_eq!(compact_title("Edit: /path/to/file.rs"), "Edit");
+        assert_eq!(compact_title("Read file: /etc/passwd"), "Read file");
+        assert_eq!(compact_title("Terminal"), "Terminal");
+        assert_eq!(compact_title("  Running:  curl  "), "Running");
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -616,10 +616,33 @@ fn sanitize_title(title: &str) -> String {
     title.replace('\r', "").replace('\n', " ; ").replace('`', "'")
 }
 
-/// For `ToolDisplay::Compact` mode: return the segment before the first `:`
-/// trimmed. Falls back to the whole title if there is no colon.
+/// For `ToolDisplay::Compact` mode: return a short label for the tool call.
+///
+/// Two title formats are in use across ACP backends:
+///
+/// - **`"Verb: command"` (Kiro and similar):** the segment before `:` is a
+///   short semantic label ("Running", "Edit", "Read file"). Detected when the
+///   colon is NOT a URL scheme separator (i.e. not followed by `//`) and the
+///   prefix is short (≤ 3 words, ≤ 20 chars).
+/// - **Raw command (claude-agent-acp):** the title is the shell command itself
+///   ("curl -s https://...", "git status"). Colons appear inside URLs, so
+///   splitting naively produces garbage ("curl -s https"). We fall back to the
+///   first word (the executable name).
 fn compact_title(title: &str) -> String {
-    title.split(':').next().unwrap_or(title).trim().to_string()
+    if let Some(idx) = title.find(':') {
+        // A URL scheme separator looks like "://"; skip it so "curl -s https://..."
+        // doesn't yield a garbled "curl -s https" prefix.
+        if !title[idx..].starts_with("://") {
+            let prefix = title[..idx].trim();
+            let word_count = prefix.split_whitespace().count();
+            // Accept as a semantic label: ≤ 3 words and ≤ 20 chars
+            if word_count <= 3 && prefix.len() <= 20 {
+                return prefix.to_string();
+            }
+        }
+    }
+    // Fallback: first word (executable name), safe for raw-command titles
+    title.split_whitespace().next().unwrap_or(title).to_string()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -793,12 +816,28 @@ mod tests {
     }
 
     #[test]
-    fn compact_title_strips_after_colon() {
+    fn compact_title_kiro_format() {
+        // Kiro / "Verb: command" backends: extract the label before ':'
         assert_eq!(compact_title("Running: curl -s url"), "Running");
         assert_eq!(compact_title("Edit: /path/to/file.rs"), "Edit");
         assert_eq!(compact_title("Read file: /etc/passwd"), "Read file");
-        assert_eq!(compact_title("Terminal"), "Terminal");
         assert_eq!(compact_title("  Running:  curl  "), "Running");
+    }
+
+    #[test]
+    fn compact_title_raw_command_format() {
+        // claude-agent-acp / raw command titles: return executable name
+        assert_eq!(compact_title("git status"), "git");
+        assert_eq!(compact_title("ls -la && echo done"), "ls");
+        assert_eq!(compact_title("pwd"), "pwd");
+        assert_eq!(compact_title("Terminal"), "Terminal");
+    }
+
+    #[test]
+    fn compact_title_url_in_command_not_truncated() {
+        // URL colons must not produce garbage like "curl -s https"
+        assert_eq!(compact_title("curl -s https://example.com"), "curl");
+        assert_eq!(compact_title("curl -s https://example.com | python3 -c 'import sys'"), "curl");
     }
 
     fn make_tool(title: &str, state: ToolState) -> ToolEntry {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -816,8 +816,8 @@ mod tests {
     }
 
     #[test]
-    fn compact_title_kiro_format() {
-        // Kiro / "Verb: command" backends: extract the label before ':'
+    fn compact_title_verb_colon_format() {
+        // "Verb: command" format: extract the short label before ':'
         assert_eq!(compact_title("Running: curl -s url"), "Running");
         assert_eq!(compact_title("Edit: /path/to/file.rs"), "Edit");
         assert_eq!(compact_title("Read file: /etc/passwd"), "Read file");

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -209,6 +209,7 @@ impl EventHandler for Handler {
             thread_channel,
             thinking_msg.id,
             reactions.clone(),
+            self.reactions_config.tool_display,
         )
         .await;
 
@@ -422,6 +423,7 @@ async fn stream_prompt(
     channel: ChannelId,
     msg_id: MessageId,
     reactions: Arc<StatusReactionController>,
+    tool_display: ToolDisplay,
 ) -> anyhow::Result<()> {
     let reactions = reactions.clone();
 
@@ -507,7 +509,7 @@ async fn stream_prompt(
                                 // Reaction: back to thinking after tools
                             }
                             text_buf.push_str(&t);
-                            let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
+                            let _ = buf_tx.send(compose_display(&tool_lines, &text_buf, tool_display));
                         }
                         AcpEvent::Thinking => {
                             reactions.set_thinking().await;
@@ -532,7 +534,7 @@ async fn stream_prompt(
                                     state: ToolState::Running,
                                 });
                             }
-                            let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
+                            let _ = buf_tx.send(compose_display(&tool_lines, &text_buf, tool_display));
                         }
                         AcpEvent::ToolDone { id, title, status } => {
                             reactions.set_thinking().await;
@@ -560,7 +562,7 @@ async fn stream_prompt(
                                     state: new_state,
                                 });
                             }
-                            let _ = buf_tx.send(compose_display(&tool_lines, &text_buf));
+                            let _ = buf_tx.send(compose_display(&tool_lines, &text_buf, tool_display));
                         }
                         _ => {}
                     }
@@ -572,7 +574,7 @@ async fn stream_prompt(
             let _ = edit_handle.await;
 
             // Final edit
-            let final_content = compose_display(&tool_lines, &text_buf);
+            let final_content = compose_display(&tool_lines, &text_buf, tool_display);
             // If ACP returned both an error and partial text, show both.
             // This can happen when the agent started producing content before hitting an error
             // (e.g. context length limit, rate limit mid-stream). Showing both gives users

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -646,7 +646,7 @@ impl ToolEntry {
         let suffix = if self.state == ToolState::Running { "..." } else { "" };
         let title = match display {
             ToolDisplay::Compact => compact_title(&self.title),
-            _ => self.title.clone(),
+            ToolDisplay::Full | ToolDisplay::None => self.title.clone(),
         };
         format!("{icon} `{}`{}", title, suffix)
     }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -635,22 +635,26 @@ struct ToolEntry {
 }
 
 impl ToolEntry {
-    fn render(&self) -> String {
+    fn render(&self, display: ToolDisplay) -> String {
         let icon = match self.state {
             ToolState::Running => "🔧",
             ToolState::Completed => "✅",
             ToolState::Failed => "❌",
         };
         let suffix = if self.state == ToolState::Running { "..." } else { "" };
-        format!("{icon} `{}`{}", self.title, suffix)
+        let title = match display {
+            ToolDisplay::Compact => compact_title(&self.title),
+            _ => self.title.clone(),
+        };
+        format!("{icon} `{}`{}", title, suffix)
     }
 }
 
-fn compose_display(tool_lines: &[ToolEntry], text: &str) -> String {
+fn compose_display(tool_lines: &[ToolEntry], text: &str, display: ToolDisplay) -> String {
     let mut out = String::new();
-    if !tool_lines.is_empty() {
+    if !matches!(display, ToolDisplay::None) && !tool_lines.is_empty() {
         for entry in tool_lines {
-            out.push_str(&entry.render());
+            out.push_str(&entry.render(display));
             out.push('\n');
         }
         out.push('\n');
@@ -793,5 +797,41 @@ mod tests {
         assert_eq!(compact_title("Read file: /etc/passwd"), "Read file");
         assert_eq!(compact_title("Terminal"), "Terminal");
         assert_eq!(compact_title("  Running:  curl  "), "Running");
+    }
+
+    fn make_tool(title: &str, state: ToolState) -> ToolEntry {
+        ToolEntry { id: "1".into(), title: title.into(), state }
+    }
+
+    #[test]
+    fn compose_display_full_shows_complete_title() {
+        let tools = vec![make_tool("Running: curl -s https://example.com | python3 -c 'import sys'", ToolState::Completed)];
+        let out = compose_display(&tools, "done", ToolDisplay::Full);
+        assert!(out.contains("Running: curl -s https://example.com"), "full mode must show complete title");
+        assert!(out.contains("done"));
+    }
+
+    #[test]
+    fn compose_display_compact_shows_only_prefix() {
+        let tools = vec![make_tool("Running: curl -s https://example.com | python3 -c 'import sys'", ToolState::Completed)];
+        let out = compose_display(&tools, "done", ToolDisplay::Compact);
+        assert!(out.contains("Running"), "compact mode must include prefix");
+        assert!(!out.contains("curl"), "compact mode must not include args");
+        assert!(out.contains("done"));
+    }
+
+    #[test]
+    fn compose_display_none_hides_all_tool_lines() {
+        let tools = vec![make_tool("Running: curl -s url", ToolState::Completed)];
+        let out = compose_display(&tools, "done", ToolDisplay::None);
+        assert!(!out.contains("Running"), "none mode must hide tool lines");
+        assert!(!out.contains("✅"), "none mode must hide icons");
+        assert!(out.contains("done"), "none mode must still show text");
+    }
+
+    #[test]
+    fn compose_display_empty_tools_no_blank_line() {
+        let out = compose_display(&[], "hello", ToolDisplay::Compact);
+        assert_eq!(out, "hello");
     }
 }


### PR DESCRIPTION
## What problem does this solve?

Tool call lines in Discord messages contain the full ACP title string, which often includes complete shell commands, file paths, or URL arguments. In public or shared channels this is noisy and can inadvertently expose sensitive paths, tokens embedded in arguments, or internal infrastructure details.

Closes #216

## At a Glance

```
ACP Agent event (ToolCallStart)
        │
        │  title = "Running: curl -s https://internal.corp/api?token=..."
        ▼
┌─────────────────────────────────────────────────┐
│            compose_display(tool_display)         │
│                                                  │
│  full    →  ✅ `Running: curl -s https://...`   │
│  compact →  ✅ `Running`                         │
│  none    →  (tool lines hidden entirely)         │
└────────────────────┬────────────────────────────┘
                     │
                     ▼
            Discord channel message
```

## Prior Art & Industry Research

**Hermes Agent:**

[`acp_adapter/tools.py → build_tool_title()`](https://github.com/NousResearch/hermes-agent/blob/main/acp_adapter/tools.py) uses a `"verb: primary_arg"` format and truncates long commands at 80 characters (e.g. `"terminal: curl -s ..."` → `"terminal: curl -s…"`). This is essentially the same compact label pattern — Hermes chose brevity by default too. Separately, [`agent/display.py`](https://github.com/NousResearch/hermes-agent/blob/main/agent/display.py) exposes `set_tool_preview_max_len()` / `get_tool_preview_max_len()` as a runtime-configurable integer cap (0 = unlimited). Hermes does not expose a "none" (hide entirely) mode.

**OpenClaw:**

OpenClaw separates tool event transport from display via ACP `ToolCallStart` / `ToolCallProgress` events streamed through [`src/channels/draft-stream-controls.ts`](https://github.com/openclaw/openclaw/blob/main/src/channels/draft-stream-controls.ts). Display decisions are made at the channel layer, not inside the event emitter — which is the same decoupling this PR achieves by threading `tool_display` through `stream_prompt()` rather than hard-coding it at the call site. OpenClaw does not expose a user-facing config option for tool verbosity.

**Other references:**

- Discord's own message length cap (2000 chars) makes verbose tool lines a practical problem, not just aesthetic — long tool outputs can crowd out agent text.

## Proposed Solution

Add a `tool_display` field to `[reactions]` in `config.toml`:

```toml
[reactions]
tool_display = "compact"   # full | compact | none
```

Three modes:

| Mode | Behavior | Example |
|------|----------|---------|
| `full` | Complete ACP title (previous behavior) | ✅ `Running: curl -s "https://..."` |
| `compact` | Short label or executable name only | ✅ `Running` or ✅ `curl` |
| `none` | Tool lines hidden; only agent text shown | _(no tool lines)_ |

**Implementation:**
- `ToolDisplay` enum in `config.rs` with `serde rename_all = "lowercase"`
- `compact_title()` helper with URL-safe heuristic (detects `://` to skip URL colons)
- `ToolEntry::render()` and `compose_display()` accept `ToolDisplay`; `None` skips the tool block
- `tool_display` plumbed through `stream_prompt()` to all four `compose_display()` call sites
- Helm chart `configmap.yaml` and `values.yaml` updated; default is `"compact"`

### Files changed

| File | Change |
|------|--------|
| `src/config.rs` | Add `ToolDisplay` enum; add `tool_display` field to `ReactionsConfig`; add deserialization tests |
| `src/discord.rs` | Import `ToolDisplay`; add `compact_title()` with URL-safe heuristic; update `ToolEntry::render`, `compose_display`, `stream_prompt`; add 7 unit tests |
| `config.toml.example` | Document `tool_display = "compact"` under `[reactions]` |
| `charts/openab/values.yaml` | Add `toolDisplay: "compact"` to reactions block |
| `charts/openab/templates/configmap.yaml` | Render `tool_display` from Helm values |
| `k8s/configmap.yaml` | Add `tool_display = "compact"` to static manifest |

## Why this approach?

**Enum over boolean:** A boolean `hide_tools: true` only handles two states. The third state (`compact`) turns out to be the most practically useful — users want to know a tool ran without reading its full arguments. Hermes Agent's experience confirms this: their `build_tool_title()` truncates by default because full titles are rarely useful to end users.

**`compact` as default (not `full`):** Changing the default is a mild breaking change in appearance, but leaving `full` as default would mean most users never benefit from the fix. The `compact` output is still informative — it signals that a tool ran — without exposing arguments.

**URL-safe heuristic in `compact_title()`:** The two ACP title formats (`"Verb: command"` from Kiro and raw-command from claude-agent-acp) collide on colon as separator vs URL scheme. A simple `split(':')[0]` would garble `"curl https://..."` into `"curl https"`. The heuristic checks whether the character after `:` is `/` to skip URL colons.

## Alternatives Considered

1. **Boolean `hide_tool_lines: true`** — Only two states. Loses the `compact` middle ground that is most useful in practice. Rejected.

2. **Keep `full` as default, opt-in to `compact`** — Avoids the appearance change but means existing deployments stay noisy. The whole point of the PR is to fix the default experience. Rejected.

3. **Server-side truncation at a character limit (like Hermes' `tool_preview_max_len`)** — An integer cap is less expressive than named modes and harder to reason about (`tool_preview_max_len = 10` vs `tool_display = "compact"`). Named modes also let us add new behaviors later without a config format change. Rejected.

4. **Strip tool lines in the Discord message formatter rather than in `compose_display()`** — Would require post-processing rendered markdown, which is fragile. Keeping the decision in `compose_display()` keeps it close to where tool entries are assembled. Rejected.

## Validation

### Automated (36 tests, all passing)

- [x] `cargo test` — 36 tests, 0 failures
- [x] `tool_display = "full"` shows complete title — `compose_display_full_shows_complete_title`
- [x] `tool_display = "compact"` shows short label only — `compose_display_compact_shows_only_prefix`
- [x] `tool_display = "none"` hides all tool lines — `compose_display_none_hides_all_tool_lines`
- [x] Default (no `tool_display` in config) = `compact` — `tool_display_defaults_to_compact`
- [x] All three TOML values parse correctly — `tool_display_deserializes_all_modes`
- [x] Invalid values rejected at parse time — `tool_display_rejects_invalid_value`
- [x] URL-containing commands not garbled — `compact_title_url_in_command_not_truncated`
- [x] `"Verb: command"` format extracts label — `compact_title_verb_colon_format`
- [x] Raw command format extracts executable — `compact_title_raw_command_format`
- [x] Empty tool list produces no blank line — `compose_display_empty_tools_no_blank_line`
- [x] Helm chart renders `tool_display = "compact"` — verified via `helm template`
