### PR TITLE
fix: initialize gemini-cli configuration directory and file

### DIFF
--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -26,11 +26,11 @@ ENV HOME=/home/node
 WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
-COPY --chown=node:node docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+COPY --chown=node:node docker/gemini/entrypoint.sh /usr/local/bin/docker-entrypoint-gemini.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-gemini.sh
 
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENTRYPOINT ["docker-entrypoint.sh", "openab"]
+ENTRYPOINT ["docker-entrypoint-gemini.sh", "openab"]
 CMD ["/etc/openab/config.toml"]

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -26,9 +26,11 @@ ENV HOME=/home/node
 WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+COPY --chown=node:node docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENTRYPOINT ["openab"]
+ENTRYPOINT ["docker-entrypoint.sh", "openab"]
 CMD ["/etc/openab/config.toml"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Initialize Gemini CLI configuration directory and file if they don't exist.
+# This prevents ENOENT/SyntaxError during first-time startup.
+if [ ! -d "/home/node/.gemini" ]; then
+    mkdir -p /home/node/.gemini
+fi
+
+if [ ! -f "/home/node/.gemini/projects.json" ]; then
+    echo "{}" > /home/node/.gemini/projects.json
+fi
+
+# Ensure correct permissions for the node user
+chmod -R 777 /home/node/.gemini
+
+exec "$@"

--- a/docker/gemini/entrypoint.sh
+++ b/docker/gemini/entrypoint.sh
@@ -3,15 +3,10 @@ set -e
 
 # Initialize Gemini CLI configuration directory and file if they don't exist.
 # This prevents ENOENT/SyntaxError during first-time startup.
-if [ ! -d "/home/node/.gemini" ]; then
-    mkdir -p /home/node/.gemini
-fi
+mkdir -p /home/node/.gemini
 
 if [ ! -f "/home/node/.gemini/projects.json" ]; then
     echo "{}" > /home/node/.gemini/projects.json
 fi
-
-# Ensure correct permissions for the node user
-chmod -R 777 /home/node/.gemini
 
 exec "$@"


### PR DESCRIPTION
Fixes #331.

This PR adds a Gemini-specific container entrypoint to ensure Gemini CLI can start cleanly on first boot in ephemeral/containerized environments where `~/.gemini` has not been initialized yet.

What this does:
- ensures `/home/node/.gemini` exists before `openab` starts
- initializes `/home/node/.gemini/projects.json` with `{}` only when the file is missing
- keeps `exec "$@"` so PID 1 is still handed off to `openab`

Implementation details:
- moved the entrypoint script out of repo root to `docker/gemini/entrypoint.sh`
- renamed the installed runtime script to `docker-entrypoint-gemini.sh`
- removed the previous `chmod -R 777` permission widening
- simplified directory initialization to `mkdir -p`

Why this is needed:
- Gemini CLI currently appears to assume that `~/.gemini` and a valid `projects.json` already exist on first startup
- when they do not exist, first-run container startup can hit:
  - `ENOENT` while saving the registry
  - `SyntaxError: Unexpected end of JSON input` if the file exists but is empty

This PR treats that behavior as an upstream Gemini CLI assumption and adds a narrow container-side workaround in the Gemini image so `openab` starts reliably.

Verification:
- verified in ECS Fargate across three stages:
  - baseline failure without initialization
  - partial fix with empty file showing JSON parse failure
  - clean startup with directory + `{}` initialization
- shell syntax check passes for the entrypoint script

Follow-up:
- it would still be worth reporting this upstream to `@google/gemini-cli` so the workaround can eventually be removed once first-run initialization is handled there.
