### PR TITLE
ci: restore workflows accidentally deleted in #180

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "Dockerfile*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo check
+        run: cargo check
+
+      - name: cargo clippy
+        run: cargo clippy -- -D warnings
+
+      - name: cargo test
+        run: cargo test

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,92 @@
+name: Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version (leave empty for auto bump, or specify e.g. 0.8.0-beta.1)"
+        required: false
+        type: string
+      bump:
+        description: "Auto bump type (ignored when version is specified)"
+        required: false
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            CURRENT=$(grep '^version:' charts/openab/Chart.yaml | awk '{print $2}')
+            BASE="${CURRENT%%-*}"
+            if [[ "$CURRENT" == *-beta.* ]]; then
+              BETA_NUM="${CURRENT##*-beta.}"
+              VERSION="${BASE}-beta.$((BETA_NUM + 1))"
+            else
+              IFS='.' read -r major minor patch <<< "$BASE"
+              case "${{ inputs.bump }}" in
+                major) major=$((major + 1)); minor=0; patch=0 ;;
+                minor) minor=$((minor + 1)); patch=0 ;;
+                patch) patch=$((patch + 1)) ;;
+              esac
+              VERSION="${major}.${minor}.${patch}-beta.1"
+            fi
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Release version: ${VERSION}"
+
+          # Determine stable version (strip pre-release suffix)
+          STABLE="${VERSION%%-*}"
+          echo "stable=${STABLE}" >> "$GITHUB_OUTPUT"
+
+      - name: Update version files
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          STABLE="${{ steps.version.outputs.stable }}"
+          # Chart.yaml always gets the full version (beta or stable)
+          sed -i "s/^version: .*/version: ${VERSION}/" charts/openab/Chart.yaml
+          sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" charts/openab/Chart.yaml
+          # Cargo.toml only gets stable version (main stays clean)
+          sed -i "s/^version = .*/version = \"${STABLE}\"/" Cargo.toml
+
+      - name: Create release PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="release/v${VERSION}"
+          git config user.name "openab-app[bot]"
+          git config user.email "274185012+openab-app[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "release: v${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "release: v${VERSION}" \
+            --body "Merge this PR to tag \`v${VERSION}\` and trigger the build pipeline." \
+            --base main --head "$BRANCH"

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,0 +1,38 @@
+name: Tag on Release PR merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create and push tag
+        run: |
+          # release/v0.8.0-beta.1 → v0.8.0-beta.1
+          VERSION="${GITHUB_HEAD_REF#release/}"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Invalid version format '${VERSION}'. Expected v{major}.{minor}.{patch}[-prerelease]"
+            exit 1
+          fi
+          git config user.name "openab-app[bot]"
+          git config user.email "274185012+openab-app[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          echo "::notice::Tagged ${VERSION}"


### PR DESCRIPTION
PR #180 (`feat: Add markdown table conversion pipeline`) accidentally deleted three workflow files during rebase:

- `.github/workflows/release-pr.yml` — workflow_dispatch to create release PRs with auto version bump
- `.github/workflows/tag-on-merge.yml` — auto-tag when release PRs are merged
- `.github/workflows/ci.yml` — PR validation checks

This restores all three from the state just before #180 was merged (commit `d5993f2`).

Without these, we cannot bump beta versions or auto-tag releases from the GitHub UI or CLI.