### PR TITLE
feat: add GitHub Copilot CLI support

### DIFF
--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -1,0 +1,33 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+FROM node:22-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub Copilot CLI
+RUN curl -fsSL https://gh.io/copilot-install | bash
+
+# Install gh CLI (for auth and token management)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/node
+WORKDIR /home/node
+
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENTRYPOINT ["openab"]
+CMD ["/etc/openab/config.toml"]

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -10,8 +10,8 @@ RUN touch src/main.rs && cargo build --release
 FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
-# Install GitHub Copilot CLI
-RUN curl -fsSL https://gh.io/copilot-install | bash
+# Install GitHub Copilot CLI via npm (pinned version)
+RUN npm install -g @github/copilot@1 --retry 3
 
 # Install gh CLI (for auth and token management)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenAB — Open Agent Broker
 
-A lightweight, secure, cloud-native ACP harness that bridges Discord and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, etc.) over stdio JSON-RPC — delivering the next-generation development experience.
+A lightweight, secure, cloud-native ACP harness that bridges Discord and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, Copilot CLI, etc.) over stdio JSON-RPC — delivering the next-generation development experience.
 
 🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://discord.gg/YNksK9M6)** 🎉
 
@@ -17,7 +17,7 @@ A lightweight, secure, cloud-native ACP harness that bridges Discord and any [Ag
 
 ## Features
 
-- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini via config
+- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, Copilot CLI via config
 - **@mention trigger** — mention the bot in an allowed channel to start a conversation
 - **Thread-based multi-turn** — auto-creates threads; no @mention needed for follow-ups
 - **Edit-streaming** — live-updates the Discord message every 1.5s as tokens arrive
@@ -68,6 +68,7 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 | Claude Code | `claude-agent-acp` | [@agentclientprotocol/claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp) | [docs/claude-code.md](docs/claude-code.md) |
 | Codex | `codex-acp` | [@zed-industries/codex-acp](https://github.com/zed-industries/codex-acp) | [docs/codex.md](docs/codex.md) |
 | Gemini | `gemini --acp` | Native | [docs/gemini.md](docs/gemini.md) |
+| Copilot CLI ⚠️ | `copilot --acp --stdio` | Native | [docs/copilot.md](docs/copilot.md) |
 
 > 🔧 Running multiple agents? See [docs/multi-agent.md](docs/multi-agent.md)
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -26,6 +26,12 @@ working_dir = "/home/agent"
 # working_dir = "/home/agent"
 # env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 
+# [agent]
+# command = "copilot"
+# args = ["--acp", "--stdio"]
+# working_dir = "/home/agent"
+# env = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }
+
 [pool]
 max_sessions = 10
 session_ttl_hours = 24

--- a/config.toml.example
+++ b/config.toml.example
@@ -30,7 +30,7 @@ working_dir = "/home/agent"
 # command = "copilot"
 # args = ["--acp", "--stdio"]
 # working_dir = "/home/agent"
-# env = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }
+# env = {}  # Auth via: kubectl exec -it <pod> -- gh auth login -p https -w
 
 [pool]
 max_sessions = 10

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -25,6 +25,7 @@ OpenAB spawns `copilot --acp --stdio` as a child process and communicates via st
 command = "copilot"
 args = ["--acp", "--stdio"]
 working_dir = "/home/agent"
+env = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }  # ⚠️ unvalidated — use device flow instead
 ```
 
 ## Docker

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -1,0 +1,90 @@
+# GitHub Copilot CLI — Agent Backend Guide
+
+How to run OpenAB with [GitHub Copilot CLI](https://github.com/github/copilot-cli) as the agent backend.
+
+## Prerequisites
+
+- An active [GitHub Copilot](https://github.com/features/copilot/plans) subscription (Free, Pro, Pro+, Business, or Enterprise)
+- Copilot CLI ACP support is in [public preview](https://github.blog/changelog/2026-01-28-acp-support-in-copilot-cli-is-now-in-public-preview/) since Jan 28, 2026
+
+## Architecture
+
+```
+┌──────────────┐  Gateway WS   ┌──────────────┐  ACP stdio    ┌──────────────────────┐
+│   Discord    │◄─────────────►│ openab       │──────────────►│ copilot --acp --stdio │
+│   User       │               │   (Rust)     │◄── JSON-RPC ──│ (Copilot CLI)         │
+└──────────────┘               └──────────────┘               └──────────────────────┘
+```
+
+OpenAB spawns `copilot --acp --stdio` as a child process and communicates via stdio JSON-RPC. No intermediate layers.
+
+## Configuration
+
+```toml
+[agent]
+command = "copilot"
+args = ["--acp", "--stdio"]
+working_dir = "/home/agent"
+```
+
+## Docker
+
+Build with the Copilot-specific Dockerfile:
+
+```bash
+docker build -f Dockerfile.copilot -t openab-copilot .
+```
+
+## Authentication
+
+Copilot CLI uses GitHub OAuth (same as `gh` CLI). In a headless container, use device flow:
+
+```bash
+# 1. Exec into the running pod/container
+kubectl exec -it deployment/openab-copilot -- bash
+
+# 2. Authenticate via device flow
+gh auth login --hostname github.com --git-protocol https -p https -w
+
+# 3. Follow the device code flow in your browser
+
+# 4. Verify
+gh auth status
+
+# 5. Restart the pod (token is persisted via PVC)
+kubectl rollout restart deployment/openab-copilot
+```
+
+The OAuth token is stored under `~/.config/gh/` and persisted across pod restarts via PVC.
+
+> **Note**: See [docs/gh-auth-device-flow.md](gh-auth-device-flow.md) for details on device flow in headless environments.
+
+## Helm Install
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.copilot.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.copilot.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.copilot.image=ghcr.io/openabdev/openab-copilot:latest \
+  --set agents.copilot.command=copilot \
+  --set 'agents.copilot.args={--acp,--stdio}' \
+  --set agents.copilot.workingDir=/home/node
+```
+
+## Model Selection
+
+Copilot CLI defaults to Claude Sonnet 4.6. Other available models include:
+
+- Claude Opus 4.6, Claude Haiku 4.5 (Anthropic)
+- GPT-5.3-Codex (OpenAI)
+- Gemini 3 Pro (Google)
+
+Model selection is controlled by Copilot CLI itself (via `/model` in interactive mode). In ACP mode, the default model is used.
+
+## Known Limitations
+
+- ⚠️ ACP support is in **public preview** — behavior may change
+- ⚠️ Headless auth with `GITHUB_TOKEN` env var has not been fully validated; device flow via `gh auth login` is the recommended path
+- Copilot CLI requires an active Copilot subscription per user/org
+- For Copilot Business/Enterprise, an admin must enable Copilot CLI from the Policies page

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -4,7 +4,7 @@ How to run OpenAB with [GitHub Copilot CLI](https://github.com/github/copilot-cl
 
 ## Prerequisites
 
-- An active [GitHub Copilot](https://github.com/features/copilot/plans) subscription (Free, Pro, Pro+, Business, or Enterprise)
+- A paid [GitHub Copilot](https://github.com/features/copilot/plans) subscription (**Pro, Pro+, Business, or Enterprise** — Free tier does not include CLI/ACP access)
 - Copilot CLI ACP support is in [public preview](https://github.blog/changelog/2026-01-28-acp-support-in-copilot-cli-is-now-in-public-preview/) since Jan 28, 2026
 
 ## Architecture
@@ -25,7 +25,7 @@ OpenAB spawns `copilot --acp --stdio` as a child process and communicates via st
 command = "copilot"
 args = ["--acp", "--stdio"]
 working_dir = "/home/agent"
-env = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }  # ⚠️ unvalidated — use device flow instead
+# Auth via: kubectl exec -it <pod> -- gh auth login -p https -w
 ```
 
 ## Docker
@@ -62,6 +62,8 @@ The OAuth token is stored under `~/.config/gh/` and persisted across pod restart
 
 ## Helm Install
 
+> **Note**: The `ghcr.io/openabdev/openab-copilot` image is not published yet. You must build it locally first with `docker build -f Dockerfile.copilot -t openab-copilot .` and push to your own registry, or use a local image.
+
 ```bash
 helm install openab openab/openab \
   --set agents.kiro.enabled=false \
@@ -70,6 +72,7 @@ helm install openab openab/openab \
   --set agents.copilot.image=ghcr.io/openabdev/openab-copilot:latest \
   --set agents.copilot.command=copilot \
   --set 'agents.copilot.args={--acp,--stdio}' \
+  --set agents.copilot.persistence.enabled=true \
   --set agents.copilot.workingDir=/home/node
 ```
 


### PR DESCRIPTION
## Summary

Add [GitHub Copilot CLI](https://github.com/github/copilot-cli) as a supported agent backend with a separate Docker image.

Copilot CLI has native ACP support (public preview since [Jan 28, 2026](https://github.blog/changelog/2026-01-28-acp-support-in-copilot-cli-is-now-in-public-preview/)) via `copilot --acp --stdio` over stdio JSON-RPC — fully compatible with OpenAB's existing architecture.

Closes #19

## Changes

### 1. `Dockerfile.copilot` (new)

- Multi-stage build: Rust build stage + `node:22-bookworm-slim` runtime
- Installs Copilot CLI via `npm install -g @github/copilot@1` (pinned major version, consistent with Claude/Codex/Gemini Dockerfiles)
- Installs `gh` CLI for auth management
- Follows the same pattern as `Dockerfile.claude` and `Dockerfile.codex`

### 2. `config.toml.example`

Added commented-out Copilot CLI config block:

```toml
# [agent]
# command = "copilot"
# args = ["--acp", "--stdio"]
# working_dir = "/home/agent"
# env = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }
```

### 3. `README.md`

- Added Copilot CLI to the intro description
- Added to the features line
- Added to the agent backends table (with ⚠️ for auth)
- Added Helm install example
- Added manual config.toml example
- Added note clarifying only one `[agent]` block can be active at a time

### 4. `docs/copilot.md` (new)

Full setup guide covering architecture, configuration, Docker build, Helm install, model selection, and known limitations.

## Architecture

```
┌──────────────┐  Gateway WS   ┌──────────────┐  ACP stdio    ┌──────────────────────┐
│   Discord    │◄─────────────►│ openab       │──────────────►│ copilot --acp --stdio │
│   User       │               │   (Rust)     │◄── JSON-RPC ──│ (Copilot CLI)         │
└──────────────┘               └──────────────┘               └──────────────────────┘
```

## Authentication

Copilot CLI uses GitHub OAuth — same mechanism as Kiro CLI. Authentication is a **post-deploy user action**, following the same device flow pattern as all other agent backends:

```bash
kubectl exec -it deployment/openab-copilot -- gh auth login --hostname github.com -p https -w
kubectl rollout restart deployment/openab-copilot
```

The token is persisted via PVC across pod restarts. Full details documented in **[docs/copilot.md](docs/copilot.md)** and **[docs/gh-auth-device-flow.md](docs/gh-auth-device-flow.md)**.

## Testing

- [ ] Local: `copilot --acp --stdio` with JSON-RPC client
- [ ] Docker: `docker build -f Dockerfile.copilot -t openab-copilot .`
- [ ] K8s: Helm install with `agents.copilot` values