### PR TITLE
feat: add Cursor Agent CLI support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
           - { suffix: "-gemini", dockerfile: "Dockerfile.gemini", artifact: "gemini" }
           - { suffix: "-copilot", dockerfile: "Dockerfile.copilot", artifact: "copilot" }
           - { suffix: "-opencode", dockerfile: "Dockerfile.opencode", artifact: "opencode" }
+          - { suffix: "-cursor", dockerfile: "Dockerfile.cursor", artifact: "cursor" }
         platform:
           - { os: linux/amd64, runner: ubuntu-latest }
           - { os: linux/arm64, runner: ubuntu-24.04-arm }
@@ -133,6 +134,7 @@ jobs:
           - { suffix: "-gemini", artifact: "gemini" }
           - { suffix: "-copilot", artifact: "copilot" }
           - { suffix: "-opencode", artifact: "opencode" }
+          - { suffix: "-cursor", artifact: "cursor" }
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -182,6 +184,7 @@ jobs:
           - { suffix: "-gemini" }
           - { suffix: "-copilot" }
           - { suffix: "-opencode" }
+          - { suffix: "-cursor" }
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -19,6 +19,7 @@ jobs:
           - { dockerfile: Dockerfile.gemini, suffix: "-gemini", agent: "gemini", agent_args: "--acp" }
           - { dockerfile: Dockerfile.copilot, suffix: "-copilot", agent: "copilot", agent_args: "--acp" }
           - { dockerfile: Dockerfile.opencode, suffix: "-opencode", agent: "opencode", agent_args: "acp" }
