### PR TITLE
Revert "chore: bump chart to 0.7.3-beta.56 (#279)"

### DIFF
--- a/charts/openab/Chart.yaml
+++ b/charts/openab/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openab
 description: Discord ↔ ACP coding CLI bridge (Kiro CLI, Claude Code, Codex, Gemini)
 type: application
-version: 0.7.3-beta.56
-appVersion: "920ae7e"
+version: 0.7.2
+appVersion: "0.7.2"

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: ghcr.io/openabdev/openab
   # tag defaults to .Chart.AppVersion
-  tag: "920ae7e"
+  tag: ""
   pullPolicy: IfNotPresent
 
 podSecurityContext:


### PR DESCRIPTION
Reverts commit b41b71cdee4264718a7936efcde17e3566e82640

This restores the chart to the stable 0.7.2 release:
- `Chart.yaml`: version → `0.7.2`, appVersion → `"0.7.2"`
- `values.yaml`: tag → `""` (defaults to `.Chart.AppVersion`)

The bot bump to `0.7.3-beta.56` with hardcoded commit SHA `920ae7e` as image tag was incorrect.