### PR TITLE
feat: add trusted_bot_ids for selective bot message processing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,8 @@ pub struct DiscordConfig {
     pub allowed_channels: Vec<String>,
     #[serde(default)]
     pub allowed_users: Vec<String>,
+    #[serde(default)]
+    pub trusted_bot_ids: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -31,6 +31,7 @@ pub struct Handler {
     pub pool: Arc<SessionPool>,
     pub allowed_channels: HashSet<u64>,
     pub allowed_users: HashSet<u64>,
+    pub trusted_bot_ids: HashSet<u64>,
     pub reactions_config: ReactionsConfig,
     pub stt_config: SttConfig,
 }
@@ -38,7 +39,7 @@ pub struct Handler {
 #[async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
-        if msg.author.bot {
+        if msg.author.bot && !self.trusted_bot_ids.contains(&msg.author.id.get()) {
             return;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,8 @@ async fn main() -> anyhow::Result<()> {
 
     let allowed_channels = parse_id_set(&cfg.discord.allowed_channels, "allowed_channels")?;
     let allowed_users = parse_id_set(&cfg.discord.allowed_users, "allowed_users")?;
-    info!(channels = allowed_channels.len(), users = allowed_users.len(), "parsed allowlists");
+    let trusted_bot_ids = parse_id_set(&cfg.discord.trusted_bot_ids, "trusted_bot_ids")?;
+    info!(channels = allowed_channels.len(), users = allowed_users.len(), trusted_bots = trusted_bot_ids.len(), "parsed allowlists");
 
     // Resolve STT config before constructing handler (auto-detect mutates cfg.stt)
     if cfg.stt.enabled {
@@ -63,6 +64,7 @@ async fn main() -> anyhow::Result<()> {
         pool: pool.clone(),
         allowed_channels,
         allowed_users,
+        trusted_bot_ids,
         reactions_config: cfg.reactions,
         stt_config: cfg.stt.clone(),
     };


### PR DESCRIPTION
## Summary

Adds a `trusted_bot_ids` config option to selectively process messages from specific bots instead of ignoring all bot messages unconditionally. This enables multi-agent collaboration where trusted bots can interact in the same channel.

## Changes

- **`config.rs`** — Add `trusted_bot_ids: Vec<String>` to `DiscordConfig`
- **`discord.rs`** — Change bot check from `if msg.author.bot { return; }` to `if msg.author.bot && !self.trusted_bot_ids.contains(&msg.author.id.get()) { return; }`
- **`main.rs`** — Parse `trusted_bot_ids` via existing `parse_id_set()` and pass to Handler

## Config example

```toml
[discord]
trusted_bot_ids = ["123456789", "987654321"]
```

## Design decisions

- **Safe default**: Empty list = all bot messages ignored (no behavior change for existing users)
- **Allowlist over flag**: `trusted_bot_ids` is more granular than `allow_bot_messages = true` (#319) — operators control exactly which bots are trusted
- **No rate limiting needed**: Since only explicitly trusted bots are allowed, the infinite loop risk is managed by the operator, not the framework
- **Self-ignore preserved**: The existing `bot_id` check downstream already prevents self-replies
- **Minimal diff**: 7 lines changed across 3 files, reuses existing `parse_id_set()` helper

## Use case

We run multiple OpenAB instances (6 specialized agents) in the same Discord server. With `trusted_bot_ids`, they can collaborate by responding to each other's messages in shared channels.

Closes #319