### PR TITLE
feat: add GitHub Copilot CLI as supported ACP backend

### DIFF
--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -28,6 +28,6 @@ COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bi
 
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-  CMD pgrep -x openab || exit 1
+  CMD kill -0 1 || exit 1
 ENTRYPOINT ["openab"]
 CMD ["/etc/openab/config.toml"]

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -1,0 +1,33 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+FROM node:22-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub Copilot CLI (native ACP support via --acp)
+RUN npm install -g @github/copilot@1 --retry 3
+
+# Install gh CLI (required for Copilot auth)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/node
+WORKDIR /home/node
+
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENTRYPOINT ["openab"]
+CMD ["/etc/openab/config.toml"]

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI (native ACP support via --acp)
-RUN npm install -g @github/copilot@1 --retry 3
+RUN npm install -g @github/copilot@1.0.24 --retry 3
 
 # Install gh CLI (required for Copilot auth)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/README.md
+++ b/README.md
@@ -164,18 +164,20 @@ args = []
 working_dir = "/home/node"
 
 # Gemini
-[agent]
-command = "gemini"
-args = ["--acp"]
-working_dir = "/home/node"
-env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
+# [agent]
+# command = "gemini"
+# args = ["--acp"]
+# working_dir = "/home/node"
+# env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 
 # GitHub Copilot (native ACP — requires copilot CLI in PATH)
-[agent]
-command = "copilot"
-args = ["--acp"]
-working_dir = "/home/node"
+# [agent]
+# command = "copilot"
+# args = ["--acp"]
+# working_dir = "/home/node"
 ```
+
+> **Note:** Each `config.toml` uses exactly one `[agent]` block. The examples above are alternatives — uncomment the one you need.
 
 ## Configuration Reference
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Supports Kiro CLI, Claude Code, Codex, Gemini, and any ACP-compatible CLI.
 | `codex` | Codex | [@zed-industries/codex-acp](https://github.com/zed-industries/codex-acp) | `codex login --device-auth` |
 | `claude` | Claude Code | [@agentclientprotocol/claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp) | `claude setup-token` |
 | `gemini` | Gemini CLI | Native `gemini --acp` | Google OAuth or `GEMINI_API_KEY` |
+| `copilot` | GitHub Copilot CLI | Native `copilot --acp` | `gh auth login` (GitHub OAuth) |
 
 ### Helm Install (recommended)
 
@@ -115,6 +116,16 @@ helm install openab openab/openab \
   --set agents.claude.image=ghcr.io/openabdev/openab-claude:latest \
   --set agents.claude.command=claude-agent-acp \
   --set agents.claude.workingDir=/home/node
+
+# Copilot only (native --acp mode)
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.copilot.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.copilot.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.copilot.image=ghcr.io/openabdev/openab-copilot:latest \
+  --set agents.copilot.command=copilot \
+  --set 'agents.copilot.args={--acp}' \
+  --set agents.copilot.workingDir=/home/node
 
 # Multi-agent (kiro + claude in one release)
 helm install openab openab/openab \
@@ -158,6 +169,12 @@ command = "gemini"
 args = ["--acp"]
 working_dir = "/home/node"
 env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
+
+# GitHub Copilot (native ACP — requires copilot CLI in PATH)
+[agent]
+command = "copilot"
+args = ["--acp"]
+working_dir = "/home/node"
 ```
 
 ## Configuration Reference

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 
 ## Pluggable Agent Backends
 
-Supports Kiro CLI, Claude Code, Codex, Gemini, and any ACP-compatible CLI.
+Supports Kiro CLI, Claude Code, Codex, Gemini, GitHub Copilot, and any ACP-compatible CLI.
 
 | Agent key | CLI | ACP Adapter | Auth |
 |-----------|-----|-------------|------|

--- a/config.toml.example
+++ b/config.toml.example
@@ -26,6 +26,11 @@ working_dir = "/home/agent"
 # working_dir = "/home/agent"
 # env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 
