### PR TITLE
feat: add --version / -V flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ async fn shutdown_signal() {
 }
 
 #[derive(Parser)]
-#[command(name = "openab")]
+#[command(name = "openab", version)]
 #[command(about = "Multi-platform ACP agent broker (Discord, Slack)", long_about = None)]
 struct Cli {
     #[command(subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use tracing::{error, info};
 
 #[derive(Parser)]
-#[command(name = "openab")]
+#[command(name = "openab", version)]
 #[command(about = "Multi-platform ACP agent broker (Discord, Slack)", long_about = None)]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## What problem does this solve?

Running `openab --version` currently fails with `failed to read --version: No such file or directory`. There is no way to check which version of openab is installed without inspecting the binary directly or checking the Helm chart. This makes debugging deployment mismatches difficult.

Closes #

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365150664560881/1493789779999985785

## At a Glance

```
User runs: openab --version  (or -V)
                │
                ▼
        ┌───────────────┐
        │  main.rs      │
        │  arg check    │  ──► prints "openab 0.7.3" → exit 0
        └───────┬───────┘
                │ (no version flag)
                ▼
        normal startup flow
```

## Prior Art & Industry Research

**OpenClaw:**
OpenClaw (TypeScript / Commander.js) handles this via custom pre-parse detection in [`src/cli/program/help.ts`](https://github.com/openclaw/openclaw/blob/main/src/cli/program/help.ts) — checks for `-V`, `--version`, and a root-level `-v` alias before Commander parses arguments. The version string is resolved dynamically from `package.json` with fallbacks to a build-time `__OPENCLAW_VERSION__` global. Output format: `OpenClaw 2026.4.14-beta.1 (abc1234)` including git commit hash.

**Hermes Agent:**
Hermes Agent (Python / argparse) registers `-V` / `--version` as `action="store_true"` on the main parser, plus a dedicated `hermes version` subcommand. Version is hardcoded in [`hermes_cli/__init__.py`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/__init__.py). Output: `Hermes Agent v0.9.0 (2026.4.13)` with additional Python version and dependency info.

**Comparison:**

| | OpenClaw | Hermes Agent | This PR |
|---|---|---|---|
| Flag | `-V`, `--version`, `-v` | `-V`, `--version` | `-V`, `--version` |
| Version source | Dynamic (package.json) | Hardcoded | `env!("CARGO_PKG_VERSION")` (Cargo.toml) |
| Output | `Name X.Y.Z (git-hash)` | `Name vX.Y.Z (date)` | `openab X.Y.Z` |
| Extra info | git commit hash | Python ver + deps | none |

## Proposed Solution

Use clap's built-in version support via `#[command(name = "openab", version)]`. clap reads the version from `Cargo.toml` at compile time via `env!("CARGO_PKG_VERSION")` and automatically handles `--version` and `-V`.

**Change:** 1 word added to `src/main.rs`, zero new dependencies.

```rust
#[derive(Parser)]
#[command(name = "openab", version)]
```

## Why This Approach?

**clap already in the project.** `main` already has clap 4 with `#[derive(Parser)]` and subcommands — using `#[command(version)]` is the idiomatic 1-line solution with no new dependencies.

**`env!("CARGO_PKG_VERSION")` over hardcoding.** Like OpenClaw's `package.json` approach, this sources the version from the single authoritative location (`Cargo.toml`) at compile time — no risk of drift.

**No git hash** (unlike OpenClaw). The build environment for release binaries may not have git history available; skipping the hash avoids a fragile build-time `git rev-parse` dependency. Can be added later if desired.

## Alternatives Considered

- **Manual pre-parse** (original approach) — rejected because clap already exists and handles this natively.
- **`version` subcommand** (like Hermes' `hermes version`) — more discoverable but inconsistent with Unix conventions where `--version` is the standard flag. Rejected.
- **Git commit hash in output** (like OpenClaw) — useful but requires build-time git access; left as a follow-up.

## Validation

- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] Manual testing — `openab --version` prints `openab 0.7.5` and exits 0; `openab -V` same; `openab run config.toml` still starts normally