### PR TITLE
feat: auto-label PRs missing Discord Discussion URL and auto-close after 3 days

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,60 @@
+name: Close Stale closing-soon PRs
+
+on:
+  schedule:
+    - cron: '0 9 * * *'  # daily at 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  close-stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'closing-soon';
+            const staleDays = 3;
+            const cutoff = new Date(Date.now() - staleDays * 24 * 60 * 60 * 1000);
+
+            const prs = await github.rest.pulls.list({
+              ...context.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            for (const pr of prs.data) {
+              if (!pr.labels.some(l => l.name === label)) continue;
+
+              // Find when the label was added
+              const events = await github.rest.issues.listEvents({
+                ...context.repo,
+                issue_number: pr.number,
+                per_page: 100
+              });
+
+              const labelEvent = events.data
+                .filter(e => e.event === 'labeled' && e.label?.name === label)
+                .pop();
+
+              if (!labelEvent) continue;
+
+              const labeledAt = new Date(labelEvent.created_at);
+              if (labeledAt > cutoff) continue;
+
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: pr.number,
+                body: `🔒 Auto-closing: this PR has had the \`${label}\` label for more than ${staleDays} days without a Discord Discussion URL being added.\n\nFeel free to reopen after adding the discussion link to the PR body.`
+              });
+
+              await github.rest.pulls.update({
+                ...context.repo,
+                pull_number: pr.number,
+                state: 'closed'
+              });
+
+              console.log(`Closed PR #${pr.number} (labeled ${labeledAt.toISOString()})`);
+            }

--- a/.github/workflows/pr-discussion-check.yml
+++ b/.github/workflows/pr-discussion-check.yml
@@ -1,0 +1,84 @@
+name: PR Discussion URL Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+concurrency:
+  group: pr-discussion-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const labels = pr.labels.map(l => l.name);
+            const marker = '<!-- openab-pr-discussion-check -->';
+            const label = 'closing-soon';
+
+            const hasDiscordUrl = /https:\/\/discord\.com\/channels\/\d+\/\d+/.test(body);
+
+            const comments = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: pr.number
+            });
+            const old = comments.data.find(c => c.body.includes(marker));
+
+            if (!hasDiscordUrl) {
+              if (!labels.includes(label)) {
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: pr.number,
+                  labels: [label]
+                });
+              }
+
+              const msg = [
+                marker,
+                '⚠️ This PR is missing a **Discord Discussion URL** in the body.',
+                '',
+                'All PRs must reference a prior Discord discussion to ensure community alignment before implementation.',
+                '',
+                'Please edit the PR description to include a link like:',
+                '```',
+                'Discord Discussion URL: https://discord.com/channels/...',
+                '```',
+                '',
+                `This PR will be **automatically closed in 3 days** if the link is not added.`
+              ].join('\n');
+
+              if (!old) {
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: pr.number,
+                  body: msg
+                });
+              }
+            } else {
+              // URL found — remove label and comment if present
+              if (labels.includes(label)) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    ...context.repo,
+                    issue_number: pr.number,
+                    name: label
+                  });
+                } catch (e) {
+                  if (e.status !== 404) throw e;
+                }
+              }
+              if (old) {
+                await github.rest.issues.deleteComment({
+                  ...context.repo,
+                  comment_id: old.id
+                });
+              }
+            }


### PR DESCRIPTION
## What

Adds two GitHub Actions workflows to enforce that all PRs reference a prior Discord discussion.

Closes #340

Discord Discussion URL: https://discord.com/channels/1490282656913559673/1493728546735128767

## Workflows

### `pr-discussion-check.yml`
- Triggers on PR `opened`, `edited`, `synchronize`
- Scans PR body for `https://discord.com/channels/{server}/{channel}` pattern
- **Missing** → adds `closing-soon` label + bot comment explaining the requirement
- **Found** (author edits body) → removes label + deletes bot comment

### `close-stale-prs.yml`
- Runs daily at 09:00 UTC (+ manual `workflow_dispatch`)
- Finds open PRs with `closing-soon` label
- Checks the label event timeline — if labeled > 3 days ago, auto-closes with a comment
- Authors can reopen after adding the discussion link

## Setup Required

Maintainer needs to create the `closing-soon` label:
```
gh label create closing-soon --description 'PR missing Discord Discussion URL — will auto-close in 3 days' --color e4e669
```

## Files Changed

- `.github/workflows/pr-discussion-check.yml` (new)
- `.github/workflows/close-stale-prs.yml` (new)