### PR TITLE
feat: add allow_bot_messages config (none/mentions/all)

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -2,6 +2,9 @@
 bot_token = "${DISCORD_BOT_TOKEN}"
 allowed_channels = ["1234567890"]
 # allowed_users = ["<YOUR_DISCORD_USER_ID>"]  # empty or omitted = allow all users
+# allow_bot_messages = "off"  # "off" (default) | "mentions" | "all"
+                               # "mentions" is recommended for multi-agent collaboration
+# trusted_bot_ids = []         # empty = any bot (mode permitting); set to restrict
 
 [agent]
 command = "kiro-cli"

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -51,3 +51,77 @@ See individual agent docs for authentication steps:
 - [Claude Code](claude-code.md)
 - [Codex](codex.md)
 - [Gemini](gemini.md)
+
+## Bot-to-Bot Communication
+
+By default, each agent ignores messages from other bots. To enable multi-agent collaboration in the same channel (e.g. a code review bot handing off to a deploy bot), configure `allow_bot_messages` in each agent's `config.toml`:
+
+```toml
+[discord]
+allow_bot_messages = "mentions"  # recommended
+```
+
+### Modes
+
+| Value | Behavior | Loop risk |
+|---|---|---|
+| `"off"` (default) | Ignore all bot messages | None |
+| `"mentions"` | Only respond to bot messages that @mention this bot | Very low — bots must explicitly @mention each other |
+| `"all"` | Respond to all bot messages | Mitigated by turn cap (10 consecutive bot messages) |
+
+### Which mode should I use?
+
+**`"mentions"` is recommended for most setups.** It enables collaboration while acting as a natural loop breaker — Bot A only processes Bot B's message if Bot B explicitly @mentions Bot A. Two bots won't accidentally ping-pong.
+
+Use `"all"` only when bots need to react to each other's messages without explicit mentions (e.g. monitoring bots). A hard cap of 10 consecutive bot-to-bot turns prevents infinite loops.
+
+### Example: Code Review → Deploy handoff
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Discord Channel #dev                                     │
+│                                                          │
+│  👤 User: "Review this PR and deploy if it looks good"   │
+│       │                                                  │
+│       ▼                                                  │
+│  🤖 Kiro (allow_bot_messages = "off"):                   │
+│       "LGTM — tests pass, no security issues.            │
+│        @DeployBot please deploy to staging."             │
+│       │                                                  │
+│       ▼                                                  │
+│  🤖 Deploy Bot (allow_bot_messages = "mentions"):        │
+│       "Deploying to staging... ✅ Done."                  │
+└──────────────────────────────────────────────────────────┘
+```
+
+Note: the review bot doesn't need `allow_bot_messages` enabled — only the bot that needs to *receive* bot messages does.
+
+### Helm values
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.discord.botToken="$KIRO_BOT_TOKEN" \
+  --set agents.kiro.discord.allowBotMessages="off" \
+  --set agents.deploy.discord.botToken="$DEPLOY_BOT_TOKEN" \
+  --set agents.deploy.discord.allowBotMessages="mentions"
+```
+
+### Safety
+
+- The bot's own messages are **always** ignored, regardless of setting
+- `"mentions"` mode is a natural loop breaker — no rate limiter needed
+- `"all"` mode has a hard cap of 10 consecutive bot-to-bot turns per channel
+- Channel and user allowlists still apply to bot messages
+- `trusted_bot_ids` further restricts which bots are allowed through
+
+### Restricting to specific bots
+
+If you only want to accept messages from specific bots (e.g. your own deploy bot), add their Discord user IDs:
+
+```toml
+[discord]
+allow_bot_messages = "mentions"
+trusted_bot_ids = ["123456789012345678"]  # only this bot's messages pass through
+```
+
+When `trusted_bot_ids` is empty (default), any bot can pass through (subject to the mode check). When set, only listed bots are accepted — all others are silently ignored.

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,34 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
 
