### PR TITLE
feat: outbound image/file attachments from agent → Discord

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: build install clean
+
+BINARY := openab
+TARGET := target/release/$(BINARY)
+INSTALL_DIR := $(HOME)/.local/bin
+
+build:
+	cargo build --release
+	@# macOS 26+ AMFI: adhoc-signed binaries from cargo hang at _dyld_start.
+	@# Re-signing fixes this. Safe no-op on Linux.
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		codesign --force --sign - $(TARGET) && \
+		echo "✓ codesigned $(TARGET)"; \
+	fi
+
+install: build
+	cp $(TARGET) $(INSTALL_DIR)/$(BINARY)
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		codesign --force --sign - $(INSTALL_DIR)/$(BINARY) && \
+		echo "✓ installed + codesigned → $(INSTALL_DIR)/$(BINARY)"; \
+	fi
+
+clean:
+	cargo clean

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -9,6 +9,7 @@ use image::ImageReader;
 use std::io::Cursor;
 use std::sync::LazyLock;
 use serenity::async_trait;
+use serenity::builder::{CreateAttachment as SerenityAttachment, CreateMessage};
 use serenity::model::channel::{Message, ReactionType};
 use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, MessageId};
@@ -16,7 +17,7 @@ use serenity::prelude::*;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::watch;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Reusable HTTP client for downloading Discord attachments.
 /// Built once with a 30s timeout and rustls TLS (no native-tls deps).
@@ -589,12 +590,33 @@ async fn stream_prompt(
                 final_content
             };
 
+            // Extract outbound file attachments from agent response.
+            // Pattern: ![alt text](/path/to/file) — only files from allowlisted dirs.
+            let (final_content, attachments) = extract_outbound_attachments(&final_content);
+
             let chunks = format::split_message(&final_content, 2000);
             for (i, chunk) in chunks.iter().enumerate() {
                 if i == 0 {
                     let _ = edit(&ctx, channel, current_msg_id, chunk).await;
                 } else {
                     let _ = channel.say(&ctx.http, chunk).await;
+                }
+            }
+
+            // Upload extracted attachments as separate messages
+            for attach_path in &attachments {
+                match SerenityAttachment::path(attach_path).await {
+                    Ok(file) => {
+                        let msg = CreateMessage::new().add_file(file);
+                        if let Err(e) = channel.send_message(&ctx.http, msg).await {
+                            warn!(path = %attach_path.display(), error = %e, "failed to send outbound attachment");
+                        } else {
+                            info!(path = %attach_path.display(), "outbound attachment sent");
+                        }
+                    }
+                    Err(e) => {
+                        warn!(path = %attach_path.display(), error = %e, "failed to read outbound attachment");
+                    }
                 }
             }
 
@@ -651,6 +673,74 @@ fn compose_display(tool_lines: &[ToolEntry], text: &str) -> String {
     }
     out.push_str(text.trim_end());
     out
+}
+
+/// Maximum file size for outbound attachments (25 MB — Discord limit).
+const OUTBOUND_MAX_SIZE: u64 = 25 * 1024 * 1024;
+
+/// Directories from which outbound attachments are allowed.
+/// Security: prevents agents from exfiltrating arbitrary files.
+const OUTBOUND_ALLOWED_PREFIXES: &[&str] = &[
+    "/tmp/",
+    "/var/folders/",
+];
+
+/// Regex for outbound attachment markers: `![alt](/path/to/file)`
+static OUTBOUND_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"!\[[^\]]*\]\((/[^\)]+)\)").unwrap()
+});
+
+/// Scan agent response for `![...](/path/to/file)` markers.
+/// Returns (cleaned text, list of valid file paths to upload).
+/// Only files from allowlisted directories, ≤25MB, that actually exist are included.
+fn extract_outbound_attachments(text: &str) -> (String, Vec<std::path::PathBuf>) {
+    let mut attachments = Vec::new();
+    let mut paths_to_strip = Vec::new();
+
+    for cap in OUTBOUND_RE.captures_iter(text) {
+        let full_match = cap.get(0).unwrap().as_str();
+        let path_str = &cap[1];
+        let path = std::path::PathBuf::from(path_str);
+
+        // Security: only allow files from allowlisted directories
+        let allowed = OUTBOUND_ALLOWED_PREFIXES
+            .iter()
+            .any(|prefix| path_str.starts_with(prefix));
+        if !allowed {
+            warn!(path = %path_str, "outbound attachment blocked: path not in allowlist");
+            continue;
+        }
+
+        // Validate file exists and is within size limit
+        match std::fs::metadata(&path) {
+            Ok(meta) if meta.is_file() && meta.len() <= OUTBOUND_MAX_SIZE => {
+                info!(path = %path_str, size = meta.len(), "outbound attachment found");
+                attachments.push(path);
+                paths_to_strip.push(full_match.to_string());
+            }
+            Ok(meta) if meta.len() > OUTBOUND_MAX_SIZE => {
+                warn!(path = %path_str, size = meta.len(), "outbound attachment too large (>25MB)");
+            }
+            Ok(_) => {
+                warn!(path = %path_str, "outbound attachment is not a regular file");
+            }
+            Err(e) => {
+                debug!(path = %path_str, error = %e, "outbound attachment not found, keeping as text");
+            }
+        }
+    }
+
+    // Strip matched markers from text
+    let mut cleaned = text.to_string();
+    for marker in &paths_to_strip {
+        cleaned = cleaned.replace(marker, "");
+    }
+    // Clean up leftover blank lines from stripped markers
+    while cleaned.contains("\n\n\n") {
+        cleaned = cleaned.replace("\n\n\n", "\n\n");
+    }
+
+    (cleaned.trim().to_string(), attachments)
 }
 
 static MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
