### PR TITLE
fix: release-pr auto-bump increments beta instead of bumping patch

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -44,13 +44,18 @@ jobs:
           else
             CURRENT=$(grep '^version:' charts/openab/Chart.yaml | awk '{print $2}')
             BASE="${CURRENT%%-*}"
-            IFS='.' read -r major minor patch <<< "$BASE"
-            case "${{ inputs.bump }}" in
-              major) major=$((major + 1)); minor=0; patch=0 ;;
-              minor) minor=$((minor + 1)); patch=0 ;;
-              patch) patch=$((patch + 1)) ;;
-            esac
-            VERSION="${major}.${minor}.${patch}-beta.1"
+            if [[ "$CURRENT" == *-beta.* ]]; then
+              BETA_NUM="${CURRENT##*-beta.}"
+              VERSION="${BASE}-beta.$((BETA_NUM + 1))"
+            else
+              IFS='.' read -r major minor patch <<< "$BASE"
+              case "${{ inputs.bump }}" in
+                major) major=$((major + 1)); minor=0; patch=0 ;;
+                minor) minor=$((minor + 1)); patch=0 ;;
+                patch) patch=$((patch + 1)) ;;
+              esac
+              VERSION="${major}.${minor}.${patch}-beta.1"
+            fi
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "::notice::Release version: ${VERSION}"


### PR DESCRIPTION
## Problem

When `release-pr.yml` runs with default `bump=patch` and Chart.yaml has a beta version like `0.7.2-beta.1`, it strips the suffix and bumps patch → `0.7.3-beta.1`. This means you can never get `0.7.2-beta.2` through the default flow.

## Fix

If the current version already has a `-beta.N` suffix, increment N instead of bumping the base version:

- `0.7.2-beta.1` → `0.7.2-beta.2` ✅
- `0.7.2` (stable) → `0.7.3-beta.1` ✅ (unchanged behavior)

One-line logic change in the Resolve version step.

Fixes #272