### PR TITLE
fix: revert claude-code to 2.1.104 due to upstream auth regression

### DIFF
--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 # Install claude-agent-acp adapter and Claude Code CLI
-ARG CLAUDE_CODE_VERSION=2.1.107
+ARG CLAUDE_CODE_VERSION=2.1.104
 RUN npm install -g @agentclientprotocol/claude-agent-acp@0.25.0 @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} --retry 3
 
 # Install gh CLI


### PR DESCRIPTION
## Summary

Revert `CLAUDE_CODE_VERSION` from `2.1.107` to `2.1.104` in `Dockerfile.claude`.

## Why

claude-code `2.1.105+` has a regression on Linux where auth token paste is broken during `/login` — users cannot paste the auth code into the TUI.

- Upstream issue: [anthropics/claude-code#47648](https://github.com/anthropics/claude-code/issues/47648)
- Request from maintainer: [PR #326 comment](https://github.com/openabdev/openab/pull/326#issuecomment-4245090106)

## Changes

```diff
- ARG CLAUDE_CODE_VERSION=2.1.107
+ ARG CLAUDE_CODE_VERSION=2.1.104
```

Single-line change. Pin to last known good version until upstream ships a fix.

## Follow-up

Bump back to latest once `anthropics/claude-code#47648` is resolved.