### PR TITLE
feat: add GitHub Copilot CLI as supported ACP backend

### DIFF
--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI (native ACP support via --acp)
-RUN npm install -g @githubnext/github-copilot-cli --retry 3
+RUN npm install -g @github/copilot@1 --retry 3
 
 # Install gh CLI (used by Copilot for GitHub integration)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -1,0 +1,33 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+FROM node:22-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub Copilot CLI (native ACP support via --acp)
+RUN npm install -g @githubnext/github-copilot-cli --retry 3
+
+# Install gh CLI (used by Copilot for GitHub integration)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/node
+WORKDIR /home/node
+
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENTRYPOINT ["openab"]
+CMD ["/etc/openab/config.toml"]

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Supports Kiro CLI, Claude Code, Codex, Gemini, and any ACP-compatible CLI.
 | `codex` | Codex | [@zed-industries/codex-acp](https://github.com/zed-industries/codex-acp) | `codex login --device-auth` |
 | `claude` | Claude Code | [@agentclientprotocol/claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp) | `claude setup-token` |
 | `gemini` | Gemini CLI | Native `gemini --acp` | Google OAuth or `GEMINI_API_KEY` |
-| `copilot` | GitHub Copilot CLI | Native `copilot --acp` | `gh auth login` or `copilot auth` |
+| `copilot` | GitHub Copilot CLI | Native `copilot --acp` | `gh auth login` (GitHub OAuth) |
 
 ### Helm Install (recommended)
 
@@ -167,13 +167,14 @@ working_dir = "/home/node"
 [agent]
 command = "gemini"
 args = ["--acp"]
+working_dir = "/home/node"
+env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 
 # GitHub Copilot (native ACP — requires copilot CLI in PATH)
 [agent]
 command = "copilot"
 args = ["--acp"]
 working_dir = "/home/node"
-env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 ```
 
 ## Configuration Reference

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Supports Kiro CLI, Claude Code, Codex, Gemini, and any ACP-compatible CLI.
 | `codex` | Codex | [@zed-industries/codex-acp](https://github.com/zed-industries/codex-acp) | `codex login --device-auth` |
 | `claude` | Claude Code | [@agentclientprotocol/claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp) | `claude setup-token` |
 | `gemini` | Gemini CLI | Native `gemini --acp` | Google OAuth or `GEMINI_API_KEY` |
+| `copilot` | GitHub Copilot CLI | Native `copilot --acp` | `gh auth login` or `copilot auth` |
 
 ### Helm Install (recommended)
 
@@ -115,6 +116,16 @@ helm install openab openab/openab \
   --set agents.claude.image=ghcr.io/openabdev/openab-claude:latest \
   --set agents.claude.command=claude-agent-acp \
   --set agents.claude.workingDir=/home/node
+
+# Copilot only (native --acp mode)
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.copilot.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.copilot.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.copilot.image=ghcr.io/openabdev/openab-copilot:latest \
+  --set agents.copilot.command=copilot \
+  --set 'agents.copilot.args={--acp}' \
+  --set agents.copilot.workingDir=/home/node
 
 # Multi-agent (kiro + claude in one release)
 helm install openab openab/openab \
@@ -155,6 +166,11 @@ working_dir = "/home/node"
 # Gemini
 [agent]
 command = "gemini"
+args = ["--acp"]
+
+# GitHub Copilot (native ACP — requires copilot CLI in PATH)
+[agent]
+command = "copilot"
 args = ["--acp"]
 working_dir = "/home/node"
 env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }


### PR DESCRIPTION
## Summary

Add first-class support for GitHub Copilot CLI via its native `--acp` mode, following the same pattern as the existing Gemini integration.

## Changes

| File | Change | Description |
|---|---|---|
| `Dockerfile.copilot` | NEW | Runtime image with Copilot CLI installed via npm + gh CLI for auth |
| `README.md` | MOD | Add Copilot to backend table, Helm install example, manual config.toml example |

## How it works

```
OpenAB (Rust)
       │ stdio JSON-RPC (ACP protocol)
       ▼
  copilot --acp (native ACP server mode)
       │ Copilot SDK internal
       ▼
  GitHub Copilot service
```

No third-party adapter needed — Copilot CLI ships built-in ACP support.

## Configuration

### Helm

```bash
helm install openab openab/openab \
  --set agents.kiro.enabled=false \
  --set agents.copilot.discord.botToken="$DISCORD_BOT_TOKEN" \
  --set-string 'agents.copilot.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
  --set agents.copilot.image=ghcr.io/openabdev/openab-copilot:latest \
  --set agents.copilot.command=copilot \
  --set 'agents.copilot.args={--acp}' \
  --set agents.copilot.workingDir=/home/node
```

### Manual config.toml

```toml
[agent]
command = "copilot"
args = ["--acp"]
working_dir = "/home/node"
```

### Auth

```bash
# Inside the container or on the host
gh auth login          # GitHub OAuth
# or
copilot auth           # Copilot-specific auth
```

## Tested capabilities

| Feature | Status |
|---|---|
| Basic chat | ✅ |
| Model switching (8 models) | ✅ |
| Mode switching (agent/plan/autopilot) | ✅ |
| Tool execution | ✅ |
| `usage_update` notifications | ✅ |
| `configOptions` (filtered model list) | ✅ |