### PR TITLE
fix: pin CLI versions in all Dockerfiles using ARG for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl unzip && rm -rf /var/lib/apt/lists/*
 
 # Install kiro-cli (auto-detect arch, copy binary directly)
+ARG KIRO_CLI_VERSION=2.0.0
 RUN ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "arm64" ]; then URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/kirocli-aarch64-linux.zip"; \
-    else URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/kirocli-x86_64-linux.zip"; fi && \
+    if [ "$ARCH" = "arm64" ]; then URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-aarch64-linux.zip"; \
+    else URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-x86_64-linux.zip"; fi && \
     curl --proto '=https' --tlsv1.2 -sSf --retry 3 --retry-delay 5 "$URL" -o /tmp/kirocli.zip && \
     unzip /tmp/kirocli.zip -d /tmp && \
     cp /tmp/kirocli/bin/* /usr/local/bin/ && \

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -11,7 +11,8 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 # Install claude-agent-acp adapter and Claude Code CLI
-RUN npm install -g @agentclientprotocol/claude-agent-acp@0.25.0 @anthropic-ai/claude-code --retry 3
+ARG CLAUDE_CODE_VERSION=2.1.107
+RUN npm install -g @agentclientprotocol/claude-agent-acp@0.25.0 @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} --retry 3
 
 # Install gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -11,7 +11,8 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
-RUN npm install -g @zed-industries/codex-acp@0.9.5 @openai/codex --retry 3
+ARG CODEX_VERSION=0.120.0
+RUN npm install -g @zed-industries/codex-acp@0.9.5 @openai/codex@${CODEX_VERSION} --retry 3
 
 # Install gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -11,7 +11,8 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
-RUN npm install -g @github/copilot@1 --retry 3
+ARG COPILOT_VERSION=1.0.25
+RUN npm install -g @github/copilot@${COPILOT_VERSION} --retry 3
 
 # Install gh CLI (for auth and token management)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -11,7 +11,8 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
-RUN npm install -g @google/gemini-cli --retry 3
+ARG GEMINI_CLI_VERSION=0.37.2
+RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} --retry 3
 
 # Install gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Summary

Pin all CLI dependency versions in Dockerfiles using `ARG` directives for reproducible builds. Changing the `ARG` value automatically busts the Docker layer cache, and version bumps are visible in git diff.

## Changes

| Dockerfile | CLI | ARG | Pinned Version |
|---|---|---|---|
| `Dockerfile` | kiro-cli | `KIRO_CLI_VERSION` | 2.0.0 |
| `Dockerfile.codex` | @openai/codex | `CODEX_VERSION` | 0.120.0 |
| `Dockerfile.claude` | @anthropic-ai/claude-code | `CLAUDE_CODE_VERSION` | 2.1.107 |
| `Dockerfile.gemini` | @google/gemini-cli | `GEMINI_CLI_VERSION` | 0.37.2 |
| `Dockerfile.copilot` | @github/copilot | `COPILOT_VERSION` | 1.0.25 |

Previously pinned dependencies (`codex-acp@0.9.5`, `claude-agent-acp@0.25.0`) are left unchanged.

## How it works

Each Dockerfile now declares an `ARG` with a default version before the `RUN` that installs the CLI:

```dockerfile
ARG GEMINI_CLI_VERSION=0.37.2
RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} --retry 3
```

For kiro-cli, the download URL uses the official `prod.download.cli.kiro.dev` with a versioned path:
```
https://prod.download.cli.kiro.dev/stable/2.0.0/kirocli-x86_64-linux.zip
```

## Checking latest versions

```bash
# kiro-cli
curl -fsSL https://prod.download.cli.kiro.dev/stable/latest/manifest.json | jq -r '.version'

# npm packages
npm view @openai/codex version
npm view @anthropic-ai/claude-code version
npm view @google/gemini-cli version
npm view @github/copilot version
```

Closes #325