### PR TITLE
feat(discord): inline text-based file attachments into prompt

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -172,7 +172,7 @@ impl EventHandler for Handler {
             msg.content.trim().to_string()
         };
 
-        // No text and no image attachments → skip to avoid wasting session slots
+        // No text and no attachments → skip to avoid wasting session slots
         if prompt.is_empty() && msg.attachments.is_empty() {
             return;
         }
@@ -397,6 +397,10 @@ fn is_text_attachment(attachment: &serenity::model::channel::Attachment) -> bool
 
 /// Download a text-based file attachment and return it as a ContentBlock::Text.
 /// Files larger than 512 KB are skipped to avoid bloating the prompt.
+///
+/// Note: the caller already guards total size via TEXT_TOTAL_CAP; the per-file
+/// MAX_SIZE check here is intentional defense-in-depth so this function remains
+/// self-contained and safe when called from other contexts.
 async fn download_and_read_text_file(
     attachment: &serenity::model::channel::Attachment,
 ) -> Option<(ContentBlock, u64)> {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -16,7 +16,7 @@ use serenity::prelude::*;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::watch;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Reusable HTTP client for downloading Discord attachments.
 /// Built once with a 30s timeout and rustls TLS (no native-tls deps).
@@ -127,8 +127,11 @@ impl EventHandler for Handler {
             text: prompt_with_sender.clone(),
         });
 