+          - { dockerfile: Dockerfile.cursor, suffix: "-cursor", agent: "cursor-agent", agent_args: "acp" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
 
 # Install Cursor Agent CLI (pinned version)
 ARG CURSOR_VERSION=2026.04.08-a41fba1

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -1,0 +1,42 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+
+# Install Cursor Agent CLI (pinned version)
+ARG CURSOR_VERSION=2026.04.08-a41fba1
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
+    curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \
+      -o /tmp/cursor.tar.gz && \
+    mkdir -p /opt/cursor-agent && \
+    tar xzf /tmp/cursor.tar.gz -C /opt/cursor-agent && \
+    ln -s /opt/cursor-agent/cursor-agent /usr/local/bin/cursor-agent && \
+    rm /tmp/cursor.tar.gz
+
+# Install gh CLI (for auth and token management)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash -u 1000 node
+ENV HOME=/home/node
+WORKDIR /home/node
+
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENTRYPOINT ["openab"]
+CMD ["/etc/openab/config.toml"]

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -43,4 +43,4 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["openab"]
-CMD ["/etc/openab/config.toml"]
+CMD ["run", "/etc/openab/config.toml"]

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -16,11 +16,10 @@ RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
     curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \
       -o /tmp/cursor.tar.gz && \
-    mkdir -p /tmp/cursor-agent && \
-    tar xzf /tmp/cursor.tar.gz -C /tmp/cursor-agent && \
-    cp /tmp/cursor-agent/cursor-agent /usr/local/bin/ && \
-    chmod +x /usr/local/bin/cursor-agent && \
-    rm -rf /tmp/cursor-agent /tmp/cursor.tar.gz
+    tar xzf /tmp/cursor.tar.gz -C /opt && \
+    mv /opt/dist-package /opt/cursor-agent && \
+    ln -s /opt/cursor-agent/cursor-agent /usr/local/bin/cursor-agent && \
+    rm /tmp/cursor.tar.gz
 
 # Install gh CLI (for auth and token management)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -11,6 +11,10 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
 
 # Install Cursor Agent CLI (pinned version)
+# Tarball source: https://downloads.cursor.com/lab/<version>/linux/<arch>/agent-cli-package.tar.gz
+# URL scheme scraped from Cursor's official downloads page — no apt/yum package exists.
+# If Cursor changes this pattern, the build fails with curl 404. Monitor
+# https://cursor.com/cli or https://docs.cursor.com/cli for version/URL updates.
 ARG CURSOR_VERSION=2026.04.08-a41fba1
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -31,8 +31,6 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash -u 1000 agent
-RUN mkdir -p /home/agent/.cursor && \
-    chown -R agent:agent /home/agent
 ENV HOME=/home/agent
 WORKDIR /home/agent
 

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -16,10 +16,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
     curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \
       -o /tmp/cursor.tar.gz && \
-    mkdir -p /opt/cursor-agent && \
-    tar xzf /tmp/cursor.tar.gz -C /opt/cursor-agent && \
-    ln -s /opt/cursor-agent/cursor-agent /usr/local/bin/cursor-agent && \
-    rm /tmp/cursor.tar.gz
+    mkdir -p /tmp/cursor-agent && \
+    tar xzf /tmp/cursor.tar.gz -C /tmp/cursor-agent && \
+    cp /tmp/cursor-agent/cursor-agent /usr/local/bin/ && \
+    chmod +x /usr/local/bin/cursor-agent && \
+    rm -rf /tmp/cursor-agent /tmp/cursor.tar.gz
 
 # Install gh CLI (for auth and token management)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -29,13 +30,15 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     apt-get update && apt-get install -y --no-install-recommends gh && \
     rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m -s /bin/bash -u 1000 node
-ENV HOME=/home/node
-WORKDIR /home/node
+RUN useradd -m -s /bin/bash -u 1000 agent
+RUN mkdir -p /home/agent/.cursor && \
+    chown -R agent:agent /home/agent
+ENV HOME=/home/agent
+WORKDIR /home/agent
 
-COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
 
-USER node
+USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["openab"]

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # URL scheme scraped from Cursor's official downloads page — no apt/yum package exists.
 # If Cursor changes this pattern, the build fails with curl 404. Monitor
 # https://cursor.com/cli or https://docs.cursor.com/cli for version/URL updates.
-ARG CURSOR_VERSION=2026.04.08-a41fba1
+ARG CURSOR_VERSION=2026.04.14-ee4b43a
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
     curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 | Gemini | `gemini --acp` | Native | [docs/gemini.md](docs/gemini.md) |
 | OpenCode | `opencode acp` | Native | [docs/opencode.md](docs/opencode.md) |
 | Copilot CLI ⚠️ | `copilot --acp --stdio` | Native | [docs/copilot.md](docs/copilot.md) |
+| Cursor ⚠️ | `cursor-agent acp` | Native | [docs/cursor.md](docs/cursor.md) |
 
 > 🔧 Running multiple agents? See [docs/multi-agent.md](docs/multi-agent.md)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 | Gemini | `gemini --acp` | Native | [docs/gemini.md](docs/gemini.md) |
 | OpenCode | `opencode acp` | Native | [docs/opencode.md](docs/opencode.md) |
 | Copilot CLI ⚠️ | `copilot --acp --stdio` | Native | [docs/copilot.md](docs/copilot.md) |
-| Cursor ⚠️ | `cursor-agent acp` | Native | [docs/cursor.md](docs/cursor.md) |
+| Cursor | `cursor-agent acp` | Native | [docs/cursor.md](docs/cursor.md) |
 
 > 🔧 Running multiple agents? See [docs/multi-agent.md](docs/multi-agent.md)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -140,7 +140,7 @@ release-pr.yml 在 Release PR 中自動更新以下檔案的版本：
 
 ## Image Variants
 
-每次 build 產出 5 個 multi-arch image (linux/amd64 + linux/arm64)：
+每次 build 產出 6 個 multi-arch image (linux/amd64 + linux/arm64)：
 
 ```
 ghcr.io/openabdev/openab          # default (kiro-cli)
@@ -148,6 +148,8 @@ ghcr.io/openabdev/openab-codex    # codex
 ghcr.io/openabdev/openab-claude   # claude
 ghcr.io/openabdev/openab-gemini   # gemini
 ghcr.io/openabdev/openab-opencode # opencode
+ghcr.io/openabdev/openab-copilot  # copilot
+ghcr.io/openabdev/openab-cursor   # cursor
 ```
 
 Image tags 依 release 類型不同：

--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -27,6 +27,9 @@ Agents deployed:
 {{- else if eq $cfg.command "opencode" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- opencode auth login
+{{- else if eq $cfg.command "cursor-agent" }}
+    Authenticate:
+    kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- cursor-agent login
 {{- end }}
 
     Restart after auth:

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -79,11 +79,36 @@ agents:
     #     enabled: true
     #     storageClass: ""
     #     size: 1Gi
-    #   # ⚠️ When set, this ConfigMap mount shadows any file at the same path on the PVC.
-    #   # The PVC file is NOT deleted but becomes invisible to the agent. Remove agentsMd to restore.
     #   agentsMd: ""
     #   resources: {}
     #   image: "ghcr.io/openabdev/openab-opencode:latest"
+    # cursor:
+    #   command: cursor-agent
+    #   args:
+    #     - acp
+    #     - --model
+    #     - auto
+    #     - --workspace
+    #     - /home/agent
+    #   discord:
+    #     botToken: ""
+    #     allowedChannels:
+    #       - "YOUR_CHANNEL_ID"
+    #     allowedUsers: []
+    #   workingDir: /home/agent
+    #   env: {}
+    #   envFrom: []
+    #   pool:
+    #     maxSessions: 10
+    #     sessionTtlHours: 24
+    #   reactions:
+    #     enabled: true
+    #     removeAfterReply: false
+    #   persistence:
+    #     enabled: true
+    #     storageClass: ""
+    #     size: 1Gi
+    #   image: "ghcr.io/openabdev/openab-cursor:latest"
     image: ""
     command: kiro-cli
     args:

--- a/config.toml.example
+++ b/config.toml.example
@@ -44,6 +44,12 @@ working_dir = "/home/agent"
 # # equivalent to --trust-all-tools on other backends.
 # # Run `opencode auth login` once before starting openab.
 
+# [agent]
+# command = "cursor-agent"
+# args = ["acp", "--model", "auto", "--workspace", "/home/agent"]
+# working_dir = "/home/agent"
+# env = {}  # Auth via: kubectl exec -it <pod> -- cursor-agent login
+
 [pool]
 max_sessions = 10
 session_ttl_hours = 24

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -1,0 +1,81 @@
+# Cursor Agent CLI — Agent Backend Guide
+
+How to run OpenAB with [Cursor Agent CLI](https://www.cursor.com/) as the agent backend.
+
+## Prerequisites
+
+- A paid [Cursor](https://www.cursor.com/pricing) subscription (**Pro or Business** — Free tier does not include Agent CLI access)
+- Cursor Agent CLI with native ACP support
+
+## Architecture
+
+```
+┌──────────────┐  Gateway WS   ┌──────────────┐  ACP stdio    ┌──────────────────────┐
+│   Discord    │◄─────────────►│ openab       │──────────────►│ cursor-agent acp      │
+│   User       │               │   (Rust)     │◄── JSON-RPC ──│ (Cursor Agent CLI)    │
+└──────────────┘               └──────────────┘               └──────────────────────┘
+```
+
+OpenAB spawns `cursor-agent acp` as a child process and communicates via stdio JSON-RPC. No intermediate layers.
+
+## Configuration
+
+```toml
+[agent]
+command = "cursor-agent"
+args = ["acp"]
+working_dir = "/home/agent"
+# Auth via: kubectl exec -it <pod> -- cursor-agent login
+```
+
+## Docker
+
+Build with the Cursor-specific Dockerfile:
+
+```bash
+docker build -f Dockerfile.cursor -t openab-cursor .
+```
+
+The Dockerfile installs a pinned version of Cursor Agent CLI via direct download from `downloads.cursor.com`. The version is controlled by the `CURSOR_VERSION` build arg.
+
+## Authentication
+
+Cursor Agent CLI uses its own login flow. In a headless container:
+
+```bash
+# 1. Exec into the running pod/container
+kubectl exec -it deployment/openab-cursor -- bash
+
+# 2. Authenticate via device flow
+cursor-agent login
+
+# 3. Follow the device code flow in your browser
+
+# 4. Restart the pod (token is persisted via PVC)
+kubectl rollout restart deployment/openab-cursor
+```
+
+The auth token is stored under `~/.cursor-agent/` and persisted across pod restarts via PVC.
+
+## Helm Install
+
+> **Note**: The `ghcr.io/openabdev/openab-cursor` image is not published yet. You must build it locally first with `docker build -f Dockerfile.cursor -t openab-cursor .` and push to your own registry, or use a local image.
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.cursor.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.cursor.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.cursor.image=ghcr.io/openabdev/openab-cursor:latest \
+  --set agents.cursor.command=cursor-agent \
+  --set 'agents.cursor.args={acp}' \
+  --set agents.cursor.persistence.enabled=true \
+  --set agents.cursor.workingDir=/home/node
+```
+
+## Known Limitations
+
+- Cursor Agent CLI is a separate distribution from Cursor Desktop — they are not the same binary
+- No official apt/yum package; the Dockerfile downloads a pinned tarball directly
+- `cursor-agent login` requires an interactive terminal for the device flow
+- Auth token persistence requires a PVC mount at the user home directory

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -95,6 +95,60 @@ In ACP mode, `--model` can be appended after `acp`. If omitted, the account defa
 
 To verify which model is active, ask the agent "who are you" — the underlying model will typically self-identify (e.g. "I am Gemini, a large language model built by Google.").
 
+## MCP Usage (ACP mode caveats)
+
+Cursor Agent CLI supports MCP servers configured via `.cursor/mcp.json` in the active workspace directory. **Which directory counts as the workspace is determined by the `--workspace` flag** — if omitted, cursor-agent auto-detects from `cwd`, which is usually `/home/agent` in OpenAB containers via the Dockerfile `WORKDIR` directive but can drift in interactive or local runs. For reproducible MCP loading, pass `--workspace` explicitly:
+
+```toml
+[agent]
+command = "cursor-agent"
+args = ["acp", "--model", "auto", "--workspace", "/home/agent"]
+```
+
+This anchors:
+- **MCP config lookup**: `/home/agent/.cursor/mcp.json`
+- **Approval file path**: `/home/agent/.cursor/projects/home-agent/mcp-approvals.json` (slug = URL-safe workspace path)
+
+Without `--workspace`, a different cwd would produce a different slug and cursor-agent would not find previously saved approvals.
+
+### Example MCP config
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "/usr/bin/npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+### Approval quirk in ACP mode
+
+Cursor's `--approve-mcps` flag **does not apply in ACP mode** — it only affects the interactive CLI. In ACP mode, MCP servers are gated by an approval file. Two options:
+
+1. **Pre-create the approvals file** at `<workspace>/.cursor/projects/<slug>/mcp-approvals.json`:
+   ```json
+   ["<server-name>-<sha256_hash>"]
+   ```
+   Hash is derived from workspace path + server config.
+
+2. **Approve once interactively**, then let Cursor persist the approval:
+   ```bash
+   kubectl exec -it deployment/openab-cursor -- cursor-agent
+   # invoke an MCP tool, approve the prompt; approval is saved
+   ```
+
+OpenAB itself auto-responds to ACP `session/request_permission` with `allow_always` (see `src/acp/connection.rs`), so once an MCP server is *loaded*, subsequent tool calls pass without prompting. The approval file only gates the initial load.
+
+### Verifying MCP is loaded
+
+```bash
+kubectl exec deployment/openab-cursor -- cursor-agent mcp list
+# Expected: "<server-name>: ready"
+```
+
 ## Known Limitations
 
 - Cursor Agent CLI is a separate distribution from Cursor Desktop — they are not the same binary

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -55,7 +55,7 @@ cursor-agent login
 kubectl rollout restart deployment/openab-cursor
 ```
 
-The auth token is stored under `~/.cursor-agent/` and persisted across pod restarts via PVC.
+The auth token is stored under `~/.cursor/` and persisted across pod restarts via PVC.
 
 ## Helm Install
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -70,8 +70,30 @@ helm install openab openab/openab \
   --set agents.cursor.command=cursor-agent \
   --set 'agents.cursor.args={acp}' \
   --set agents.cursor.persistence.enabled=true \
-  --set agents.cursor.workingDir=/home/node
+  --set agents.cursor.workingDir=/home/agent
 ```
+
+## Model Selection
+
+List available models:
+
+```bash
+cursor-agent --list-models
+# or
+cursor-agent models
+```
+
+To specify a model, pass `--model` as an arg:
+
+```toml
+[agent]
+command = "cursor-agent"
+args = ["acp", "--model", "auto"]
+```
+
+In ACP mode, `--model` can be appended after `acp`. If omitted, the account default is used.
+
+To verify which model is active, ask the agent "who are you" — the underlying model will typically self-identify (e.g. "I am Gemini, a large language model built by Google.").
 
 ## Known Limitations
 


### PR DESCRIPTION
## What problem does this solve?

OpenAB supports several ACP-compatible coding CLIs (Kiro, Claude Code, Codex, Gemini, Copilot) but not **Cursor Agent CLI**. Cursor ships native ACP support (`cursor-agent acp`) and access to 80+ models (Claude, GPT-5, Gemini 3, Grok 4, Kimi K2, Composer, `auto`) behind one subscription, which is strictly additive for users who already pay for Cursor.

Ref #18

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1493798720142180473

## At a Glance

```
Discord mention
      │
      ▼
openab (Rust) ── spawn("cursor-agent", ["acp", "--model", "auto"])
      │
      ▼
cursor-agent acp                    ← native ACP, stdio JSON-RPC
      │
      ├─ initialize                 → agentCapabilities: { loadSession: true }
      ├─ session/new                → sessionId
      └─ session/prompt             → session/update stream → stopReason: end_turn
```

No changes to `src/` — this is a **configuration-only** integration.

## Prior Art & Industry Research

**OpenClaw** ([openclaw/openclaw](https://github.com/openclaw/openclaw)) — personal AI assistant gateway across 20+ messaging platforms. Coding‑CLI story is explicitly **ACP‑based**: a bundled `acpx` runtime plugin drives harnesses via `/acp spawn <agentId>` and `sessions_spawn({ runtime: "acp" })` ([docs/tools/acp-agents.md](https://github.com/openclaw/openclaw/blob/main/docs/tools/acp-agents.md)).
- **Cursor support**: Yes — Cursor is a listed ACP target alongside Codex, Claude Code, Gemini, Copilot under the shared `acpx` runtime.
- **Abstraction**: ACP is primary (`src/acp/*`, `extensions/acpx/`); a separate text-only "CLI Backends" path exists as fallback but is *not* ACP.
- **Pluggability**: Unified — any `acpx`-registered harness is swappable by `agentId`.
- **Known Cursor pain**: openclaw/openclaw#56463 (`cursor-agent acp` works from CLI but dies via gateway — "queue owner unavailable"), openclaw/openclaw#56102 (MCP `protocolVersion: 2025-11-25` rejection from VS Code/Cursor).

**Hermes Agent** ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)) — Nous Research's self-hosted agent across Telegram/Discord/Slack/WhatsApp/Signal/Email + CLI. Uses ACP in the **opposite direction** from openab: runs *as an ACP server* for editors via `hermes acp` ([docs/acp-setup.md](https://github.com/NousResearch/hermes-agent/blob/main/docs/acp-setup.md)).
- **Cursor CLI as backend**: **No**. Only in-tree ACP client is Copilot-specific (`agent/copilot_acp_client.py`). Generalizing it is still an *open proposal* — NousResearch/hermes-agent#5257 (open, unmerged) and NousResearch/hermes-agent#524 (Cursor config import, also open).
- **Abstraction**: LLM-provider-centric (`hermes_cli/providers.py`); coding CLIs are not first-class backends.
- **Pluggability**: No runtime-swap story for CLI harnesses yet.

**Takeaway**: OpenClaw ships the closest analog but through a heavier `acpx` router (and the Cursor path has known gateway bugs). Hermes doesn't do this at all yet. OpenAB's existing direct `spawn(cli, ["acp"])` → stdio JSON-RPC pattern is already well-aligned; this PR just adds Cursor as one more entry in the same pluggable model.

## Proposed Solution

Add Cursor as a first-class agent backend alongside the existing five, **without touching `src/`**:

| File | Change | Description |
|---|---|---|
| `Dockerfile.cursor` | NEW | Multi-stage: rust:1-bookworm builder + debian:bookworm-slim runtime; pinned tarball from `downloads.cursor.com`; `agent` user (uid 1000) |
| `docs/cursor.md` | NEW | Setup guide: architecture, config, Docker, auth, Helm, model selection, limitations |
| `config.toml.example` | MOD | Commented `cursor-agent` `[agent]` block |
| `README.md` | MOD | Cursor row in the agent backends table |
| `.github/workflows/build.yml` | MOD | `-cursor` variant in all 3 CI matrix sections |
| `RELEASING.md` | MOD | cursor (and missing copilot) in image variants, count 4 → 6 |
| `charts/openab/values.yaml` | MOD | Commented cursor example block |
| `charts/openab/templates/NOTES.txt` | MOD | `cursor-agent login` auth instructions |

## Why This Approach

**Native ACP over adapter.** `cursor-agent acp` speaks ACP directly over stdio JSON-RPC. Our existing `src/acp/connection.rs` already sends `protocolVersion: 1` as an integer, which matches the Cursor response verbatim — no shim required. Verified against cursor-agent v2026.04.08-a41fba1:

```
→ initialize  { protocolVersion: 1, clientInfo: { name: "test", version: "0.1" } }
← { protocolVersion: 1,
    agentCapabilities: { loadSession: true,
      mcpCapabilities: { http: true, sse: true },
      promptCapabilities: { audio: false, embeddedContext: false, image: true } },
    authMethods: [{ id: "cursor_login", name: "Cursor Login" }] }
```

**debian:bookworm-slim base, not node:22.** The Cursor tarball is self-contained — it bundles its own `node` binary and JS chunks. A Node base image would add ~170 MB of runtime we'd never use.

**Pinned tarball, not npm/npx.** Cursor Agent CLI is not published on npm; the canonical distribution is `downloads.cursor.com/lab/{version}/linux/{arch}/agent-cli-package.tar.gz`. `ARG CURSOR_VERSION=2026.04.08-a41fba1` pins the version for reproducible builds.

**Tradeoffs:** (1) Cursor Agent CLI requires interactive `cursor-agent login` for auth — same story as kiro-cli; PVC persistence required. (2) Cursor is a separate distribution from Cursor Desktop; version upgrades happen on Cursor's cadence, not ours.

## Alternatives Considered

| Alternative | Rejected because |
|---|---|
| `node:22` base image + `npm install -g` | Cursor isn't published on npm; `node:22` adds ~170 MB of runtime the self-contained tarball doesn't need |
| Third-party ACP adapter (like `codex-acp` pattern) | Cursor ships native ACP — adding an adapter would be strict regression in surface area and latency |
| `cursor-agent exec` (non-interactive mode) | Loses ACP session persistence, streaming, and tool-call plumbing that openab already relies on |
| Bundling Cursor into the default `Dockerfile` | Would force all users to pull Cursor even if they use Kiro/Claude/Codex; separate `Dockerfile.cursor` keeps the default image lean |

## Validation

- [x] `cargo check` passes (no `src/` changes, but verified clean — 45.09s cold)
- [x] `cargo test` passes — **34 passed, 0 failed** (ran locally on this branch)
- [x] Docker build: `docker build -f Dockerfile.cursor -t openab-cursor:local .` succeeds
- [x] K8s deploy: Helm install with `agents.cursor` values on OrbStack + hostPath auth mount
- [x] ACP handshake: JSON-RPC `initialize` round-trip verified against cursor-agent v2026.04.08-a41fba1 (see response above)
- [x] End-to-end: Octocat bot mentioned in Discord, spawned `cursor-agent acp --model auto`, streamed reply back to thread ✅
- [ ] CI matrix (`.github/workflows/build.yml`) will run on merge — local `act` run not attempted

**Manual test steps (reproducible):**
```bash
# 1. Build
docker build -f Dockerfile.cursor -t openab-cursor:local .

# 2. Deploy (OrbStack k8s)
helm upgrade --install openab openab/openab -n openab --create-namespace \
  --set agents.cursor.enabled=true \
  --set agents.cursor.image=openab-cursor:local \
  --set agents.cursor.command=cursor-agent \
  --set 'agents.cursor.args={acp,--model,auto}' \
  --set agents.cursor.discord.botToken=$TOKEN

# 3. Auth (one-time, device flow)
kubectl exec -it deployment/openab-cursor -n openab -- cursor-agent login
kubectl rollout restart deployment/openab-cursor -n openab

# 4. Test
#    In Discord: @Octocat who are you?
#    → thread opens, streams reply from Cursor agent
```

