### PR TITLE
fix: add 'run' subcommand to Dockerfile CMD after clap migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["openab"]
-CMD ["/etc/openab/config.toml"]
+CMD ["run", "/etc/openab/config.toml"]

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -31,4 +31,4 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["openab"]
-CMD ["/etc/openab/config.toml"]
+CMD ["run", "/etc/openab/config.toml"]

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -31,4 +31,4 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["openab"]
-CMD ["/etc/openab/config.toml"]
+CMD ["run", "/etc/openab/config.toml"]

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -31,4 +31,4 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["openab"]
-CMD ["/etc/openab/config.toml"]
+CMD ["run", "/etc/openab/config.toml"]

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -31,4 +31,4 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["openab"]
-CMD ["/etc/openab/config.toml"]
+CMD ["run", "/etc/openab/config.toml"]


### PR DESCRIPTION
## What problem does this solve?

After #191 added clap CLI with subcommands, all Dockerfiles still pass the config path as a positional argument, breaking every Docker/K8s deployment on v0.7.4+.

```
error: unrecognized subcommand '/etc/openab/config.toml'
```

Closes #334

## At a Glance

```
ENTRYPOINT ["openab"]
CMD ["/etc/openab/config.toml"]          ← clap sees this as subcommand name
     ↓ fix
CMD ["run", "/etc/openab/config.toml"]   ← clap routes to Commands::Run
```

## Prior Art & Industry Research

**OpenClaw:** Uses `CMD ["node", "dist/main.js"]` — no subcommands, not applicable.

**Hermes Agent:** Uses `CMD ["python", "-m", "hermes_agent"]` — no subcommands, not applicable.

Neither project uses a Rust clap-style CLI with subcommands in Docker, so there's no prior art to draw from. This is a straightforward Docker CMD compatibility fix.

## Proposed Solution

Change `CMD` in all 5 Dockerfiles from `["/etc/openab/config.toml"]` to `["run", "/etc/openab/config.toml"]`.

## Why this approach?

The only correct fix — the clap CLI requires the `run` subcommand before the config path. No other options.

## Alternatives Considered

- **Make config path a global argument instead of subcommand-specific**: Would require changing clap CLI structure in main.rs — much larger change for the same result.
- **Default subcommand without explicit `run`**: Already implemented (`unwrap_or(Commands::Run { config: None })`), but only works when no arguments are passed. A positional arg is always interpreted as a subcommand name by clap.

## Validation

- [x] `cargo check` passes
- [x] `cargo test` passes (40 tests)
- [x] Manual testing: `docker run openab:latest` now starts correctly with `/etc/openab/config.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)