+/// Controls whether the bot processes messages from other Discord bots.
+///
+/// Inspired by Hermes Agent's `DISCORD_ALLOW_BOTS` 3-value design:
+/// - `Off` (default): ignore all bot messages (safe default, no behavior change)
+/// - `Mentions`: only process bot messages that @mention this bot (natural loop breaker)
+/// - `All`: process all bot messages (capped at `MAX_CONSECUTIVE_BOT_TURNS`)
+///
+/// The bot's own messages are always ignored regardless of this setting.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AllowBots {
+    #[default]
+    Off,
+    Mentions,
+    All,
+}
+
+impl<'de> Deserialize<'de> for AllowBots {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        match s.to_lowercase().as_str() {
+            "off" | "none" | "false" => Ok(Self::Off),
+            "mentions" => Ok(Self::Mentions),
+            "all" | "true" => Ok(Self::All),
+            other => Err(serde::de::Error::unknown_variant(other, &["off", "mentions", "all"])),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct Config {
     pub discord: DiscordConfig,
@@ -48,6 +76,15 @@ pub struct DiscordConfig {
     pub allowed_channels: Vec<String>,
     #[serde(default)]
     pub allowed_users: Vec<String>,
+    #[serde(default)]
+    pub allow_bot_messages: AllowBots,
+    /// When non-empty, only bot messages from these IDs pass the bot gate.
+    /// Combines with `allow_bot_messages`: the mode check runs first, then
+    /// the allowlist filters further. Empty = allow any bot (mode permitting).
+    /// Only relevant when `allow_bot_messages` is `"mentions"` or `"all"`;
+    /// ignored when `"off"` since all bot messages are rejected before this check.
+    #[serde(default)]
+    pub trusted_bot_ids: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -18,10 +18,14 @@ use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::{debug, error, info};
 
-/// Hard cap on consecutive bot-to-bot turns per thread/channel.
-/// Prevents infinite loops when `allow_bot_messages = "all"`.
+/// Hard cap on consecutive bot messages (from any other bot) in a
+/// channel or thread. When this many recent messages are all from
+/// bots other than ourselves, we stop responding to prevent runaway
+/// loops between multiple bots in "all" mode.
+///
+/// Note: must be ≤ 255 because Serenity's `GetMessages::limit()` takes `u8`.
 /// Inspired by OpenClaw's `session.agentToAgent.maxPingPongTurns`.
-const MAX_BOT_TURNS_PER_THREAD: usize = 10;
+const MAX_CONSECUTIVE_BOT_TURNS: u8 = 10;
 
 /// Reusable HTTP client for downloading Discord attachments.
 /// Built once with a 30s timeout and rustls TLS (no native-tls deps).
@@ -69,19 +73,51 @@ impl EventHandler for Handler {
                 AllowBots::Off => return,
                 AllowBots::Mentions => if !is_mentioned { return; },
                 AllowBots::All => {
-                    // Safety net: cap consecutive bot messages to prevent
-                    // infinite loops when two bots both use "all" mode.
-                    if let Ok(history) = msg.channel_id
-                        .messages(&ctx.http, serenity::builder::GetMessages::new().before(msg.id).limit(MAX_BOT_TURNS_PER_THREAD as u8))
-                        .await
-                    {
-                        let consecutive_bot = history.iter()
-                            .take_while(|m| m.author.bot && m.author.id != bot_id)
-                            .count();
-                        if consecutive_bot >= MAX_BOT_TURNS_PER_THREAD {
-                            tracing::warn!(channel_id = %msg.channel_id, cap = MAX_BOT_TURNS_PER_THREAD, "bot turn cap reached, ignoring");
-                            return;
+                    // Safety net: count consecutive messages from any bot
+                    // (excluding ourselves) in recent history. If all recent
+                    // messages are from other bots, we've likely entered a
+                    // loop. This counts *all* other-bot messages, not just
+                    // one specific bot — so 3 bots taking turns still hits
+                    // the cap (which is intentionally conservative).
+                    //
+                    // Try cache first to avoid an API call on every bot
+                    // message. Fall back to API on cache miss. If both fail,
+                    // reject the message (fail-closed) to avoid unbounded
+                    // loops during Discord API outages.
+                    let cap = MAX_CONSECUTIVE_BOT_TURNS as usize;
+                    let history = ctx.cache.channel_messages(msg.channel_id)
+                        .map(|msgs| {
+                            let mut recent: Vec<_> = msgs.iter()
+                                .filter(|(mid, _)| **mid < msg.id)
+                                .map(|(_, m)| m.clone())
+                                .collect();
+                            recent.sort_unstable_by(|a, b| b.id.cmp(&a.id)); // newest first
+                            recent.truncate(cap);
+                            recent
+                        })
+                        .filter(|msgs| !msgs.is_empty());
+
+                    let recent = if let Some(cached) = history {
+                        cached
+                    } else {
+                        match msg.channel_id
+                            .messages(&ctx.http, serenity::builder::GetMessages::new().before(msg.id).limit(MAX_CONSECUTIVE_BOT_TURNS))
+                            .await
+                        {
+                            Ok(msgs) => msgs,
+                            Err(e) => {
+                                tracing::warn!(channel_id = %msg.channel_id, error = %e, "failed to fetch history for bot turn cap, rejecting (fail-closed)");
+                                return;
+                            }
                         }
+                    };
+
+                    let consecutive_bot = recent.iter()
+                        .take_while(|m| m.author.bot && m.author.id != bot_id)
+                        .count();
+                    if consecutive_bot >= cap {
+                        tracing::warn!(channel_id = %msg.channel_id, cap, "bot turn cap reached, ignoring");
+                        return;
                     }
                 },
             }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,5 +1,5 @@
 use crate::acp::{classify_notification, AcpEvent, ContentBlock, SessionPool};
-use crate::config::{ReactionsConfig, SttConfig};
+use crate::config::{AllowBots, ReactionsConfig, SttConfig};
 use crate::error_display::{format_coded_error, format_user_error};
 use crate::format;
 use crate::reactions::StatusReactionController;
@@ -18,6 +18,11 @@ use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::{debug, error, info};
 
+/// Hard cap on consecutive bot-to-bot turns per thread/channel.
+/// Prevents infinite loops when `allow_bot_messages = "all"`.
+/// Inspired by OpenClaw's `session.agentToAgent.maxPingPongTurns`.
+const MAX_BOT_TURNS_PER_THREAD: usize = 10;
+
 /// Reusable HTTP client for downloading Discord attachments.
 /// Built once with a 30s timeout and rustls TLS (no native-tls deps).
 static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
@@ -33,16 +38,19 @@ pub struct Handler {
     pub allowed_users: HashSet<u64>,
     pub reactions_config: ReactionsConfig,
     pub stt_config: SttConfig,
+    pub allow_bot_messages: AllowBots,
+    pub trusted_bot_ids: HashSet<u64>,
 }
 
 #[async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
-        if msg.author.bot {
+        let bot_id = ctx.cache.current_user().id;
+
+        // Always ignore own messages
+        if msg.author.id == bot_id {
             return;
         }
-
-        let bot_id = ctx.cache.current_user().id;
 
         let channel_id = msg.channel_id.get();
         let in_allowed_channel =
@@ -51,6 +59,39 @@ impl EventHandler for Handler {
         let is_mentioned = msg.mentions_user_id(bot_id)
             || msg.content.contains(&format!("<@{}>", bot_id))
             || msg.mention_roles.iter().any(|r| msg.content.contains(&format!("<@&{}>", r)));
+
+        // Bot message gating — runs after self-ignore but before channel/user
+        // allowlist checks. This ordering is intentional: channel checks below
+        // apply uniformly to both human and bot messages, so a bot mention in
+        // a non-allowed channel is still rejected by the channel check.
+        if msg.author.bot {
+            match self.allow_bot_messages {
+                AllowBots::Off => return,
+                AllowBots::Mentions => if !is_mentioned { return; },
+                AllowBots::All => {
+                    // Safety net: cap consecutive bot messages to prevent
+                    // infinite loops when two bots both use "all" mode.
+                    if let Ok(history) = msg.channel_id
+                        .messages(&ctx.http, serenity::builder::GetMessages::new().before(msg.id).limit(MAX_BOT_TURNS_PER_THREAD as u8))
+                        .await
+                    {
+                        let consecutive_bot = history.iter()
+                            .take_while(|m| m.author.bot && m.author.id != bot_id)
+                            .count();
+                        if consecutive_bot >= MAX_BOT_TURNS_PER_THREAD {
+                            tracing::warn!(channel_id = %msg.channel_id, cap = MAX_BOT_TURNS_PER_THREAD, "bot turn cap reached, ignoring");
+                            return;
+                        }
+                    }
+                },
+            }
+
+            // If trusted_bot_ids is set, only allow bots on the list
+            if !self.trusted_bot_ids.is_empty() && !self.trusted_bot_ids.contains(&msg.author.id.get()) {
+                tracing::debug!(bot_id = %msg.author.id, "bot not in trusted_bot_ids, ignoring");
+                return;
+            }
+        }
 
         let in_thread = if !in_allowed_channel {
             match msg.channel_id.to_channel(&ctx.http).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ async fn main() -> anyhow::Result<()> {
         channels = ?cfg.discord.allowed_channels,
         users = ?cfg.discord.allowed_users,
         reactions = cfg.reactions.enabled,
+        allow_bot_messages = ?cfg.discord.allow_bot_messages,
         "config loaded"
     );
 
@@ -41,7 +42,8 @@ async fn main() -> anyhow::Result<()> {
 
     let allowed_channels = parse_id_set(&cfg.discord.allowed_channels, "allowed_channels")?;
     let allowed_users = parse_id_set(&cfg.discord.allowed_users, "allowed_users")?;
-    info!(channels = allowed_channels.len(), users = allowed_users.len(), "parsed allowlists");
+    let trusted_bot_ids = parse_id_set(&cfg.discord.trusted_bot_ids, "trusted_bot_ids")?;
+    info!(channels = allowed_channels.len(), users = allowed_users.len(), trusted_bots = ?trusted_bot_ids, "parsed allowlists");
 
     // Resolve STT config before constructing handler (auto-detect mutates cfg.stt)
     if cfg.stt.enabled {
@@ -65,6 +67,8 @@ async fn main() -> anyhow::Result<()> {
         allowed_users,
         reactions_config: cfg.reactions,
         stt_config: cfg.stt.clone(),
+        allow_bot_messages: cfg.discord.allow_bot_messages,
+        trusted_bot_ids,
     };
 
     let intents = GatewayIntents::GUILD_MESSAGES


### PR DESCRIPTION
## Summary

Adds `allow_bot_messages` (3-value mode) and `trusted_bot_ids` (allowlist) to control bot-to-bot message handling in Discord, enabling multi-agent collaboration.

Closes #319, supersedes #322

## Message Flow

```
                    ┌─────────────────────┐
                    │  Discord message in  │
                    └──────────┬──────────┘
                               │
                    ┌──────────▼──────────┐
                    │  msg.author == self? │
                    └──────────┬──────────┘
                          yes/ \no
                         ┌──┘   └──┐
                      [drop]       │
                               ┌───▼───────────────┐
                               │  msg.author.bot?   │
                               └───┬───────────────┘
                              no/ \yes
                            ┌──┘   └──────────────────────┐
                            │                              │
                            │              ┌───────────────▼───────────────┐
                            │              │      allow_bot_messages?      │
                            │              └───────────────┬───────────────┘
                            │                 /      |       \
                            │              "off"  "mentions"  "all"
                            │                │       │          │
                            │             [drop]     │    ┌─────▼──────────┐
                            │                        │    │ consecutive    │
                            │                ┌───────▼─┐  │ bot turns     │
                            │                │ @mention │  │ >= 10?        │
                            │                │ this bot?│  └─────┬─────┘
                            │                └────┬────┘    yes/ \no
                            │               no/ \yes       ┌──┘   └──┐
                            │              ┌──┘   └──┐  [drop]       │
                            │           [drop]       │                │
                            │                        │                │
                            │              ┌─────────▼────────────────▼──┐
                            │              │    trusted_bot_ids empty?   │
                            │              └─────────┬──────────────────┘
                            │                   yes/ \no
                            │                  ┌──┘   └──────────────┐
                            │                  │        ┌────────────▼───────────┐
                            │                  │        │ author in trusted list?│
                            │                  │        └────────────┬───────────┘
                            │                  │               no/ \yes
                            │                  │              ┌──┘   └──┐
                            │                  │           [drop]       │
                            │                  │                        │
                    ┌───────▼──────────────────▼────────────────────────▼──┐
                    │              channel / user allowlists               │
                    └──────────────────────┬──────────────────────────────┘
                                           │
                    ┌──────────────────────▼──────────────────────────────┐
                    │                  process message                    │
                    └────────────────────────────────────────────────────┘
```

## Config

```toml
[discord]
allow_bot_messages = "off"        # default — ignore all bot messages
# allow_bot_messages = "mentions" # only process bot messages that @mention this bot
# allow_bot_messages = "all"      # process all bot messages (with turn cap safety net)
# trusted_bot_ids = []            # empty = any bot (mode permitting); set to restrict
```

The two options compose: `allow_bot_messages` controls the mode, `trusted_bot_ids` further restricts which bots pass through. Case-insensitive mode values; also accepts `"none"`/`"false"` → off, `"true"` → all.

## Design Decisions

### 3-value enum instead of boolean

Adopts the pattern from [Hermes Agent](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/discord) (`DISCORD_ALLOW_BOTS`). The `"mentions"` mode is the key addition over a simple boolean — it acts as a natural loop breaker because Bot A only responds to Bot B when Bot B explicitly @mentions Bot A. This is the recommended setting for multi-agent collaboration.

| Value | Behavior |
|---|---|
| `"off"` (default) | Ignore all bot messages — no behavior change for existing users |
| `"mentions"` | Only process bot messages that `@mention` this bot — natural loop breaker |
| `"all"` | Process all bot messages — capped at `MAX_CONSECUTIVE_BOT_TURNS` (10) |

### `trusted_bot_ids` allowlist

Complements the mode setting. When non-empty, only messages from listed bot IDs pass through (after the mode check). This addresses the use case from #322 — operators who want to restrict bot interaction to specific known bots rather than allowing any bot. Only relevant when `allow_bot_messages` is `"mentions"` or `"all"`.

### Turn cap instead of per-channel rate limiter

The original issue proposed a per-channel sliding-window rate limiter. Both [OpenClaw](https://molty.finna.ai/docs/gateway/configuration-reference) and Hermes Agent shipped without per-channel rate limiters — OpenClaw uses a simple `session.agentToAgent.maxPingPongTurns` turn cap instead.

We follow the same approach: `MAX_CONSECUTIVE_BOT_TURNS = 10` checks recent channel history (cache-first, API fallback, fail-closed) and stops responding when 10 consecutive bot messages are detected.

### Other design choices

- `AllowBots::Off` naming avoids confusion with `Option::None`
- Self-ignore check moved above bot filter (was previously unreachable for bot messages)
- Bot gating runs before channel checks (intentional — channel checks apply uniformly)

## Changes

- **`config.rs`**: Add `AllowBots` enum (`Off`/`Mentions`/`All`) with case-insensitive `Deserialize`, add `allow_bot_messages` and `trusted_bot_ids` fields to `DiscordConfig`
- **`discord.rs`**: Add fields to `Handler`, move self-ignore above bot filter, gate bot messages through `AllowBots` enum + `trusted_bot_ids`, add `MAX_CONSECUTIVE_BOT_TURNS` safety net (cache-first, fail-closed) for `"all"` mode
- **`main.rs`**: Wire config into `Handler`, parse `trusted_bot_ids`, add to startup log
- **`config.toml.example`**: Document both options
- **`docs/multi-agent.md`**: Add bot-to-bot communication section with modes, examples, and `trusted_bot_ids` usage

## Prior Art

See [triage comment](https://github.com/openabdev/openab/issues/319#issuecomment-4241703502) for full comparison with OpenClaw and Hermes Agent implementations.