+# [agent]
+# command = "copilot"
+# args = ["--acp"]
+# working_dir = "/home/agent"
+
 [pool]
 max_sessions = 10
 session_ttl_hours = 24

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -1,0 +1,121 @@
+# GitHub Copilot CLI — Agent Backend Guide
+
+How to run OpenAB with [GitHub Copilot CLI](https://github.com/github/copilot-cli) as the agent backend.
+
+## Prerequisites
+
+- An active [GitHub Copilot](https://github.com/features/copilot/plans) subscription (Free, Pro, Pro+, Business, or Enterprise)
+- Copilot CLI v1.0.24+ (`npm install -g @github/copilot`)
+- ACP support is in [public preview](https://github.blog/changelog/2026-01-28-acp-support-in-copilot-cli-is-now-in-public-preview/) since Jan 28, 2026
+
+## Architecture
+
+```
+┌──────────────┐  Gateway WS   ┌──────────────┐  ACP stdio    ┌──────────────────────┐
+│   Discord    │◄─────────────►│ openab       │──────────────►│ copilot --acp         │
+│   User       │               │   (Rust)     │◄── JSON-RPC ──│ (Copilot CLI)         │
+└──────────────┘               └──────────────┘               └──────────────────────┘
+```
+
+OpenAB spawns `copilot --acp` as a child process and communicates via stdio JSON-RPC. No intermediate adapter needed.
+
+## Configuration
+
+### config.toml
+
+```toml
+[agent]
+command = "copilot"
+args = ["--acp"]
+working_dir = "/home/agent"
+```
+
+## Docker
+
+Build with the Copilot-specific Dockerfile:
+
+```bash
+docker build -f Dockerfile.copilot -t openab-copilot .
+```
+
+## Authentication
+
+Copilot CLI uses GitHub OAuth (same as `gh` CLI). In a headless container, use device flow:
+
+```bash
+# 1. Exec into the running pod/container
+kubectl exec -it deployment/openab-copilot -- bash
+
+# 2. Authenticate via device flow
+gh auth login --hostname github.com --git-protocol https -p https -w
+
+# 3. Follow the device code flow in your browser
+
+# 4. Verify
+gh auth status
+
+# 5. Restart the pod (token is persisted via PVC)
+kubectl rollout restart deployment/openab-copilot
+```
+
+The OAuth token is stored under `~/.config/gh/` and persisted across pod restarts via PVC.
+
+> **Note**: See [gh-auth-device-flow.md](gh-auth-device-flow.md) for details on device flow in headless environments.
+
+## Helm Install
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.copilot.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.copilot.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.copilot.image=ghcr.io/openabdev/openab-copilot:latest \
+  --set agents.copilot.command=copilot \
+  --set 'agents.copilot.args={--acp}' \
+  --set agents.copilot.workingDir=/home/node
+```
+
+## Verified Capabilities
+
+Tested end-to-end with `copilot --acp` v1.0.24:
+
+| Feature | Status | Details |
+|---|---|---|
+| `initialize` | ✅ | Returns agentInfo |
+| `session/new` | ✅ | 3 modes, 8 models, configOptions=true |
+| `session/prompt` | ✅ | Streaming via `agent_message_chunk` |
+| `session/set_model` | ✅ | 8 available models |
+| `session/set_mode` | ✅ | agent / plan / autopilot |
+| `session/request_permission` | ✅ | Auto-approved by OpenAB |
+| `usage_update` notification | ❌ | Not emitted (context_used/size stay 0) |
+
+### Available Models (v1.0.24)
+
+Models available depend on your Copilot plan. Typical Pro plan includes:
+
+| Model | Provider |
+|---|---|
+| Claude Opus 4.6 | Anthropic |
+| Claude Sonnet 4.6 | Anthropic |
+| Claude Haiku 4.5 | Anthropic |
+| GPT-5.3-Codex | OpenAI |
+| GPT-5-mini | OpenAI |
+| Gemini 3 Pro | Google |
+| Gemini 3 Flash | Google |
+| o3-mini | OpenAI |
+
+### Available Modes
+
+| Mode | Description |
+|---|---|
+| `agent` | Default — full tool access |
+| `plan` | Read-only planning mode |
+| `autopilot` | Auto-approve all tool calls |
+
+## Known Limitations
+
+- ⚠️ ACP support is in **public preview** — behavior may change
+- `usage_update` notifications are not emitted — context window tracking shows 0/0
+- Headless auth with `GITHUB_TOKEN` env var is not fully validated; device flow via `gh auth login` is recommended
+- Copilot CLI requires an active Copilot subscription per user/org
+- For Copilot Business/Enterprise, an admin must enable Copilot CLI from the Policies page

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -87,11 +87,13 @@ Tested end-to-end with `copilot --acp` v1.0.24:
 | `session/set_model` | ✅ | 8 available models |
 | `session/set_mode` | ✅ | agent / plan / autopilot |
 | `session/request_permission` | ✅ | Auto-approved by OpenAB |
-| `usage_update` notification | ❌ | Not emitted (context_used/size stay 0) |
+| `usage_update` notification | ✅ | Emits `used` (tokens) and `size` (context window) |
+| `session/list` | ✅ | Lists past sessions |
+| `session/load` | ✅ | Loads a previous session |
 
 ### Available Models (v1.0.24)
 
-Models available depend on your Copilot plan. Typical Pro plan includes:
+Models available depend on your Copilot plan and may change. The list below is from a Pro plan tested on 2026-04-13. Use `/model` in Discord to see your actual available models.
 
 | Model | Provider |
 |---|---|


### PR DESCRIPTION
## Summary

Add first-class support for GitHub Copilot CLI via its native `copilot --acp` mode, following the same pattern as the existing Gemini integration.

Closes #19

## Changes

| File | Change | Description |
|---|---|---|
| `Dockerfile.copilot` | NEW | Runtime image with `@github/copilot@1.0.24` + `gh` CLI for auth, non-root user, HEALTHCHECK |
| `docs/copilot.md` | NEW | Full setup guide: architecture, config, Docker, K8s auth, Helm, verified capabilities, known limitations |
| `config.toml.example` | MOD | Add commented-out Copilot agent block |
| `README.md` | MOD | Backend table entry, intro sentence, Helm install example, manual config example |

## How it works

```
Discord user
       │
       ▼
  OpenAB (Rust binary)
       │ stdio JSON-RPC (ACP protocol)
       ▼
  copilot --acp (native ACP server mode)
       │ Copilot SDK internal
       ▼
  GitHub Copilot service
```

No third-party adapter needed — Copilot CLI ships built-in ACP support.

## Configuration

### config.toml

```toml
[agent]
command = "copilot"
args = ["--acp"]
working_dir = "/home/node"
```

### Helm

```bash
helm install openab openab/openab \
  --set agents.kiro.enabled=false \
  --set agents.copilot.discord.botToken="$DISCORD_BOT_TOKEN" \
  --set-string 'agents.copilot.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
  --set agents.copilot.image=ghcr.io/openabdev/openab-copilot:latest \
  --set agents.copilot.command=copilot \
  --set 'agents.copilot.args={--acp}' \
  --set agents.copilot.workingDir=/home/node
```

### Auth

```bash
# Headless / K8s:
kubectl exec -it deployment/openab-copilot -- gh auth login -p https -w
kubectl rollout restart deployment/openab-copilot

# Local:
gh auth login
```

Token stored at `~/.config/gh/`, persisted via PVC.

## Verified Capabilities

Tested end-to-end with `copilot --acp` v1.0.24 (**all verified, not checkboxes**):

| Feature | Status | Details |
|---|---|---|
| `initialize` | ✅ | Returns agentInfo |
| `session/new` | ✅ | 3 modes, 8 models, configOptions=true |
| `session/prompt` | ✅ | Streaming via `agent_message_chunk` |
| `session/set_model` | ✅ | 8 models available |
| `session/set_mode` | ✅ | agent / plan / autopilot |
| `session/request_permission` | ✅ | Auto-approved by OpenAB |
| `usage_update` | ❌ | Not emitted (context tracking stays 0/0) |

### Available Models (Copilot Pro, v1.0.24)

| Model | Provider |
|---|---|
| Claude Opus 4.6 | Anthropic |
| Claude Sonnet 4.6 | Anthropic |
| Claude Haiku 4.5 | Anthropic |
| GPT-5.3-Codex | OpenAI |
| GPT-5-mini | OpenAI |
| Gemini 3 Pro | Google |
| Gemini 3 Flash | Google |
| o3-mini | OpenAI |

## Known Limitations

- ⚠️ ACP support is in **public preview** — behavior may change
- `usage_update` not emitted — context window tracking shows 0/0
- Headless auth with `GITHUB_TOKEN` env var not fully validated; device flow recommended
- Requires active Copilot subscription (Free/Pro/Business/Enterprise)
- Copilot Business/Enterprise: admin must enable CLI from Policies page

## Note for maintainer

`Dockerfile.copilot` needs to be added to the CI build matrix in `.github/workflows/build.yml`:

```yaml
- { suffix: "-copilot", dockerfile: "Dockerfile.copilot", artifact: "copilot" }
```

OAuth tokens cannot modify workflow files (requires `workflow` scope).