@@ -778,5 +868,71 @@ mod tests {
     fn invalid_data_returns_error() {
         let garbage = vec![0x00, 0x01, 0x02, 0x03];
         assert!(resize_and_compress(&garbage).is_err());
+    }
+
+    #[test]
+    fn outbound_extracts_tmp_file() {
+        // Create a temp file
+        let path = "/tmp/openab_test_outbound.png";
+        std::fs::write(path, b"fake png data").unwrap();
+
+        let text = "Here is a screenshot:\n![screenshot](/tmp/openab_test_outbound.png)\nDone.";
+        let (cleaned, attachments) = extract_outbound_attachments(text);
+
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0], std::path::PathBuf::from(path));
+        assert!(!cleaned.contains("openab_test_outbound"));
+        assert!(cleaned.contains("Here is a screenshot:"));
+        assert!(cleaned.contains("Done."));
+
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn outbound_blocks_non_allowlisted_path() {
+        let text = "![secret](/etc/passwd)";
+        let (cleaned, attachments) = extract_outbound_attachments(text);
+
+        assert!(attachments.is_empty());
+        // Blocked markers stay in text (not stripped)
+        assert!(cleaned.contains("/etc/passwd"));
+    }
+
+    #[test]
+    fn outbound_ignores_nonexistent_file() {
+        let text = "![img](/tmp/nonexistent_file_abc123.png)";
+        let (cleaned, attachments) = extract_outbound_attachments(text);
+
+        assert!(attachments.is_empty());
+        // Non-existent files stay in text as regular markdown
+        assert!(cleaned.contains("nonexistent_file_abc123"));
+    }
+
+    #[test]
+    fn outbound_handles_multiple_attachments() {
+        let p1 = "/tmp/openab_test_multi_1.png";
+        let p2 = "/tmp/openab_test_multi_2.jpg";
+        std::fs::write(p1, b"data1").unwrap();
+        std::fs::write(p2, b"data2").unwrap();
+
+        let text = format!("A ![one]({p1}) B ![two]({p2}) C");
+        let (cleaned, attachments) = extract_outbound_attachments(&text);
+
+        assert_eq!(attachments.len(), 2);
+        assert!(cleaned.contains("A"));
+        assert!(cleaned.contains("B"));
+        assert!(cleaned.contains("C"));
+
+        std::fs::remove_file(p1).ok();
+        std::fs::remove_file(p2).ok();
+    }
+
+    #[test]
+    fn outbound_no_markers_passthrough() {
+        let text = "Just regular text with no images.";
+        let (cleaned, attachments) = extract_outbound_attachments(text);
+
+        assert!(attachments.is_empty());
+        assert_eq!(cleaned, text);
     }
 }


### PR DESCRIPTION
## What problem does this solve?