-        // Process attachments: route by content type (audio → STT, image → encode)
+        // Process attachments: route by content type (audio → STT, text file → inline, image → encode)
         if !msg.attachments.is_empty() {
+            let mut text_file_bytes: u64 = 0;
+            const TEXT_TOTAL_CAP: u64 = 1024 * 1024; // 1 MB total for all text file attachments
+
             for attachment in &msg.attachments {
                 if is_audio_attachment(attachment) {
                     if self.stt_config.enabled {
@@ -142,7 +145,12 @@ impl EventHandler for Handler {
                         debug!(filename = %attachment.filename, "skipping audio attachment (STT disabled)");
                     }
                 } else if is_text_attachment(attachment) {
+                    if text_file_bytes + u64::from(attachment.size) > TEXT_TOTAL_CAP {
+                        warn!(filename = %attachment.filename, total = text_file_bytes, "text attachments total exceeds 1MB cap, skipping remaining");
+                        continue;
+                    }
                     if let Some(content_block) = download_and_read_text_file(attachment).await {
+                        text_file_bytes += u64::from(attachment.size);
                         debug!(filename = %attachment.filename, "adding text file attachment");
                         content_blocks.push(content_block);
                     }
@@ -251,20 +259,44 @@ const TEXT_EXTENSIONS: &[&str] = &[
     "txt", "csv", "log", "md", "json", "jsonl", "yaml", "yml", "toml", "xml",
     "rs", "py", "js", "ts", "jsx", "tsx", "go", "java", "c", "cpp", "h", "hpp",
     "rb", "sh", "bash", "zsh", "fish", "ps1", "bat", "sql", "html", "css",
-    "scss", "less", "ini", "cfg", "conf", "env", "dockerfile", "makefile",
+    "scss", "less", "ini", "cfg", "conf", "env",
+];
+
+/// Exact filenames (no extension) recognised as text files.
+const TEXT_FILENAMES: &[&str] = &[
+    "dockerfile", "makefile", "justfile", "rakefile", "gemfile",
+    "procfile", "vagrantfile", ".gitignore", ".dockerignore", ".editorconfig",
+];
+
+/// MIME types recognised as text-based (beyond `text/*`).
+const TEXT_MIME_TYPES: &[&str] = &[
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/typescript",
+    "application/x-yaml",
+    "application/x-sh",
+    "application/toml",
+    "application/x-toml",
 ];
 
 /// Check if an attachment is a text-based file we can inline.
 fn is_text_attachment(attachment: &serenity::model::channel::Attachment) -> bool {
     let mime = attachment.content_type.as_deref().unwrap_or("");
-    if mime.starts_with("text/") || mime == "application/json" || mime == "application/xml" {
+    let mime_base = mime.split(';').next().unwrap_or(mime).trim();
+    if mime_base.starts_with("text/") || TEXT_MIME_TYPES.contains(&mime_base) {
         return true;
     }
-    attachment
-        .filename
-        .rsplit('.')
-        .next()
-        .is_some_and(|ext| TEXT_EXTENSIONS.contains(&ext.to_lowercase().as_str()))
+    // Check extension
+    if attachment.filename.contains('.') {
+        if let Some(ext) = attachment.filename.rsplit('.').next() {
+            if TEXT_EXTENSIONS.contains(&ext.to_lowercase().as_str()) {
+                return true;
+            }
+        }
+    }
+    // Check exact filename (Dockerfile, Makefile, etc.)
+    TEXT_FILENAMES.contains(&attachment.filename.to_lowercase().as_str())
 }
 
 /// Download a text-based file attachment and return it as a ContentBlock::Text.
@@ -275,24 +307,33 @@ async fn download_and_read_text_file(
     const MAX_SIZE: u64 = 512 * 1024; // 512 KB
 
     if u64::from(attachment.size) > MAX_SIZE {
-        error!(filename = %attachment.filename, size = attachment.size, "text file exceeds 512KB limit");
+        warn!(filename = %attachment.filename, size = attachment.size, "text file exceeds 512KB limit, skipping");
         return None;
     }
 
     let resp = HTTP_CLIENT.get(&attachment.url).send().await.ok()?;
     if !resp.status().is_success() {
-        error!(url = %attachment.url, status = %resp.status(), "text file download failed");
+        warn!(url = %attachment.url, status = %resp.status(), "text file download failed");
         return None;
     }
     let bytes = resp.bytes().await.ok()?;
+
+    // Defense-in-depth: verify actual download size
+    if bytes.len() as u64 > MAX_SIZE {
+        warn!(filename = %attachment.filename, size = bytes.len(), "downloaded text file exceeds 512KB limit, skipping");
+        return None;
+    }
 
     let text = String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| {
         String::from_utf8_lossy(&bytes).into_owned()
     });
 
+    // Use enough backticks to avoid conflicts with content that contains triple backticks
+    let fence = if text.contains("```") { "````" } else { "```" };
+
     debug!(filename = %attachment.filename, chars = text.len(), "text file inlined");
     Some(ContentBlock::Text {
-        text: format!("[File: {}]\n```\n{}\n```", attachment.filename, text),
+        text: format!("[File: {}]\n{fence}\n{}\n{fence}", attachment.filename, text),
     })
 }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -164,7 +164,7 @@ impl EventHandler for Handler {
                                 .filter(|(mid, _)| **mid < msg.id)
                                 .map(|(_, m)| m.clone())
                                 .collect();
-                            recent.sort_unstable_by(|a, b| b.id.cmp(&a.id));
+                            recent.sort_unstable_by_key(|m| std::cmp::Reverse(m.id));
                             recent.truncate(cap);
                             recent
                         })

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -141,6 +141,11 @@ impl EventHandler for Handler {
                     } else {
                         debug!(filename = %attachment.filename, "skipping audio attachment (STT disabled)");
                     }
+                } else if is_text_attachment(attachment) {
+                    if let Some(content_block) = download_and_read_text_file(attachment).await {
+                        debug!(filename = %attachment.filename, "adding text file attachment");
+                        content_blocks.push(content_block);
+                    }
                 } else if let Some(content_block) = download_and_encode_image(attachment).await {
                     debug!(url = %attachment.url, filename = %attachment.filename, "adding image attachment");
                     content_blocks.push(content_block);
@@ -239,6 +244,56 @@ impl EventHandler for Handler {
     async fn ready(&self, _ctx: Context, ready: Ready) {
         info!(user = %ready.user.name, "discord bot connected");
     }
+}
+
+/// Extensions recognised as text-based files that can be inlined into the prompt.
+const TEXT_EXTENSIONS: &[&str] = &[
+    "txt", "csv", "log", "md", "json", "jsonl", "yaml", "yml", "toml", "xml",
+    "rs", "py", "js", "ts", "jsx", "tsx", "go", "java", "c", "cpp", "h", "hpp",
+    "rb", "sh", "bash", "zsh", "fish", "ps1", "bat", "sql", "html", "css",
+    "scss", "less", "ini", "cfg", "conf", "env", "dockerfile", "makefile",
+];
+
+/// Check if an attachment is a text-based file we can inline.
+fn is_text_attachment(attachment: &serenity::model::channel::Attachment) -> bool {
+    let mime = attachment.content_type.as_deref().unwrap_or("");
+    if mime.starts_with("text/") || mime == "application/json" || mime == "application/xml" {
+        return true;
+    }
+    attachment
+        .filename
+        .rsplit('.')
+        .next()
+        .is_some_and(|ext| TEXT_EXTENSIONS.contains(&ext.to_lowercase().as_str()))
+}
+
+/// Download a text-based file attachment and return it as a ContentBlock::Text.
+/// Files larger than 512 KB are skipped to avoid bloating the prompt.
+async fn download_and_read_text_file(
+    attachment: &serenity::model::channel::Attachment,
+) -> Option<ContentBlock> {
+    const MAX_SIZE: u64 = 512 * 1024; // 512 KB
+
+    if u64::from(attachment.size) > MAX_SIZE {
+        error!(filename = %attachment.filename, size = attachment.size, "text file exceeds 512KB limit");
+        return None;
+    }
+
+    let resp = HTTP_CLIENT.get(&attachment.url).send().await.ok()?;
+    if !resp.status().is_success() {
+        error!(url = %attachment.url, status = %resp.status(), "text file download failed");
+        return None;
+    }
+    let bytes = resp.bytes().await.ok()?;
+
+    let text = String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| {
+        String::from_utf8_lossy(&bytes).into_owned()
+    });
+
+    debug!(filename = %attachment.filename, chars = text.len(), "text file inlined");
+    Some(ContentBlock::Text {
+        text: format!("[File: {}]\n```\n{}\n```", attachment.filename, text),
+    })
 }
 
 /// Check if an attachment is an audio file (voice messages are typically audio/ogg).

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -130,7 +130,9 @@ impl EventHandler for Handler {
         // Process attachments: route by content type (audio → STT, text file → inline, image → encode)
         if !msg.attachments.is_empty() {
             let mut text_file_bytes: u64 = 0;
+            let mut text_file_count: u32 = 0;
             const TEXT_TOTAL_CAP: u64 = 1024 * 1024; // 1 MB total for all text file attachments
+            const TEXT_FILE_COUNT_CAP: u32 = 5;
 
             for attachment in &msg.attachments {
                 if is_audio_attachment(attachment) {
@@ -145,12 +147,19 @@ impl EventHandler for Handler {
                         debug!(filename = %attachment.filename, "skipping audio attachment (STT disabled)");
                     }
                 } else if is_text_attachment(attachment) {
+                    if text_file_count >= TEXT_FILE_COUNT_CAP {
+                        warn!(filename = %attachment.filename, count = text_file_count, "text file count cap reached, skipping");
+                        continue;
+                    }
+                    // Pre-check with Discord-reported size (fast path, avoids unnecessary download).
+                    // Running total uses actual downloaded bytes for accurate accounting.
                     if text_file_bytes + u64::from(attachment.size) > TEXT_TOTAL_CAP {
                         warn!(filename = %attachment.filename, total = text_file_bytes, "text attachments total exceeds 1MB cap, skipping remaining");
                         continue;
                     }
-                    if let Some(content_block) = download_and_read_text_file(attachment).await {
-                        text_file_bytes += u64::from(attachment.size);
+                    if let Some((content_block, actual_bytes)) = download_and_read_text_file(attachment).await {
+                        text_file_bytes += actual_bytes;
+                        text_file_count += 1;
                         debug!(filename = %attachment.filename, "adding text file attachment");
                         content_blocks.push(content_block);
                     }
@@ -273,7 +282,6 @@ const TEXT_MIME_TYPES: &[&str] = &[
     "application/json",
     "application/xml",
     "application/javascript",
-    "application/typescript",
     "application/x-yaml",
     "application/x-sh",
     "application/toml",
@@ -303,7 +311,7 @@ fn is_text_attachment(attachment: &serenity::model::channel::Attachment) -> bool
 /// Files larger than 512 KB are skipped to avoid bloating the prompt.
 async fn download_and_read_text_file(
     attachment: &serenity::model::channel::Attachment,
-) -> Option<ContentBlock> {
+) -> Option<(ContentBlock, u64)> {
     const MAX_SIZE: u64 = 512 * 1024; // 512 KB
 
     if u64::from(attachment.size) > MAX_SIZE {
@@ -317,24 +325,27 @@ async fn download_and_read_text_file(
         return None;
     }
     let bytes = resp.bytes().await.ok()?;
+    let actual_size = bytes.len() as u64;
 
     // Defense-in-depth: verify actual download size
-    if bytes.len() as u64 > MAX_SIZE {
-        warn!(filename = %attachment.filename, size = bytes.len(), "downloaded text file exceeds 512KB limit, skipping");
+    if actual_size > MAX_SIZE {
+        warn!(filename = %attachment.filename, size = actual_size, "downloaded text file exceeds 512KB limit, skipping");
         return None;
     }
 
-    let text = String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| {
-        String::from_utf8_lossy(&bytes).into_owned()
-    });
+    // from_utf8_lossy returns Cow::Borrowed for valid UTF-8 (zero-copy)
+    let text = String::from_utf8_lossy(&bytes).into_owned();
 
-    // Use enough backticks to avoid conflicts with content that contains triple backticks
-    let fence = if text.contains("```") { "````" } else { "```" };
+    // Dynamic fence: keep adding backticks until the fence doesn't appear in content
+    let mut fence = "```".to_string();
+    while text.contains(fence.as_str()) {
+        fence.push('`');
+    }
 
-    debug!(filename = %attachment.filename, chars = text.len(), "text file inlined");
-    Some(ContentBlock::Text {
+    debug!(filename = %attachment.filename, bytes = text.len(), "text file inlined");
+    Some((ContentBlock::Text {
         text: format!("[File: {}]\n{fence}\n{}\n{fence}", attachment.filename, text),
-    })
+    }, actual_size))
 }
 
 /// Check if an attachment is an audio file (voice messages are typically audio/ogg).


### PR DESCRIPTION
## Context

Issue #161 requested multimodal attachment support (images, files, voice). Image support was shipped in #158 / #210, and voice STT was shipped in #225 / #228. **This PR addresses the remaining scope: text-based file attachments.**

## Summary

Download text-based file attachments from Discord messages and inject their content as `ContentBlock::Text` blocks, so downstream ACP agents can read uploaded code, configs, logs, etc.

## Changes

- **`is_text_attachment()`** — detects text files via MIME type (`text/*`, `application/json`, `application/xml`) and a `TEXT_EXTENSIONS` whitelist (~40 common extensions: `.txt`, `.csv`, `.log`, `.md`, `.json`, `.rs`, `.py`, `.js`, `.go`, etc.)
- **`download_and_read_text_file()`** — downloads the attachment (512 KB size limit), reads as UTF-8 with lossy fallback, wraps in a code block with filename header
- **Attachment routing** updated: audio → text file → image → skip

## Design Decisions

- **512 KB hardcoded limit** — consistent with image (10 MB) and audio (25 MB) which also use hardcoded limits. No config needed.
- **UTF-8 lossy fallback** — gracefully handles files with occasional non-UTF-8 bytes instead of rejecting them entirely.
- **Code block wrapping** — `[File: name.ext]\n` ` ` `\n...\n` ` ` format gives the agent clear file boundaries.
- **`.env` in `TEXT_EXTENSIONS`** — intentionally included so agents can read `.env.example` and similar template files. Actual secret `.env` files should not be shared in Discord channels where the bot operates; this is a channel-level access concern, not a bot concern.

Closes #161

https://discord.com/channels/1488041051187974246/1490282656913559673/1494333565221994719