### PR TITLE
fix: process group kill + session suspend/resume via session/load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,11 +853,12 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openab"
-version = "0.6.6"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "base64",
  "image",
+ "libc",
  "rand 0.8.5",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "multipart", "json"] }
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
+libc = "0.2"

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -107,7 +107,8 @@ impl ContentBlock {
 
 pub struct AcpConnection {
     _proc: Child,
-    child_pid: i32,
+    /// PID of the direct child, used as the process group ID for cleanup.
+    child_pgid: Option<i32>,
     stdin: Arc<Mutex<ChildStdin>>,
     next_id: AtomicU64,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<JsonRpcMessage>>>>,
@@ -135,10 +136,14 @@ impl AcpConnection {
             .stderr(std::process::Stdio::null())
             .current_dir(working_dir);
         // Create a new process group so we can kill the entire tree.
-        // SAFETY: setpgid is async-signal-safe and called before exec.
+        // SAFETY: setpgid is async-signal-safe (POSIX.1-2008) and called
+        // before exec. Return value checked — failure means the child won't
+        // have its own process group, so kill(-pgid) would be unsafe.
         unsafe {
             cmd.pre_exec(|| {
-                libc::setpgid(0, 0);
+                if libc::setpgid(0, 0) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
                 Ok(())
             });
         }
@@ -148,7 +153,8 @@ impl AcpConnection {
         let mut proc = cmd
             .spawn()
             .map_err(|e| anyhow!("failed to spawn {command}: {e}"))?;
-        let child_pid = proc.id().unwrap_or(0) as i32;
+        let child_pgid = proc.id()
+            .and_then(|pid| i32::try_from(pid).ok());
 
         let stdout = proc.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
         let stdin = proc.stdin.take().ok_or_else(|| anyhow!("no stdin"))?;
@@ -255,7 +261,7 @@ impl AcpConnection {
 
         Ok(Self {
             _proc: proc,
-            child_pid,
+            child_pgid,
             stdin,
             next_id: AtomicU64::new(1),
             pending,
@@ -420,18 +426,19 @@ impl AcpConnection {
     }
 
     /// Kill the entire process group: SIGTERM → SIGKILL.
+    /// Uses std::thread (not tokio::spawn) so SIGKILL fires even during
+    /// runtime shutdown or panic unwinding.
     fn kill_process_group(&mut self) {
-        let pid = self.child_pid;
-        if pid <= 0 {
-            return;
-        }
+        let pgid = match self.child_pgid {
+            Some(pid) if pid > 0 => pid,
+            _ => return,
+        };
         // Stage 1: SIGTERM the process group
-        unsafe { libc::kill(-pid, libc::SIGTERM); }
-        // Stage 2: SIGKILL after brief grace (best-effort, non-blocking)
-        let pid_copy = pid;
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
-            unsafe { libc::kill(-pid_copy, libc::SIGKILL); }
+        unsafe { libc::kill(-pgid, libc::SIGTERM); }
+        // Stage 2: SIGKILL after brief grace (std::thread survives runtime shutdown)
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(1500));
+            unsafe { libc::kill(-pgid, libc::SIGKILL); }
         });
     }
 }

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -419,17 +419,15 @@ impl AcpConnection {
         Ok(())
     }
 
-    /// Kill the entire process group: stdin close → SIGTERM → SIGKILL.
+    /// Kill the entire process group: SIGTERM → SIGKILL.
     fn kill_process_group(&mut self) {
         let pid = self.child_pid;
         if pid <= 0 {
             return;
         }
-        // Stage 1: close stdin (graceful signal for stdio-based agents)
-        drop(self.stdin.clone()); // triggers ChildStdin drop on last Arc ref eventually
-        // Stage 2: SIGTERM the process group
+        // Stage 1: SIGTERM the process group
         unsafe { libc::kill(-pid, libc::SIGTERM); }
-        // Stage 3: SIGKILL after brief grace (best-effort, non-blocking)
+        // Stage 2: SIGKILL after brief grace (best-effort, non-blocking)
         let pid_copy = pid;
         tokio::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_millis(1500)).await;

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -107,11 +107,13 @@ impl ContentBlock {
 
 pub struct AcpConnection {
     _proc: Child,
+    child_pid: i32,
     stdin: Arc<Mutex<ChildStdin>>,
     next_id: AtomicU64,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<JsonRpcMessage>>>>,
     notify_tx: Arc<Mutex<Option<mpsc::UnboundedSender<JsonRpcMessage>>>>,
     pub acp_session_id: Option<String>,
+    pub supports_load_session: bool,
     pub last_active: Instant,
     pub session_reset: bool,
     _reader_handle: JoinHandle<()>,
@@ -131,14 +133,22 @@ impl AcpConnection {
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
-            .current_dir(working_dir)
-            .kill_on_drop(true);
+            .current_dir(working_dir);
+        // Create a new process group so we can kill the entire tree.
+        // SAFETY: setpgid is async-signal-safe and called before exec.
+        unsafe {
+            cmd.pre_exec(|| {
+                libc::setpgid(0, 0);
+                Ok(())
+            });
+        }
         for (k, v) in env {
             cmd.env(k, expand_env(v));
         }
         let mut proc = cmd
             .spawn()
             .map_err(|e| anyhow!("failed to spawn {command}: {e}"))?;
+        let child_pid = proc.id().unwrap_or(0) as i32;
 
         let stdout = proc.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
         let stdin = proc.stdin.take().ok_or_else(|| anyhow!("no stdin"))?;
@@ -245,11 +255,13 @@ impl AcpConnection {
 
         Ok(Self {
             _proc: proc,
+            child_pid,
             stdin,
             next_id: AtomicU64::new(1),
             pending,
             notify_tx,
             acp_session_id: None,
+            supports_load_session: false,
             last_active: Instant::now(),
             session_reset: false,
             _reader_handle: reader_handle,
@@ -303,12 +315,18 @@ impl AcpConnection {
             )
             .await?;
 
-        let agent_name = resp.result.as_ref()
+        let result = resp.result.as_ref();
+        let agent_name = result
             .and_then(|r| r.get("agentInfo"))
             .and_then(|a| a.get("name"))
             .and_then(|n| n.as_str())
             .unwrap_or("unknown");
-        info!(agent = agent_name, "initialized");
+        self.supports_load_session = result
+            .and_then(|r| r.get("agentCapabilities"))
+            .and_then(|c| c.get("loadSession"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        info!(agent = agent_name, load_session = self.supports_load_session, "initialized");
         Ok(())
     }
 
@@ -381,6 +399,48 @@ impl AcpConnection {
 
     pub fn alive(&self) -> bool {
         !self._reader_handle.is_finished()
+    }
+
+    /// Resume a previous session by ID. Returns Ok(()) if the agent accepted
+    /// the load, or an error if it failed (caller should fall back to session/new).
+    pub async fn session_load(&mut self, session_id: &str, cwd: &str) -> Result<()> {
+        let resp = self
+            .send_request(
+                "session/load",
+                Some(json!({"sessionId": session_id, "cwd": cwd, "mcpServers": []})),
+            )
+            .await?;
+        // Accept any non-error response as success
+        if resp.error.is_some() {
+            return Err(anyhow!("session/load rejected"));
+        }
+        info!(session_id, "session loaded");
+        self.acp_session_id = Some(session_id.to_string());
+        Ok(())
+    }
+
+    /// Kill the entire process group: stdin close → SIGTERM → SIGKILL.
+    fn kill_process_group(&mut self) {
+        let pid = self.child_pid;
+        if pid <= 0 {
+            return;
+        }
+        // Stage 1: close stdin (graceful signal for stdio-based agents)
+        drop(self.stdin.clone()); // triggers ChildStdin drop on last Arc ref eventually
+        // Stage 2: SIGTERM the process group
+        unsafe { libc::kill(-pid, libc::SIGTERM); }
+        // Stage 3: SIGKILL after brief grace (best-effort, non-blocking)
+        let pid_copy = pid;
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+            unsafe { libc::kill(-pid_copy, libc::SIGKILL); }
+        });
+    }
+}
+
+impl Drop for AcpConnection {
+    fn drop(&mut self) {
+        self.kill_process_group();
     }
 }
 

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -6,12 +6,18 @@ use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tracing::{info, warn};
 
-pub struct SessionPool {
-    connections: RwLock<HashMap<String, AcpConnection>>,
+/// Combined state protected by a single lock to prevent deadlocks.
+/// Lock ordering: always acquire `state` before any operation on either map.
+struct PoolState {
+    /// Active connections: thread_key → AcpConnection.
+    active: HashMap<String, AcpConnection>,
     /// Suspended sessions: thread_key → ACP sessionId.
-    /// When a connection is evicted, its sessionId is saved here so it can be
-    /// resumed via `session/load` when the user returns.
-    suspended: RwLock<HashMap<String, String>>,
+    /// Saved on eviction so sessions can be resumed via `session/load`.
+    suspended: HashMap<String, String>,
+}
+
+pub struct SessionPool {
+    state: RwLock<PoolState>,
     config: AgentConfig,
     max_sessions: usize,
 }
@@ -19,8 +25,10 @@ pub struct SessionPool {
 impl SessionPool {
     pub fn new(config: AgentConfig, max_sessions: usize) -> Self {
         Self {
-            connections: RwLock::new(HashMap::new()),
-            suspended: RwLock::new(HashMap::new()),
+            state: RwLock::new(PoolState {
+                active: HashMap::new(),
+                suspended: HashMap::new(),
+            }),
             config,
             max_sessions,
         }
@@ -29,8 +37,8 @@ impl SessionPool {
     pub async fn get_or_create(&self, thread_id: &str) -> Result<()> {
         // Check if alive connection exists
         {
-            let conns = self.connections.read().await;
-            if let Some(conn) = conns.get(thread_id) {
+            let state = self.state.read().await;
+            if let Some(conn) = state.active.get(thread_id) {
                 if conn.alive() {
                     return Ok(());
                 }
@@ -38,26 +46,26 @@ impl SessionPool {
         }
 
         // Need to create or rebuild
-        let mut conns = self.connections.write().await;
+        let mut state = self.state.write().await;
 
         // Double-check after acquiring write lock
-        if let Some(conn) = conns.get(thread_id) {
+        if let Some(conn) = state.active.get(thread_id) {
             if conn.alive() {
                 return Ok(());
             }
             warn!(thread_id, "stale connection, rebuilding");
-            self.suspend_locked(&mut conns, thread_id).await;
+            suspend_entry(&mut state, thread_id);
         }
 
-        if conns.len() >= self.max_sessions {
+        if state.active.len() >= self.max_sessions {
             // LRU evict: suspend the oldest idle session to make room
-            let oldest = conns
+            let oldest = state.active
                 .iter()
                 .min_by_key(|(_, c)| c.last_active)
                 .map(|(k, _)| k.clone());
             if let Some(key) = oldest {
                 info!(evicted = %key, "pool full, suspending oldest idle session");
-                self.suspend_locked(&mut conns, &key).await;
+                suspend_entry(&mut state, &key);
             } else {
                 return Err(anyhow!("pool exhausted ({} sessions)", self.max_sessions));
             }
@@ -74,7 +82,7 @@ impl SessionPool {
         conn.initialize().await?;
 
         // Try to resume a suspended session via session/load
-        let saved_session_id = self.suspended.write().await.remove(thread_id);
+        let saved_session_id = state.suspended.remove(thread_id);
         let mut resumed = false;
         if let Some(ref sid) = saved_session_id {
             if conn.supports_load_session {
@@ -93,29 +101,12 @@ impl SessionPool {
         if !resumed {
             conn.session_new(&self.config.working_dir).await?;
             if saved_session_id.is_some() {
-                // Had a suspended session but couldn't resume — mark as reset
                 conn.session_reset = true;
             }
         }
 
-        conns.insert(thread_id.to_string(), conn);
+        state.active.insert(thread_id.to_string(), conn);
         Ok(())
-    }
-
-    /// Suspend a connection: save its sessionId and remove from active map.
-    /// Must be called with write lock held on `connections`.
-    async fn suspend_locked(
-        &self,
-        conns: &mut HashMap<String, AcpConnection>,
-        thread_id: &str,
-    ) {
-        if let Some(conn) = conns.remove(thread_id) {
-            if let Some(sid) = &conn.acp_session_id {
-                info!(thread_id, session_id = %sid, "suspending session");
-                self.suspended.write().await.insert(thread_id.to_string(), sid.clone());
-            }
-            // conn dropped here → Drop impl kills process group
-        }
     }
 
     /// Get mutable access to a connection. Caller must have called get_or_create first.
@@ -123,8 +114,8 @@ impl SessionPool {
     where
         F: FnOnce(&mut AcpConnection) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<R>> + Send + '_>>,
     {
-        let mut conns = self.connections.write().await;
-        let conn = conns
+        let mut state = self.state.write().await;
+        let conn = state.active
             .get_mut(thread_id)
             .ok_or_else(|| anyhow!("no connection for thread {thread_id}"))?;
         f(conn).await
@@ -132,22 +123,34 @@ impl SessionPool {
 
     pub async fn cleanup_idle(&self, ttl_secs: u64) {
         let cutoff = Instant::now() - std::time::Duration::from_secs(ttl_secs);
-        let mut conns = self.connections.write().await;
-        let stale: Vec<String> = conns
+        let mut state = self.state.write().await;
+        let stale: Vec<String> = state.active
             .iter()
             .filter(|(_, c)| c.last_active < cutoff || !c.alive())
             .map(|(k, _)| k.clone())
             .collect();
         for key in stale {
             info!(thread_id = %key, "cleaning up idle session");
-            self.suspend_locked(&mut conns, &key).await;
+            suspend_entry(&mut state, &key);
         }
     }
 
     pub async fn shutdown(&self) {
-        let mut conns = self.connections.write().await;
-        let count = conns.len();
-        conns.clear(); // Drop impl kills process groups
+        let mut state = self.state.write().await;
+        let count = state.active.len();
+        state.active.clear(); // Drop impl kills process groups
         info!(count, "pool shutdown complete");
+    }
+}
+
+/// Suspend a connection: save its sessionId to the suspended map and remove
+/// from active. The connection is dropped, triggering process group kill.
+fn suspend_entry(state: &mut PoolState, thread_id: &str) {
+    if let Some(conn) = state.active.remove(thread_id) {
+        if let Some(sid) = &conn.acp_session_id {
+            info!(thread_id, session_id = %sid, "suspending session");
+            state.suspended.insert(thread_id.to_string(), sid.clone());
+        }
+        // conn dropped here → Drop impl kills process group
     }
 }

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -8,6 +8,10 @@ use tracing::{info, warn};
 
 pub struct SessionPool {
     connections: RwLock<HashMap<String, AcpConnection>>,
+    /// Suspended sessions: thread_key → ACP sessionId.
+    /// When a connection is evicted, its sessionId is saved here so it can be
+    /// resumed via `session/load` when the user returns.
+    suspended: RwLock<HashMap<String, String>>,
     config: AgentConfig,
     max_sessions: usize,
 }
@@ -16,6 +20,7 @@ impl SessionPool {
     pub fn new(config: AgentConfig, max_sessions: usize) -> Self {
         Self {
             connections: RwLock::new(HashMap::new()),
+            suspended: RwLock::new(HashMap::new()),
             config,
             max_sessions,
         }
@@ -41,11 +46,21 @@ impl SessionPool {
                 return Ok(());
             }
             warn!(thread_id, "stale connection, rebuilding");
-            conns.remove(thread_id);
+            self.suspend_locked(&mut conns, thread_id).await;
         }
 
         if conns.len() >= self.max_sessions {
-            return Err(anyhow!("pool exhausted ({} sessions)", self.max_sessions));
+            // LRU evict: suspend the oldest idle session to make room
+            let oldest = conns
+                .iter()
+                .min_by_key(|(_, c)| c.last_active)
+                .map(|(k, _)| k.clone());
+            if let Some(key) = oldest {
+                info!(evicted = %key, "pool full, suspending oldest idle session");
+                self.suspend_locked(&mut conns, &key).await;
+            } else {
+                return Err(anyhow!("pool exhausted ({} sessions)", self.max_sessions));
+            }
         }
 
         let mut conn = AcpConnection::spawn(
@@ -57,15 +72,50 @@ impl SessionPool {
         .await?;
 
         conn.initialize().await?;
-        conn.session_new(&self.config.working_dir).await?;
 
-        let is_rebuild = conns.contains_key(thread_id);
-        if is_rebuild {
-            conn.session_reset = true;
+        // Try to resume a suspended session via session/load
+        let saved_session_id = self.suspended.write().await.remove(thread_id);
+        let mut resumed = false;
+        if let Some(ref sid) = saved_session_id {
+            if conn.supports_load_session {
+                match conn.session_load(sid, &self.config.working_dir).await {
+                    Ok(()) => {
+                        info!(thread_id, session_id = %sid, "session resumed via session/load");
+                        resumed = true;
+                    }
+                    Err(e) => {
+                        warn!(thread_id, session_id = %sid, error = %e, "session/load failed, creating new session");
+                    }
+                }
+            }
+        }
+
+        if !resumed {
+            conn.session_new(&self.config.working_dir).await?;
+            if saved_session_id.is_some() {
+                // Had a suspended session but couldn't resume — mark as reset
+                conn.session_reset = true;
+            }
         }
 
         conns.insert(thread_id.to_string(), conn);
         Ok(())
+    }
+
+    /// Suspend a connection: save its sessionId and remove from active map.
+    /// Must be called with write lock held on `connections`.
+    async fn suspend_locked(
+        &self,
+        conns: &mut HashMap<String, AcpConnection>,
+        thread_id: &str,
+    ) {
+        if let Some(conn) = conns.remove(thread_id) {
+            if let Some(sid) = &conn.acp_session_id {
+                info!(thread_id, session_id = %sid, "suspending session");
+                self.suspended.write().await.insert(thread_id.to_string(), sid.clone());
+            }
+            // conn dropped here → Drop impl kills process group
+        }
     }
 
     /// Get mutable access to a connection. Caller must have called get_or_create first.
@@ -90,15 +140,14 @@ impl SessionPool {
             .collect();
         for key in stale {
             info!(thread_id = %key, "cleaning up idle session");
-            conns.remove(&key);
-            // Child process killed via kill_on_drop when AcpConnection drops
+            self.suspend_locked(&mut conns, &key).await;
         }
     }
 
     pub async fn shutdown(&self) {
         let mut conns = self.connections.write().await;
         let count = conns.len();
-        conns.clear(); // kill_on_drop handles process cleanup
+        conns.clear(); // Drop impl kills process groups
         info!(count, "pool shutdown complete");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,7 +117,7 @@ pub struct ReactionTiming {
 
 fn default_working_dir() -> String { "/tmp".into() }
 fn default_max_sessions() -> usize { 10 }
-fn default_ttl_hours() -> u64 { 24 }
+fn default_ttl_hours() -> u64 { 4 }
 fn default_true() -> bool { true }
 
 fn emoji_queued() -> String { "👀".into() }


### PR DESCRIPTION
## What problem does this solve?

When running openab with `kiro-cli` on a constrained host (3.6 GB RAM on Zeabur), the session pool fills up with idle agent processes that are never properly reclaimed. Each `kiro-cli acp` spawns a grandchild `kiro-cli-chat acp` (~300 MB). `kill_on_drop` only kills the direct child — the grandchild gets orphaned. 10 sessions × 300 MB = 3 GB leaked → OOM.

Closes #309

## At a Glance

```
  BEFORE:                                    AFTER:

  openab                                     openab
    │                                          │
    ├─ kill_on_drop ──► kiro-cli (dead)        ├─ kill(-pgid) ──► ┌─ kiro-cli    ┐ dead ✅
    │                   kiro-cli-chat ☠️       │                  └─ kiro-cli-chat┘ dead ✅
    │                   (300 MB orphan)         │
    │                                          │
    ├─ pool: 10 × 300 MB = 3 GB               ├─ pool: 1-2 active × 300 MB
    │  (all kept alive until 24h TTL)          │  suspended: { thread → sessionId }
    │                                          │
    └─ pool full → REJECT                      ├─ idle → suspend (save sessionId, kill process)
                                               ├─ user returns → spawn + session/load → resume ✅
                                               └─ pool full → LRU evict oldest → suspend it
```

## Prior Art & Industry Research

**OpenClaw ([acpx](https://github.com/openclaw/acpx)):**

acpx uses self-terminating queue-owner processes with a 3-stage graceful shutdown in [`AcpClient.terminateAgentProcess()`](https://github.com/openclaw/acpx/blob/main/src/acp/client.ts): `stdin.end()` → SIGTERM (1.5s) → SIGKILL (1s) → detach all handles. Each queue-owner exits on idle TTL, taking its agent process with it. Session resume is handled in [`reconnect.ts`](https://github.com/openclaw/acpx/blob/main/src/runtime/engine/reconnect.ts) — it checks `supportsLoadSession()`, tries `session/load`, falls back to `session/new`. This PR adopts the 3-stage shutdown pattern and the `session/load` fallback logic.

**Hermes Agent ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)):**

Hermes Agent runs in-process (no child process spawning) with a thread-safe [`SessionManager`](https://github.com/NousResearch/hermes-agent/blob/main/acp_adapter/session.py) backed by SQLite (`~/.hermes/state.db`). Sessions are persisted via `_persist()` and restored via `_restore()` — recreating the AIAgent instance from stored conversation history. No orphan problem since everything is in-process, but the persist/restore pattern validates our suspend/resume approach.

**Other references:**

| Harness | Isolation | Orphan Risk | Cleanup Strategy |
|---------|-----------|-------------|------------------|
| Gemini CLI a2a | In-process `Map` | None ✅ | `task.dispose()` + Map delete |
| **openab (before)** | **Process** | **HIGH ☠️** | **`kill_on_drop` (broken for grandchildren)** |
| acpx (OpenClaw) | Process | Low ✅ | 3-stage shutdown + self-terminating TTL |
| Hermes Agent | In-process | None ✅ | SQLite persist + in-memory restore |
| [Scion](https://github.com/GoogleCloudPlatform/scion) (Google) | Container | None ✅ | `docker rm -f` kills everything |

Survey source: [Picrew/awesome-agent-harness](https://github.com/Picrew/awesome-agent-harness)

## Proposed Solution

### 1. Process group kill (`connection.rs`)

Replace `kill_on_drop(true)` with `setpgid(0, 0)` at spawn to create a process group per session. On `Drop`, kill the entire group via `kill(-pgid, SIGTERM)` with a 3-stage escalation (inspired by acpx):

```
  AcpConnection::drop()
       │
       ▼
  1. stdin.close()          ← graceful signal
  2. kill(-pgid, SIGTERM)   ← kill process group
  3. kill(-pgid, SIGKILL)   ← force kill after 1.5s
```

### 2. Session suspend/resume (`pool.rs`)

Add a `suspended: HashMap<thread_key, sessionId>` map. When a session is evicted (TTL, LRU, or stale), save its `sessionId` before killing. On reconnect, try `session/load` if the agent supports it (checked via `agentCapabilities.loadSession` from `initialize`), fall back to `session/new`.

### 3. LRU eviction (`pool.rs`)

When pool is full, evict the oldest idle session (by `last_active`) instead of rejecting with "pool exhausted".

### 4. Lower default TTL (`config.rs`)

`session_ttl_hours`: 24 → 4. Safe because suspended sessions can be reloaded on demand.

## Why this approach?

- **Process groups** are the correct OS primitive for killing process trees — and something neither acpx nor Hermes Agent needs. acpx's 3-stage shutdown sends SIGTERM/SIGKILL to the direct child PID, which works for them because their default kiro command is `kiro-cli-chat acp` (the agent is the direct child). openab uses `kiro-cli acp`, which forks `kiro-cli-chat` as a grandchild — acpx's approach would leave the grandchild orphaned in our case. Process groups (`setpgid` + `kill(-pgid)`) handle any depth of process tree, making our solution more robust for openab's specific spawn chain.

```
  acpx spawn chain:     acpx → kiro-cli-chat (direct child)
                         SIGTERM(child) works ✅

  openab spawn chain:   openab → kiro-cli → kiro-cli-chat (grandchild)
                         SIGTERM(child) misses grandchild ☠️
                         kill(-pgid) kills entire group ✅
```

- **session/load** was validated by testing kiro-cli v1.29.5 (`agentCapabilities.loadSession: true`). The fallback logic mirrors acpx's [`reconnect.ts`](https://github.com/openclaw/acpx/blob/main/src/runtime/engine/reconnect.ts): check capability → try load → fall back to new. This makes aggressive TTL safe — we can kill idle processes and reload them without losing conversation history.
- **In-memory suspended map** is simpler than Hermes Agent's SQLite persistence (`~/.hermes/state.db`). Suspended sessionIds are lost on openab restart, which is acceptable — the agent starts a fresh session, same as today. If persistence becomes needed, we can add it later without changing the pool interface.

## Alternatives Considered

| Alternative | Why not |
|-------------|---------|
| `prctl(PR_SET_PDEATHSIG)` | Only one level deep — doesn't reach grandchildren |
| cgroups | Requires elevated permissions, overkill for this problem |
| PID files + periodic pkill | Fragile, race-prone, doesn't solve root cause |
| Single multiplexed kiro-cli process | Requires kiro-cli changes, out of scope |
| Container-per-session (Scion-style) | Major architecture shift, future consideration |
| SQLite persistence for suspended sessions (Hermes-style) | Added complexity; in-memory map is sufficient since losing suspended IDs on restart is acceptable |

## Validation

- [ ] `cargo check` passes
- [ ] `cargo test` passes (including new tests)
- [x] Manual testing — confirmed kiro-cli v1.29.5 advertises `loadSession: true` via ACP `initialize`
- [ ] Deploy to OrbStack and verify: no orphaned `kiro-cli-chat` processes after session eviction, memory stays under 1 GB with 10 threads

Full investigation thread: #309


