### PR TITLE
fix: improve gateway intents and auth error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 
 ## Quick Start
 
+### Prerequisites
+
+Before running openab, enable these in the [Discord Developer Portal](https://discord.com/developers/applications):
+
+1. **Bot → Privileged Gateway Intents**:
+   - ✅ Message Content Intent
+   - ✅ Server Members Intent
+2. **OAuth2 → URL Generator → Bot Permissions**:
+   - Send Messages, Embed Links, Attach Files
+   - Read Message History, Add Reactions
+
+See [docs/discord.md](docs/discord.md) for a detailed step-by-step guide.
+
 ### 1. Create a Bot
 
 <details>

--- a/README.md
+++ b/README.md
@@ -29,9 +29,22 @@ A lightweight, secure, cloud-native ACP harness that bridges Discord and any [Ag
 
 ## Quick Start
 
-### 1. Create a Discord Bot
+### Prerequisites
+
+Before running openab, enable these in the [Discord Developer Portal](https://discord.com/developers/applications):
+
+1. **Bot → Privileged Gateway Intents**:
+   - ✅ Message Content Intent
+   - ✅ Server Members Intent
+2. **OAuth2 → URL Generator → Bot Permissions**:
+   - Send Messages, Embed Links, Attach Files
+   - Read Message History, Add Reactions
 
 See [docs/discord-bot-howto.md](docs/discord-bot-howto.md) for a detailed step-by-step guide.
+
+### 1. Create a Discord Bot
+
+Follow the [prerequisites](#prerequisites) above, then create your bot.
 
 ### 2. Install with Helm (Kiro CLI — default)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod gateway;
 
 use adapter::AdapterRouter;
 use clap::Parser;
+use serenity::gateway::GatewayError;
 use serenity::prelude::*;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -336,7 +337,25 @@ async fn main() -> anyhow::Result<()> {
         });
 
         info!("discord bot running");
-        client.start().await?;
+        match client.start().await {
+            Err(serenity::Error::Gateway(GatewayError::DisallowedGatewayIntents)) => {
+                error!(
+                    "Discord rejected privileged intents. \
+                     Enable MESSAGE CONTENT INTENT at: \
+                     https://discord.com/developers/applications → Bot → Privileged Gateway Intents"
+                );
+                std::process::exit(1);
+            }
+            Err(serenity::Error::Gateway(GatewayError::InvalidAuthentication)) => {
+                error!(
+                    "Discord rejected bot token. \
+                     Verify your bot_token in config.toml is correct and has not been reset."
+                );
+                std::process::exit(1);
+            }
+            Err(e) => return Err(e.into()),
+            Ok(_) => {}
+        }
     } else {
         // No Discord — wait for SIGINT or SIGTERM
         info!("running without discord, press ctrl+c to stop");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,12 @@ mod format;
 mod reactions;
 mod stt;
 
+use serenity::gateway::GatewayError;
 use serenity::prelude::*;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::info;
+use tracing::{error, info};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -98,7 +99,25 @@ async fn main() -> anyhow::Result<()> {
     });
 
     info!("starting discord bot");
-    client.start().await?;
+    match client.start().await {
+        Err(serenity::Error::Gateway(GatewayError::DisallowedGatewayIntents)) => {
+            error!(
+                "Discord rejected privileged intents. \
+                 Enable MESSAGE CONTENT INTENT at: \
+                 https://discord.com/developers/applications → Bot → Privileged Gateway Intents"
+            );
+            std::process::exit(1);
+        }
+        Err(serenity::Error::Gateway(GatewayError::InvalidAuthentication)) => {
+            error!(
+                "Discord rejected bot token. \
+                 Verify your bot_token in config.toml is correct and has not been reset."
+            );
+            std::process::exit(1);
+        }
+        Err(e) => return Err(e.into()),
+        Ok(_) => {}
+    }
 
     // Cleanup
     cleanup_handle.abort();


### PR DESCRIPTION
## Summary

Closes #116

Catch `DisallowedGatewayIntents` and `InvalidAuthentication` errors from the Discord gateway with actionable error messages instead of cryptic serenity errors that cause CrashLoopBackOff with no guidance.

## Changes

| File | Change |
|------|--------|
| `src/main.rs` | Replace bare `client.start().await?` with match block catching `DisallowedGatewayIntents` and `InvalidAuthentication` |
| `README.md` | Add prerequisites section documenting required Discord Developer Portal settings |

## Error messages

**DisallowedGatewayIntents:**
> Discord rejected privileged intents. Enable MESSAGE CONTENT INTENT at: https://discord.com/developers/applications → Bot → Privileged Gateway Intents

**InvalidAuthentication:**
> Discord rejected bot token. Verify your bot_token in config.toml is correct and has not been reset.

## What is NOT changed

Per discussion in #116:
- Intents are **not** made configurable in `config.toml` — openab requires `MESSAGE_CONTENT` to function
- Only the two most common DX footguns are caught — not every possible serenity error

## Testing

- Verified `serenity::Error::Gateway(GatewayError::DisallowedGatewayIntents)` and `GatewayError::InvalidAuthentication` exist in serenity 0.12.5
- Issue confirmed reproducible on `0.7.2-beta.3` (see #116 comment)