Agents running through OpenAB can receive images from users (PR #158), but have **no native path to send images/files back**. The only workaround is agents calling the Discord REST API directly via `curl` with the bot token — requiring the agent to know the token and channel ID, sending messages outside OpenAB's thread context, and breaking portability across agents.

Closes #298

## At a Glance

```
┌──────────────────────┐
│   CLI Agent Process   │
│  (Claude Code / Codex │
│   / Cursor / Copilot) │
└──────────┬───────────┘
           │ ACP response text:
           │ "Here's the screenshot
           │  ![img](/tmp/screen.png)"
           ▼
┌──────────────────────────────────┐
│            OpenAB                │
│                                  │
│  1. extract_outbound_attachments │
│     ├─ regex: ![...](/path)      │
│     ├─ allowlist: /tmp/, /var/   │
│     ├─ size ≤ 25MB               │
│     └─ strip marker from text    │
│                                  │
│  2. Text reply (marker removed)  │
│     → edit_message(text)         │
│                                  │
│  3. File attachment              │
│     → CreateAttachment::path()   │
│     → channel.send_message(file) │
└──────────────┬───────────────────┘
               ▼
┌──────────────────────┐
│   Discord Channel     │
│                       │
│   📝 cleaned text     │
│   📎 native attachment│
└───────────────────────┘
```

## Prior Art & Industry Research

**OpenClaw:**

Uses a `MEDIA: /path/to/file` text directive pattern. The agent writes `MEDIA: <path-or-url>` inline in its response text. The gateway's `splitMediaFromOutput()` ([`src/media/parse.ts`](https://github.com/openclaw/openclaw)) extracts these via regex, then routes through a 4-stage pipeline: parse → load (with SSRF protection, HEIC conversion, size capping) → normalize → channel delivery. Each channel plugin implements `sendPhoto`/`sendDocument`/etc.

Key lessons from OpenClaw:
- Text-directive approach is simple but causes **false positives** — `MEDIA:` appearing in tool results or docs triggers unintended file loading ([#18780](https://github.com/openclaw/openclaw/issues/18780), [#16935](https://github.com/openclaw/openclaw/issues/16935))
- A security advisory ([GHSA-r8g4-86fx-92mq](https://github.com/openclaw/openclaw/security/advisories/GHSA-r8g4-86fx-92mq)) was issued because MEDIA: could reference arbitrary local files → fixed with `mediaLocalRoots` directory allowlist
- Relative paths break due to working directory changes before async delivery ([#8759](https://github.com/openclaw/openclaw/issues/8759))
- Multiple images sent as separate messages, not albums ([#14027](https://github.com/openclaw/openclaw/issues/14027))

**Hermes Agent:**

Uses a nearly identical `MEDIA:/path/to/file` tag convention. `BasePlatformAdapter.extract_media()` ([`gateway/platforms/base.py`](https://github.com/NousResearch/hermes-agent)) parses output, returns `(media_files_list, cleaned_text)`. Tags are stripped from displayed text. File routing is extension-based: `.png/.jpg` → `send_image_file()`, `.ogg/.mp3` → `send_voice()`, `.mp4` → `send_video()`, everything else → `send_document()`. Each platform adapter overrides the methods it supports, with graceful fallback to text.

Key lessons from Hermes:
- **Fallback chain** — unsupported media types degrade to text (send URL/path), never crash
- **Post-stream extraction** — MEDIA: tags stripped from streamed text immediately, but file delivery happens after stream completes
- Agents lack explicit `send_image` tools — they embed `MEDIA:` in text and rely on post-processing ([#4701](https://github.com/NousResearch/hermes-agent/issues/4701))

**Other references — the agent runtimes we tested with:**

OpenAB bridges CLI agents to Discord via ACP (Agent Client Protocol). The four agents we tested are:

| Agent Runtime | Vendor | How it produces media references |
|---|---|---|
| **Claude Code** (`@agentclientprotocol/claude-agent-acp`) | Anthropic | Naturally produces markdown `![alt](path)` when referencing files. Can generate images via tools and reference them in output. |
| **Codex CLI** | OpenAI | Produces markdown image syntax. File I/O via shell commands; references output files in markdown. |
| **Cursor** (CLI agent mode) | Anysphere | Produces markdown when describing files. Has filesystem access and can create/read images. |
| **GitHub Copilot** (CLI agent) | Microsoft | Produces markdown output. Can invoke shell commands to create files and reference them. |

All four agents naturally output `![description](path)` when referencing local files — this is standard LLM markdown behavior, which is why we chose markdown syntax over a custom `MEDIA:` directive.

**Comparison table:**

| Aspect | OpenClaw | Hermes Agent | OpenAB (this PR) |
|---|---|---|---|
| Marker syntax | `MEDIA: /path` | `MEDIA:/path` | `![alt](/path)` (markdown) |
| Extraction | Regex on text output | Regex on text output | Regex on text output |
| Path security | `mediaLocalRoots` allowlist (post-CVE) | No explicit allowlist | `/tmp/`, `/var/folders/` allowlist |
| Size limit | 50MB images, 16MB audio/video | Platform-dependent | 25MB (Discord limit) |
| File type routing | Extension → channel-specific method | Extension → adapter method | Single path (CreateAttachment) |
| Multi-file | Separate messages (no batching) | Per-file delivery | Separate messages |
| False positive risk | High (any `MEDIA:` in text) | Moderate | Low (markdown `![]()` is structural) |
| Platforms | 7+ (Telegram, Discord, Slack…) | 17+ | Discord only |
| Tested agents | n/a (built-in agent) | n/a (built-in agent) | Claude Code, Codex, Cursor, Copilot |

## Proposed Solution

### Outbound Attachment Detection & Upload

1. Agent response containing `![alt](/path/to/file)` is intercepted by `extract_outbound_attachments()` in `discord.rs`
2. Security validation: path must start with `/tmp/` or `/var/folders/`, file must exist, be a regular file, and ≤ 25MB
3. Valid files uploaded via serenity `CreateAttachment::path()` + `CreateMessage::new().add_file()`
4. Markers stripped from the text reply; leftover blank lines cleaned up
5. Attachments sent as follow-up messages to the channel

### macOS Build Fix (Makefile)

`cargo build` on macOS 26.3+ produces adhoc-signed binaries that hang at `_dyld_start` due to AMFI enforcement. `make build` / `make install` auto-run `codesign --force --sign -` on Darwin. No-op on Linux.

## Why this approach?

We chose **markdown image syntax** (`![alt](/path)`) over `MEDIA:` for three reasons:

1. **Lower false positive risk** — Both OpenClaw and Hermes suffer from `MEDIA:` appearing in tool outputs, documentation, or release notes and triggering unintended file loads. Markdown `![]()` syntax is structurally distinct and rarely appears in agent prose outside of intentional use.

2. **Natural for all 4 tested agent runtimes** — Claude Code, Codex, Cursor, and Copilot all produce markdown `![description](path)` when referencing images. No special prompting needed — the agents already know this syntax.

3. **Minimal code change** — OpenAB is Discord-only, so we don't need the multi-platform routing complexity of OpenClaw (4-stage pipeline) or Hermes (per-platform adapter chain). A single regex + `CreateAttachment` covers the use case in ~70 lines of Rust.

The path allowlist approach was directly informed by OpenClaw's CVE ([GHSA-r8g4-86fx-92mq](https://github.com/openclaw/openclaw/security/advisories/GHSA-r8g4-86fx-92mq)) — we enforce it from day one rather than retrofitting after a security incident.

## Alternatives Considered

| Alternative | Why not chosen |
|---|---|
| `MEDIA:` directive (OpenClaw/Hermes style) | Higher false positive risk; not native markdown — agents would need explicit prompting to use it |
| Dedicated XML tag `<attachment path="..." />` | Unambiguous but requires agents to learn a custom syntax; LLMs don't naturally produce this |
| ACP content block extension | Future-proof but ACP spec doesn't yet support file/image output blocks; would require upstream spec changes |
| Agent calls Discord API directly (current workaround) | Works but requires bot token + channel ID in agent context; messages land outside OpenAB's session/thread management |
| serenity `EditMessage` with attachment | serenity's `EditMessage` doesn't support adding attachments to existing messages; must use `CreateMessage` for follow-up |

## Validation

- [x] `cargo check` passes
- [x] `cargo test` — 39/39 pass, including 5 new outbound attachment tests:
  - `outbound_no_markers_passthrough` — text without markers unchanged
  - `outbound_extracts_tmp_file` — `/tmp/` file correctly extracted
  - `outbound_blocks_non_allowlisted_path` — `/etc/passwd` blocked
  - `outbound_ignores_nonexistent_file` — missing file kept as text
  - `outbound_handles_multiple_attachments` — multiple files in one response
- [x] Live tested with **4 different agent runtimes** on macOS via launchd multi-agent deployment:
  - **Claude Code** (Anthropic, via `@agentclientprotocol/claude-agent-acp`)
  - **Codex CLI** (OpenAI)
  - **Cursor** (Anysphere, IDE agent mode)
  - **GitHub Copilot** (Microsoft, CLI agent)
- [x] Verified in Discord: image appears as native attachment, text marker stripped, non-allowlisted paths blocked

**Observation from live testing:**

Some agents (notably Codex and Copilot) attempted to bypass the native mechanism by calling the Discord REST API directly via `curl` with the bot token. This confirms the original problem statement — agents resort to hacky workarounds when no native path exists. Notably, even when an agent used the `curl` workaround, OpenAB's outbound handler **still triggered simultaneously** on the `![](/path)` markers in the same response, successfully uploading the file through the native path. After the agents discovered the native mechanism (by reading `discord.rs`), they switched to using `![alt](/path)` exclusively.

**Log output confirming successful upload:**
```
INFO openab::discord: outbound attachment found path=/tmp/test_outbound.png size=588
INFO openab::discord: outbound attachment sent path=/tmp/test_outbound.png
WARN openab::discord: outbound attachment blocked: path not in allowlist path=/path/to/file
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)