### PR TITLE
feat: inject per-user MCP servers into ACP sessions

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -58,3 +58,33 @@ stall_soft_ms = 10000
 stall_hard_ms = 30000
 done_hold_ms = 1500
 error_hold_ms = 2500
+
+# Optional usage dashboard command (`/usage`)
+[usage]
+enabled = true
+timeout_secs = 30
+
+[[usage.runners]]
+name = "copilot-quota"
+label = "Copilot 配額"
+color = 5763719
+command = "node"
+args = ["scripts/usage/copilot-quota.js"]
+template = "🧾 Copilot 配額 {{ remaining_pct }}%\n總請求 {{ total_requests }} / {{ requests_cap }}"
+progress_fields = ["remaining_pct"]
+env = { RUNNER = "copilot" }
+
+# Optional custom usage command (`/cusage`)
+[cusage]
+enabled = true
+timeout_secs = 30
+
+[[cusage.runners]]
+name = "daily-report"
+label = "每日使用報告"
+color = 4286946
+command = "node"
+args = ["scripts/usage/daily-report.js", "--tz", "Asia/Taipei"]
+template = "📅 今日訊息 {{ messages }}\nToken: {{ tokens }}\n成本: ${{ cost }}"
+env = { REPORT_SCOPE = "daily" }
+working_dir = "."

--- a/config.toml.example
+++ b/config.toml.example
@@ -88,3 +88,29 @@ args = ["scripts/usage/daily-report.js", "--tz", "Asia/Taipei"]
 template = "📅 今日訊息 {{ messages }}\nToken: {{ tokens }}\n成本: ${{ cost }}"
 env = { REPORT_SCOPE = "daily" }
 working_dir = "."
+
+# Minimal runnable example (no external scripts required):
+#
+# [usage]
+# enabled = true
+# timeout_secs = 5
+#
+# [[usage.runners]]
+# name = "ping"
+# label = "簡易檢查"
+# color = 5763719
+# command = "node"
+# args = ["-e", "console.log('{\"ok\":true,\"status\":\"ok\",\"value\":100,\"note\":\"no external script needed\"}')"]
+# template = "status={{ status }} value={{ value }} note={{ note }}"
+#
+# [cusage]
+# enabled = true
+# timeout_secs = 5
+#
+# [[cusage.runners]]
+# name = "ping"
+# label = "簡易回報"
+# color = 4286946
+# command = "node"
+# args = ["-e", "console.log('{\"ok\":true,\"items\":[1,2,3],\"label\":\"hello\"}')"]
+# template = "label={{ label }} items={{ items }}"

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -149,6 +149,7 @@ impl AcpConnection {
             cmd.env(k, expand_env(v));
         }
         let mut proc = cmd
+            .kill_on_drop(true)
             .spawn()
             .map_err(|e| anyhow!("failed to spawn {command}: {e}"))?;
         let child_pgid = proc.id().and_then(|pid| i32::try_from(pid).ok());

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -135,10 +135,8 @@ impl AcpConnection {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
             .current_dir(working_dir);
-        // Create a new process group so we can kill the entire tree.
-        // SAFETY: setpgid is async-signal-safe (POSIX.1-2008) and called
-        // before exec. Return value checked — failure means the child won't
-        // have its own process group, so kill(-pgid) would be unsafe.
+        // Create a new process group so we can kill the entire tree (Unix only).
+        #[cfg(unix)]
         unsafe {
             cmd.pre_exec(|| {
                 if libc::setpgid(0, 0) != 0 {
@@ -153,8 +151,7 @@ impl AcpConnection {
         let mut proc = cmd
             .spawn()
             .map_err(|e| anyhow!("failed to spawn {command}: {e}"))?;
-        let child_pgid = proc.id()
-            .and_then(|pid| i32::try_from(pid).ok());
+        let child_pgid = proc.id().and_then(|pid| i32::try_from(pid).ok());
 
         let stdout = proc.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
         let stdin = proc.stdin.take().ok_or_else(|| anyhow!("no stdin"))?;
@@ -332,19 +329,29 @@ impl AcpConnection {
             .and_then(|c| c.get("loadSession"))
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        info!(agent = agent_name, load_session = self.supports_load_session, "initialized");
+        info!(
+            agent = agent_name,
+            load_session = self.supports_load_session,
+            "initialized"
+        );
         Ok(())
     }
 
-    pub async fn session_new(&mut self, cwd: &str) -> Result<String> {
+    pub async fn session_new(
+        &mut self,
+        cwd: &str,
+        mcp_servers: &[serde_json::Value],
+    ) -> Result<String> {
         let resp = self
             .send_request(
                 "session/new",
-                Some(json!({"cwd": cwd, "mcpServers": []})),
+                Some(json!({"cwd": cwd, "mcpServers": mcp_servers})),
             )
             .await?;
 
-        let session_id = resp.result.as_ref()
+        let session_id = resp
+            .result
+            .as_ref()
             .and_then(|r| r.get("sessionId"))
             .and_then(|s| s.as_str())
             .ok_or_else(|| anyhow!("no sessionId in session/new response"))?
@@ -375,10 +382,7 @@ impl AcpConnection {
         let id = self.next_id();
 
         // Convert content blocks to JSON
-        let prompt_json: Vec<Value> = content_blocks
-            .iter()
-            .map(|b| b.to_json())
-            .collect();
+        let prompt_json: Vec<Value> = content_blocks.iter().map(|b| b.to_json()).collect();
 
         let req = JsonRpcRequest::new(
             id,
@@ -409,11 +413,16 @@ impl AcpConnection {
 
     /// Resume a previous session by ID. Returns Ok(()) if the agent accepted
     /// the load, or an error if it failed (caller should fall back to session/new).
-    pub async fn session_load(&mut self, session_id: &str, cwd: &str) -> Result<()> {
+    pub async fn session_load(
+        &mut self,
+        session_id: &str,
+        cwd: &str,
+        mcp_servers: &[serde_json::Value],
+    ) -> Result<()> {
         let resp = self
             .send_request(
                 "session/load",
-                Some(json!({"sessionId": session_id, "cwd": cwd, "mcpServers": []})),
+                Some(json!({"sessionId": session_id, "cwd": cwd, "mcpServers": mcp_servers})),
             )
             .await?;
         // Accept any non-error response as success
@@ -425,21 +434,28 @@ impl AcpConnection {
         Ok(())
     }
 
-    /// Kill the entire process group: SIGTERM → SIGKILL.
-    /// Uses std::thread (not tokio::spawn) so SIGKILL fires even during
-    /// runtime shutdown or panic unwinding.
+    /// Kill the entire process group: SIGTERM → SIGKILL (Unix only).
+    /// On Windows, rely on Child::kill_on_drop or external process management.
+    #[cfg(unix)]
     fn kill_process_group(&mut self) {
         let pgid = match self.child_pgid {
             Some(pid) if pid > 0 => pid,
             _ => return,
         };
-        // Stage 1: SIGTERM the process group
-        unsafe { libc::kill(-pgid, libc::SIGTERM); }
-        // Stage 2: SIGKILL after brief grace (std::thread survives runtime shutdown)
+        unsafe {
+            libc::kill(-pgid, libc::SIGTERM);
+        }
         std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(1500));
-            unsafe { libc::kill(-pgid, libc::SIGKILL); }
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
         });
+    }
+
+    #[cfg(not(unix))]
+    fn kill_process_group(&mut self) {
+        // On Windows, rely on kill_on_drop(true) set during spawn
     }
 }
 

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -105,6 +105,20 @@ impl ContentBlock {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ModelInfo {
+    pub model_id: String,
+    pub name: String,
+    pub description: String,
+}
+
+/// A native slash command exposed by the ACP agent via `available_commands_update`.
+#[derive(Debug, Clone)]
+pub struct NativeCommand {
+    pub name: String,
+    pub description: String,
+}
+
 pub struct AcpConnection {
     _proc: Child,
     /// PID of the direct child, used as the process group ID for cleanup.
@@ -117,6 +131,12 @@ pub struct AcpConnection {
     pub supports_load_session: bool,
     pub last_active: Instant,
     pub session_reset: bool,
+    /// One-shot context block prepended to the next user-visible prompt.
+    /// Used for backend-specific MCP protocol guidance without a hidden prompt.
+    pub startup_context: Option<String>,
+    pub current_model: String,
+    pub available_models: Vec<ModelInfo>,
+    pub native_commands: Arc<Mutex<Vec<NativeCommand>>>,
     _reader_handle: JoinHandle<()>,
 }
 
@@ -163,10 +183,13 @@ impl AcpConnection {
         let notify_tx: Arc<Mutex<Option<mpsc::UnboundedSender<JsonRpcMessage>>>> =
             Arc::new(Mutex::new(None));
 
+        let native_commands: Arc<Mutex<Vec<NativeCommand>>> = Arc::new(Mutex::new(Vec::new()));
+
         let reader_handle = {
             let pending = pending.clone();
             let notify_tx = notify_tx.clone();
             let stdin_clone = stdin.clone();
+            let native_cmds = native_commands.clone();
             tokio::spawn(async move {
                 let mut reader = BufReader::new(stdout);
                 let mut line = String::new();
@@ -196,7 +219,6 @@ impl AcpConnection {
                                 .and_then(|t| t.get("title"))
                                 .and_then(|t| t.as_str())
                                 .unwrap_or("?");
-
                             let outcome = build_permission_response(msg.params.as_ref());
                             info!(title, %outcome, "auto-respond permission");
                             let reply = JsonRpcResponse::new(id, outcome);
@@ -207,6 +229,35 @@ impl AcpConnection {
                             }
                         }
                         continue;
+                    }
+
+                    // Capture native agent slash commands from available_commands_update
+                    if msg.method.as_deref() == Some("session/update") {
+                        if let Some(upd) = msg.params.as_ref().and_then(|p| p.get("update")) {
+                            if upd.get("sessionUpdate").and_then(|v| v.as_str())
+                                == Some("available_commands_update")
+                            {
+                                if let Some(cmds) =
+                                    upd.get("availableCommands").and_then(|v| v.as_array())
+                                {
+                                    let parsed: Vec<NativeCommand> = cmds
+                                        .iter()
+                                        .filter_map(|c| {
+                                            let name = c.get("name")?.as_str()?.to_string();
+                                            let description = c
+                                                .get("description")
+                                                .and_then(|d| d.as_str())
+                                                .unwrap_or("")
+                                                .to_string();
+                                            Some(NativeCommand { name, description })
+                                        })
+                                        .collect();
+                                    info!(count = parsed.len(), "captured native agent commands");
+                                    *native_cmds.lock().await = parsed;
+                                }
+                            }
+                        }
+                        // Don't consume — still forward to subscriber below
                     }
 
                     // Response (has id) → resolve pending AND forward to subscriber
@@ -268,6 +319,10 @@ impl AcpConnection {
             supports_load_session: false,
             last_active: Instant::now(),
             session_reset: false,
+            startup_context: None,
+            current_model: "auto".to_string(),
+            available_models: Vec::new(),
+            native_commands,
             _reader_handle: reader_handle,
         })
     }
@@ -295,7 +350,16 @@ impl AcpConnection {
 
         self.send_raw(&data).await?;
 
-        let timeout_secs = if method == "session/new" { 120 } else { 30 };
+        // Gemini CLI's --acp mode takes ~20-25s to cold-start (slow plugin/auth
+        // loading), so the default 30s initialize timeout is marginal. Bump to
+        // 90s for initialize and keep 120s for session/new. Other methods
+        // (prompt, set_model, etc.) stay at 30s since they run against a
+        // warm process.
+        let timeout_secs = match method {
+            "initialize" => 90,
+            "session/new" => 120,
+            _ => 30,
+        };
         let resp = tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), rx)
             .await
             .map_err(|_| anyhow!("timeout waiting for {method} response"))?
@@ -360,13 +424,134 @@ impl AcpConnection {
 
         info!(session_id = %session_id, "session created");
         self.acp_session_id = Some(session_id.clone());
+
+        if let Some(models) = resp.result.as_ref().and_then(|r| r.get("models")) {
+            if let Some(current) = models.get("currentModelId").and_then(|v| v.as_str()) {
+                self.current_model = current.to_string();
+            }
+            if let Some(arr) = models.get("availableModels").and_then(|v| v.as_array()) {
+                self.available_models = arr
+                    .iter()
+                    .filter_map(|m| {
+                        let model_id = m.get("modelId")?.as_str()?.to_string();
+                        let name = m
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(&model_id)
+                            .to_string();
+                        let description = m
+                            .get("description")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if description.contains("[Deprecated]")
+                            || description.contains("[Internal]")
+                        {
+                            return None;
+                        }
+                        Some(ModelInfo {
+                            model_id,
+                            name,
+                            description,
+                        })
+                    })
+                    .collect();
+                info!(
+                    count = self.available_models.len(),
+                    current = %self.current_model,
+                    "parsed available models"
+                );
+            }
+        }
+
         Ok(session_id)
     }
 
-    /// Send a prompt with content blocks (text and/or images) and return a receiver
-    /// for streaming notifications. The final message on the channel will have id set
-    /// (the prompt response).
-    pub async fn session_prompt(
+    pub async fn session_set_model(&mut self, model_id: &str) -> Result<()> {
+        let session_id = self
+            .acp_session_id
+            .as_ref()
+            .ok_or_else(|| anyhow!("no active session"))?
+            .clone();
+        self.send_request(
+            "session/set_model",
+            Some(json!({
+                "sessionId": session_id,
+                "modelId": model_id,
+            })),
+        )
+        .await?;
+        self.current_model = model_id.to_string();
+        Ok(())
+    }
+
+    pub fn resolve_model_alias(&self, input: &str) -> Option<String> {
+        // Aliases disabled: accept only exact model IDs.
+        // Case-insensitive match against available_models.
+        let lower = input.to_lowercase();
+        self.available_models
+            .iter()
+            .find(|m| m.model_id.to_lowercase() == lower)
+            .map(|m| m.model_id.clone())
+    }
+
+    /// Query the bridge's `_meta/getUsage` extension to get session token usage
+    /// and account quota. Only works with agents that implement this custom method
+    /// (e.g. our copilot-agent-acp bridge). Returns the raw JSON result for the
+    /// caller to parse / render.
+    pub async fn session_get_usage(&self) -> Result<Value> {
+        let session_id = self
+            .acp_session_id
+            .as_ref()
+            .ok_or_else(|| anyhow!("no active session"))?
+            .clone();
+        let resp = self
+            .send_request("_meta/getUsage", Some(json!({ "sessionId": session_id })))
+            .await?;
+        Ok(resp.result.unwrap_or(Value::Null))
+    }
+
+    /// Query the bridge's `_meta/getRecentPermissions` extension for the
+    /// audit trail of recent tool permission requests in the current session.
+    pub async fn session_get_recent_permissions(&self) -> Result<Value> {
+        let session_id = self
+            .acp_session_id
+            .as_ref()
+            .ok_or_else(|| anyhow!("no active session"))?
+            .clone();
+        let resp = self
+            .send_request(
+                "_meta/getRecentPermissions",
+                Some(json!({ "sessionId": session_id })),
+            )
+            .await?;
+        Ok(resp.result.unwrap_or(Value::Null))
+    }
+
+    /// Query the bridge's `_meta/compactSession` extension for real LLM-based
+    /// conversation history compaction (preserves summarized context).
+    pub async fn session_compact(&self) -> Result<Value> {
+        let session_id = self
+            .acp_session_id
+            .as_ref()
+            .ok_or_else(|| anyhow!("no active session"))?
+            .clone();
+        let resp = self
+            .send_request(
+                "_meta/compactSession",
+                Some(json!({ "sessionId": session_id })),
+            )
+            .await?;
+        Ok(resp.result.unwrap_or(Value::Null))
+    }
+
+    /// Ping the bridge to verify it's alive and responsive.
+    pub async fn session_ping(&self) -> Result<Value> {
+        let resp = self.send_request("_meta/ping", Some(json!({}))).await?;
+        Ok(resp.result.unwrap_or(Value::Null))
+    }
+
+    async fn send_prompt_request(
         &mut self,
         content_blocks: Vec<ContentBlock>,
     ) -> Result<(mpsc::UnboundedReceiver<JsonRpcMessage>, u64)> {
@@ -402,6 +587,22 @@ impl AcpConnection {
         Ok((rx, id))
     }
 
+    /// Send a prompt with content blocks (text and/or images) and return a receiver
+    /// for streaming notifications. The final message on the channel will have id set
+    /// (the prompt response).
+    pub async fn session_prompt(
+        &mut self,
+        mut content_blocks: Vec<ContentBlock>,
+    ) -> Result<(mpsc::UnboundedReceiver<JsonRpcMessage>, u64)> {
+        if let Some(context) = self.startup_context.take() {
+            let mut prefixed = Vec::with_capacity(content_blocks.len() + 1);
+            prefixed.push(ContentBlock::Text { text: context });
+            prefixed.append(&mut content_blocks);
+            content_blocks = prefixed;
+        }
+        self.send_prompt_request(content_blocks).await
+    }
+
     /// Call after prompt streaming is done to clean up subscriber.
     pub async fn prompt_done(&mut self) {
         *self.notify_tx.lock().await = None;
@@ -432,11 +633,42 @@ impl AcpConnection {
         }
         info!(session_id, "session loaded");
         self.acp_session_id = Some(session_id.to_string());
+
+        // Parse model metadata (mirrors session_new logic)
+        if let Some(models) = resp.result.as_ref().and_then(|r| r.get("models")) {
+            if let Some(current) = models.get("currentModelId").and_then(|v| v.as_str()) {
+                self.current_model = current.to_string();
+            }
+            if let Some(arr) = models.get("availableModels").and_then(|v| v.as_array()) {
+                self.available_models = arr
+                    .iter()
+                    .filter_map(|m| {
+                        let model_id = m.get("modelId")?.as_str()?.to_string();
+                        let name = m
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(&model_id)
+                            .to_string();
+                        let description = m
+                            .get("description")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        Some(ModelInfo {
+                            model_id,
+                            name,
+                            description,
+                        })
+                    })
+                    .collect();
+            }
+        }
+
         Ok(())
     }
 
     /// Kill the entire process group: SIGTERM → SIGKILL (Unix only).
-    /// On Windows, rely on Child::kill_on_drop or external process management.
+    /// On Windows, the child process is killed via Drop on the Child handle.
     #[cfg(unix)]
     fn kill_process_group(&mut self) {
         let pgid = match self.child_pgid {
@@ -456,109 +688,27 @@ impl AcpConnection {
 
     #[cfg(not(unix))]
     fn kill_process_group(&mut self) {
-        // On Windows, rely on kill_on_drop(true) set during spawn
+        if let Some(pgid) = self.child_pgid {
+            let _ = std::process::Command::new("taskkill")
+                .arg("/PID")
+                .arg(pgid.to_string())
+                .arg("/T")
+                .arg("/F")
+                .status();
+            return;
+        }
+
+        // Fallback for environments where taskkill does not have enough
+        // information or is unavailable (e.g. unexpected pid conversion
+        // failure). Child::kill() terminates at least the immediate child.
+        if let Err(err) = self._proc.start_kill() {
+            debug!(error = %err, "failed to start killing ACP child process on drop");
+        }
     }
 }
 
 impl Drop for AcpConnection {
     fn drop(&mut self) {
         self.kill_process_group();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{build_permission_response, pick_best_option};
-    use serde_json::json;
-
-    #[test]
-    fn picks_allow_always_over_other_options() {
-        let options = vec![
-            json!({"kind": "allow_once", "optionId": "once"}),
-            json!({"kind": "allow_always", "optionId": "always"}),
-            json!({"kind": "reject_once", "optionId": "reject"}),
-        ];
-
-        assert_eq!(pick_best_option(&options), Some("always".to_string()));
-    }
-
-    #[test]
-    fn falls_back_to_first_unknown_non_reject_kind() {
-        let options = vec![
-            json!({"kind": "reject_once", "optionId": "reject"}),
-            json!({"kind": "workspace_write", "optionId": "workspace-write"}),
-        ];
-
-        assert_eq!(
-            pick_best_option(&options),
-            Some("workspace-write".to_string())
-        );
-    }
-
-    #[test]
-    fn selects_bypass_permissions_for_exit_plan_mode() {
-        let options = vec![
-            json!({"optionId": "bypassPermissions", "kind": "allow_always"}),
-            json!({"optionId": "acceptEdits", "kind": "allow_always"}),
-            json!({"optionId": "default", "kind": "allow_once"}),
-            json!({"optionId": "plan", "kind": "reject_once"}),
-        ];
-
-        assert_eq!(
-            pick_best_option(&options),
-            Some("bypassPermissions".to_string())
-        );
-    }
-
-    #[test]
-    fn returns_none_when_only_reject_options_exist() {
-        let options = vec![
-            json!({"kind": "reject_once", "optionId": "reject-once"}),
-            json!({"kind": "reject_always", "optionId": "reject-always"}),
-        ];
-
-        assert_eq!(pick_best_option(&options), None);
-    }
-
-    #[test]
-    fn builds_cancelled_outcome_when_no_selectable_option_exists() {
-        let response = build_permission_response(Some(&json!({
-            "options": [
-                {"kind": "reject_once", "optionId": "reject-once"}
-            ]
-        })));
-
-        assert_eq!(response, json!({"outcome": {"outcome": "cancelled"}}));
-    }
-
-    #[test]
-    fn builds_cancelled_when_options_array_is_empty() {
-        let response = build_permission_response(Some(&json!({
-            "options": []
-        })));
-
-        assert_eq!(response, json!({"outcome": {"outcome": "cancelled"}}));
-    }
-
-    #[test]
-    fn falls_back_to_allow_always_when_options_are_missing() {
-        let response = build_permission_response(Some(&json!({
-            "toolCall": {"title": "legacy"}
-        })));
-
-        assert_eq!(
-            response,
-            json!({"outcome": {"outcome": "selected", "optionId": "allow_always"}})
-        );
-    }
-
-    #[test]
-    fn falls_back_to_allow_always_when_params_is_none() {
-        let response = build_permission_response(None);
-
-        assert_eq!(
-            response,
-            json!({"outcome": {"outcome": "selected", "optionId": "allow_always"}})
-        );
     }
 }

--- a/src/acp/mcp_prefetch.rs
+++ b/src/acp/mcp_prefetch.rs
@@ -1,0 +1,452 @@
+use anyhow::{anyhow, Context, Result};
+use serde_json::{json, Value};
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+
+const DEFAULT_TIMEOUT_SECS: u64 = 10;
+const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+const OPENAB_CLIENT_NAME: &str = "openab";
+const OPENAB_CLIENT_VERSION: &str = "0.1.0";
+
+pub async fn prefetch_mempalace_context(server: &Value) -> Result<Option<String>> {
+    let status = fetch_mempalace_status(server).await?;
+    Ok(build_startup_context(&status))
+}
+
+async fn fetch_mempalace_status(server: &Value) -> Result<Value> {
+    match server.get("type").and_then(|value| value.as_str()) {
+        Some("http") | Some("sse") => fetch_status_over_http(server).await,
+        Some("stdio") | Some("local") => fetch_status_over_stdio(server).await,
+        Some(other) => Err(anyhow!("unsupported mempalace MCP transport: {other}")),
+        None if server.get("url").is_some() => fetch_status_over_http(server).await,
+        None if server.get("command").is_some() => fetch_status_over_stdio(server).await,
+        None => Err(anyhow!(
+            "mempalace MCP server is missing both url and command"
+        )),
+    }
+}
+
+fn build_startup_context(status: &Value) -> Option<String> {
+    let protocol = status.get("protocol").and_then(|value| value.as_str())?;
+    let aaak = status.get("aaak_dialect").and_then(|value| value.as_str());
+    let total_drawers = status.get("total_drawers").and_then(|value| value.as_u64());
+    let wing_count = status
+        .get("wings")
+        .and_then(|value| value.as_object())
+        .map(|wings| wings.len());
+
+    let mut context = String::from(
+        "MemPalace wake-up context was prefetched by the bridge from `mempalace_status`. \
+This replaces any separate bootstrap prompt or wake-up tool call. Use this as the source \
+of truth for memory behavior and diary writes instead of local CLAUDE.md or AGENTS.md files.",
+    );
+
+    if let Some(total_drawers) = total_drawers {
+        context.push_str(&format!(
+            "\n\nPalace overview: {total_drawers} drawer(s) loaded."
+        ));
+        if let Some(wing_count) = wing_count {
+            context.push_str(&format!(" {wing_count} wing(s) are currently indexed."));
+        }
+    }
+
+    context.push_str("\n\nProtocol:\n");
+    context.push_str(protocol);
+
+    if let Some(aaak) = aaak {
+        context.push_str("\n\nAAAK Dialect:\n");
+        context.push_str(aaak);
+    }
+
+    Some(context)
+}
+
+async fn fetch_status_over_http(server: &Value) -> Result<Value> {
+    let url = server
+        .get("url")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| anyhow!("mempalace HTTP MCP server is missing url"))?;
+    let timeout_secs = request_timeout_secs(server);
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+        .context("failed to build MCP HTTP client")?;
+
+    let mut request = client
+        .post(url)
+        .header(
+            reqwest::header::ACCEPT,
+            "application/json, text/event-stream",
+        )
+        .header(reqwest::header::CONTENT_TYPE, "application/json");
+
+    if let Some(headers) = server.get("headers").and_then(|value| value.as_object()) {
+        for (name, value) in headers {
+            if let Some(value) = value.as_str() {
+                request = request.header(name, value);
+            }
+        }
+    }
+
+    let response = request
+        .body(build_tools_call_request(1).to_string())
+        .send()
+        .await
+        .with_context(|| format!("failed calling mempalace MCP at {url}"))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .context("failed reading mempalace MCP response body")?;
+    if !status.is_success() {
+        return Err(anyhow!(
+            "mempalace MCP returned HTTP {}: {}",
+            status,
+            body.trim()
+        ));
+    }
+
+    parse_http_tools_call_response(&body)
+}
+
+async fn fetch_status_over_stdio(server: &Value) -> Result<Value> {
+    let command = server
+        .get("command")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| anyhow!("mempalace stdio MCP server is missing command"))?;
+    let args: Vec<String> = server
+        .get("args")
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+    let timeout_secs = request_timeout_secs(server);
+
+    let mut child = Command::new(command);
+    child
+        .args(&args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true);
+
+    if let Some(cwd) = server.get("cwd").and_then(|value| value.as_str()) {
+        child.current_dir(cwd);
+    }
+    if let Some(env) = server.get("env").and_then(|value| value.as_object()) {
+        for (key, value) in env {
+            if let Some(value) = value.as_str() {
+                child.env(key, expand_env(value));
+            }
+        }
+    }
+
+    let mut child = child
+        .spawn()
+        .with_context(|| format!("failed to spawn mempalace MCP command `{command}`"))?;
+    let mut stdin = child.stdin.take().ok_or_else(|| anyhow!("no MCP stdin"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("no MCP stdout"))?;
+    let mut reader = BufReader::new(stdout);
+
+    send_stdio_request(&mut stdin, &build_initialize_request(1)).await?;
+    read_stdio_response(&mut reader, 1, timeout_secs).await?;
+
+    send_stdio_request(
+        &mut stdin,
+        &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+    )
+    .await?;
+
+    send_stdio_request(&mut stdin, &build_tools_call_request(2)).await?;
+    let response = read_stdio_response(&mut reader, 2, timeout_secs).await?;
+    let _ = child.kill().await;
+
+    parse_tool_call_response(&response)
+}
+
+async fn send_stdio_request(stdin: &mut tokio::process::ChildStdin, payload: &Value) -> Result<()> {
+    let line = serde_json::to_string(payload).context("failed to encode MCP stdio request")?;
+    stdin
+        .write_all(line.as_bytes())
+        .await
+        .context("failed writing MCP stdio request")?;
+    stdin
+        .write_all(b"\n")
+        .await
+        .context("failed terminating MCP stdio request")?;
+    stdin.flush().await.context("failed flushing MCP stdio")?;
+    Ok(())
+}
+
+async fn read_stdio_response(
+    reader: &mut BufReader<tokio::process::ChildStdout>,
+    request_id: u64,
+    timeout_secs: u64,
+) -> Result<Value> {
+    tokio::time::timeout(Duration::from_secs(timeout_secs), async {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let read = reader
+                .read_line(&mut line)
+                .await
+                .context("failed reading MCP stdio response")?;
+            if read == 0 {
+                return Err(anyhow!("mempalace MCP stdio closed before responding"));
+            }
+            let message: Value =
+                serde_json::from_str(line.trim()).context("invalid MCP stdio JSON response")?;
+            if message.get("id").and_then(|value| value.as_u64()) == Some(request_id) {
+                return Ok(message);
+            }
+        }
+    })
+    .await
+    .map_err(|_| anyhow!("timeout waiting for mempalace MCP stdio response"))?
+}
+
+fn build_initialize_request(id: u64) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {
+                "name": OPENAB_CLIENT_NAME,
+                "version": OPENAB_CLIENT_VERSION
+            }
+        }
+    })
+}
+
+fn build_tools_call_request(id: u64) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": "mempalace_status",
+            "arguments": {}
+        }
+    })
+}
+
+fn parse_http_tools_call_response(body: &str) -> Result<Value> {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("empty mempalace MCP HTTP response"));
+    }
+
+    if let Ok(response) = serde_json::from_str::<Value>(trimmed) {
+        return parse_tool_call_response(&response);
+    }
+
+    for event_data in parse_sse_data_messages(trimmed) {
+        if let Ok(response) = serde_json::from_str::<Value>(&event_data) {
+            if response.get("id").is_some() || response.get("result").is_some() {
+                return parse_tool_call_response(&response);
+            }
+        }
+    }
+
+    Err(anyhow!("unrecognized mempalace MCP HTTP response format"))
+}
+
+fn parse_sse_data_messages(body: &str) -> Vec<String> {
+    let mut events = Vec::new();
+    let mut data_lines = Vec::new();
+
+    for line in body.lines() {
+        if line.trim().is_empty() {
+            if !data_lines.is_empty() {
+                events.push(data_lines.join("\n"));
+                data_lines.clear();
+            }
+            continue;
+        }
+
+        if let Some(data) = line.strip_prefix("data:") {
+            let data = data.trim_start();
+            if data != "[DONE]" {
+                data_lines.push(data.to_string());
+            }
+        }
+    }
+
+    if !data_lines.is_empty() {
+        events.push(data_lines.join("\n"));
+    }
+
+    events
+}
+
+fn parse_tool_call_response(response: &Value) -> Result<Value> {
+    if let Some(error) = response.get("error") {
+        let message = error
+            .get("message")
+            .and_then(|value| value.as_str())
+            .unwrap_or("unknown MCP tool error");
+        return Err(anyhow!("mempalace_status failed: {message}"));
+    }
+
+    let text = response
+        .get("result")
+        .and_then(|value| value.get("content"))
+        .and_then(|value| value.as_array())
+        .and_then(|content| {
+            content.iter().find_map(|item| {
+                item.get("text")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_owned)
+            })
+        })
+        .ok_or_else(|| anyhow!("mempalace_status returned no text content"))?;
+
+    serde_json::from_str(&text).context("invalid JSON payload inside mempalace_status response")
+}
+
+fn request_timeout_secs(server: &Value) -> u64 {
+    let timeout = server
+        .get("timeout")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(DEFAULT_TIMEOUT_SECS);
+    timeout.clamp(1, 60)
+}
+
+fn expand_env(value: &str) -> String {
+    if value.starts_with("${") && value.ends_with('}') {
+        let key = &value[2..value.len() - 1];
+        std::env::var(key).unwrap_or_default()
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::TcpListener;
+
+    #[test]
+    fn builds_startup_context_from_status_payload() {
+        let context = build_startup_context(&json!({
+            "total_drawers": 12,
+            "wings": {"project": 7, "people": 5},
+            "protocol": "IMPORTANT — protocol",
+            "aaak_dialect": "AAAK SPEC"
+        }))
+        .expect("context");
+
+        assert!(context.contains("prefetched by the bridge"));
+        assert!(context.contains("12 drawer(s)"));
+        assert!(context.contains("IMPORTANT — protocol"));
+        assert!(context.contains("AAAK SPEC"));
+    }
+
+    #[test]
+    fn parses_sse_data_messages_into_tool_response() {
+        let body = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"{\\n  \\\"protocol\\\": \\\"PROTO\\\"\\n}\"}]}}\n\n";
+        let status = parse_http_tools_call_response(body).expect("parsed SSE response");
+
+        assert_eq!(status["protocol"], "PROTO");
+    }
+
+    #[tokio::test]
+    async fn prefetches_mempalace_context_over_http() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let mut buffer = vec![0_u8; 4096];
+            let mut request = Vec::new();
+
+            loop {
+                let read = stream.read(&mut buffer).await.expect("read request");
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+
+                let header_end = request
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                    .map(|offset| offset + 4);
+                let Some(header_end) = header_end else {
+                    continue;
+                };
+
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let lower = line.to_ascii_lowercase();
+                        lower
+                            .strip_prefix("content-length:")
+                            .and_then(|value| value.trim().parse::<usize>().ok())
+                    })
+                    .unwrap_or(0);
+
+                while request.len() < header_end + content_length {
+                    let read = stream.read(&mut buffer).await.expect("read body");
+                    if read == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&buffer[..read]);
+                }
+
+                let body = &request[header_end..header_end + content_length];
+                let rpc: Value = serde_json::from_slice(body).expect("decode request JSON");
+                assert_eq!(rpc["method"], "tools/call");
+                assert_eq!(rpc["params"]["name"], "mempalace_status");
+
+                let response_body = json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "content": [{
+                            "type": "text",
+                            "text": "{\"protocol\":\"PROTO\",\"aaak_dialect\":\"SPEC\",\"total_drawers\":5,\"wings\":{\"project\":5}}"
+                        }]
+                    }
+                })
+                .to_string();
+
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                    response_body.len(),
+                    response_body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("write response");
+                break;
+            }
+        });
+
+        let context = prefetch_mempalace_context(&json!({
+            "type": "http",
+            "url": format!("http://{addr}/mcp")
+        }))
+        .await
+        .expect("prefetch succeeded")
+        .expect("startup context");
+
+        assert!(context.contains("PROTO"));
+        assert!(context.contains("SPEC"));
+        server.await.expect("server task");
+    }
+}

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -2,6 +2,6 @@ pub mod connection;
 pub mod pool;
 pub mod protocol;
 
+pub use connection::ContentBlock;
 pub use pool::SessionPool;
 pub use protocol::{classify_notification, AcpEvent};
-pub use connection::ContentBlock;

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -1,4 +1,5 @@
 pub mod connection;
+mod mcp_prefetch;
 pub mod pool;
 pub mod protocol;
 

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -34,7 +34,11 @@ impl SessionPool {
         }
     }
 
-    pub async fn get_or_create(&self, thread_id: &str) -> Result<()> {
+    pub async fn get_or_create(
+        &self,
+        thread_id: &str,
+        mcp_servers: &[serde_json::Value],
+    ) -> Result<()> {
         // Check if alive connection exists
         {
             let state = self.state.read().await;
@@ -59,7 +63,8 @@ impl SessionPool {
 
         if state.active.len() >= self.max_sessions {
             // LRU evict: suspend the oldest idle session to make room
-            let oldest = state.active
+            let oldest = state
+                .active
                 .iter()
                 .min_by_key(|(_, c)| c.last_active)
                 .map(|(k, _)| k.clone());
@@ -86,7 +91,10 @@ impl SessionPool {
         let mut resumed = false;
         if let Some(ref sid) = saved_session_id {
             if conn.supports_load_session {
-                match conn.session_load(sid, &self.config.working_dir).await {
+                match conn
+                    .session_load(sid, &self.config.working_dir, mcp_servers)
+                    .await
+                {
                     Ok(()) => {
                         info!(thread_id, session_id = %sid, "session resumed via session/load");
                         resumed = true;
@@ -99,7 +107,8 @@ impl SessionPool {
         }
 
         if !resumed {
-            conn.session_new(&self.config.working_dir).await?;
+            conn.session_new(&self.config.working_dir, mcp_servers)
+                .await?;
             if saved_session_id.is_some() {
                 conn.session_reset = true;
             }
@@ -112,21 +121,27 @@ impl SessionPool {
     /// Get mutable access to a connection. Caller must have called get_or_create first.
     pub async fn with_connection<F, R>(&self, thread_id: &str, f: F) -> Result<R>
     where
-        F: FnOnce(&mut AcpConnection) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<R>> + Send + '_>>,
+        F: FnOnce(
+            &mut AcpConnection,
+        )
+            -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<R>> + Send + '_>>,
     {
         let mut state = self.state.write().await;
-        let conn = state.active
+        let conn = state
+            .active
             .get_mut(thread_id)
             .ok_or_else(|| anyhow!("no connection for thread {thread_id}"))?;
         f(conn).await
     }
 
     pub async fn cleanup_idle(&self, ttl_secs: u64) {
-        let cutoff = Instant::now() - std::time::Duration::from_secs(ttl_secs);
+        let now = Instant::now();
+        let ttl = std::time::Duration::from_secs(ttl_secs);
         let mut state = self.state.write().await;
-        let stale: Vec<String> = state.active
+        let stale: Vec<String> = state
+            .active
             .iter()
-            .filter(|(_, c)| c.last_active < cutoff || !c.alive())
+            .filter(|(_, c)| now.saturating_duration_since(c.last_active) >= ttl || !c.alive())
             .map(|(k, _)| k.clone())
             .collect();
         for key in stale {

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -1,7 +1,10 @@
-use crate::acp::connection::AcpConnection;
+use super::mcp_prefetch::prefetch_mempalace_context;
+use crate::acp::connection::{AcpConnection, ModelInfo, NativeCommand};
 use crate::config::AgentConfig;
 use anyhow::{anyhow, Result};
+use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tracing::{info, warn};
@@ -20,6 +23,11 @@ pub struct SessionPool {
     state: RwLock<PoolState>,
     config: AgentConfig,
     max_sessions: usize,
+    /// Snapshot of available models for slash command autocomplete.
+    cached_models: RwLock<Vec<ModelInfo>>,
+    cached_current_model: RwLock<String>,
+    /// Native slash commands reported by the agent via `available_commands_update`.
+    cached_native_commands: Arc<RwLock<Vec<NativeCommand>>>,
 }
 
 impl SessionPool {
@@ -31,6 +39,34 @@ impl SessionPool {
             }),
             config,
             max_sessions,
+            cached_models: RwLock::new(Vec::new()),
+            cached_current_model: RwLock::new("auto".to_string()),
+            cached_native_commands: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    pub async fn cached_models(&self) -> Vec<ModelInfo> {
+        self.cached_models.read().await.clone()
+    }
+
+    pub async fn cached_current_model(&self) -> String {
+        self.cached_current_model.read().await.clone()
+    }
+
+    pub async fn cached_native_commands(&self) -> Vec<NativeCommand> {
+        self.cached_native_commands.read().await.clone()
+    }
+
+    pub async fn has_active_session(&self, thread_id: &str) -> bool {
+        let state = self.state.read().await;
+        matches!(state.active.get(thread_id), Some(conn) if conn.alive())
+    }
+
+    /// Replace the cached model list. Used by the background refresh task
+    /// in `main.rs` to keep `/model` autocomplete in sync with upstream.
+    pub async fn set_cached_models(&self, models: Vec<ModelInfo>) {
+        if !models.is_empty() {
+            *self.cached_models.write().await = models;
         }
     }
 
@@ -49,7 +85,11 @@ impl SessionPool {
             }
         }
 
-        // Need to create or rebuild
+        // Need to create or rebuild.
+        let startup_context =
+            startup_context_for_backend(&self.config.command, &self.config.args, mcp_servers).await;
+
+        // Need to create or rebuild.
         let mut state = self.state.write().await;
 
         // Double-check after acquiring write lock
@@ -109,12 +149,35 @@ impl SessionPool {
         if !resumed {
             conn.session_new(&self.config.working_dir, mcp_servers)
                 .await?;
+            conn.startup_context = startup_context;
             if saved_session_id.is_some() {
                 conn.session_reset = true;
             }
         }
 
+        // Refresh model cache snapshot for slash command autocomplete.
+        if !conn.available_models.is_empty() {
+            *self.cached_models.write().await = conn.available_models.clone();
+        }
+        *self.cached_current_model.write().await = conn.current_model.clone();
+
+        // Insert conn into pool and release the write lock immediately.
+        let native_cmds_handle = conn.native_commands.clone();
         state.active.insert(thread_id.to_string(), conn);
+        drop(state); // Release write lock — no more blocking other threads
+
+        // Snapshot native agent commands asynchronously — don't block the caller.
+        // The 2s delay gives slower backends time to push available_commands_update.
+        let cached_cmds = self.cached_native_commands.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+            let cmds = native_cmds_handle.lock().await.clone();
+            if !cmds.is_empty() {
+                info!(count = cmds.len(), "caching native agent commands (async)");
+                *cached_cmds.write().await = cmds;
+            }
+        });
+
         Ok(())
     }
 
@@ -132,6 +195,14 @@ impl SessionPool {
             .get_mut(thread_id)
             .ok_or_else(|| anyhow!("no connection for thread {thread_id}"))?;
         f(conn).await
+    }
+
+    /// Drop a session for a specific thread. Returns true if one was removed.
+    pub async fn drop_session(&self, thread_id: &str) -> bool {
+        let mut state = self.state.write().await;
+        let existed = state.active.remove(thread_id).is_some();
+        state.suspended.remove(thread_id);
+        existed
     }
 
     pub async fn cleanup_idle(&self, ttl_secs: u64) {
@@ -158,6 +229,40 @@ impl SessionPool {
     }
 }
 
+async fn startup_context_for_backend(
+    command: &str,
+    args: &[String],
+    mcp_servers: &[Value],
+) -> Option<String> {
+    if !backend_needs_mempalace_prefetch(command, args) {
+        return None;
+    }
+
+    let server = find_mempalace_server(mcp_servers)?;
+    match prefetch_mempalace_context(server).await {
+        Ok(context) => context,
+        Err(error) => {
+            warn!(error = %error, "mempalace protocol prefetch failed");
+            None
+        }
+    }
+}
+
+fn backend_needs_mempalace_prefetch(command: &str, args: &[String]) -> bool {
+    let joined = format!("{} {}", command, args.join(" ")).to_lowercase();
+    (joined.contains("copilot") || joined.contains("gemini") || joined.contains("codex"))
+        && !joined.contains("claude")
+}
+
+fn find_mempalace_server(mcp_servers: &[Value]) -> Option<&Value> {
+    mcp_servers.iter().find(|server| {
+        server
+            .get("name")
+            .and_then(|name| name.as_str())
+            .is_some_and(|name| name.eq_ignore_ascii_case("mempalace"))
+    })
+}
+
 /// Suspend a connection: save its sessionId to the suspended map and remove
 /// from active. The connection is dropped, triggering process group kill.
 fn suspend_entry(state: &mut PoolState, thread_id: &str) {
@@ -167,5 +272,33 @@ fn suspend_entry(state: &mut PoolState, thread_id: &str) {
             state.suspended.insert(thread_id.to_string(), sid.clone());
         }
         // conn dropped here → Drop impl kills process group
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn flags_codex_for_mempalace_prefetch() {
+        assert!(backend_needs_mempalace_prefetch("codex-acp", &[]));
+    }
+
+    #[test]
+    fn skips_mempalace_prefetch_for_claude() {
+        assert!(!backend_needs_mempalace_prefetch("claude-agent-acp", &[]));
+    }
+
+    #[test]
+    fn finds_mempalace_server_when_present() {
+        let servers = [
+            json!({"name": "github"}),
+            json!({"name": "mempalace", "type": "http", "url": "http://127.0.0.1:18793/mcp"}),
+        ];
+        let server = find_mempalace_server(&servers);
+
+        assert!(server.is_some());
+        assert_eq!(server.unwrap()["name"], "mempalace");
     }
 }

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -62,14 +62,6 @@ impl SessionPool {
         matches!(state.active.get(thread_id), Some(conn) if conn.alive())
     }
 
-    /// Replace the cached model list. Used by the background refresh task
-    /// in `main.rs` to keep `/model` autocomplete in sync with upstream.
-    pub async fn set_cached_models(&self, models: Vec<ModelInfo>) {
-        if !models.is_empty() {
-            *self.cached_models.write().await = models;
-        }
-    }
-
     pub async fn get_or_create(
         &self,
         thread_id: &str,

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -14,7 +14,12 @@ pub struct JsonRpcRequest {
 
 impl JsonRpcRequest {
     pub fn new(id: u64, method: impl Into<String>, params: Option<Value>) -> Self {
-        Self { jsonrpc: "2.0", id, method: method.into(), params }
+        Self {
+            jsonrpc: "2.0",
+            id,
+            method: method.into(),
+            params,
+        }
     }
 }
 
@@ -27,7 +32,11 @@ pub struct JsonRpcResponse {
 
 impl JsonRpcResponse {
     pub fn new(id: u64, result: Value) -> Self {
-        Self { jsonrpc: "2.0", id, result }
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result,
+        }
     }
 }
 
@@ -60,8 +69,15 @@ impl std::fmt::Display for JsonRpcError {
 pub enum AcpEvent {
     Text(String),
     Thinking,
-    ToolStart { id: String, title: String },
-    ToolDone { id: String, title: String, status: String },
+    ToolStart {
+        id: String,
+        title: String,
+    },
+    ToolDone {
+        id: String,
+        title: String,
+        status: String,
+    },
     Status,
 }
 
@@ -88,18 +104,32 @@ pub fn classify_notification(msg: &JsonRpcMessage) -> Option<AcpEvent> {
             let text = update.get("content")?.get("text")?.as_str()?;
             Some(AcpEvent::Text(text.to_string()))
         }
-        "agent_thought_chunk" => {
-            Some(AcpEvent::Thinking)
-        }
+        "agent_thought_chunk" => Some(AcpEvent::Thinking),
         "tool_call" => {
-            let title = update.get("title").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let title = update
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
             Some(AcpEvent::ToolStart { id: tool_id, title })
         }
         "tool_call_update" => {
-            let title = update.get("title").and_then(|v| v.as_str()).unwrap_or("").to_string();
-            let status = update.get("status").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let title = update
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let status = update
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
             if status == "completed" || status == "failed" {
-                Some(AcpEvent::ToolDone { id: tool_id, title, status })
+                Some(AcpEvent::ToolDone {
+                    id: tool_id,
+                    title,
+                    status,
+                })
             } else {
                 Some(AcpEvent::ToolStart { id: tool_id, title })
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,40 @@
 use regex::Regex;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
+
+/// An MCP server entry injected into ACP session/new.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerEntry {
+    pub name: String,
+    #[serde(flatten)]
+    pub config: serde_json::Value,
+}
+
+/// Read MCP server entries from a user's profile JSON.
+/// Returns an empty vec on any error (graceful fallback).
+pub fn read_mcp_profile(profiles_dir: &str, user_id: &str) -> Vec<McpServerEntry> {
+    let path = std::path::PathBuf::from(profiles_dir).join(format!("{user_id}.json"));
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return vec![],
+    };
+    let parsed: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return vec![],
+    };
+    let servers = match parsed.get("mcpServers").and_then(|v| v.as_object()) {
+        Some(map) => map,
+        None => return vec![],
+    };
+    servers
+        .iter()
+        .map(|(name, config)| McpServerEntry {
+            name: name.clone(),
+            config: config.clone(),
+        })
+        .collect()
+}
 
 /// Controls whether the bot processes messages from other Discord bots.
 ///
@@ -26,7 +59,10 @@ impl<'de> Deserialize<'de> for AllowBots {
             "off" | "none" | "false" => Ok(Self::Off),
             "mentions" => Ok(Self::Mentions),
             "all" | "true" => Ok(Self::All),
-            other => Err(serde::de::Error::unknown_variant(other, &["off", "mentions", "all"])),
+            other => Err(serde::de::Error::unknown_variant(
+                other,
+                &["off", "mentions", "all"],
+            )),
         }
     }
 }
@@ -41,6 +77,12 @@ pub struct Config {
     pub reactions: ReactionsConfig,
     #[serde(default)]
     pub stt: SttConfig,
+    /// Optional path to a soul/persona text file shown via `/soul`.
+    #[serde(default)]
+    pub soul_file: Option<String>,
+    /// Directory for per-user MCP profiles.
+    #[serde(default)]
+    pub mcp_profiles_dir: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -66,8 +108,12 @@ impl Default for SttConfig {
     }
 }
 
-fn default_stt_model() -> String { "whisper-large-v3-turbo".into() }
-fn default_stt_base_url() -> String { "https://api.groq.com/openai/v1".into() }
+fn default_stt_model() -> String {
+    "whisper-large-v3-turbo".into()
+}
+fn default_stt_base_url() -> String {
+    "https://api.groq.com/openai/v1".into()
+}
 
 #[derive(Debug, Deserialize)]
 pub struct DiscordConfig {
@@ -152,28 +198,63 @@ pub struct ReactionTiming {
 
 // --- defaults ---
 
-fn default_working_dir() -> String { "/tmp".into() }
-fn default_max_sessions() -> usize { 10 }
-fn default_ttl_hours() -> u64 { 4 }
-fn default_true() -> bool { true }
+fn default_working_dir() -> String {
+    "/tmp".into()
+}
+fn default_max_sessions() -> usize {
+    10
+}
+fn default_ttl_hours() -> u64 {
+    4
+}
+fn default_true() -> bool {
+    true
+}
 
-fn emoji_queued() -> String { "👀".into() }
-fn emoji_thinking() -> String { "🤔".into() }
-fn emoji_tool() -> String { "🔥".into() }
-fn emoji_coding() -> String { "👨‍💻".into() }
-fn emoji_web() -> String { "⚡".into() }
-fn emoji_done() -> String { "🆗".into() }
-fn emoji_error() -> String { "😱".into() }
+fn emoji_queued() -> String {
+    "👀".into()
+}
+fn emoji_thinking() -> String {
+    "🤔".into()
+}
+fn emoji_tool() -> String {
+    "🔥".into()
+}
+fn emoji_coding() -> String {
+    "👨‍💻".into()
+}
+fn emoji_web() -> String {
+    "⚡".into()
+}
+fn emoji_done() -> String {
+    "🆗".into()
+}
+fn emoji_error() -> String {
+    "😱".into()
+}
 
-fn default_debounce_ms() -> u64 { 700 }
-fn default_stall_soft_ms() -> u64 { 10_000 }
-fn default_stall_hard_ms() -> u64 { 30_000 }
-fn default_done_hold_ms() -> u64 { 1_500 }
-fn default_error_hold_ms() -> u64 { 2_500 }
+fn default_debounce_ms() -> u64 {
+    700
+}
+fn default_stall_soft_ms() -> u64 {
+    10_000
+}
+fn default_stall_hard_ms() -> u64 {
+    30_000
+}
+fn default_done_hold_ms() -> u64 {
+    1_500
+}
+fn default_error_hold_ms() -> u64 {
+    2_500
+}
 
 impl Default for PoolConfig {
     fn default() -> Self {
-        Self { max_sessions: default_max_sessions(), session_ttl_hours: default_ttl_hours() }
+        Self {
+            max_sessions: default_max_sessions(),
+            session_ttl_hours: default_ttl_hours(),
+        }
     }
 }
 
@@ -191,8 +272,13 @@ impl Default for ReactionsConfig {
 impl Default for ReactionEmojis {
     fn default() -> Self {
         Self {
-            queued: emoji_queued(), thinking: emoji_thinking(), tool: emoji_tool(),
-            coding: emoji_coding(), web: emoji_web(), done: emoji_done(), error: emoji_error(),
+            queued: emoji_queued(),
+            thinking: emoji_thinking(),
+            tool: emoji_tool(),
+            coding: emoji_coding(),
+            web: emoji_web(),
+            done: emoji_done(),
+            error: emoji_error(),
         }
     }
 }
@@ -200,8 +286,10 @@ impl Default for ReactionEmojis {
 impl Default for ReactionTiming {
     fn default() -> Self {
         Self {
-            debounce_ms: default_debounce_ms(), stall_soft_ms: default_stall_soft_ms(),
-            stall_hard_ms: default_stall_hard_ms(), done_hold_ms: default_done_hold_ms(),
+            debounce_ms: default_debounce_ms(),
+            stall_soft_ms: default_stall_soft_ms(),
+            stall_hard_ms: default_stall_hard_ms(),
+            done_hold_ms: default_done_hold_ms(),
             error_hold_ms: default_error_hold_ms(),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,12 +77,46 @@ pub struct Config {
     pub reactions: ReactionsConfig,
     #[serde(default)]
     pub stt: SttConfig,
+    /// Optional usage dashboard command config (`/usage`).
+    #[serde(default)]
+    pub usage: Option<UsageConfig>,
+    /// Optional custom usage dashboard config (`/cusage`).
+    #[serde(default)]
+    pub cusage: Option<UsageConfig>,
     /// Optional path to a soul/persona text file shown via `/soul`.
     #[serde(default)]
     pub soul_file: Option<String>,
     /// Directory for per-user MCP profiles.
     #[serde(default)]
     pub mcp_profiles_dir: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UsageConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_usage_timeout")]
+    pub timeout_secs: u64,
+    #[serde(default)]
+    pub runners: Vec<UsageRunnerConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UsageRunnerConfig {
+    pub name: String,
+    pub label: String,
+    #[serde(default = "default_usage_color")]
+    pub color: u32,
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    pub template: String,
+    #[serde(default)]
+    pub progress_fields: Vec<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub working_dir: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -162,6 +196,14 @@ pub struct ReactionsConfig {
     pub emojis: ReactionEmojis,
     #[serde(default)]
     pub timing: ReactionTiming,
+    #[serde(default)]
+    pub presets: Vec<EmojiPreset>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EmojiPreset {
+    pub name: String,
+    pub emojis: ReactionEmojis,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -209,6 +251,12 @@ fn default_ttl_hours() -> u64 {
 }
 fn default_true() -> bool {
     true
+}
+fn default_usage_timeout() -> u64 {
+    30
+}
+fn default_usage_color() -> u32 {
+    0x5865F2
 }
 
 fn emoji_queued() -> String {
@@ -265,6 +313,7 @@ impl Default for ReactionsConfig {
             remove_after_reply: false,
             emojis: ReactionEmojis::default(),
             timing: ReactionTiming::default(),
+            presets: Vec::new(),
         }
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,20 +1,20 @@
 use crate::acp::{classify_notification, AcpEvent, ContentBlock, SessionPool};
-use crate::config::{AllowBots, ReactionsConfig, SttConfig};
+use crate::config::{read_mcp_profile, AllowBots, ReactionsConfig, SttConfig};
 use crate::error_display::{format_coded_error, format_user_error};
 use crate::format;
 use crate::reactions::StatusReactionController;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use image::ImageReader;
-use std::io::Cursor;
-use std::sync::LazyLock;
 use serenity::async_trait;
 use serenity::model::channel::{Message, ReactionType};
 use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, MessageId};
 use serenity::prelude::*;
 use std::collections::HashSet;
+use std::io::Cursor;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use tokio::sync::watch;
 use tracing::{debug, error, info};
 
@@ -44,6 +44,35 @@ pub struct Handler {
     pub stt_config: SttConfig,
     pub allow_bot_messages: AllowBots,
     pub trusted_bot_ids: HashSet<u64>,
+    pub mcp_profiles_dir: Option<String>,
+}
+
+impl Handler {
+    /// Build the mcpServers JSON array for a Discord user from their profile.
+    fn mcp_servers_for_user(&self, user_id: u64) -> Vec<serde_json::Value> {
+        let Some(ref dir) = self.mcp_profiles_dir else {
+            return vec![];
+        };
+        let entries = read_mcp_profile(dir, &user_id.to_string());
+        if entries.is_empty() {
+            return vec![];
+        }
+        tracing::info!(
+            user_id,
+            count = entries.len(),
+            "injecting MCP servers from profile"
+        );
+        entries
+            .into_iter()
+            .map(|e| {
+                let mut obj = e.config.clone();
+                if let Some(map) = obj.as_object_mut() {
+                    map.insert("name".to_string(), serde_json::Value::String(e.name));
+                }
+                obj
+            })
+            .collect()
+    }
 }
 
 #[async_trait]
@@ -62,7 +91,10 @@ impl EventHandler for Handler {
 
         let is_mentioned = msg.mentions_user_id(bot_id)
             || msg.content.contains(&format!("<@{}>", bot_id))
-            || msg.mention_roles.iter().any(|r| msg.content.contains(&format!("<@&{}>", r)));
+            || msg
+                .mention_roles
+                .iter()
+                .any(|r| msg.content.contains(&format!("<@&{}>", r)));
 
         // Bot message gating — runs after self-ignore but before channel/user
         // allowlist checks. This ordering is intentional: channel checks below
@@ -71,7 +103,11 @@ impl EventHandler for Handler {
         if msg.author.bot {
             match self.allow_bot_messages {
                 AllowBots::Off => return,
-                AllowBots::Mentions => if !is_mentioned { return; },
+                AllowBots::Mentions => {
+                    if !is_mentioned {
+                        return;
+                    }
+                }
                 AllowBots::All => {
                     // Safety net: count consecutive messages from any bot
                     // (excluding ourselves) in recent history. If all recent
@@ -85,9 +121,12 @@ impl EventHandler for Handler {
                     // reject the message (fail-closed) to avoid unbounded
                     // loops during Discord API outages.
                     let cap = MAX_CONSECUTIVE_BOT_TURNS as usize;
-                    let history = ctx.cache.channel_messages(msg.channel_id)
+                    let history = ctx
+                        .cache
+                        .channel_messages(msg.channel_id)
                         .map(|msgs| {
-                            let mut recent: Vec<_> = msgs.iter()
+                            let mut recent: Vec<_> = msgs
+                                .iter()
                                 .filter(|(mid, _)| **mid < msg.id)
                                 .map(|(_, m)| m.clone())
                                 .collect();
@@ -100,8 +139,14 @@ impl EventHandler for Handler {
                     let recent = if let Some(cached) = history {
                         cached
                     } else {
-                        match msg.channel_id
-                            .messages(&ctx.http, serenity::builder::GetMessages::new().before(msg.id).limit(MAX_CONSECUTIVE_BOT_TURNS))
+                        match msg
+                            .channel_id
+                            .messages(
+                                &ctx.http,
+                                serenity::builder::GetMessages::new()
+                                    .before(msg.id)
+                                    .limit(MAX_CONSECUTIVE_BOT_TURNS),
+                            )
                             .await
                         {
                             Ok(msgs) => msgs,
@@ -112,18 +157,21 @@ impl EventHandler for Handler {
                         }
                     };
 
-                    let consecutive_bot = recent.iter()
+                    let consecutive_bot = recent
+                        .iter()
                         .take_while(|m| m.author.bot && m.author.id != bot_id)
                         .count();
                     if consecutive_bot >= cap {
                         tracing::warn!(channel_id = %msg.channel_id, cap, "bot turn cap reached, ignoring");
                         return;
                     }
-                },
+                }
             }
 
             // If trusted_bot_ids is set, only allow bots on the list
-            if !self.trusted_bot_ids.is_empty() && !self.trusted_bot_ids.contains(&msg.author.id.get()) {
+            if !self.trusted_bot_ids.is_empty()
+                && !self.trusted_bot_ids.contains(&msg.author.id.get())
+            {
                 tracing::debug!(bot_id = %msg.author.id, "bot not in trusted_bot_ids, ignoring");
                 return;
             }
@@ -160,7 +208,10 @@ impl EventHandler for Handler {
 
         if !self.allowed_users.is_empty() && !self.allowed_users.contains(&msg.author.id.get()) {
             tracing::info!(user_id = %msg.author.id, "denied user, ignoring");
-            if let Err(e) = msg.react(&ctx.http, ReactionType::Unicode("🚫".into())).await {
+            if let Err(e) = msg
+                .react(&ctx.http, ReactionType::Unicode("🚫".into()))
+                .await
+            {
                 tracing::warn!(error = %e, "failed to react with 🚫");
             }
             return;
@@ -181,7 +232,9 @@ impl EventHandler for Handler {
         let mut content_blocks = vec![];
 
         // Inject structured sender context so the downstream CLI can identify who sent the message
-        let display_name = msg.member.as_ref()
+        let display_name = msg
+            .member
+            .as_ref()
             .and_then(|m| m.nick.as_ref())
             .unwrap_or(&msg.author.name);
         let sender_ctx = serde_json::json!({
@@ -209,11 +262,16 @@ impl EventHandler for Handler {
             for attachment in &msg.attachments {
                 if is_audio_attachment(attachment) {
                     if self.stt_config.enabled {
-                        if let Some(transcript) = download_and_transcribe(attachment, &self.stt_config).await {
+                        if let Some(transcript) =
+                            download_and_transcribe(attachment, &self.stt_config).await
+                        {
                             debug!(filename = %attachment.filename, chars = transcript.len(), "voice transcript injected");
-                            content_blocks.insert(0, ContentBlock::Text {
-                                text: format!("[Voice message transcript]: {transcript}"),
-                            });
+                            content_blocks.insert(
+                                0,
+                                ContentBlock::Text {
+                                    text: format!("[Voice message transcript]: {transcript}"),
+                                },
+                            );
                         }
                     } else {
                         debug!(filename = %attachment.filename, "skipping audio attachment (STT disabled)");
@@ -259,9 +317,16 @@ impl EventHandler for Handler {
         };
 
         let thread_key = thread_id.to_string();
-        if let Err(e) = self.pool.get_or_create(&thread_key).await {
+        let mcp_servers = self.mcp_servers_for_user(msg.author.id.get());
+        if let Err(e) = self.pool.get_or_create(&thread_key, &mcp_servers).await {
             let msg = format_user_error(&e.to_string());
-            let _ = edit(&ctx, thread_channel, thinking_msg.id, &format!("⚠️ {}", msg)).await;
+            let _ = edit(
+                &ctx,
+                thread_channel,
+                thinking_msg.id,
+                &format!("⚠️ {}", msg),
+            )
+            .await;
             error!("pool error: {e}");
             return;
         }
@@ -346,7 +411,14 @@ async fn download_and_transcribe(
     let mime_type = attachment.content_type.as_deref().unwrap_or("audio/ogg");
     let mime_type = mime_type.split(';').next().unwrap_or(mime_type).trim();
 
-    crate::stt::transcribe(&HTTP_CLIENT, stt_config, bytes, attachment.filename.clone(), mime_type).await
+    crate::stt::transcribe(
+        &HTTP_CLIENT,
+        stt_config,
+        bytes,
+        attachment.filename.clone(),
+        mime_type,
+    )
+    .await
 }
 
 /// Maximum dimension (width or height) for resized images.
@@ -363,7 +435,9 @@ const IMAGE_JPEG_QUALITY: u8 = 75;
 /// Large images are resized so the longest side is at most 1200px and
 /// re-encoded as JPEG at quality 75. This keeps the base64 payload well
 /// under typical JSON-RPC transport limits (~200-400KB after encoding).
-async fn download_and_encode_image(attachment: &serenity::model::channel::Attachment) -> Option<ContentBlock> {
+async fn download_and_encode_image(
+    attachment: &serenity::model::channel::Attachment,
+) -> Option<ContentBlock> {
     const MAX_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
 
     let url = &attachment.url;
@@ -372,21 +446,17 @@ async fn download_and_encode_image(attachment: &serenity::model::channel::Attach
     }
 
     // Determine media type — prefer content-type header, fallback to extension
-    let media_type = attachment
-        .content_type
-        .as_deref()
-        .or_else(|| {
-            attachment
-                .filename
-                .rsplit('.')
-                .next()
-                .and_then(|ext| match ext.to_lowercase().as_str() {
+    let media_type =
+        attachment.content_type.as_deref().or_else(|| {
+            attachment.filename.rsplit('.').next().and_then(|ext| {
+                match ext.to_lowercase().as_str() {
                     "png" => Some("image/png"),
                     "jpg" | "jpeg" => Some("image/jpeg"),
                     "gif" => Some("image/gif"),
                     "webp" => Some("image/webp"),
                     _ => None,
-                })
+                }
+            })
         });
 
     let Some(mime) = media_type else {
@@ -406,7 +476,10 @@ async fn download_and_encode_image(attachment: &serenity::model::channel::Attach
 
     let response = match HTTP_CLIENT.get(url).send().await {
         Ok(resp) => resp,
-        Err(e) => { error!(url = %url, error = %e, "download failed"); return None; }
+        Err(e) => {
+            error!(url = %url, error = %e, "download failed");
+            return None;
+        }
     };
     if !response.status().is_success() {
         error!(url = %url, status = %response.status(), "HTTP error downloading image");
@@ -414,7 +487,10 @@ async fn download_and_encode_image(attachment: &serenity::model::channel::Attach
     }
     let bytes = match response.bytes().await {
         Ok(b) => b,
-        Err(e) => { error!(url = %url, error = %e, "read failed"); return None; }
+        Err(e) => {
+            error!(url = %url, error = %e, "read failed");
+            return None;
+        }
     };
 
     // Defense-in-depth: verify actual download size
@@ -455,8 +531,7 @@ async fn download_and_encode_image(attachment: &serenity::model::channel::Attach
 /// Returns (compressed_bytes, mime_type). GIFs are passed through unchanged
 /// to preserve animation.
 fn resize_and_compress(raw: &[u8]) -> Result<(Vec<u8>, String), image::ImageError> {
-    let reader = ImageReader::new(Cursor::new(raw))
-        .with_guessed_format()?;
+    let reader = ImageReader::new(Cursor::new(raw)).with_guessed_format()?;
 
     let format = reader.format();
 
@@ -487,8 +562,18 @@ fn resize_and_compress(raw: &[u8]) -> Result<(Vec<u8>, String), image::ImageErro
     Ok((buf.into_inner(), "image/jpeg".to_string()))
 }
 
-async fn edit(ctx: &Context, ch: ChannelId, msg_id: MessageId, content: &str) -> serenity::Result<Message> {
-    ch.edit_message(&ctx.http, msg_id, serenity::builder::EditMessage::new().content(content)).await
+async fn edit(
+    ctx: &Context,
+    ch: ChannelId,
+    msg_id: MessageId,
+    content: &str,
+) -> serenity::Result<Message> {
+    ch.edit_message(
+        &ctx.http,
+        msg_id,
+        serenity::builder::EditMessage::new().content(content),
+    )
+    .await
 }
 
 async fn stream_prompt(
@@ -688,7 +773,10 @@ async fn stream_prompt(
 /// collapse newlines to ` ; ` and rewrite embedded backticks so they
 /// don't break the wrapping span.
 fn sanitize_title(title: &str) -> String {
-    title.replace('\r', "").replace('\n', " ; ").replace('`', "'")
+    title
+        .replace('\r', "")
+        .replace('\n', " ; ")
+        .replace('`', "'")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -712,7 +800,11 @@ impl ToolEntry {
             ToolState::Completed => "✅",
             ToolState::Failed => "❌",
         };
-        let suffix = if self.state == ToolState::Running { "..." } else { "" };
+        let suffix = if self.state == ToolState::Running {
+            "..."
+        } else {
+            ""
+        };
         format!("{icon} `{}`{}", self.title, suffix)
     }
 }
@@ -730,9 +822,8 @@ fn compose_display(tool_lines: &[ToolEntry], text: &str) -> String {
     out
 }
 
-static MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r"<@[!&]?\d+>").unwrap()
-});
+static MENTION_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"<@[!&]?\d+>").unwrap());
 
 fn strip_mention(content: &str) -> String {
     MENTION_RE.replace_all(content, "").trim().to_string()
@@ -772,7 +863,6 @@ async fn get_or_create_thread(ctx: &Context, msg: &Message, prompt: &str) -> any
 
     Ok(thread.id.get())
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -832,7 +922,12 @@ mod tests {
         let png = make_png(3000, 2000);
         let (compressed, _) = resize_and_compress(&png).unwrap();
 
-        assert!(compressed.len() < png.len(), "compressed {} should be < original {}", compressed.len(), png.len());
+        assert!(
+            compressed.len() < png.len(),
+            "compressed {} should be < original {}",
+            compressed.len(),
+            png.len()
+        );
     }
 
     #[test]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -49,27 +49,36 @@ pub struct Handler {
 
 impl Handler {
     /// Build the mcpServers JSON array for a Discord user from their profile.
-    fn mcp_servers_for_user(&self, user_id: u64) -> Vec<serde_json::Value> {
-        let Some(ref dir) = self.mcp_profiles_dir else {
+    /// Uses spawn_blocking to avoid blocking the Tokio runtime on file I/O.
+    async fn mcp_servers_for_user(&self, user_id: u64) -> Vec<serde_json::Value> {
+        let Some(dir) = self.mcp_profiles_dir.clone() else {
             return vec![];
         };
-        let entries = read_mcp_profile(dir, &user_id.to_string());
+        let uid = user_id.to_string();
+        let entries = match tokio::task::spawn_blocking(move || read_mcp_profile(&dir, &uid)).await
+        {
+            Ok(e) => e,
+            Err(_) => return vec![],
+        };
         if entries.is_empty() {
             return vec![];
         }
-        tracing::info!(
+        tracing::debug!(
             user_id,
             count = entries.len(),
             "injecting MCP servers from profile"
         );
         entries
             .into_iter()
-            .map(|e| {
+            .filter_map(|e| {
                 let mut obj = e.config.clone();
                 if let Some(map) = obj.as_object_mut() {
                     map.insert("name".to_string(), serde_json::Value::String(e.name));
+                    Some(obj)
+                } else {
+                    tracing::warn!(name = %e.name, "skipping non-object MCP profile entry");
+                    None
                 }
-                obj
             })
             .collect()
     }
@@ -317,7 +326,7 @@ impl EventHandler for Handler {
         };
 
         let thread_key = thread_id.to_string();
-        let mcp_servers = self.mcp_servers_for_user(msg.author.id.get());
+        let mcp_servers = self.mcp_servers_for_user(msg.author.id.get()).await;
         if let Err(e) = self.pool.get_or_create(&thread_key, &mcp_servers).await {
             let msg = format_user_error(&e.to_string());
             let _ = edit(

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1089,7 +1089,19 @@ impl Handler {
             } else {
                 ""
             };
-            let label = format!("{}{marker}", m.model_id);
+            let detail = if !m.description.is_empty() {
+                m.description.clone()
+            } else if m.name != m.model_id {
+                m.name.clone()
+            } else {
+                String::new()
+            };
+            let label = if detail.is_empty() {
+                format!("{}{marker}", m.model_id)
+            } else {
+                let detail = detail.chars().take(60).collect::<String>();
+                format!("{}{marker} — {}", m.model_id, detail)
+            };
             choices.push(AutocompleteChoice::new(label, m.model_id.clone()));
         }
 
@@ -1886,10 +1898,15 @@ impl Handler {
                                 } else {
                                     "•"
                                 };
-                                out.push_str(&format!(
-                                    "{} `{}` — {}\n",
-                                    marker, m.model_id, m.name
-                                ));
+                                out.push_str(&format!("{} `{}` — {}", marker, m.model_id, m.name));
+                                if !m.description.is_empty() {
+                                    out.push_str(&format!(
+                                        "\n  {}\n",
+                                        m.description.chars().take(120).collect::<String>()
+                                    ));
+                                } else {
+                                    out.push('\n');
+                                }
                             }
                             out.push_str(&format!("\nCurrent: `{}`", conn.current_model));
                             Ok(out)

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,5 +1,26 @@
 use crate::acp::{classify_notification, AcpEvent, ContentBlock, SessionPool};
 use crate::config::{read_mcp_profile, AllowBots, ReactionsConfig, SttConfig};
+
+/// Resolve the copilot-rpc.js path relative to the running executable.
+pub fn copilot_rpc_script_path() -> String {
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            for candidate in [
+                dir.join("scripts").join("copilot-rpc.js"),
+                dir.join("..")
+                    .join("..")
+                    .join("scripts")
+                    .join("copilot-rpc.js"),
+                dir.join("copilot-rpc.js"),
+            ] {
+                if candidate.exists() {
+                    return candidate.to_string_lossy().into_owned();
+                }
+            }
+        }
+    }
+    "scripts/copilot-rpc.js".to_string()
+}
 use crate::error_display::{format_coded_error, format_user_error};
 use crate::format;
 use crate::reactions::StatusReactionController;
@@ -7,6 +28,14 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use image::ImageReader;
 use serenity::async_trait;
+use serenity::builder::{
+    AutocompleteChoice, CreateAutocompleteResponse, CreateCommand, CreateCommandOption,
+    CreateEmbed, CreateInteractionResponse, CreateInteractionResponseMessage,
+    EditInteractionResponse,
+};
+use serenity::model::application::{
+    CommandDataOptionValue, CommandInteraction, CommandOptionType, Interaction,
+};
 use serenity::model::channel::{Message, ReactionType};
 use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, MessageId};
@@ -16,7 +45,7 @@ use std::io::Cursor;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use tokio::sync::watch;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Hard cap on consecutive bot messages (from any other bot) in a
 /// channel or thread. When this many recent messages are all from
@@ -36,51 +65,263 @@ static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
         .expect("static HTTP client must build")
 });
 
+/// Alias shortcuts disabled: autocomplete shows full model IDs only.
+const MODEL_ALIASES: &[(&str, &str)] = &[];
+
+/// Read-only top-level slash commands (no args, just display).
+const COPILOT_READONLY_COMMANDS: &[(&str, &str)] = &[
+    ("status", "Show Copilot CLI version, auth, and model count"),
+    ("plugins", "List installed Copilot plugins"),
+    ("plan", "Read the current session plan.md"),
+    ("files", "List files in the session workspace"),
+    ("auth", "Show Copilot GitHub auth status"),
+];
+
+/// Map read-only command name → copilot-rpc.js subcommand.
+fn copilot_readonly_to_rpc(name: &str) -> Option<&'static str> {
+    match name {
+        "status" => Some("status"),
+        "plugins" => Some("plugins"),
+        "plan" => Some("plan-read"),
+        "files" => Some("files"),
+        "auth" => Some("auth"),
+        _ => None,
+    }
+}
+
+/// Interactive commands that take a <name> argument + dispatch to an action RPC.
+/// Tuple: (discord_cmd, description, list_rpc_for_autocomplete, action_rpc,
+///         autocomplete_data_key, autocomplete_name_key)
+const COPILOT_INTERACTIVE_COMMANDS: &[(&str, &str, &str, &str, &str, &str)] = &[
+    (
+        "agent",
+        "Select an agent by name",
+        "agents",
+        "agent-select",
+        "agents",
+        "name",
+    ),
+    (
+        "skill-on",
+        "Enable a skill by name",
+        "skills",
+        "skill-enable",
+        "skills",
+        "name",
+    ),
+    (
+        "skill-off",
+        "Disable a skill by name",
+        "skills",
+        "skill-disable",
+        "skills",
+        "name",
+    ),
+    (
+        "mcp-on",
+        "Enable an MCP server by name",
+        "mcp-list",
+        "mcp-enable",
+        "servers",
+        "name",
+    ),
+    (
+        "mcp-off",
+        "Disable an MCP server by name",
+        "mcp-list",
+        "mcp-disable",
+        "servers",
+        "name",
+    ),
+    (
+        "ext-on",
+        "Enable an extension by name",
+        "extensions",
+        "extension-enable",
+        "extensions",
+        "name",
+    ),
+    (
+        "ext-off",
+        "Disable an extension by name",
+        "extensions",
+        "extension-disable",
+        "extensions",
+        "name",
+    ),
+];
+
+/// Map interactive command name → (list_rpc, action_rpc, data_key, name_key).
+fn copilot_interactive_spec(
+    name: &str,
+) -> Option<(&'static str, &'static str, &'static str, &'static str)> {
+    for (cmd, _, list_rpc, action_rpc, data_key, name_key) in COPILOT_INTERACTIVE_COMMANDS {
+        if *cmd == name {
+            return Some((list_rpc, action_rpc, data_key, name_key));
+        }
+    }
+    None
+}
+
+/// Static mode choices (Copilot has 6 fixed modes).
+const COPILOT_MODES: &[(&str, &str)] = &[
+    (
+        "https://agentclientprotocol.com/protocol/session-modes#agent",
+        "Agent (default)",
+    ),
+    (
+        "https://agentclientprotocol.com/protocol/session-modes#plan",
+        "Plan Mode",
+    ),
+    (
+        "https://agentclientprotocol.com/protocol/session-modes#autopilot",
+        "Autopilot",
+    ),
+];
+
+/// Static choices for /reload <kind>.
+/// Each tuple: (discord_value, copilot_rpc_subcommand, label)
+const COPILOT_RELOAD_KINDS: &[(&str, &str, &str)] = &[
+    ("agents", "agent-reload", "Agents"),
+    ("skills", "skill-reload", "Skills"),
+    ("mcp", "mcp-reload", "MCP servers"),
+    ("extensions", "extension-reload", "Extensions"),
+];
+
+/// Backend type inferred from the agent command in config.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendType {
+    Claude,
+    /// Custom copilot-agent-acp bridge (supports SDK RPCs like _meta/getUsage)
+    CopilotBridge,
+    /// Native `copilot --acp` (no SDK RPCs — standard ACP only)
+    CopilotNative,
+    Gemini,
+    Codex,
+    Other,
+}
+
+impl BackendType {
+    /// Infer backend from the agent command + args strings.
+    pub fn from_agent_config(command: &str, args: &[String]) -> Self {
+        let joined = format!("{} {}", command, args.join(" ")).to_lowercase();
+        if joined.contains("copilot-agent-acp") {
+            BackendType::CopilotBridge
+        } else if joined.contains("copilot") {
+            BackendType::CopilotNative
+        } else if joined.contains("claude") {
+            BackendType::Claude
+        } else if joined.contains("gemini") {
+            BackendType::Gemini
+        } else if joined.contains("codex") {
+            BackendType::Codex
+        } else {
+            BackendType::Other
+        }
+    }
+
+    /// Does this backend support Copilot SDK RPCs (copilot-rpc.js)?
+    /// Only the custom bridge has these — native `copilot --acp` does not.
+    pub fn has_copilot_rpc(&self) -> bool {
+        *self == BackendType::CopilotBridge
+    }
+
+    /// Does this backend support _meta/* RPC methods?
+    /// Only claude-agent-acp and copilot-agent-acp bridges support these.
+    /// Native CLI backends (copilot --acp, gemini --acp, codex-acp) do not.
+    pub fn has_meta_rpc(&self) -> bool {
+        matches!(self, BackendType::Claude | BackendType::CopilotBridge)
+    }
+}
+
 pub struct Handler {
     pub pool: Arc<SessionPool>,
     pub allowed_channels: HashSet<u64>,
     pub allowed_users: HashSet<u64>,
-    pub reactions_config: ReactionsConfig,
+    pub reactions_config: Arc<tokio::sync::RwLock<ReactionsConfig>>,
+    pub emoji_presets: Vec<crate::config::EmojiPreset>,
+    pub usage_config: Option<crate::config::UsageConfig>,
+    pub cusage_config: Option<crate::config::UsageConfig>,
+    pub backend: BackendType,
+    pub copilot_list_cache:
+        Arc<tokio::sync::RwLock<std::collections::HashMap<String, Vec<String>>>>,
     pub stt_config: SttConfig,
+    pub soul_file: Option<String>,
+    pub mcp_profiles_dir: Option<String>,
     pub allow_bot_messages: AllowBots,
     pub trusted_bot_ids: HashSet<u64>,
-    pub mcp_profiles_dir: Option<String>,
 }
 
 impl Handler {
+    fn session_key_for_user(&self, thread_id: u64, user_id: u64) -> String {
+        format!("{thread_id}:{user_id}")
+    }
+
     /// Build the mcpServers JSON array for a Discord user from their profile.
-    /// Uses spawn_blocking to avoid blocking the Tokio runtime on file I/O.
     async fn mcp_servers_for_user(&self, user_id: u64) -> Vec<serde_json::Value> {
-        let Some(dir) = self.mcp_profiles_dir.clone() else {
+        let Some(ref dir) = self.mcp_profiles_dir else {
             return vec![];
         };
-        let uid = user_id.to_string();
-        let entries = match tokio::task::spawn_blocking(move || read_mcp_profile(&dir, &uid)).await
-        {
-            Ok(e) => e,
-            Err(_) => return vec![],
-        };
+        let dir = dir.to_owned();
+        let user_id = user_id.to_string();
+        let user_id_for_read = user_id.clone();
+        let entries =
+            match tokio::task::spawn_blocking(move || read_mcp_profile(&dir, &user_id_for_read))
+                .await
+            {
+                Ok(entries) => entries,
+                Err(err) => {
+                    warn!(
+                        user_id = user_id,
+                        error = %err,
+                        "failed to load MCP profile file off-thread"
+                    );
+                    return vec![];
+                }
+            };
+
         if entries.is_empty() {
             return vec![];
         }
-        tracing::debug!(
-            user_id,
+
+        debug!(
+            user_id = %user_id,
             count = entries.len(),
-            "injecting MCP servers from profile"
+            "loaded MCP servers from profile"
         );
+
         entries
             .into_iter()
-            .filter_map(|e| {
-                let mut obj = e.config.clone();
-                if let Some(map) = obj.as_object_mut() {
-                    map.insert("name".to_string(), serde_json::Value::String(e.name));
-                    Some(obj)
-                } else {
-                    tracing::warn!(name = %e.name, "skipping non-object MCP profile entry");
+            .filter_map(|e| match e.config {
+                serde_json::Value::Object(mut obj) => {
+                    obj.insert("name".to_string(), serde_json::Value::String(e.name));
+                    Some(serde_json::Value::Object(obj))
+                }
+                _ => {
+                    warn!(
+                        user_id = %user_id,
+                        server_name = %e.name,
+                        "skipping MCP profile entry: config is not an object"
+                    );
                     None
                 }
             })
             .collect()
+    }
+
+    async fn ensure_session_for_user(
+        &self,
+        thread_id: u64,
+        user_id: u64,
+    ) -> anyhow::Result<String> {
+        let session_key = self.session_key_for_user(thread_id, user_id);
+        if self.pool.has_active_session(&session_key).await {
+            return Ok(session_key);
+        }
+
+        let mcp_servers = self.mcp_servers_for_user(user_id).await;
+        self.pool.get_or_create(&session_key, &mcp_servers).await?;
+        Ok(session_key)
     }
 }
 
@@ -88,9 +329,10 @@ impl Handler {
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
         let bot_id = ctx.cache.current_user().id;
+        let is_selftest = msg.author.id == bot_id && msg.content.contains("OPENAB_SELFTEST:");
 
         // Always ignore own messages
-        if msg.author.id == bot_id {
+        if msg.author.id == bot_id && !is_selftest {
             return;
         }
 
@@ -109,7 +351,7 @@ impl EventHandler for Handler {
         // allowlist checks. This ordering is intentional: channel checks below
         // apply uniformly to both human and bot messages, so a bot mention in
         // a non-allowed channel is still rejected by the channel check.
-        if msg.author.bot {
+        if msg.author.bot && !is_selftest {
             match self.allow_bot_messages {
                 AllowBots::Off => return,
                 AllowBots::Mentions => {
@@ -208,6 +450,17 @@ impl EventHandler for Handler {
             false
         };
 
+        tracing::info!(
+            bot_id = %bot_id,
+            channel_id,
+            in_allowed_channel,
+            in_thread,
+            is_mentioned,
+            content = %msg.content.chars().take(50).collect::<String>(),
+            mentions = ?msg.mentions.iter().map(|u| u.id.get()).collect::<Vec<_>>(),
+            "message gate check"
+        );
+
         if !in_allowed_channel && !in_thread {
             return;
         }
@@ -215,7 +468,10 @@ impl EventHandler for Handler {
             return;
         }
 
-        if !self.allowed_users.is_empty() && !self.allowed_users.contains(&msg.author.id.get()) {
+        if !is_selftest
+            && !self.allowed_users.is_empty()
+            && !self.allowed_users.contains(&msg.author.id.get())
+        {
             tracing::info!(user_id = %msg.author.id, "denied user, ignoring");
             if let Err(e) = msg
                 .react(&ctx.http, ReactionType::Unicode("🚫".into()))
@@ -325,9 +581,11 @@ impl EventHandler for Handler {
             }
         };
 
-        let thread_key = thread_id.to_string();
-        let mcp_servers = self.mcp_servers_for_user(msg.author.id.get()).await;
-        if let Err(e) = self.pool.get_or_create(&thread_key, &mcp_servers).await {
+        let thread_key = self.session_key_for_user(thread_id, msg.author.id.get());
+        if let Err(e) = self
+            .ensure_session_for_user(thread_id, msg.author.id.get())
+            .await
+        {
             let msg = format_user_error(&e.to_string());
             let _ = edit(
                 &ctx,
@@ -341,14 +599,19 @@ impl EventHandler for Handler {
         }
 
         // Create reaction controller on the user's original message
+        let rcfg = self.reactions_config.read().await;
         let reactions = Arc::new(StatusReactionController::new(
-            self.reactions_config.enabled,
+            rcfg.enabled,
             ctx.http.clone(),
             msg.channel_id,
             msg.id,
-            self.reactions_config.emojis.clone(),
-            self.reactions_config.timing.clone(),
+            rcfg.emojis.clone(),
+            rcfg.timing.clone(),
         ));
+        let hold_done_ms = rcfg.timing.done_hold_ms;
+        let hold_error_ms = rcfg.timing.error_hold_ms;
+        let remove_after = rcfg.remove_after_reply;
+        drop(rcfg);
         reactions.set_queued().await;
 
         // Stream prompt with live edits (pass content blocks instead of just text)
@@ -370,11 +633,11 @@ impl EventHandler for Handler {
 
         // Hold emoji briefly then clear
         let hold_ms = if result.is_ok() {
-            self.reactions_config.timing.done_hold_ms
+            hold_done_ms
         } else {
-            self.reactions_config.timing.error_hold_ms
+            hold_error_ms
         };
-        if self.reactions_config.remove_after_reply {
+        if remove_after {
             let reactions = reactions;
             tokio::spawn(async move {
                 tokio::time::sleep(std::time::Duration::from_millis(hold_ms)).await;
@@ -387,9 +650,3028 @@ impl EventHandler for Handler {
         }
     }
 
-    async fn ready(&self, _ctx: Context, ready: Ready) {
-        info!(user = %ready.user.name, "discord bot connected");
+    async fn ready(&self, ctx: Context, ready: Ready) {
+        info!(user = %ready.user.name, guilds = ready.guilds.len(), "discord bot connected");
+
+        // Register guild commands in every guild we're in.
+        // Guild commands appear instantly (vs. global commands which can take
+        // up to 1 hour to propagate).
+        // CopilotNative: pure chat bot — no slash commands at all.
+        if self.backend == BackendType::CopilotNative {
+            for guild in &ready.guilds {
+                match guild
+                    .id
+                    .set_commands(&ctx.http, Vec::<CreateCommand>::new())
+                    .await
+                {
+                    Ok(_) => {
+                        info!(guild_id = %guild.id, "cleared all slash commands (CopilotNative)")
+                    }
+                    Err(e) => {
+                        error!(guild_id = %guild.id, error = %e, "failed to clear slash commands")
+                    }
+                }
+            }
+            return;
+        }
+
+        let model_cmd = CreateCommand::new("model")
+            .description("Switch or query the AI model used by this bot")
+            .add_option(
+                CreateCommandOption::new(
+                    CommandOptionType::String,
+                    "model",
+                    "Model id — leave empty to view current",
+                )
+                .required(false)
+                .set_autocomplete(true),
+            );
+
+        let mut commands = vec![model_cmd];
+
+        // Copilot-only commands: read-only info, interactive, mode, reload
+        if self.backend.has_copilot_rpc() {
+            // Read-only info commands
+            for (name, desc) in COPILOT_READONLY_COMMANDS {
+                commands.push(CreateCommand::new(*name).description(*desc));
+            }
+
+            // Interactive commands with <name> arg + autocomplete
+            for (name, desc, _list, _action, _dk, _nk) in COPILOT_INTERACTIVE_COMMANDS {
+                commands.push(
+                    CreateCommand::new(*name).description(*desc).add_option(
+                        CreateCommandOption::new(
+                            CommandOptionType::String,
+                            "name",
+                            "Name (autocomplete)",
+                        )
+                        .required(true)
+                        .set_autocomplete(true),
+                    ),
+                );
+            }
+
+            // /mode with static choices (Discord renders as dropdown)
+            let mode_cmd = {
+                let mut opt =
+                    CreateCommandOption::new(CommandOptionType::String, "mode", "Session mode")
+                        .required(true);
+                for (value, label) in COPILOT_MODES {
+                    opt = opt.add_string_choice(*label, *value);
+                }
+                CreateCommand::new("mode")
+                    .description("Switch Copilot session mode (agent / plan / autopilot)")
+                    .add_option(opt)
+            };
+            commands.push(mode_cmd);
+        } // end Copilot-only
+
+        // /reload <kind> — reload agents/skills/mcp/extensions (Copilot-only)
+        if self.backend.has_copilot_rpc() {
+            let reload_cmd = {
+                let mut opt =
+                    CreateCommandOption::new(CommandOptionType::String, "kind", "What to reload")
+                        .required(true);
+                for (value, _rpc, label) in COPILOT_RELOAD_KINDS {
+                    opt = opt.add_string_choice(*label, *value);
+                }
+                CreateCommand::new("reload")
+                    .description(
+                        "Reload Copilot agents/skills/mcp/extensions without restarting the bot",
+                    )
+                    .add_option(opt)
+            };
+            commands.push(reload_cmd);
+        } // end Copilot-only reload
+
+        // /compact — reset the current Discord thread's agent session
+        commands.push(CreateCommand::new("compact").description(
+            "Compact the current thread's agent session (frees tokens by starting fresh)",
+        ));
+
+        // /new-session — explicit reset (alias semantic for compact with different wording)
+        commands.push(
+            CreateCommand::new("new-session")
+                .description("Reset the current thread's agent session completely"),
+        );
+
+        // /tokens and /permissions — only for backends with _meta RPC support
+        if self.backend.has_meta_rpc() {
+            commands.push(
+                CreateCommand::new("tokens")
+                    .description("Show current thread's context window token usage"),
+            );
+            commands.push(
+                CreateCommand::new("permissions")
+                    .description("Show recent tool permission requests in this thread"),
+            );
+        }
+
+        // Only register /usage if the user has configured it.
+        if self
+            .usage_config
+            .as_ref()
+            .is_some_and(|u| u.enabled && !u.runners.is_empty())
+        {
+            commands.push(
+                CreateCommand::new("usage")
+                    .description("Show usage quotas for configured backends"),
+            );
+        }
+
+        // /cusage — custom usage report (daily/weekly/monthly breakdown)
+        if self
+            .cusage_config
+            .as_ref()
+            .is_some_and(|u| u.enabled && !u.runners.is_empty())
+        {
+            commands.push(
+                CreateCommand::new("cusage")
+                    .description("Show detailed usage breakdown (daily/weekly/monthly)"),
+            );
+        }
+
+        // /native — run an agent's built-in slash command (memory, extensions, etc.)
+        commands.push(
+            CreateCommand::new("native")
+                .description("Run an agent-native slash command (e.g. /memory show, /compact)")
+                .add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "command",
+                        "Agent command name (autocomplete from agent's list)",
+                    )
+                    .required(true)
+                    .set_autocomplete(true),
+                )
+                .add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "args",
+                        "Optional arguments",
+                    )
+                    .required(false),
+                ),
+        );
+
+        // /plan-mode — enter plan mode (send /plan prompt to the agent)
+        commands.push(
+            CreateCommand::new("plan-mode")
+                .description("Enter plan mode — agent plans before executing")
+                .add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "description",
+                        "What to plan (optional)",
+                    )
+                    .required(false),
+                ),
+        );
+
+        // /mcp — list MCP servers connected to the agent
+        commands.push(
+            CreateCommand::new("mcp")
+                .description("List MCP servers and tools connected to the agent"),
+        );
+
+        // /mcp-add, /mcp-remove, /mcp-list — per-user MCP profile management
+        if self.mcp_profiles_dir.is_some() {
+            commands.push(
+                CreateCommand::new("mcp-add")
+                    .description("Add an MCP server to your personal profile")
+                    .add_option(
+                        CreateCommandOption::new(
+                            CommandOptionType::String,
+                            "name",
+                            "Server name (e.g. notion, github)",
+                        )
+                        .required(true),
+                    )
+                    .add_option(
+                        CreateCommandOption::new(
+                            CommandOptionType::String,
+                            "url",
+                            "Server URL (for HTTP/SSE servers)",
+                        )
+                        .required(true),
+                    ),
+            );
+            commands.push(
+                CreateCommand::new("mcp-remove")
+                    .description("Remove an MCP server from your personal profile")
+                    .add_option(
+                        CreateCommandOption::new(
+                            CommandOptionType::String,
+                            "name",
+                            "Server name to remove",
+                        )
+                        .required(true),
+                    ),
+            );
+            commands.push(
+                CreateCommand::new("mcp-list")
+                    .description("List MCP servers in your personal profile"),
+            );
+            // /mcp-browse — browse MCP registry
+            commands.push(
+                CreateCommand::new("mcp-browse")
+                    .description("Browse available MCP servers from the registry"),
+            );
+
+            // /mcp-install — install from registry to profile
+            commands.push(
+                CreateCommand::new("mcp-install")
+                    .description("Install an MCP server from the registry to your profile")
+                    .add_option(
+                        CreateCommandOption::new(
+                            CommandOptionType::String,
+                            "name",
+                            "Server name from registry",
+                        )
+                        .required(true),
+                    ),
+            );
+
+            // /mcp-status — ping installed MCP servers
+            commands.push(
+                CreateCommand::new("mcp-status")
+                    .description("Check connection status of your installed MCP servers"),
+            );
+        }
+
+        // /export — export conversation history from the current thread
+        commands.push(
+            CreateCommand::new("export")
+                .description("Export the current thread's conversation as text"),
+        );
+
+        // /doctor — diagnose agent connection health
+        commands.push(
+            CreateCommand::new("doctor")
+                .description("Diagnose agent connection health (ping, session, uptime)"),
+        );
+
+        // /soul — show the bot's persona / system prompt, or switch emoji preset
+        if self.soul_file.is_some() {
+            let mut soul_cmd =
+                CreateCommand::new("soul").description("Show this bot's persona and style");
+            if !self.emoji_presets.is_empty() {
+                let mut action_opt = CreateCommandOption::new(
+                    CommandOptionType::String,
+                    "action",
+                    "View persona or change emoji preset",
+                );
+                action_opt = action_opt.add_string_choice("view", "view");
+                action_opt = action_opt.add_string_choice("emoji", "emoji");
+                soul_cmd = soul_cmd.add_option(action_opt);
+            }
+            commands.push(soul_cmd);
+        }
+
+        // /stats — detailed session statistics
+        commands.push(
+            CreateCommand::new("stats").description(
+                "Show detailed session statistics (uptime, messages, native commands)",
+            ),
+        );
+
+        for guild in &ready.guilds {
+            match guild.id.set_commands(&ctx.http, commands.clone()).await {
+                Ok(cmds) => {
+                    info!(guild_id = %guild.id, count = cmds.len(), "registered slash commands")
+                }
+                Err(e) => {
+                    error!(guild_id = %guild.id, error = %e, "failed to register slash commands")
+                }
+            }
+        }
     }
+
+    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
+        match interaction {
+            Interaction::Command(cmd) if cmd.data.name == "model" => {
+                self.handle_model_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "usage" => {
+                self.handle_usage_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "cusage" => {
+                self.handle_cusage_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if copilot_readonly_to_rpc(&cmd.data.name).is_some() => {
+                self.handle_copilot_readonly(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "mode" => {
+                self.handle_copilot_mode(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "reload" => {
+                self.handle_copilot_reload(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd)
+                if cmd.data.name == "compact" || cmd.data.name == "new-session" =>
+            {
+                self.handle_reset_session(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "tokens" => {
+                self.handle_tokens_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "permissions" => {
+                self.handle_permissions_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "native" => {
+                self.handle_native_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "plan-mode" => {
+                self.handle_plan_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "mcp" => {
+                self.handle_mcp_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "export" => {
+                self.handle_export_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "doctor" => {
+                self.handle_doctor_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "stats" => {
+                self.handle_stats_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "soul" => {
+                self.handle_soul_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd)
+                if cmd.data.name == "mcp-add"
+                    || cmd.data.name == "mcp-remove"
+                    || cmd.data.name == "mcp-list" =>
+            {
+                self.handle_mcp_profile_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd)
+                if cmd.data.name == "mcp-browse"
+                    || cmd.data.name == "mcp-install"
+                    || cmd.data.name == "mcp-status" =>
+            {
+                self.handle_mcp_registry_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if copilot_interactive_spec(&cmd.data.name).is_some() => {
+                self.handle_copilot_interactive(&ctx, &cmd).await;
+            }
+            Interaction::Autocomplete(ac) if ac.data.name == "model" => {
+                self.handle_model_autocomplete(&ctx, &ac).await;
+            }
+            Interaction::Autocomplete(ac) if ac.data.name == "native" => {
+                self.handle_native_autocomplete(&ctx, &ac).await;
+            }
+            Interaction::Autocomplete(ac) if copilot_interactive_spec(&ac.data.name).is_some() => {
+                self.handle_copilot_interactive_autocomplete(&ctx, &ac)
+                    .await;
+            }
+            Interaction::Component(comp) if comp.data.custom_id == "soul_emoji_select" => {
+                self.handle_soul_emoji_select(&ctx, &comp).await;
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Handler {
+    /// Resolve `partial` (the user's typing in the autocomplete field) to up
+    /// to 25 suggestions, drawing from cached aliases + cached model ids.
+    async fn handle_model_autocomplete(&self, ctx: &Context, ac: &CommandInteraction) {
+        let partial = ac
+            .data
+            .options
+            .first()
+            .and_then(|o| match &o.value {
+                CommandDataOptionValue::Autocomplete { value, .. } => Some(value.as_str()),
+                CommandDataOptionValue::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .unwrap_or("")
+            .to_lowercase();
+
+        let models = self.pool.cached_models().await;
+        let current = self.pool.cached_current_model().await;
+
+        let mut choices: Vec<AutocompleteChoice> = Vec::new();
+
+        // Aliases first — cheap shortcuts most users will reach for
+        for (alias, target) in MODEL_ALIASES {
+            if !partial.is_empty() && !alias.starts_with(&partial) {
+                continue;
+            }
+            // Only surface an alias if its target is actually available
+            // (or if it's "auto", which is always valid).
+            if *target != "auto" && !models.iter().any(|m| m.model_id == *target) {
+                continue;
+            }
+            let label = if *target == "auto" {
+                "auto (smart routing)".to_string()
+            } else {
+                format!("{alias} → {target}")
+            };
+            choices.push(AutocompleteChoice::new(label, (*alias).to_string()));
+            if choices.len() >= 25 {
+                break;
+            }
+        }
+
+        // Then real model ids
+        for m in &models {
+            if choices.len() >= 25 {
+                break;
+            }
+            if !partial.is_empty() && !m.model_id.to_lowercase().contains(&partial) {
+                continue;
+            }
+            let marker = if m.model_id == current {
+                " (current)"
+            } else {
+                ""
+            };
+            let label = format!("{}{marker}", m.model_id);
+            choices.push(AutocompleteChoice::new(label, m.model_id.clone()));
+        }
+
+        let response = CreateInteractionResponse::Autocomplete(
+            CreateAutocompleteResponse::new().set_choices(choices),
+        );
+        if let Err(e) = ac.create_response(&ctx.http, response).await {
+            warn!(error = %e, "failed to send autocomplete response");
+        }
+    }
+
+    /// Autocomplete for /native — suggest agent-native commands.
+    async fn handle_native_autocomplete(&self, ctx: &Context, ac: &CommandInteraction) {
+        let partial = ac
+            .data
+            .options
+            .first()
+            .and_then(|o| match &o.value {
+                CommandDataOptionValue::Autocomplete { value, .. } => Some(value.as_str()),
+                CommandDataOptionValue::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .unwrap_or("")
+            .to_lowercase();
+
+        let cmds = self.pool.cached_native_commands().await;
+        let mut choices: Vec<AutocompleteChoice> = Vec::new();
+        for c in &cmds {
+            if choices.len() >= 25 {
+                break;
+            }
+            if !partial.is_empty() && !c.name.to_lowercase().contains(&partial) {
+                continue;
+            }
+            let label = if c.description.is_empty() {
+                c.name.clone()
+            } else {
+                format!(
+                    "{} — {}",
+                    c.name,
+                    c.description.chars().take(60).collect::<String>()
+                )
+            };
+            choices.push(AutocompleteChoice::new(label, c.name.clone()));
+        }
+        let response = CreateInteractionResponse::Autocomplete(
+            CreateAutocompleteResponse::new().set_choices(choices),
+        );
+        if let Err(e) = ac.create_response(&ctx.http, response).await {
+            warn!(error = %e, "failed to send native autocomplete");
+        }
+    }
+
+    /// Handle /native <command> [args] — send as prompt to the agent which parses it.
+    async fn handle_native_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        // Allowlist: channel + thread parent + user (reuse existing guard)
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        // Additional user allowlist (copilot_guard_ok checks channel, this checks user)
+        if !self.allowed_users.is_empty() && !self.allowed_users.contains(&cmd.user.id.get()) {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⛔ Not authorized")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        }
+
+        let command_name = cmd
+            .data
+            .options
+            .iter()
+            .find(|o| o.name == "command")
+            .and_then(|o| o.value.as_str())
+            .unwrap_or("");
+        let args = cmd
+            .data
+            .options
+            .iter()
+            .find(|o| o.name == "args")
+            .and_then(|o| o.value.as_str())
+            .unwrap_or("");
+
+        if command_name.is_empty() {
+            let cmds = self.pool.cached_native_commands().await;
+            let list = if cmds.is_empty() {
+                "No native commands detected from this agent.".to_string()
+            } else {
+                cmds.iter()
+                    .map(|c| format!("• `{}` — {}", c.name, c.description))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            };
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content(format!("**Agent Native Commands:**\n{list}"))
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        }
+
+        // Build the prompt text — agent CLIs parse /command internally
+        let prompt_text = if args.is_empty() {
+            format!("/{command_name}")
+        } else {
+            format!("/{command_name} {args}")
+        };
+
+        let _ = cmd
+            .create_response(
+                &ctx.http,
+                CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new().content(format!("⚡ `{prompt_text}`")),
+                ),
+            )
+            .await;
+
+        // Get the thread id from the channel
+        let thread_id = cmd.channel_id.get();
+        let thread_key = self.session_key_for_user(thread_id, cmd.user.id.get());
+
+        // Ensure session exists (with user's MCP servers)
+        if let Err(e) = self
+            .ensure_session_for_user(thread_id, cmd.user.id.get())
+            .await
+        {
+            let _ = cmd
+                .channel_id
+                .say(&ctx.http, format!("⚠️ Session error: {e}"))
+                .await;
+            return;
+        }
+
+        // Send as prompt
+        use crate::acp::connection::ContentBlock;
+        let result = self
+            .pool
+            .with_connection(&thread_key, |conn| {
+                let prompt_text = prompt_text.clone();
+                Box::pin(async move {
+                    let (mut rx, request_id) = conn
+                        .session_prompt(vec![ContentBlock::Text { text: prompt_text }])
+                        .await?;
+
+                    let mut reply = String::new();
+                    while let Some(msg) = rx.recv().await {
+                        // Final response (has id)
+                        if msg.id == Some(request_id) {
+                            if let Some(result) = &msg.result {
+                                if let Some(content) = result.get("content") {
+                                    if let Some(arr) = content.as_array() {
+                                        for block in arr {
+                                            if let Some(text) =
+                                                block.get("text").and_then(|t| t.as_str())
+                                            {
+                                                reply.push_str(text);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            break;
+                        }
+                        // Streaming text chunks
+                        if let Some(params) = &msg.params {
+                            if let Some(upd) = params.get("update") {
+                                if upd.get("sessionUpdate").and_then(|v| v.as_str())
+                                    == Some("agent_message_chunk")
+                                {
+                                    if let Some(text) = upd
+                                        .get("content")
+                                        .and_then(|c| c.get("text"))
+                                        .and_then(|t| t.as_str())
+                                    {
+                                        reply.push_str(text);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    conn.prompt_done().await;
+                    Ok(reply)
+                })
+            })
+            .await;
+
+        match result {
+            Ok(reply) if reply.is_empty() => {
+                let _ = cmd
+                    .channel_id
+                    .say(&ctx.http, "✅ Command executed (no output)")
+                    .await;
+            }
+            Ok(reply) => {
+                // Discord message limit is 2000 chars
+                let truncated = if reply.len() > 1900 {
+                    format!("{}…\n*(truncated)*", &reply[..1900])
+                } else {
+                    reply
+                };
+                let _ = cmd.channel_id.say(&ctx.http, &truncated).await;
+            }
+            Err(e) => {
+                let _ = cmd.channel_id.say(&ctx.http, format!("⚠️ {e}")).await;
+            }
+        }
+    }
+
+    /// Handle /plan — send /plan to the agent as a prompt.
+    async fn handle_plan_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        let desc = cmd
+            .data
+            .options
+            .iter()
+            .find(|o| o.name == "description")
+            .and_then(|o| o.value.as_str())
+            .unwrap_or("");
+        let prompt_text = if desc.is_empty() {
+            "/plan".to_string()
+        } else {
+            format!("/plan {desc}")
+        };
+
+        let _ = cmd
+            .create_response(
+                &ctx.http,
+                CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new().content(format!("📋 `{prompt_text}`")),
+                ),
+            )
+            .await;
+
+        let thread_id = cmd.channel_id.get();
+        let thread_key = self.session_key_for_user(thread_id, cmd.user.id.get());
+        if let Err(e) = self
+            .ensure_session_for_user(thread_id, cmd.user.id.get())
+            .await
+        {
+            let _ = cmd.channel_id.say(&ctx.http, format!("⚠️ {e}")).await;
+            return;
+        }
+
+        use crate::acp::connection::ContentBlock;
+        let result = self
+            .pool
+            .with_connection(&thread_key, |conn| {
+                let pt = prompt_text.clone();
+                Box::pin(async move {
+                    let (mut rx, request_id) = conn
+                        .session_prompt(vec![ContentBlock::Text { text: pt }])
+                        .await?;
+                    let mut reply = String::new();
+                    while let Some(msg) = rx.recv().await {
+                        if msg.id == Some(request_id) {
+                            if let Some(r) = &msg.result {
+                                if let Some(arr) = r.get("content").and_then(|c| c.as_array()) {
+                                    for b in arr {
+                                        if let Some(t) = b.get("text").and_then(|t| t.as_str()) {
+                                            reply.push_str(t);
+                                        }
+                                    }
+                                }
+                            }
+                            break;
+                        }
+                        if let Some(params) = &msg.params {
+                            if let Some(upd) = params.get("update") {
+                                if upd.get("sessionUpdate").and_then(|v| v.as_str())
+                                    == Some("agent_message_chunk")
+                                {
+                                    if let Some(t) = upd
+                                        .get("content")
+                                        .and_then(|c| c.get("text"))
+                                        .and_then(|t| t.as_str())
+                                    {
+                                        reply.push_str(t);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    conn.prompt_done().await;
+                    Ok(reply)
+                })
+            })
+            .await;
+
+        match result {
+            Ok(r) if r.is_empty() => {
+                let _ = cmd
+                    .channel_id
+                    .say(&ctx.http, "✅ Plan mode activated (no output)")
+                    .await;
+            }
+            Ok(r) => {
+                let truncated = if r.len() > 1900 {
+                    format!("{}…\n*(truncated)*", &r[..1900])
+                } else {
+                    r
+                };
+                let _ = cmd.channel_id.say(&ctx.http, &truncated).await;
+            }
+            Err(e) => {
+                let _ = cmd.channel_id.say(&ctx.http, format!("⚠️ {e}")).await;
+            }
+        }
+    }
+
+    /// Handle /mcp — send /mcp to the agent as a prompt.
+    async fn handle_mcp_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        let _ = cmd
+            .create_response(
+                &ctx.http,
+                CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new().content("🔌 Querying MCP servers…"),
+                ),
+            )
+            .await;
+
+        let thread_id = cmd.channel_id.get();
+        let thread_key = self.session_key_for_user(thread_id, cmd.user.id.get());
+        if let Err(e) = self
+            .ensure_session_for_user(thread_id, cmd.user.id.get())
+            .await
+        {
+            let _ = cmd.channel_id.say(&ctx.http, format!("⚠️ {e}")).await;
+            return;
+        }
+
+        use crate::acp::connection::ContentBlock;
+        let result = self
+            .pool
+            .with_connection(&thread_key, |conn| {
+                Box::pin(async move {
+                    let (mut rx, request_id) = conn
+                        .session_prompt(vec![ContentBlock::Text {
+                            text: "/mcp".to_string(),
+                        }])
+                        .await?;
+                    let mut reply = String::new();
+                    while let Some(msg) = rx.recv().await {
+                        if msg.id == Some(request_id) {
+                            if let Some(r) = &msg.result {
+                                if let Some(arr) = r.get("content").and_then(|c| c.as_array()) {
+                                    for b in arr {
+                                        if let Some(t) = b.get("text").and_then(|t| t.as_str()) {
+                                            reply.push_str(t);
+                                        }
+                                    }
+                                }
+                            }
+                            break;
+                        }
+                        if let Some(params) = &msg.params {
+                            if let Some(upd) = params.get("update") {
+                                if upd.get("sessionUpdate").and_then(|v| v.as_str())
+                                    == Some("agent_message_chunk")
+                                {
+                                    if let Some(t) = upd
+                                        .get("content")
+                                        .and_then(|c| c.get("text"))
+                                        .and_then(|t| t.as_str())
+                                    {
+                                        reply.push_str(t);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    conn.prompt_done().await;
+                    Ok(reply)
+                })
+            })
+            .await;
+
+        match result {
+            Ok(r) if r.is_empty() => {
+                let _ = cmd
+                    .channel_id
+                    .say(&ctx.http, "ℹ️ No MCP information returned.")
+                    .await;
+            }
+            Ok(r) => {
+                let truncated = if r.len() > 1900 {
+                    format!("{}…\n*(truncated)*", &r[..1900])
+                } else {
+                    r
+                };
+                let _ = cmd.channel_id.say(&ctx.http, &truncated).await;
+            }
+            Err(e) => {
+                let _ = cmd.channel_id.say(&ctx.http, format!("⚠️ {e}")).await;
+            }
+        }
+    }
+
+    /// Handle /export — fetch recent messages from the current thread and send as text.
+    async fn handle_export_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, "failed to defer /export");
+            return;
+        }
+
+        // Fetch up to 100 recent messages from this channel
+        use serenity::builder::GetMessages;
+        let messages = match cmd
+            .channel_id
+            .messages(&ctx.http, GetMessages::new().limit(100))
+            .await
+        {
+            Ok(msgs) => msgs,
+            Err(e) => {
+                let _ = cmd
+                    .edit_response(
+                        &ctx.http,
+                        EditInteractionResponse::new()
+                            .content(format!("⚠️ Failed to fetch messages: {e}")),
+                    )
+                    .await;
+                return;
+            }
+        };
+
+        let mut lines: Vec<String> = messages
+            .iter()
+            .rev()
+            .map(|m| {
+                let ts = m.timestamp.to_string();
+                let author = &m.author.name;
+                let content = if m.content.len() > 500 {
+                    format!("{}…", &m.content[..500])
+                } else {
+                    m.content.clone()
+                };
+                format!("[{ts}] {author}: {content}")
+            })
+            .collect();
+
+        if lines.is_empty() {
+            lines.push("(no messages)".to_string());
+        }
+
+        let export = lines.join("\n");
+        let truncated = if export.len() > 1900 {
+            format!(
+                "```\n{}…\n```\n*(truncated to 100 messages)*",
+                &export[..1800]
+            )
+        } else {
+            format!("```\n{export}\n```")
+        };
+
+        let embed = CreateEmbed::new()
+            .title("📄 /export")
+            .description(truncated)
+            .color(0x5865F2);
+
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+            .await;
+    }
+
+    /// Handle /doctor — diagnose agent connection health.
+    async fn handle_doctor_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, "failed to defer /doctor");
+            return;
+        }
+
+        let thread_id = cmd.channel_id.get();
+        let thread_key = self.session_key_for_user(thread_id, cmd.user.id.get());
+        let mut report = String::new();
+
+        // 1. Check if a session exists for this thread/user
+        let session_exists = self
+            .ensure_session_for_user(thread_id, cmd.user.id.get())
+            .await
+            .is_ok();
+        report.push_str(&format!(
+            "**Session:** {}\n",
+            if session_exists {
+                "✅ active"
+            } else {
+                "❌ failed to create"
+            }
+        ));
+
+        if session_exists {
+            // 2. Ping the agent
+            let ping_result = self
+                .pool
+                .with_connection(&thread_key, |conn| {
+                    Box::pin(async move { conn.session_ping().await })
+                })
+                .await;
+            match ping_result {
+                Ok(_) => report.push_str("**Ping:** ✅ responsive\n"),
+                Err(e) => report.push_str(&format!("**Ping:** ⚠️ {e}\n")),
+            }
+
+            // 3. Session info
+            let session_info = self
+                .pool
+                .with_connection(&thread_key, |conn| {
+                    Box::pin(async move {
+                        let sid = conn.acp_session_id.as_deref().unwrap_or("none").to_string();
+                        let model = conn.current_model.clone();
+                        let alive = conn.alive();
+                        let elapsed_secs = conn.last_active.elapsed().as_secs();
+                        let native_count = conn.native_commands.lock().await.len();
+                        Ok(format!(
+                            "**Session ID:** `{sid}`\n**Model:** `{model}`\n**Process:** {}\n**Last active:** {elapsed_secs}s ago\n**Native commands:** {native_count}\n",
+                            if alive { "✅ alive" } else { "❌ dead" }
+                        ))
+                    })
+                })
+                .await;
+            if let Ok(info) = session_info {
+                report.push_str(&info);
+            }
+        }
+
+        // 4. Pool info
+        let models = self.pool.cached_models().await;
+        let native_cmds = self.pool.cached_native_commands().await;
+        report.push_str(&format!("**Cached models:** {}\n", models.len()));
+        report.push_str(&format!("**Cached native cmds:** {}\n", native_cmds.len()));
+
+        let embed = CreateEmbed::new()
+            .title("🩺 /doctor")
+            .description(report)
+            .color(0x2ECC71);
+
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+            .await;
+    }
+
+    /// Handle /stats — detailed session statistics.
+    async fn handle_stats_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, "failed to defer /stats");
+            return;
+        }
+
+        let thread_id = cmd.channel_id.get();
+        let thread_key = self.session_key_for_user(thread_id, cmd.user.id.get());
+        let mut report = String::new();
+
+        // Try to get usage from bridge
+        let has_session = self
+            .ensure_session_for_user(thread_id, cmd.user.id.get())
+            .await
+            .is_ok();
+        if has_session {
+            let usage = self
+                .pool
+                .with_connection(&thread_key, |conn| {
+                    Box::pin(async move { conn.session_get_usage().await })
+                })
+                .await;
+
+            match usage {
+                Ok(v) => {
+                    // Session-level token stats (top-level or nested under session_usage)
+                    let session = v.get("session_usage").unwrap_or(&v);
+                    if let Some(input) = session.get("inputTokens").and_then(|n| n.as_u64()) {
+                        report.push_str(&format!("**Input tokens:** {input}\n"));
+                    }
+                    if let Some(output) = session.get("outputTokens").and_then(|n| n.as_u64()) {
+                        report.push_str(&format!("**Output tokens:** {output}\n"));
+                    }
+                    if let Some(total) = session.get("totalTokens").and_then(|n| n.as_u64()) {
+                        report.push_str(&format!("**Total tokens:** {total}\n"));
+                    }
+                    if let Some(turns) = session.get("turns").and_then(|n| n.as_u64()) {
+                        report.push_str(&format!("**Turns:** {turns}\n"));
+                    }
+                    if let Some(cost) = v
+                        .get("cost")
+                        .or_else(|| v.get("cost_totals"))
+                        .and_then(|n| n.as_f64())
+                    {
+                        report.push_str(&format!("**Estimated cost:** ${cost:.4}\n"));
+                    }
+
+                    // Account-level quota (from copilot-agent-acp bridge)
+                    if let Some(aq) = v.get("account_quota") {
+                        for key in ["premium_interactions", "chat", "completions"] {
+                            if let Some(q) = aq.pointer(&format!("/quotaSnapshots/{key}")) {
+                                let pct = q
+                                    .get("remainingPercentage")
+                                    .and_then(|v| v.as_f64())
+                                    .unwrap_or(0.0);
+                                let used =
+                                    q.get("usedRequests").and_then(|v| v.as_u64()).unwrap_or(0);
+                                let total = q
+                                    .get("entitlementRequests")
+                                    .and_then(|v| v.as_u64())
+                                    .unwrap_or(0);
+                                if total > 0 {
+                                    let label = match key {
+                                        "premium_interactions" => "🔥 Premium",
+                                        "chat" => "💬 Chat",
+                                        "completions" => "⚡ Completions",
+                                        _ => key,
+                                    };
+                                    report.push_str(&format!(
+                                        "**{label}:** {pct:.1}% remaining ({used}/{total})\n"
+                                    ));
+                                }
+                            }
+                        }
+                    }
+
+                    if report.is_empty() {
+                        report.push_str(&format!(
+                            "```json\n{}\n```",
+                            serde_json::to_string_pretty(&v).unwrap_or_default()
+                        ));
+                    }
+                }
+                Err(_) => {
+                    report.push_str("_Usage stats not available from this backend._\n");
+                }
+            }
+
+            // Session metadata
+            let meta = self
+                .pool
+                .with_connection(&thread_key, |conn| {
+                    Box::pin(async move {
+                        let elapsed_secs = conn.last_active.elapsed().as_secs();
+                        let model = conn.current_model.clone();
+                        let alive = conn.alive();
+                        Ok(format!(
+                            "\n**Model:** `{model}`\n**Session age:** {elapsed_secs}s\n**Process alive:** {}\n",
+                            if alive { "✅" } else { "❌" }
+                        ))
+                    })
+                })
+                .await;
+            if let Ok(m) = meta {
+                report.push_str(&m);
+            }
+        } else {
+            report.push_str("No active session in this thread.\n");
+        }
+
+        // Native commands summary
+        let native = self.pool.cached_native_commands().await;
+        if !native.is_empty() {
+            report.push_str(&format!(
+                "\n**Native commands:** {} available via `/native`\n",
+                native.len()
+            ));
+        }
+
+        let embed = CreateEmbed::new()
+            .title("📊 /stats")
+            .description(report)
+            .color(0x5865F2);
+
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+            .await;
+    }
+
+    /// Handle the actual /model command submission.
+    async fn handle_model_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        // Allowlist: channel
+        let channel_id = cmd.channel_id.get();
+        let in_allowed_channel =
+            self.allowed_channels.is_empty() || self.allowed_channels.contains(&channel_id);
+
+        let in_thread = if !in_allowed_channel {
+            match cmd.channel_id.to_channel(&ctx.http).await {
+                Ok(serenity::model::channel::Channel::Guild(gc)) => gc
+                    .parent_id
+                    .is_some_and(|pid| self.allowed_channels.contains(&pid.get())),
+                _ => false,
+            }
+        } else {
+            false
+        };
+
+        if !in_allowed_channel && !in_thread {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⚠️ This channel is not allowlisted.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        }
+
+        // Allowlist: user
+        if !self.allowed_users.is_empty() && !self.allowed_users.contains(&cmd.user.id.get()) {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("🚫 You are not authorized to use this command.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        }
+
+        // Extract the model option (None → list current)
+        let arg = cmd.data.options.first().and_then(|o| match &o.value {
+            CommandDataOptionValue::String(s) => {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            }
+            _ => None,
+        });
+
+        // Defer the response — session spawn can take up to ~10s on cold pool
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, "failed to defer /model response");
+            return;
+        }
+
+        let thread_id = cmd.channel_id.get();
+        let thread_key = self.session_key_for_user(thread_id, cmd.user.id.get());
+        if let Err(e) = self
+            .ensure_session_for_user(thread_id, cmd.user.id.get())
+            .await
+        {
+            let _ = cmd
+                .edit_response(
+                    &ctx.http,
+                    EditInteractionResponse::new()
+                        .content(format!("⚠️ Failed to start agent: {e}")),
+                )
+                .await;
+            return;
+        }
+
+        let reply = self
+            .pool
+            .with_connection(&thread_key, |conn| {
+                let arg = arg.clone();
+                Box::pin(async move {
+                    match arg {
+                        None => {
+                            if conn.available_models.is_empty() {
+                                return Ok::<String, anyhow::Error>(
+                                    "_(no models reported by agent — backend may not support model switching)_"
+                                        .to_string(),
+                                );
+                            }
+                            let mut out = String::from("**Available models:**\n");
+                            for m in &conn.available_models {
+                                let marker = if m.model_id == conn.current_model {
+                                    "**▶**"
+                                } else {
+                                    "•"
+                                };
+                                out.push_str(&format!(
+                                    "{} `{}` — {}\n",
+                                    marker, m.model_id, m.name
+                                ));
+                            }
+                            out.push_str(&format!("\nCurrent: `{}`", conn.current_model));
+                            Ok(out)
+                        }
+                        Some(input) => match conn.resolve_model_alias(&input) {
+                            Some(model_id) => match conn.session_set_model(&model_id).await {
+                                Ok(()) => Ok(format!("✅ Switched to `{model_id}`")),
+                                Err(e) => Ok(format!("⚠️ Failed to set model: {e}")),
+                            },
+                            None => Ok(format!("❌ Unknown model: `{input}`")),
+                        },
+                    }
+                })
+            })
+            .await;
+
+        let text = match reply {
+            Ok(t) => t,
+            Err(e) => format!("⚠️ {e}"),
+        };
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().content(text))
+            .await;
+    }
+
+    /// Handle the `/soul` slash command: display the bot's persona file or show emoji preset picker.
+    async fn handle_soul_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        use serenity::all::{
+            CreateActionRow, CreateEmbed, CreateSelectMenu, CreateSelectMenuKind,
+            CreateSelectMenuOption,
+        };
+
+        // Check if user selected "emoji" action
+        let action = cmd
+            .data
+            .options
+            .iter()
+            .find(|o| o.name == "action")
+            .and_then(|o| o.value.as_str())
+            .unwrap_or("view");
+
+        if action == "emoji" && !self.emoji_presets.is_empty() {
+            // Build select menu with preset options
+            let options: Vec<CreateSelectMenuOption> = self
+                .emoji_presets
+                .iter()
+                .map(|p| {
+                    let e = &p.emojis;
+                    let desc = format!(
+                        "{} {} {} {} {} {} {}",
+                        e.queued, e.thinking, e.tool, e.coding, e.web, e.done, e.error
+                    );
+                    CreateSelectMenuOption::new(&p.name, &p.name).description(desc)
+                })
+                .collect();
+
+            let select = CreateSelectMenu::new(
+                "soul_emoji_select",
+                CreateSelectMenuKind::String { options },
+            )
+            .placeholder("選擇 emoji 風格...");
+
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("🎨 選擇 reaction emoji 風格：")
+                            .components(vec![CreateActionRow::SelectMenu(select)])
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        }
+
+        // Default: show persona embed
+        let (title, description, color) = match &self.soul_file {
+            Some(path) => match tokio::fs::read_to_string(path).await {
+                Ok(text) => {
+                    let trimmed = text.trim();
+                    let bot_name = match self.backend {
+                        BackendType::Claude => "CICX",
+                        BackendType::CopilotBridge => "GITX",
+                        BackendType::CopilotNative => "COPILX",
+                        BackendType::Gemini => "GIMINIX",
+                        BackendType::Codex => "CODEX",
+                        BackendType::Other => "Bot",
+                    };
+                    let desc = if trimmed.len() > 3900 {
+                        format!("{}…\n\n_({} chars total)_", &trimmed[..3900], trimmed.len())
+                    } else {
+                        trimmed.to_string()
+                    };
+                    (format!("🔱 {bot_name} の魂"), desc, 0x1B2838u32)
+                }
+                Err(e) => (
+                    "⚠️ Error".to_string(),
+                    format!("Failed to read soul file: {e}"),
+                    0xFF4444u32,
+                ),
+            },
+            None => (
+                "💤 No Soul".to_string(),
+                "No soul file configured.".to_string(),
+                0x888888u32,
+            ),
+        };
+
+        let embed = CreateEmbed::new()
+            .title(title)
+            .description(description)
+            .color(color)
+            .footer(serenity::all::CreateEmbedFooter::new(
+                "「...勞動是為了有不勞動的時間。」",
+            ));
+
+        let _ = cmd
+            .create_response(
+                &ctx.http,
+                CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new()
+                        .embed(embed)
+                        .ephemeral(true),
+                ),
+            )
+            .await;
+    }
+
+    /// Handle the emoji preset selection from the `/soul emoji` select menu.
+    async fn handle_soul_emoji_select(
+        &self,
+        ctx: &Context,
+        component: &serenity::all::ComponentInteraction,
+    ) {
+        use serenity::all::ComponentInteractionDataKind;
+
+        let selected = match &component.data.kind {
+            ComponentInteractionDataKind::StringSelect { values } => values.first().cloned(),
+            _ => None,
+        };
+
+        let Some(preset_name) = selected else {
+            let _ = component
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⚠️ 未選擇 preset")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        };
+
+        let preset = self.emoji_presets.iter().find(|p| p.name == preset_name);
+        let Some(preset) = preset else {
+            let _ = component
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content(format!("⚠️ 找不到 preset: {preset_name}"))
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        };
+
+        // Update the shared reactions config
+        {
+            let mut rcfg = self.reactions_config.write().await;
+            rcfg.emojis = preset.emojis.clone();
+        }
+
+        let e = &preset.emojis;
+        let summary = format!(
+            "✔️ 已切換到「**{}**」風格\n\n\
+            {} queued · {} thinking · {} tool · {} coding\n\
+            {} web · {} done · {} error",
+            preset_name, e.queued, e.thinking, e.tool, e.coding, e.web, e.done, e.error
+        );
+
+        let _ = component
+            .create_response(
+                &ctx.http,
+                CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new()
+                        .content(summary)
+                        .ephemeral(true),
+                ),
+            )
+            .await;
+    }
+
+    /// Handle `/mcp-add`, `/mcp-remove`, `/mcp-list` — per-user MCP profile management.
+    async fn handle_mcp_profile_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        let Some(dir) = &self.mcp_profiles_dir else {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⚠️ MCP profiles not configured (mcp_profiles_dir missing).")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        };
+
+        let user_id = cmd.user.id.get().to_string();
+        let profile_path = std::path::PathBuf::from(dir).join(format!("{user_id}.json"));
+
+        // Read existing profile or create empty one
+        let mut profile: serde_json::Value = if profile_path.exists() {
+            match tokio::fs::read_to_string(&profile_path).await {
+                Ok(s) => serde_json::from_str(&s).unwrap_or_else(|_| {
+                    serde_json::json!({
+                        "discord_user_id": user_id,
+                        "mcpServers": {},
+                        "enabled": true
+                    })
+                }),
+                Err(_) => serde_json::json!({
+                    "discord_user_id": user_id,
+                    "mcpServers": {},
+                    "enabled": true
+                }),
+            }
+        } else {
+            serde_json::json!({
+                "discord_user_id": user_id,
+                "mcpServers": {},
+                "enabled": true
+            })
+        };
+
+        match cmd.data.name.as_str() {
+            "mcp-add" => {
+                let name = cmd
+                    .data
+                    .options
+                    .iter()
+                    .find(|o| o.name == "name")
+                    .and_then(|o| o.value.as_str())
+                    .unwrap_or("");
+                let url = cmd
+                    .data
+                    .options
+                    .iter()
+                    .find(|o| o.name == "url")
+                    .and_then(|o| o.value.as_str())
+                    .unwrap_or("");
+
+                if name.is_empty() || url.is_empty() {
+                    let _ = cmd
+                        .create_response(
+                            &ctx.http,
+                            CreateInteractionResponse::Message(
+                                CreateInteractionResponseMessage::new()
+                                    .content("⚠️ Both name and URL are required.")
+                                    .ephemeral(true),
+                            ),
+                        )
+                        .await;
+                    return;
+                }
+
+                profile["mcpServers"][name] = serde_json::json!({
+                    "type": "http",
+                    "url": url,
+                    "tools": ["*"]
+                });
+                profile["updated_at"] =
+                    serde_json::Value::String(format!("{:?}", std::time::SystemTime::now()));
+
+                match tokio::fs::write(
+                    &profile_path,
+                    serde_json::to_string_pretty(&profile).unwrap_or_default(),
+                )
+                .await
+                {
+                    Ok(_) => {
+                        let _ = cmd.create_response(&ctx.http, CreateInteractionResponse::Message(
+                            CreateInteractionResponseMessage::new()
+                                .content(format!("✅ MCP server **{name}** added (`{url}`)\n_Takes effect on next session. Use `/new-session` to apply now._"))
+                                .ephemeral(true),
+                        )).await;
+                    }
+                    Err(e) => {
+                        let _ = cmd
+                            .create_response(
+                                &ctx.http,
+                                CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new()
+                                        .content(format!("⚠️ Failed to save profile: {e}"))
+                                        .ephemeral(true),
+                                ),
+                            )
+                            .await;
+                    }
+                }
+            }
+            "mcp-remove" => {
+                let name = cmd
+                    .data
+                    .options
+                    .iter()
+                    .find(|o| o.name == "name")
+                    .and_then(|o| o.value.as_str())
+                    .unwrap_or("");
+
+                if let Some(servers) = profile["mcpServers"].as_object_mut() {
+                    if servers.remove(name).is_some() {
+                        profile["updated_at"] = serde_json::Value::String(format!(
+                            "{:?}",
+                            std::time::SystemTime::now()
+                        ));
+                        let _ = tokio::fs::write(
+                            &profile_path,
+                            serde_json::to_string_pretty(&profile).unwrap_or_default(),
+                        )
+                        .await;
+                        let _ = cmd.create_response(&ctx.http, CreateInteractionResponse::Message(
+                            CreateInteractionResponseMessage::new()
+                                .content(format!("🗑️ MCP server **{name}** removed.\n_Takes effect on next session. Use `/new-session` to apply now._"))
+                                .ephemeral(true),
+                        )).await;
+                    } else {
+                        let _ = cmd
+                            .create_response(
+                                &ctx.http,
+                                CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new()
+                                        .content(format!(
+                                            "⚠️ Server **{name}** not found in your profile."
+                                        ))
+                                        .ephemeral(true),
+                                ),
+                            )
+                            .await;
+                    }
+                }
+            }
+            "mcp-list" => {
+                let servers = profile["mcpServers"].as_object();
+                let list = match servers {
+                    Some(s) if !s.is_empty() => s
+                        .iter()
+                        .map(|(name, cfg)| {
+                            let url = cfg["url"].as_str().unwrap_or("(stdio)");
+                            let stype = cfg["type"].as_str().unwrap_or("http");
+                            format!("• **{name}** — `{stype}` {url}")
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                    _ => "No MCP servers configured. Use `/mcp-add` to add one.".to_string(),
+                };
+                let _ = cmd
+                    .create_response(
+                        &ctx.http,
+                        CreateInteractionResponse::Message(
+                            CreateInteractionResponseMessage::new()
+                                .content(format!("🔌 **Your MCP Servers:**\n{list}"))
+                                .ephemeral(true),
+                        ),
+                    )
+                    .await;
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle `/mcp-browse`, `/mcp-install`, `/mcp-status` — MCP registry commands.
+    async fn handle_mcp_registry_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        let Some(dir) = &self.mcp_profiles_dir else {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⚠️ MCP profiles not configured.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        };
+
+        // Load registry
+        let registry_path = std::path::PathBuf::from(dir)
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
+            .join("mcp-registry.json");
+        let registry: serde_json::Value = match tokio::fs::read_to_string(&registry_path).await {
+            Ok(s) => serde_json::from_str(&s).unwrap_or(serde_json::json!({"servers":[]})),
+            Err(_) => {
+                let _ = cmd
+                    .create_response(
+                        &ctx.http,
+                        CreateInteractionResponse::Message(
+                            CreateInteractionResponseMessage::new()
+                                .content("⚠️ MCP registry not found.")
+                                .ephemeral(true),
+                        ),
+                    )
+                    .await;
+                return;
+            }
+        };
+
+        let user_id = cmd.user.id.get().to_string();
+        let profile_path = std::path::PathBuf::from(dir).join(format!("{user_id}.json"));
+
+        match cmd.data.name.as_str() {
+            "mcp-browse" => {
+                let servers = registry["servers"].as_array();
+                let list = match servers {
+                    Some(arr) if !arr.is_empty() => arr
+                        .iter()
+                        .map(|s| {
+                            let name = s["name"].as_str().unwrap_or("?");
+                            let desc = s["description"].as_str().unwrap_or("");
+                            let cat = s["category"].as_str().unwrap_or("other");
+                            let auth = s["auth"].as_str().unwrap_or("none");
+                            format!("• **{name}** [{cat}] — {desc}\n  Auth: `{auth}`")
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                    _ => "No servers in registry.".to_string(),
+                };
+                let count = servers.map(|a| a.len()).unwrap_or(0);
+                let _ = cmd.create_response(&ctx.http, CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new()
+                        .content(format!("🔌 **MCP Registry** ({count} servers)\n\n{list}\n\n_Use `/mcp-install <name>` to add one._"))
+                        .ephemeral(true),
+                )).await;
+            }
+            "mcp-install" => {
+                let name = cmd
+                    .data
+                    .options
+                    .iter()
+                    .find(|o| o.name == "name")
+                    .and_then(|o| o.value.as_str())
+                    .unwrap_or("");
+
+                let server = registry["servers"]
+                    .as_array()
+                    .and_then(|arr| arr.iter().find(|s| s["name"].as_str() == Some(name)));
+
+                let Some(server) = server else {
+                    let _ = cmd.create_response(&ctx.http, CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content(format!("⚠️ Server **{name}** not found in registry. Use `/mcp-browse` to see available servers."))
+                            .ephemeral(true),
+                    )).await;
+                    return;
+                };
+
+                // Read or create profile
+                let mut profile: serde_json::Value = if profile_path.exists() {
+                    tokio::fs::read_to_string(&profile_path).await.ok()
+                        .and_then(|s| serde_json::from_str(&s).ok())
+                        .unwrap_or(serde_json::json!({"discord_user_id": user_id, "mcpServers": {}, "enabled": true}))
+                } else {
+                    serde_json::json!({"discord_user_id": user_id, "mcpServers": {}, "enabled": true})
+                };
+
+                // Copy server config to profile
+                let mut cfg = server.clone();
+                cfg.as_object_mut().map(|o| {
+                    o.remove("name");
+                    o.remove("description");
+                    o.remove("category");
+                    o.remove("auth");
+                });
+                if cfg.get("tools").is_none() {
+                    cfg["tools"] = serde_json::json!(["*"]);
+                }
+                profile["mcpServers"][name] = cfg;
+                profile["updated_at"] =
+                    serde_json::Value::String(format!("{:?}", std::time::SystemTime::now()));
+
+                match tokio::fs::write(
+                    &profile_path,
+                    serde_json::to_string_pretty(&profile).unwrap_or_default(),
+                )
+                .await
+                {
+                    Ok(_) => {
+                        let auth = server["auth"].as_str().unwrap_or("none");
+                        let msg = if auth == "none" {
+                            format!("✅ **{name}** installed to your profile.\n_Takes effect on next session. Use `/new-session` to apply now._")
+                        } else {
+                            format!("✅ **{name}** installed to your profile.\n⚠️ Auth required: `{auth}`\n_Takes effect on next session. Use `/new-session` to apply now._")
+                        };
+                        let _ = cmd
+                            .create_response(
+                                &ctx.http,
+                                CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new()
+                                        .content(msg)
+                                        .ephemeral(true),
+                                ),
+                            )
+                            .await;
+                    }
+                    Err(e) => {
+                        let _ = cmd
+                            .create_response(
+                                &ctx.http,
+                                CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new()
+                                        .content(format!("⚠️ Failed to save: {e}"))
+                                        .ephemeral(true),
+                                ),
+                            )
+                            .await;
+                    }
+                }
+            }
+            "mcp-status" => {
+                let profile: serde_json::Value = if profile_path.exists() {
+                    tokio::fs::read_to_string(&profile_path)
+                        .await
+                        .ok()
+                        .and_then(|s| serde_json::from_str(&s).ok())
+                        .unwrap_or(serde_json::json!({"mcpServers":{}}))
+                } else {
+                    serde_json::json!({"mcpServers":{}})
+                };
+
+                let servers = profile["mcpServers"].as_object();
+                let list = match servers {
+                    Some(s) if !s.is_empty() => {
+                        s.iter()
+                            .map(|(name, cfg)| {
+                                let stype = cfg["type"].as_str().unwrap_or("stdio");
+                                // Simple status: installed = ✅, no runtime check yet
+                                format!("• ✅ **{name}** (`{stype}`) — installed")
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    }
+                    _ => {
+                        "No MCP servers installed. Use `/mcp-browse` → `/mcp-install`.".to_string()
+                    }
+                };
+                let _ = cmd
+                    .create_response(
+                        &ctx.http,
+                        CreateInteractionResponse::Message(
+                            CreateInteractionResponseMessage::new()
+                                .content(format!("📊 **MCP Status:**\n{list}"))
+                                .ephemeral(true),
+                        ),
+                    )
+                    .await;
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle the `/usage` slash command: run all configured usage runners
+    /// in parallel and display the results as an embed.
+    async fn handle_usage_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        // Channel allowlist
+        let channel_id = cmd.channel_id.get();
+        let in_allowed_channel =
+            self.allowed_channels.is_empty() || self.allowed_channels.contains(&channel_id);
+
+        let in_thread = if !in_allowed_channel {
+            match cmd.channel_id.to_channel(&ctx.http).await {
+                Ok(serenity::model::channel::Channel::Guild(gc)) => gc
+                    .parent_id
+                    .is_some_and(|pid| self.allowed_channels.contains(&pid.get())),
+                _ => false,
+            }
+        } else {
+            false
+        };
+
+        if !in_allowed_channel && !in_thread {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⚠️ This channel is not allowlisted.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        }
+
+        // User allowlist
+        if !self.allowed_users.is_empty() && !self.allowed_users.contains(&cmd.user.id.get()) {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("🚫 You are not authorized to use this command.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        }
+
+        let Some(usage_cfg) = self.usage_config.as_ref() else {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⚠️ `/usage` is not configured. See `[usage]` in config.toml.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        };
+
+        if !usage_cfg.enabled || usage_cfg.runners.is_empty() {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⚠️ No usage runners configured.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        }
+
+        // Defer — runners may take up to `timeout_secs` each
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, "failed to defer /usage response");
+            return;
+        }
+
+        let results = crate::usage::run_all(usage_cfg).await;
+        let mut embed = build_usage_embed(&results);
+
+        // Append session-level token stats if a session exists in this thread
+        let thread_id = cmd.channel_id.get();
+        let thread_key = self.session_key_for_user(thread_id, cmd.user.id.get());
+        if self
+            .ensure_session_for_user(thread_id, cmd.user.id.get())
+            .await
+            .is_ok()
+        {
+            let session_info = self
+                .pool
+                .with_connection(&thread_key, |conn| {
+                    Box::pin(async move {
+                        let model = conn.current_model.clone();
+                        let elapsed = conn.last_active.elapsed().as_secs();
+                        let usage = conn.session_get_usage().await.ok();
+                        let mut lines = vec![format!("**Model:** `{model}` • **Age:** {elapsed}s")];
+                        if let Some(v) = usage {
+                            let session = v.get("session_usage").unwrap_or(&v);
+                            if let Some(input) = session.get("inputTokens").and_then(|n| n.as_u64())
+                            {
+                                if let Some(output) =
+                                    session.get("outputTokens").and_then(|n| n.as_u64())
+                                {
+                                    let total = input + output;
+                                    lines.push(format!("**Tokens:** {total} (↑{input} ↓{output})"));
+                                }
+                            }
+                            if let Some(turns) = session.get("turns").and_then(|n| n.as_u64()) {
+                                lines.push(format!("**Turns:** {turns}"));
+                            }
+                            if let Some(cost) = v
+                                .get("cost")
+                                .or_else(|| v.get("cost_totals"))
+                                .and_then(|n| n.as_f64())
+                            {
+                                lines.push(format!("**Cost:** ${cost:.4}"));
+                            }
+                            // Account quota from copilot-agent-acp bridge
+                            if let Some(premium) =
+                                v.pointer("/account_quota/quotaSnapshots/premium_interactions")
+                            {
+                                if let Some(pct) =
+                                    premium.get("remainingPercentage").and_then(|v| v.as_f64())
+                                {
+                                    let used = premium
+                                        .get("usedRequests")
+                                        .and_then(|v| v.as_u64())
+                                        .unwrap_or(0);
+                                    let total = premium
+                                        .get("entitlementRequests")
+                                        .and_then(|v| v.as_u64())
+                                        .unwrap_or(0);
+                                    lines.push(format!(
+                                        "🔥 **Premium:** {pct:.1}% ({used}/{total})"
+                                    ));
+                                }
+                            }
+                        }
+                        Ok(lines.join("\n"))
+                    })
+                })
+                .await;
+            if let Ok(info) = session_info {
+                embed = embed.field("📡 Current Session", &info, false);
+            }
+        }
+
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+            .await;
+    }
+
+    /// Handle `/cusage` — custom usage breakdown (daily/weekly/monthly).
+    async fn handle_cusage_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        let Some(cusage_cfg) = self.cusage_config.as_ref() else {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⚠️ `/cusage` is not configured.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        };
+
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, "failed to defer /cusage response");
+            return;
+        }
+
+        let results = crate::usage::run_all(cusage_cfg).await;
+        let embed = build_usage_embed(&results);
+
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+            .await;
+    }
+
+    /// Generic handler for top-level Copilot slash commands.
+    /// Looks up the Discord command name in the dispatch table and runs copilot-rpc.js.
+    async fn handle_copilot_readonly(&self, ctx: &Context, cmd: &CommandInteraction) {
+        let Some(rpc_sub) = copilot_readonly_to_rpc(&cmd.data.name) else {
+            return;
+        };
+        let display_name = cmd.data.name.clone();
+
+        // Channel allowlist
+        let channel_id = cmd.channel_id.get();
+        let in_allowed_channel =
+            self.allowed_channels.is_empty() || self.allowed_channels.contains(&channel_id);
+        let in_thread = if !in_allowed_channel {
+            match cmd.channel_id.to_channel(&ctx.http).await {
+                Ok(serenity::model::channel::Channel::Guild(gc)) => gc
+                    .parent_id
+                    .is_some_and(|pid| self.allowed_channels.contains(&pid.get())),
+                _ => false,
+            }
+        } else {
+            false
+        };
+        if !in_allowed_channel && !in_thread {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⚠️ This channel is not allowlisted.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        }
+        if !self.allowed_users.is_empty() && !self.allowed_users.contains(&cmd.user.id.get()) {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("🚫 You are not authorized to use this command.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        }
+
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, cmd = %display_name, "failed to defer response");
+            return;
+        }
+
+        let script = &copilot_rpc_script_path();
+        let output = tokio::time::timeout(
+            std::time::Duration::from_secs(45),
+            tokio::process::Command::new("node")
+                .arg(script)
+                .arg(rpc_sub)
+                .output(),
+        )
+        .await;
+
+        let embed = match output {
+            Ok(Ok(out)) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let json_line = stdout
+                    .lines()
+                    .rev()
+                    .find(|l| l.trim().starts_with('{'))
+                    .unwrap_or("")
+                    .trim();
+                build_copilot_embed(&display_name, rpc_sub, json_line)
+            }
+            Ok(Ok(out)) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                CreateEmbed::new()
+                    .title(format!("⚠️ /{display_name}"))
+                    .description(format!(
+                        "exit {}: ```{}```",
+                        out.status,
+                        stderr.chars().take(500).collect::<String>()
+                    ))
+                    .color(0xED4245)
+            }
+            Ok(Err(e)) => CreateEmbed::new()
+                .title(format!("⚠️ /{display_name}"))
+                .description(format!("spawn failed: {e}"))
+                .color(0xED4245),
+            Err(_) => CreateEmbed::new()
+                .title(format!("⏱️ /{display_name}"))
+                .description("timeout after 45s")
+                .color(0xED4245),
+        };
+
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+            .await;
+    }
+
+    /// Handle /mode — set Copilot session mode via static choices.
+    async fn handle_copilot_mode(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        let mode_id = cmd
+            .data
+            .options
+            .first()
+            .and_then(|o| match &o.value {
+                CommandDataOptionValue::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .unwrap_or_default();
+
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, "failed to defer /mode");
+            return;
+        }
+
+        let embed = run_copilot_rpc_action("mode", "mode-set", &mode_id).await;
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+            .await;
+    }
+
+    /// Handle /reload <kind> — reload a Copilot config category via SDK RPC.
+    async fn handle_copilot_reload(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        let kind = cmd
+            .data
+            .options
+            .first()
+            .and_then(|o| match &o.value {
+                CommandDataOptionValue::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .unwrap_or_default();
+
+        let rpc_sub = COPILOT_RELOAD_KINDS
+            .iter()
+            .find(|(v, _, _)| *v == kind)
+            .map(|(_, rpc, _)| *rpc);
+
+        let Some(rpc_sub) = rpc_sub else {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content(format!("❌ Unknown reload kind: `{kind}`"))
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        };
+
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, "failed to defer /reload");
+            return;
+        }
+
+        // reload commands take no arg, but run_copilot_rpc_action expects one.
+        // Pass an empty string; copilot-rpc.js ignores args for reload subcommands.
+        let script = &copilot_rpc_script_path();
+        let output = tokio::time::timeout(
+            std::time::Duration::from_secs(45),
+            tokio::process::Command::new("node")
+                .arg(script)
+                .arg(rpc_sub)
+                .output(),
+        )
+        .await;
+
+        let embed = match output {
+            Ok(Ok(out)) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let json_line = stdout
+                    .lines()
+                    .rev()
+                    .find(|l| l.trim().starts_with('{'))
+                    .unwrap_or("")
+                    .trim();
+                let parsed: Result<serde_json::Value, _> = serde_json::from_str(json_line);
+                match parsed {
+                    Ok(v) if v.get("ok").and_then(|b| b.as_bool()) == Some(true) => {
+                        CreateEmbed::new()
+                            .title("✅ /reload")
+                            .description(format!("Reloaded: **{kind}**"))
+                            .color(0x2ECC71)
+                    }
+                    Ok(v) => CreateEmbed::new()
+                        .title("⚠️ /reload")
+                        .description(format!(
+                            "```{}```",
+                            v.get("error")
+                                .and_then(|s| s.as_str())
+                                .unwrap_or("unknown error")
+                        ))
+                        .color(0xED4245),
+                    Err(e) => CreateEmbed::new()
+                        .title("⚠️ /reload")
+                        .description(format!("invalid JSON: {e}"))
+                        .color(0xED4245),
+                }
+            }
+            Ok(Ok(out)) => CreateEmbed::new()
+                .title("⚠️ /reload")
+                .description(format!(
+                    "exit {}: ```{}```",
+                    out.status,
+                    String::from_utf8_lossy(&out.stderr)
+                        .chars()
+                        .take(400)
+                        .collect::<String>()
+                ))
+                .color(0xED4245),
+            Ok(Err(e)) => CreateEmbed::new()
+                .title("⚠️ /reload")
+                .description(format!("spawn failed: {e}"))
+                .color(0xED4245),
+            Err(_) => CreateEmbed::new()
+                .title("⏱️ /reload")
+                .description("timeout after 45s")
+                .color(0xED4245),
+        };
+
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+            .await;
+    }
+
+    /// Handle /compact and /new-session — drop the current thread's AcpConnection.
+    /// Both commands have the same effect (fresh session on next message) but
+    /// are presented with different wording to match user mental models.
+    async fn handle_reset_session(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+
+        let cmd_name = cmd.data.name.clone();
+        let thread_id = cmd.channel_id.get();
+        let thread_key = self.session_key_for_user(thread_id, cmd.user.id.get());
+
+        // For /compact: try the bridge's real LLM compaction first (preserves
+        // summarized context). Fall back to drop-session if the bridge doesn't
+        // support _meta/compactSession.
+        if cmd_name == "compact" {
+            if let Err(e) = cmd.defer(&ctx.http).await {
+                error!(error = %e, "failed to defer /compact");
+                return;
+            }
+            // Ensure a session exists before trying to compact
+            if let Err(e) = self
+                .ensure_session_for_user(thread_id, cmd.user.id.get())
+                .await
+            {
+                let _ = cmd
+                    .edit_response(
+                        &ctx.http,
+                        EditInteractionResponse::new()
+                            .content(format!("⚠️ Failed to start agent: {e}")),
+                    )
+                    .await;
+                return;
+            }
+
+            let compact_res = self
+                .pool
+                .with_connection(&thread_key, |conn| {
+                    Box::pin(async move { conn.session_compact().await })
+                })
+                .await;
+
+            let embed = match compact_res {
+                Ok(v) => {
+                    let removed = v
+                        .get("tokens_removed")
+                        .and_then(|n| n.as_u64())
+                        .map(|n| format!("{n} tokens freed"))
+                        .unwrap_or_else(|| "compacted".to_string());
+                    CreateEmbed::new()
+                        .title("✅ /compact")
+                        .description(format!("LLM-compacted conversation history — **{removed}**\n_Context preserved as summary._"))
+                        .color(0x2ECC71)
+                }
+                Err(e) => {
+                    // Fall back to drop-session
+                    let dropped = self.pool.drop_session(&thread_key).await;
+                    let note = if dropped {
+                        "Session dropped (history cleared)."
+                    } else {
+                        "No active session."
+                    };
+                    CreateEmbed::new()
+                        .title("ℹ️ /compact (fallback)")
+                        .description(format!("Bridge compaction unavailable: {e}\n\n{note}"))
+                        .color(0x5865F2)
+                }
+            };
+
+            let _ = cmd
+                .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+                .await;
+            return;
+        }
+
+        // /new-session: hard reset, drop the pool entry.
+        let dropped = self.pool.drop_session(&thread_key).await;
+
+        let (title, body, color) = if dropped {
+            (
+                format!("✅ /{cmd_name}"),
+                "Session reset — your next message in this thread will start a fresh agent session.".to_string(),
+                0x2ECC71,
+            )
+        } else {
+            (
+                format!("ℹ️ /{cmd_name}"),
+                "No active session to reset. Your next message will start fresh anyway."
+                    .to_string(),
+                0x5865F2,
+            )
+        };
+
+        let embed = CreateEmbed::new()
+            .title(title)
+            .description(body)
+            .color(color);
+        let _ = cmd
+            .create_response(
+                &ctx.http,
+                CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new().add_embed(embed),
+                ),
+            )
+            .await;
+    }
+
+    /// Handle /tokens — ask the bridge for current session token usage via `_meta/getUsage`.
+    /// Only works if the agent backend is the copilot-agent-acp bridge.
+    async fn handle_tokens_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, "failed to defer /tokens");
+            return;
+        }
+
+        let thread_id = cmd.channel_id.get();
+        let thread_key = self.session_key_for_user(thread_id, cmd.user.id.get());
+        // Ensure a session exists so the bridge has something to report on.
+        if let Err(e) = self
+            .ensure_session_for_user(thread_id, cmd.user.id.get())
+            .await
+        {
+            let _ = cmd
+                .edit_response(
+                    &ctx.http,
+                    EditInteractionResponse::new()
+                        .content(format!("⚠️ Failed to start agent: {e}")),
+                )
+                .await;
+            return;
+        }
+
+        let usage_result = self
+            .pool
+            .with_connection(&thread_key, |conn| {
+                Box::pin(async move { conn.session_get_usage().await })
+            })
+            .await;
+
+        let embed = match usage_result {
+            Ok(v) => render_session_tokens(&v),
+            Err(e) => CreateEmbed::new()
+                .title("⚠️ /tokens")
+                .description(format!(
+                    "This backend does not support `_meta/getUsage`.\n\nError: ```{e}```\n\n\
+                     To enable: change `config-copilot.toml` agent command to `copilot-agent-acp`."
+                ))
+                .color(0xED4245),
+        };
+
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+            .await;
+    }
+
+    /// Handle /permissions — show recent tool permission audit log.
+    async fn handle_permissions_command(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, "failed to defer /permissions");
+            return;
+        }
+
+        let thread_id = cmd.channel_id.get();
+        let thread_key = self.session_key_for_user(thread_id, cmd.user.id.get());
+        if let Err(e) = self
+            .ensure_session_for_user(thread_id, cmd.user.id.get())
+            .await
+        {
+            let _ = cmd
+                .edit_response(
+                    &ctx.http,
+                    EditInteractionResponse::new()
+                        .content(format!("⚠️ Failed to start agent: {e}")),
+                )
+                .await;
+            return;
+        }
+
+        let result = self
+            .pool
+            .with_connection(&thread_key, |conn| {
+                Box::pin(async move { conn.session_get_recent_permissions().await })
+            })
+            .await;
+
+        let embed = match result {
+            Ok(v) => render_permissions(&v),
+            Err(e) => CreateEmbed::new()
+                .title("⚠️ /permissions")
+                .description(format!(
+                    "Backend does not support `_meta/getRecentPermissions`.\n```{e}```"
+                ))
+                .color(0xED4245),
+        };
+
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+            .await;
+    }
+
+    /// Handle interactive commands: /agent, /skill-on, /skill-off, /mcp-on, /mcp-off, /ext-on, /ext-off.
+    async fn handle_copilot_interactive(&self, ctx: &Context, cmd: &CommandInteraction) {
+        if !self.copilot_guard_ok(ctx, cmd).await {
+            return;
+        }
+        let Some((_, action_rpc, _, _)) = copilot_interactive_spec(&cmd.data.name) else {
+            return;
+        };
+        let cmd_name = cmd.data.name.clone();
+        let name_arg = cmd
+            .data
+            .options
+            .first()
+            .and_then(|o| match &o.value {
+                CommandDataOptionValue::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .unwrap_or_default();
+
+        if name_arg.is_empty() {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⚠️ Missing name argument.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return;
+        }
+
+        if let Err(e) = cmd.defer(&ctx.http).await {
+            error!(error = %e, cmd = %cmd_name, "failed to defer interactive");
+            return;
+        }
+
+        let embed = run_copilot_rpc_action(&cmd_name, action_rpc, &name_arg).await;
+        let _ = cmd
+            .edit_response(&ctx.http, EditInteractionResponse::new().embed(embed))
+            .await;
+    }
+
+    /// Autocomplete handler for interactive commands: fetches the list RPC
+    /// and filters by the user's partial input. Falls back to empty on error.
+    async fn handle_copilot_interactive_autocomplete(
+        &self,
+        ctx: &Context,
+        ac: &CommandInteraction,
+    ) {
+        let Some((list_rpc, _, data_key, name_key)) = copilot_interactive_spec(&ac.data.name)
+        else {
+            return;
+        };
+
+        let partial = ac
+            .data
+            .options
+            .first()
+            .and_then(|o| match &o.value {
+                CommandDataOptionValue::Autocomplete { value, .. } => Some(value.as_str()),
+                CommandDataOptionValue::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .unwrap_or("")
+            .to_lowercase();
+
+        // Read from the background-refreshed list cache — instant, no Node
+        // subprocess spawn. The cache is populated by `refresh_copilot_list_cache`
+        // in main.rs every 5 minutes.
+        let _ = data_key;
+        let _ = name_key;
+        let mut choices: Vec<AutocompleteChoice> = Vec::new();
+        let cache = self.copilot_list_cache.read().await;
+        if let Some(names) = cache.get(list_rpc) {
+            for name in names {
+                if partial.is_empty() || name.to_lowercase().contains(&partial) {
+                    let label = name.chars().take(100).collect::<String>();
+                    choices.push(AutocompleteChoice::new(label.clone(), label));
+                    if choices.len() >= 25 {
+                        break;
+                    }
+                }
+            }
+        }
+        drop(cache);
+
+        let response = CreateInteractionResponse::Autocomplete(
+            CreateAutocompleteResponse::new().set_choices(choices),
+        );
+        if let Err(e) = ac.create_response(&ctx.http, response).await {
+            warn!(error = %e, "failed to send interactive autocomplete");
+        }
+    }
+
+    /// Shared allowlist guard for all Copilot slash commands.
+    /// Returns true if the interaction may proceed; sends an ephemeral error otherwise.
+    async fn copilot_guard_ok(&self, ctx: &Context, cmd: &CommandInteraction) -> bool {
+        let channel_id = cmd.channel_id.get();
+        let in_allowed_channel =
+            self.allowed_channels.is_empty() || self.allowed_channels.contains(&channel_id);
+        let in_thread = if !in_allowed_channel {
+            match cmd.channel_id.to_channel(&ctx.http).await {
+                Ok(serenity::model::channel::Channel::Guild(gc)) => gc
+                    .parent_id
+                    .is_some_and(|pid| self.allowed_channels.contains(&pid.get())),
+                _ => false,
+            }
+        } else {
+            false
+        };
+        if !in_allowed_channel && !in_thread {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("⚠️ This channel is not allowlisted.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return false;
+        }
+        if !self.allowed_users.is_empty() && !self.allowed_users.contains(&cmd.user.id.get()) {
+            let _ = cmd
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("🚫 You are not authorized to use this command.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await;
+            return false;
+        }
+        true
+    }
+}
+
+/// Run a copilot-rpc.js action that takes one argument, return a rendered embed.
+async fn run_copilot_rpc_action(display_name: &str, rpc_sub: &str, arg: &str) -> CreateEmbed {
+    let script = &copilot_rpc_script_path();
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(45),
+        tokio::process::Command::new("node")
+            .arg(script)
+            .arg(rpc_sub)
+            .arg(arg)
+            .output(),
+    )
+    .await;
+
+    match output {
+        Ok(Ok(out)) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let json_line = stdout
+                .lines()
+                .rev()
+                .find(|l| l.trim().starts_with('{'))
+                .unwrap_or("")
+                .trim();
+            let parsed: Result<serde_json::Value, _> = serde_json::from_str(json_line);
+            match parsed {
+                Ok(v) if v.get("ok").and_then(|b| b.as_bool()) == Some(true) => CreateEmbed::new()
+                    .title(format!("✅ /{display_name}"))
+                    .description(format!("Applied: `{arg}`"))
+                    .color(0x2ECC71),
+                Ok(v) => {
+                    let err = v
+                        .get("error")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("unknown error");
+                    CreateEmbed::new()
+                        .title(format!("⚠️ /{display_name}"))
+                        .description(format!("```{err}```"))
+                        .color(0xED4245)
+                }
+                Err(e) => CreateEmbed::new()
+                    .title(format!("⚠️ /{display_name}"))
+                    .description(format!("invalid JSON: {e}"))
+                    .color(0xED4245),
+            }
+        }
+        Ok(Ok(out)) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            CreateEmbed::new()
+                .title(format!("⚠️ /{display_name}"))
+                .description(format!(
+                    "exit {}: ```{}```",
+                    out.status,
+                    stderr.chars().take(400).collect::<String>()
+                ))
+                .color(0xED4245)
+        }
+        Ok(Err(e)) => CreateEmbed::new()
+            .title(format!("⚠️ /{display_name}"))
+            .description(format!("spawn failed: {e}"))
+            .color(0xED4245),
+        Err(_) => CreateEmbed::new()
+            .title(format!("⏱️ /{display_name}"))
+            .description("timeout after 45s")
+            .color(0xED4245),
+    }
+}
+
+/// Render an embed from the Node helper's JSON output.
+///
+/// `display_name` = the Discord command the user invoked (for error/title display)
+/// `rpc_sub` = the subcommand passed to copilot-rpc.js (determines renderer)
+fn build_copilot_embed(display_name: &str, rpc_sub: &str, json_line: &str) -> CreateEmbed {
+    let parsed: Result<serde_json::Value, _> = serde_json::from_str(json_line);
+    let v = match parsed {
+        Ok(v) => v,
+        Err(e) => {
+            return CreateEmbed::new()
+                .title(format!("⚠️ /{display_name}"))
+                .description(format!(
+                    "invalid JSON from helper: {e}\n\n```{}```",
+                    json_line.chars().take(300).collect::<String>()
+                ))
+                .color(0xED4245);
+        }
+    };
+
+    if v.get("ok").and_then(|b| b.as_bool()) != Some(true) {
+        let err = v.get("error").and_then(|s| s.as_str()).unwrap_or("unknown");
+        return CreateEmbed::new()
+            .title(format!("⚠️ /{display_name}"))
+            .description(format!("```{err}```"))
+            .color(0xED4245);
+    }
+
+    let data = v.get("data").cloned().unwrap_or(serde_json::Value::Null);
+    let title = format!("⚡ /{display_name}");
+
+    match rpc_sub {
+        "usage" => render_usage(&data),
+        "status" => render_status(&data),
+        "models" => render_list(&title, &data, "models", "id"),
+        "agents" => render_list(&title, &data, "agents", "name"),
+        "skills" => render_list(&title, &data, "skills", "name"),
+        "plugins" => render_list(&title, &data, "plugins", "name"),
+        "extensions" => render_list(&title, &data, "extensions", "name"),
+        "mcp-list" => render_list(&title, &data, "servers", "name"),
+        "files" => render_list(&title, &data, "files", "path"),
+        _ => {
+            let pretty =
+                serde_json::to_string_pretty(&data).unwrap_or_else(|_| format!("{data:?}"));
+            let body = pretty.chars().take(3800).collect::<String>();
+            CreateEmbed::new()
+                .title(title)
+                .description(format!("```json\n{body}\n```"))
+                .color(0x24292F)
+        }
+    }
+}
+
+/// Render session token usage from the bridge's `_meta/getUsage` response.
+/// Render the bridge's `_meta/getRecentPermissions` response as an embed.
+fn render_permissions(data: &serde_json::Value) -> CreateEmbed {
+    let perms = data.get("permissions").and_then(|v| v.as_array());
+    let count = data.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
+
+    let embed = CreateEmbed::new()
+        .title(format!("🔐 Recent Tool Permissions ({count})"))
+        .color(0x24292F);
+
+    let Some(arr) = perms else {
+        return embed.description("_(no audit data)_");
+    };
+
+    if arr.is_empty() {
+        return embed
+            .description("_(no permissions requested yet — send a message that triggers a tool)_");
+    }
+
+    // Show the most recent 10 entries (bridge stores 50, embed space is limited)
+    let lines: Vec<String> = arr
+        .iter()
+        .rev()
+        .take(10)
+        .enumerate()
+        .map(|(i, p)| {
+            let kind = p.get("kind").and_then(|v| v.as_str()).unwrap_or("?");
+            let cmd = p.get("command").and_then(|v| v.as_str()).unwrap_or("");
+            let intention = p.get("intention").and_then(|v| v.as_str()).unwrap_or("");
+            let ts = p.get("ts").and_then(|v| v.as_str()).unwrap_or("");
+            let cmd_short: String = cmd.chars().take(120).collect();
+            let intention_short: String = intention.chars().take(80).collect();
+            format!(
+                "`{:>2}.` [{kind}] `{}`{}\n    {}",
+                i + 1,
+                cmd_short,
+                if cmd.len() > 120 { "…" } else { "" },
+                if intention.is_empty() {
+                    format!("_{ts}_")
+                } else {
+                    format!("{intention_short} · _{ts}_")
+                }
+            )
+        })
+        .collect();
+
+    embed.description(lines.join("\n\n"))
+}
+
+fn render_session_tokens(data: &serde_json::Value) -> CreateEmbed {
+    let session_usage = data.get("session_usage");
+    let account_quota = data.get("account_quota");
+    let cost_totals = data.get("cost_totals");
+
+    let mut embed = CreateEmbed::new()
+        .title("🧮 Session Token Usage")
+        .color(0x24292F);
+
+    // Session-level token info
+    if let Some(su) = session_usage.filter(|v| !v.is_null()) {
+        let token_limit = su.get("tokenLimit").and_then(|v| v.as_u64()).unwrap_or(0);
+        let current = su
+            .get("currentTokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let system_t = su.get("systemTokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let conv_t = su
+            .get("conversationTokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let tools_t = su
+            .get("toolDefinitionsTokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let msgs = su
+            .get("messagesLength")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+
+        let pct = if token_limit > 0 {
+            (current as f64 / token_limit as f64 * 100.0).round() as i64
+        } else {
+            0
+        };
+        let bar = progress_bar(pct as u32);
+
+        let body = format!(
+            "{bar} `{pct}%`\n\
+             **Context:** {:.1}k / {:.0}k\n\
+             • System: {:.1}k\n\
+             • Tools defs: {:.1}k\n\
+             • Conversation: {:.1}k\n\
+             • Messages: {msgs}",
+            current as f64 / 1000.0,
+            token_limit as f64 / 1000.0,
+            system_t as f64 / 1000.0,
+            tools_t as f64 / 1000.0,
+            conv_t as f64 / 1000.0,
+        );
+        embed = embed.field("📊 Current thread", body, false);
+    } else {
+        embed = embed.field(
+            "📊 Current thread",
+            "_(no usage captured yet — send a message first)_",
+            false,
+        );
+    }
+
+    // Cost totals (if bridge has been tracking assistant.usage events)
+    if let Some(ct) = cost_totals.filter(|v| !v.is_null()) {
+        let turns = ct.get("turns").and_then(|v| v.as_u64()).unwrap_or(0);
+        let in_t = ct.get("inputTokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let out_t = ct.get("outputTokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let cache_r = ct
+            .get("cacheReadTokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let cost = ct.get("cost").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let model = ct.get("lastModel").and_then(|v| v.as_str()).unwrap_or("?");
+        let body = format!(
+            "**{turns}** turns · model: `{model}`\n\
+             Input: {:.1}k · Output: {:.1}k · Cached: {:.1}k\n\
+             💰 **{cost:.2}** premium requests",
+            in_t as f64 / 1000.0,
+            out_t as f64 / 1000.0,
+            cache_r as f64 / 1000.0,
+        );
+        embed = embed.field("💸 This session", body, false);
+    }
+
+    // Account-level quota (if included)
+    if let Some(aq) = account_quota.filter(|v| !v.is_null()) {
+        if let Some(premium) = aq.pointer("/quotaSnapshots/premium_interactions") {
+            let pct = premium
+                .get("remainingPercentage")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            let used = premium
+                .get("usedRequests")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let entitled = premium
+                .get("entitlementRequests")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let bar = progress_bar(pct as u32);
+            embed = embed.field(
+                "🔥 Premium monthly",
+                format!(
+                    "{bar} `{:>3}%`\n**{used}** / {entitled} used",
+                    pct.round() as i64
+                ),
+                false,
+            );
+        }
+    }
+
+    embed
+}
+
+fn render_usage(data: &serde_json::Value) -> CreateEmbed {
+    let snap = data.get("quotaSnapshots");
+    let mut embed = CreateEmbed::new()
+        .title("⚡ Copilot Usage Quota")
+        .color(0x24292F);
+
+    for key in ["premium_interactions", "chat", "completions"] {
+        if let Some(q) = snap.and_then(|s| s.get(key)) {
+            let pct = q
+                .get("remainingPercentage")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            let used = q.get("usedRequests").and_then(|v| v.as_u64()).unwrap_or(0);
+            let entitled = q
+                .get("entitlementRequests")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let reset = q.get("resetDate").and_then(|v| v.as_str()).unwrap_or("?");
+            let bar = progress_bar(pct as u32);
+            let pretty_key = match key {
+                "premium_interactions" => "🔥 Premium interactions",
+                "chat" => "💬 Chat",
+                "completions" => "✍️ Completions",
+                _ => key,
+            };
+            let body = format!(
+                "{bar} `{:>3}%`\nUsed: **{used}** / {entitled}\nResets: {reset}",
+                pct.round() as i64
+            );
+            embed = embed.field(pretty_key, body, false);
+        }
+    }
+    embed
+}
+
+fn render_status(data: &serde_json::Value) -> CreateEmbed {
+    let cli_ver = data
+        .pointer("/cli/version")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?");
+    let proto_ver = data
+        .pointer("/cli/protocolVersion")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let auth_user = data
+        .pointer("/auth/login")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?");
+    let auth_type = data
+        .pointer("/auth/authType")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?");
+    let auth_ok = data
+        .pointer("/auth/isAuthenticated")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let model_count = data
+        .pointer("/model_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    CreateEmbed::new()
+        .title("⚡ Copilot Status")
+        .color(0x24292F)
+        .field("CLI", format!("v{cli_ver} (protocol {proto_ver})"), true)
+        .field(
+            "Auth",
+            if auth_ok {
+                format!("✅ {auth_user} ({auth_type})")
+            } else {
+                "❌ not authenticated".into()
+            },
+            true,
+        )
+        .field("Models", format!("{model_count} available"), true)
+}
+
+fn render_list(
+    title: &str,
+    data: &serde_json::Value,
+    array_key: &str,
+    name_key: &str,
+) -> CreateEmbed {
+    let arr = data.get(array_key).and_then(|v| v.as_array());
+    let count = arr.map(|a| a.len()).unwrap_or(0);
+    let items: Vec<String> = arr
+        .map(|a| {
+            a.iter()
+                .take(25)
+                .enumerate()
+                .map(|(i, item)| {
+                    let name = item.get(name_key).and_then(|v| v.as_str()).unwrap_or("?");
+                    format!("`{:>2}.` {name}", i + 1)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let body = if items.is_empty() {
+        "_(empty)_".to_string()
+    } else {
+        let mut s = items.join("\n");
+        if count > items.len() {
+            s.push_str(&format!("\n… and {} more", count - items.len()));
+        }
+        s
+    };
+    CreateEmbed::new()
+        .title(format!("{title} ({count})"))
+        .description(body)
+        .color(0x24292F)
+}
+
+fn progress_bar(pct: u32) -> String {
+    let pct = pct.min(100);
+    let filled = ((pct as f64 / 10.0).round() as usize).min(10);
+    let empty = 10 - filled;
+    format!("{}{}", "█".repeat(filled), "░".repeat(empty))
+}
+
+/// Compose an embed from usage runner results. Each runner becomes one field.
+fn build_usage_embed(results: &[crate::usage::RunnerResult]) -> CreateEmbed {
+    let mut embed = CreateEmbed::new()
+        .title("📊 Agent Usage Report")
+        .color(0x5865F2);
+
+    if results.is_empty() {
+        embed = embed.description("_(no runners)_");
+        return embed;
+    }
+
+    // Pick the first successful runner's color for the embed bar
+    if let Some(crate::usage::RunnerResult::Ok { color, .. }) = results
+        .iter()
+        .find(|r| matches!(r, crate::usage::RunnerResult::Ok { .. }))
+    {
+        embed = embed.color(*color);
+    }
+
+    for r in results {
+        match r {
+            crate::usage::RunnerResult::Ok {
+                label, rendered, ..
+            } => {
+                let body = rendered.trim();
+                let body = if body.is_empty() { "_(empty)_" } else { body };
+                embed = embed.field(label, body, false);
+            }
+            crate::usage::RunnerResult::Err { label, reason, .. } => {
+                embed = embed.field(label, format!("⚠️ {reason}"), false);
+            }
+        }
+    }
+
+    embed
 }
 
 /// Check if an attachment is an audio file (voice messages are typically audio/ogg).
@@ -585,6 +3867,117 @@ async fn edit(
     .await
 }
 
+/// Replace aggregate session summary with per-model breakdown from cost-totals files.
+/// Looks for pattern "Input: Xk · Output: Yk" and appends per-model lines.
+/// Replace Copilot CLI's aggregate session summary with per-model breakdown.
+/// Replaces both the "N turns · model: X" line and the "Input: Xk · Output: Yk" line.
+fn enrich_session_summary_with_per_model(content: String) -> String {
+    // Match the aggregate token line
+    static RE_AGGREGATE: LazyLock<regex::Regex> = LazyLock::new(|| {
+        regex::Regex::new(r"(?m)(\d+)\s+turns?\s*·\s*model:\s*\S+\n\s*Input:\s*[\d.]+k\s*·\s*Output:\s*[\d.]+k(?:\s*·\s*Cached:\s*[\d.]+k)?").unwrap()
+    });
+
+    if !RE_AGGREGATE.is_match(&content) {
+        return content;
+    }
+
+    // Read the most recent cost-totals file
+    let dir = std::path::PathBuf::from(
+        std::env::var("APPDATA")
+            .unwrap_or_else(|_| "C:/Users/Administrator/AppData/Roaming".into()),
+    )
+    .join("openab");
+
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return content;
+    };
+    let mut best: Option<(std::path::PathBuf, std::time::SystemTime)> = None;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with("cost-totals-") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(mtime) = meta.modified() {
+                if best.as_ref().is_none_or(|(_, t)| mtime > *t) {
+                    best = Some((entry.path(), mtime));
+                }
+            }
+        }
+    }
+
+    let Some((path, mtime)) = best else {
+        return content;
+    };
+    if mtime.elapsed().map_or(true, |d| d.as_secs() > 86400) {
+        return content;
+    }
+
+    let Ok(data) = std::fs::read_to_string(&path) else {
+        return content;
+    };
+    let Ok(json): Result<serde_json::Value, _> = serde_json::from_str(&data) else {
+        return content;
+    };
+
+    let Some(per_model) = json.get("perModel").and_then(|v| v.as_object()) else {
+        return content;
+    };
+    if per_model.len() <= 1 {
+        return content; // Only one model — aggregate is already correct
+    }
+
+    // Build per-model lines, sorted by turns (descending)
+    let mut entries: Vec<_> = per_model.iter().collect();
+    entries.sort_by(|a, b| {
+        let ta = b.1.get("turns").and_then(|v| v.as_u64()).unwrap_or(0);
+        let tb = a.1.get("turns").and_then(|v| v.as_u64()).unwrap_or(0);
+        ta.cmp(&tb)
+    });
+
+    let total_turns: u64 = entries
+        .iter()
+        .map(|(_, s)| s.get("turns").and_then(|v| v.as_u64()).unwrap_or(0))
+        .sum();
+
+    let mut lines = Vec::new();
+    for (model, stats) in &entries {
+        let turns = stats.get("turns").and_then(|v| v.as_u64()).unwrap_or(0);
+        let input = stats
+            .get("inputTokens")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0)
+            / 1000.0;
+        let output = stats
+            .get("outputTokens")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0)
+            / 1000.0;
+        let cached = stats
+            .get("cacheReadTokens")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0)
+            / 1000.0;
+        let mut parts = vec![format!("{input:.1}k in"), format!("{output:.1}k out")];
+        if cached > 0.0 {
+            parts.push(format!("{cached:.1}k cached"));
+        }
+        lines.push(format!(
+            "{turns} turns **{model}** ({}) ",
+            parts.join(" · ")
+        ));
+    }
+
+    let replacement = format!(
+        "{total_turns} turns · {} models\n{}",
+        entries.len(),
+        lines.join("\n")
+    );
+    RE_AGGREGATE
+        .replace(&content, replacement.as_str())
+        .to_string()
+}
+
 async fn stream_prompt(
     pool: &SessionPool,
     thread_key: &str,
@@ -604,7 +3997,7 @@ async fn stream_prompt(
             let reset = conn.session_reset;
             conn.session_reset = false;
 
-            let (mut rx, _): (_, _) = conn.session_prompt(content_blocks).await?;
+            let (mut rx, request_id): (_, _) = conn.session_prompt(content_blocks).await?;
             reactions.set_thinking().await;
 
             let initial = if reset {
@@ -662,7 +4055,7 @@ async fn stream_prompt(
             let mut got_first_text = false;
             let mut response_error: Option<String> = None;
             while let Some(notification) = rx.recv().await {
-                if notification.id.is_some() {
+                if notification.id == Some(request_id) {
                     // Capture error from ACP response to display in Discord
                     if let Some(ref err) = notification.error {
                         response_error = Some(format_coded_error(err.code, &err.message));
@@ -742,8 +4135,18 @@ async fn stream_prompt(
             drop(buf_tx);
             let _ = edit_handle.await;
 
-            // Final edit
+            // Final edit — sanitize known Copilot CLI quota display bugs
             let final_content = compose_display(&tool_lines, &text_buf);
+            // Copilot Pro API returns entitlementRequests=1 (placeholder), making CLI show "X / 1 used".
+            // Copilot Pro API returns entitlementRequests=1 (placeholder, real quota ~300/mo).
+            // Strip the misleading "/1" denominator but keep the used count.
+            static RE_QUOTA: LazyLock<regex::Regex> =
+                LazyLock::new(|| regex::Regex::new(r"(\d+)\s*/\s*1\s+used").unwrap());
+            let final_content = RE_QUOTA
+                .replace_all(&final_content, "$1 premium reqs used")
+                .to_string();
+            // Replace aggregate "Input: Xk · Output: Yk" with per-model breakdown if available
+            let final_content = enrich_session_summary_with_per_model(final_content);
             // If ACP returned both an error and partial text, show both.
             // This can happen when the agent started producing content before hitting an error
             // (e.g. context length limit, rate limit mid-stream). Showing both gives users

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -16,18 +16,25 @@ pub fn format_user_error(message: &str) -> String {
         if let Some(start) = msg_lower.find("timeout waiting for ") {
             let rest = &message[start + "timeout waiting for ".len()..];
             let method = rest.split_whitespace().next().unwrap_or("request");
-            return format!("**Request Timeout**\nTimeout waiting for {}, please try again.", method);
+            return format!(
+                "**Request Timeout**\nTimeout waiting for {}, please try again.",
+                method
+            );
         }
-        return "**Request Timeout**\nTimeout waiting for a response, please try again.".to_string();
+        return "**Request Timeout**\nTimeout waiting for a response, please try again."
+            .to_string();
     }
     if msg_lower.contains("connection closed") || msg_lower.contains("channel closed") {
-        return "**Connection Lost**\nThe connection to the agent was lost, please try again.".to_string();
+        return "**Connection Lost**\nThe connection to the agent was lost, please try again."
+            .to_string();
     }
     if msg_lower.contains("failed to spawn") || msg_lower.contains("no such file") {
-        return "**Agent Not Found**\nCould not start the agent — please check your configuration.".to_string();
+        return "**Agent Not Found**\nCould not start the agent — please check your configuration."
+            .to_string();
     }
     if msg_lower.contains("pool exhausted") {
-        return "**Service Busy**\nAll agent sessions are in use, please try again shortly.".to_string();
+        return "**Service Busy**\nAll agent sessions are in use, please try again shortly."
+            .to_string();
     }
     if msg_lower.contains("invalid api key") || msg_lower.contains("unauthorized") {
         return "**Unauthorized**\nPlease check your API key configuration.".to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,9 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let cmd = Cli::parse().command.unwrap_or(Commands::Run { config: None });
+    let cmd = Cli::parse()
+        .command
+        .unwrap_or(Commands::Run { config: None });
 
     match cmd {
         Commands::Setup { output } => {
@@ -101,6 +103,7 @@ async fn main() -> anyhow::Result<()> {
                 stt_config: cfg.stt.clone(),
                 allow_bot_messages: cfg.discord.allow_bot_messages,
                 trusted_bot_ids,
+                mcp_profiles_dir: cfg.mcp_profiles_dir.clone(),
             };
 
             let intents = GatewayIntents::GUILD_MESSAGES
@@ -153,7 +156,9 @@ fn parse_id_set(raw: &[String], label: &str) -> anyhow::Result<HashSet<u64>> {
         })
         .collect();
     if !raw.is_empty() && set.is_empty() {
-        anyhow::bail!("all {label} entries failed to parse — refusing to start with an empty allowlist");
+        anyhow::bail!(
+            "all {label} entries failed to parse — refusing to start with an empty allowlist"
+        );
     }
     Ok(set)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod format;
 mod reactions;
 mod setup;
 mod stt;
+mod usage;
 
 use clap::Parser;
 use serenity::prelude::*;
@@ -71,6 +72,8 @@ async fn main() -> anyhow::Result<()> {
                 "config loaded"
             );
 
+            let backend =
+                discord::BackendType::from_agent_config(&cfg.agent.command, &cfg.agent.args);
             let pool = Arc::new(acp::SessionPool::new(cfg.agent, cfg.pool.max_sessions));
             let ttl_secs = cfg.pool.session_ttl_hours * 3600;
 
@@ -95,14 +98,24 @@ async fn main() -> anyhow::Result<()> {
                 info!(model = %cfg.stt.model, base_url = %cfg.stt.base_url, "STT enabled");
             }
 
+            let reaction_config = cfg.reactions;
+            let emoji_presets = reaction_config.presets.clone();
             let handler = discord::Handler {
                 pool: pool.clone(),
                 allowed_channels,
                 allowed_users,
-                reactions_config: cfg.reactions,
+                reactions_config: Arc::new(tokio::sync::RwLock::new(reaction_config)),
+                emoji_presets,
+                usage_config: cfg.usage,
+                cusage_config: cfg.cusage,
+                backend,
+                copilot_list_cache: Arc::new(tokio::sync::RwLock::new(
+                    std::collections::HashMap::new(),
+                )),
                 stt_config: cfg.stt.clone(),
                 allow_bot_messages: cfg.discord.allow_bot_messages,
                 trusted_bot_ids,
+                soul_file: cfg.soul_file,
                 mcp_profiles_dir: cfg.mcp_profiles_dir.clone(),
             };
 

--- a/src/reactions.rs
+++ b/src/reactions.rs
@@ -7,7 +7,13 @@ use tokio::sync::Mutex;
 use tokio::time::Duration;
 
 const CODING_TOKENS: &[&str] = &["exec", "process", "read", "write", "edit", "bash", "shell"];
-const WEB_TOKENS: &[&str] = &["web_search", "web_fetch", "web-search", "web-fetch", "browser"];
+const WEB_TOKENS: &[&str] = &[
+    "web_search",
+    "web_fetch",
+    "web-search",
+    "web-fetch",
+    "browser",
+];
 
 fn classify_tool<'a>(name: &str, emojis: &'a ReactionEmojis) -> &'a str {
     let n = name.to_lowercase();
@@ -65,19 +71,25 @@ impl StatusReactionController {
     }
 
     pub async fn set_queued(&self) {
-        if !self.enabled { return; }
+        if !self.enabled {
+            return;
+        }
         let emoji = { self.inner.lock().await.emojis.queued.clone() };
         self.apply_immediate(&emoji).await;
     }
 
     pub async fn set_thinking(&self) {
-        if !self.enabled { return; }
+        if !self.enabled {
+            return;
+        }
         let emoji = { self.inner.lock().await.emojis.thinking.clone() };
         self.schedule_debounced(&emoji).await;
     }
 
     pub async fn set_tool(&self, tool_name: &str) {
-        if !self.enabled { return; }
+        if !self.enabled {
+            return;
+        }
         let emoji = {
             let inner = self.inner.lock().await;
             classify_tool(tool_name, &inner.emojis).to_string()
@@ -86,7 +98,9 @@ impl StatusReactionController {
     }
 
     pub async fn set_done(&self) {
-        if !self.enabled { return; }
+        if !self.enabled {
+            return;
+        }
         let emoji = { self.inner.lock().await.emojis.done.clone() };
         self.finish(&emoji).await;
         // Add a random mood face
@@ -97,13 +111,17 @@ impl StatusReactionController {
     }
 
     pub async fn set_error(&self) {
-        if !self.enabled { return; }
+        if !self.enabled {
+            return;
+        }
         let emoji = { self.inner.lock().await.emojis.error.clone() };
         self.finish(&emoji).await;
     }
 
     pub async fn clear(&self) {
-        if !self.enabled { return; }
+        if !self.enabled {
+            return;
+        }
         let mut inner = self.inner.lock().await;
         cancel_timers(&mut inner);
         let current = inner.current.clone();
@@ -148,7 +166,9 @@ impl StatusReactionController {
         inner.debounce_handle = Some(tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(debounce_ms)).await;
             let mut inner = ctrl.lock().await;
-            if inner.finished { return; }
+            if inner.finished {
+                return;
+            }
             let old = inner.current.clone();
             inner.current = emoji.clone();
             let http = inner.http.clone();
@@ -166,7 +186,9 @@ impl StatusReactionController {
 
     async fn finish(&self, emoji: &str) {
         let mut inner = self.inner.lock().await;
-        if inner.finished { return; }
+        if inner.finished {
+            return;
+        }
         inner.finished = true;
         cancel_timers(&mut inner);
 
@@ -190,8 +212,12 @@ impl StatusReactionController {
     }
 
     fn reset_stall_timers_inner(&self, inner: &mut Inner) {
-        if let Some(h) = inner.stall_soft_handle.take() { h.abort(); }
-        if let Some(h) = inner.stall_hard_handle.take() { h.abort(); }
+        if let Some(h) = inner.stall_soft_handle.take() {
+            h.abort();
+        }
+        if let Some(h) = inner.stall_hard_handle.take() {
+            h.abort();
+        }
 
         let soft_ms = inner.timing.stall_soft_ms;
         let hard_ms = inner.timing.stall_hard_ms;
@@ -202,7 +228,9 @@ impl StatusReactionController {
             async move {
                 tokio::time::sleep(Duration::from_millis(soft_ms)).await;
                 let mut inner = ctrl.lock().await;
-                if inner.finished { return; }
+                if inner.finished {
+                    return;
+                }
                 let old = inner.current.clone();
                 inner.current = "🥱".to_string();
                 let http = inner.http.clone();
@@ -219,7 +247,9 @@ impl StatusReactionController {
         inner.stall_hard_handle = Some(tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(hard_ms)).await;
             let mut inner = ctrl.lock().await;
-            if inner.finished { return; }
+            if inner.finished {
+                return;
+            }
             let old = inner.current.clone();
             inner.current = "😨".to_string();
             let http = inner.http.clone();
@@ -235,21 +265,39 @@ impl StatusReactionController {
 }
 
 fn cancel_debounce(inner: &mut Inner) {
-    if let Some(h) = inner.debounce_handle.take() { h.abort(); }
+    if let Some(h) = inner.debounce_handle.take() {
+        h.abort();
+    }
 }
 
 fn cancel_timers(inner: &mut Inner) {
-    if let Some(h) = inner.debounce_handle.take() { h.abort(); }
-    if let Some(h) = inner.stall_soft_handle.take() { h.abort(); }
-    if let Some(h) = inner.stall_hard_handle.take() { h.abort(); }
+    if let Some(h) = inner.debounce_handle.take() {
+        h.abort();
+    }
+    if let Some(h) = inner.stall_soft_handle.take() {
+        h.abort();
+    }
+    if let Some(h) = inner.stall_hard_handle.take() {
+        h.abort();
+    }
 }
 
-async fn add_reaction(http: &Http, ch: ChannelId, msg: MessageId, emoji: &str) -> serenity::Result<()> {
+async fn add_reaction(
+    http: &Http,
+    ch: ChannelId,
+    msg: MessageId,
+    emoji: &str,
+) -> serenity::Result<()> {
     let reaction = ReactionType::Unicode(emoji.to_string());
     http.create_reaction(ch, msg, &reaction).await
 }
 
-async fn remove_reaction(http: &Http, ch: ChannelId, msg: MessageId, emoji: &str) -> serenity::Result<()> {
+async fn remove_reaction(
+    http: &Http,
+    ch: ChannelId,
+    msg: MessageId,
+    emoji: &str,
+) -> serenity::Result<()> {
     let reaction = ReactionType::Unicode(emoji.to_string());
     http.delete_reaction_me(ch, msg, &reaction).await
 }

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -85,10 +85,7 @@ pub fn generate_config(
         },
         agent: {
             let (command, args): (&str, Vec<String>) = match agent_command {
-                "kiro" => (
-                    "kiro-cli",
-                    vec!["acp".into(), "--trust-all-tools".into()],
-                ),
+                "kiro" => ("kiro-cli", vec!["acp".into(), "--trust-all-tools".into()]),
                 "claude" => ("claude-agent-acp", vec![]),
                 "codex" => ("codex-acp", vec![]),
                 "gemini" => ("gemini", vec!["--acp".into()]),
@@ -152,14 +149,7 @@ mod tests {
 
     #[test]
     fn test_generate_config_kiro_working_dir() {
-        let config = generate_config(
-            "tok",
-            "kiro",
-            vec!["ch".to_string()],
-            "/home/agent",
-            10,
-            24,
-        );
+        let config = generate_config("tok", "kiro", vec!["ch".to_string()], "/home/agent", 10, 24);
         assert!(config.contains(r#"working_dir = "/home/agent""#));
         assert!(config.contains("acp"));
         assert!(config.contains("--trust-all-tools"));

--- a/src/setup/validate.rs
+++ b/src/setup/validate.rs
@@ -5,10 +5,15 @@ pub fn validate_bot_token(token: &str) -> anyhow::Result<()> {
     if token.is_empty() {
         anyhow::bail!("Token cannot be empty");
     }
-    if !token
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '_' || c == '/' || c == '*' || c == '=')
-    {
+    if !token.chars().all(|c| {
+        c.is_ascii_alphanumeric()
+            || c == '-'
+            || c == '.'
+            || c == '_'
+            || c == '/'
+            || c == '*'
+            || c == '='
+    }) {
         anyhow::bail!(
             "Token must only contain ASCII letters, numbers, dash, period, underscore, slash, or equals"
         );

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -154,7 +154,11 @@ fn print_box(lines: &[&str]) {
         .unwrap_or(60);
     let width = width.clamp(60, 76);
     println!();
-    cprintln!(C.cyan, "{}", "╔".to_string() + &BORDER.to_string().repeat(width + 2) + "╗");
+    cprintln!(
+        C.cyan,
+        "{}",
+        "╔".to_string() + &BORDER.to_string().repeat(width + 2) + "╗"
+    );
     for line in lines {
         let padded = format!(" {:<width$} ", format!("{}", line), width = width);
         print!("{}", C.cyan);
@@ -163,7 +167,11 @@ fn print_box(lines: &[&str]) {
         print!("{}", C.cyan);
         println!("║");
     }
-    cprintln!(C.cyan, "{}", "╚".to_string() + &BORDER.to_string().repeat(width + 2) + "╝");
+    cprintln!(
+        C.cyan,
+        "{}",
+        "╚".to_string() + &BORDER.to_string().repeat(width + 2) + "╝"
+    );
     println!();
 }
 
@@ -299,10 +307,7 @@ fn section_channels(client: &DiscordClient) -> anyhow::Result<Vec<String>> {
     println!();
 
     if guilds.is_empty() {
-        cprintln!(
-            C.yellow,
-            "  No servers found. Enter channel IDs manually."
-        );
+        cprintln!(C.yellow, "  No servers found. Enter channel IDs manually.");
         let input = prompt("  Channel ID(s), comma-separated");
         let ids: Vec<String> = input
             .split(',')
@@ -342,21 +347,11 @@ fn section_channels(client: &DiscordClient) -> anyhow::Result<Vec<String>> {
         return Ok(ids);
     }
 
-    let channel_names: Vec<String> = channels
-        .iter()
-        .map(|(_, n, _)| format!("#{}", n))
-        .collect();
-    let channel_names_refs: Vec<&str> = channel_names
-        .iter()
-        .map(|s| s.as_str())
-        .collect();
+    let channel_names: Vec<String> = channels.iter().map(|(_, n, _)| format!("#{}", n)).collect();
+    let channel_names_refs: Vec<&str> = channel_names.iter().map(|s| s.as_str()).collect();
 
-    let selected =
-        prompt_checklist("  Select channels (by number):", &channel_names_refs);
-    let selected_ids: Vec<String> = selected
-        .iter()
-        .map(|&i| channels[i].0.clone())
-        .collect();
+    let selected = prompt_checklist("  Select channels (by number):", &channel_names_refs);
+    let selected_ids: Vec<String> = selected.iter().map(|&i| channels[i].0.clone()).collect();
 
     println!();
     cprintln!(C.green, "  Selected {} channel(s)", selected_ids.len());
@@ -408,12 +403,7 @@ fn section_agent() -> (String, String, bool) {
 
     let working_dir = prompt_default("  Working directory", default_dir);
 
-    cprintln!(
-        C.green,
-        "  Agent: {} | Working dir: {}",
-        agent,
-        working_dir
-    );
+    cprintln!(C.green, "  Agent: {} | Working dir: {}", agent, working_dir);
     println!();
 
     (agent.to_string(), working_dir, is_local)
@@ -428,9 +418,7 @@ fn section_pool() -> (usize, u64) {
     cprintln!(C.bold, "--- Step 4: Session Pool ---");
     println!();
 
-    let max_sessions: usize = prompt_default("  Max sessions", "10")
-        .parse()
-        .unwrap_or(10);
+    let max_sessions: usize = prompt_default("  Max sessions", "10").parse().unwrap_or(10);
     let ttl_hours: u64 = prompt_default("  Session TTL (hours)", "24")
         .parse()
         .unwrap_or(24);
@@ -457,9 +445,7 @@ fn section_preview_and_save(config_content: &str, output_path: &PathBuf) -> anyh
     println!("{}", mask_bot_token(config_content));
     println!();
 
-    if output_path.exists()
-        && !prompt_yes_no("  File exists. Overwrite?", false)
-    {
+    if output_path.exists() && !prompt_yes_no("  File exists. Overwrite?", false) {
         println!("  Saving cancelled.");
         return Ok(());
     }
@@ -517,7 +503,10 @@ fn print_next_steps(agent: &str, output_path: &Path, is_local: bool) {
     if is_local {
         match agent {
             "kiro" => {
-                cprintln!(C.cyan, "  1. Install kiro-cli (see https://kiro.dev for installer)");
+                cprintln!(
+                    C.cyan,
+                    "  1. Install kiro-cli (see https://kiro.dev for installer)"
+                );
                 cprintln!(C.cyan, "  2. Authenticate:");
                 println!("       kiro-cli login --use-device-flow");
             }
@@ -536,7 +525,10 @@ fn print_next_steps(agent: &str, output_path: &Path, is_local: bool) {
             "gemini" => {
                 cprintln!(C.cyan, "  1. Install Gemini CLI:");
                 println!("       npm install -g @google/gemini-cli");
-                cprintln!(C.cyan, "  2. Authenticate via Google OAuth, or set GEMINI_API_KEY in config.toml");
+                cprintln!(
+                    C.cyan,
+                    "  2. Authenticate via Google OAuth, or set GEMINI_API_KEY in config.toml"
+                );
             }
             _ => {}
         }
@@ -552,22 +544,28 @@ fn print_next_steps(agent: &str, output_path: &Path, is_local: bool) {
         println!();
         cprintln!(C.cyan, "  1. Deploy with Helm (or your preferred method):");
         println!("       helm install openab openab/openab \\");
-        println!("         --set agents.{}.discord.botToken=\"$BOT_TOKEN\"", agent);
+        println!(
+            "         --set agents.{}.discord.botToken=\"$BOT_TOKEN\"",
+            agent
+        );
         println!();
-        cprintln!(C.cyan, "  2. Authenticate inside the pod (first time only):");
+        cprintln!(
+            C.cyan,
+            "  2. Authenticate inside the pod (first time only):"
+        );
         match agent {
             "kiro" => println!(
                 "       kubectl exec -it deployment/openab-kiro -- kiro-cli login --use-device-flow"
             ),
-            "claude" => println!(
-                "       kubectl exec -it deployment/openab-claude -- claude setup-token"
-            ),
+            "claude" => {
+                println!("       kubectl exec -it deployment/openab-claude -- claude setup-token")
+            }
             "codex" => println!(
                 "       kubectl exec -it deployment/openab-codex -- codex login --device-auth"
             ),
-            "gemini" => println!(
-                "       Set GEMINI_API_KEY via secret, or exec into the pod for OAuth"
-            ),
+            "gemini" => {
+                println!("       Set GEMINI_API_KEY via secret, or exec into the pod for OAuth")
+            }
             _ => {}
         }
         println!();
@@ -605,10 +603,7 @@ pub fn run_setup(output_path: Option<PathBuf>) -> anyhow::Result<()> {
     println!();
     let bot_token = prompt_password("  Bot Token (or press Enter to skip)");
     if bot_token.is_empty() {
-        cprintln!(
-            C.yellow,
-            "  Skipped. Set bot_token manually in config.toml"
-        );
+        cprintln!(C.yellow, "  Skipped. Set bot_token manually in config.toml");
         println!();
         cprintln!(
             C.green,
@@ -632,11 +627,7 @@ pub fn run_setup(output_path: Option<PathBuf>) -> anyhow::Result<()> {
             vec![]
         }
         Err(e) => {
-            cprintln!(
-                C.yellow,
-                "  Channel fetch failed: {}. Enter manually.",
-                e
-            );
+            cprintln!(C.yellow, "  Channel fetch failed: {}. Enter manually.", e);
             let input = prompt("  Channel ID(s), comma-separated");
             let ids: Vec<String> = input
                 .split(',')

--- a/src/stt.rs
+++ b/src/stt.rs
@@ -10,7 +10,10 @@ pub async fn transcribe(
     filename: String,
     mime_type: &str,
 ) -> Option<String> {
-    let url = format!("{}/audio/transcriptions", cfg.base_url.trim_end_matches('/'));
+    let url = format!(
+        "{}/audio/transcriptions",
+        cfg.base_url.trim_end_matches('/')
+    );
 
     let file_part = multipart::Part::bytes(audio_bytes)
         .file_name(filename)

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,0 +1,200 @@
+//! Pluggable usage/quota reporting framework.
+//!
+//! Each runner is an external command that outputs a single line of JSON.
+//! OpenAB runs them in parallel, parses the JSON, renders it through a
+//! template string, and returns a list of results for `/usage` to display.
+//!
+//! Runners are fully user-defined in `config.toml` — OpenAB ships no
+//! hardcoded backends. See `docs/usage-command-howto.md` for examples.
+
+use crate::config::{UsageConfig, UsageRunnerConfig};
+use serde_json::Value;
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+/// Per-runner result.
+#[derive(Debug, Clone)]
+pub enum RunnerResult {
+    Ok {
+        #[allow(dead_code)]
+        name: String,
+        label: String,
+        color: u32,
+        rendered: String,
+    },
+    Err {
+        #[allow(dead_code)]
+        name: String,
+        label: String,
+        reason: String,
+    },
+}
+
+/// Execute all configured runners and collect results.
+pub async fn run_all(config: &UsageConfig) -> Vec<RunnerResult> {
+    let timeout = config.timeout_secs;
+    let mut results = Vec::with_capacity(config.runners.len());
+    for runner in &config.runners {
+        results.push(run_one(runner, timeout).await);
+    }
+    results
+}
+
+async fn run_one(runner: &UsageRunnerConfig, timeout_secs: u64) -> RunnerResult {
+    debug!(name = %runner.name, cmd = %runner.command, "running usage runner");
+
+    let exec = async {
+        let mut cmd = Command::new(&runner.command);
+        cmd.args(&runner.args);
+        for (k, v) in &runner.env {
+            cmd.env(k, v);
+        }
+        if let Some(cwd) = &runner.working_dir {
+            cmd.current_dir(cwd);
+        }
+        cmd.output().await
+    };
+
+    let out = match tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), exec).await {
+        Ok(Ok(out)) => out,
+        Ok(Err(e)) => return err(runner, format!("spawn failed: {e}")),
+        Err(_) => return err(runner, format!("timeout after {timeout_secs}s")),
+    };
+
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let exit = out
+            .status
+            .code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "signal".into());
+        let reason = format!(
+            "exit {exit}: {}",
+            stderr.trim().chars().take(200).collect::<String>(),
+        );
+        return err(runner, reason);
+    }
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let first_line = stdout.lines().next().unwrap_or("").trim();
+    if first_line.is_empty() {
+        return err(runner, "runner produced no output".into());
+    }
+
+    let json: Value = match serde_json::from_str(first_line) {
+        Ok(v) => v,
+        Err(e) => {
+            return err(
+                runner,
+                format!(
+                    "invalid JSON: {e} (got: {})",
+                    first_line.chars().take(120).collect::<String>(),
+                ),
+            );
+        }
+    };
+
+    // Check ok field if present (optional contract)
+    if let Some(false) = json.get("ok").and_then(|v| v.as_bool()) {
+        let reason = json
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("runner reported failure")
+            .to_string();
+        return err(runner, reason);
+    }
+
+    let rendered = render_template(&runner.template, &json, &runner.progress_fields);
+
+    RunnerResult::Ok {
+        name: runner.name.clone(),
+        label: runner.label.clone(),
+        color: runner.color,
+        rendered,
+    }
+}
+
+/// Simple `{{ field }}` substitution. Zero new deps (no Tera/Handlebars).
+///
+/// Fields listed in `progress_fields` get prefixed with a 10-char unicode
+/// progress bar if their value is numeric.
+fn render_template(tpl: &str, data: &Value, progress_fields: &[String]) -> String {
+    let mut out = tpl.to_string();
+
+    let Some(obj) = data.as_object() else {
+        return out;
+    };
+
+    for (k, v) in obj {
+        let placeholder = format!("{{{{ {k} }}}}");
+        let value_str = match v {
+            Value::String(s) => s.clone(),
+            Value::Number(n) => n.to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::Null => "null".to_string(),
+            _ => v.to_string(),
+        };
+
+        let replacement = if progress_fields.iter().any(|f| f == k) {
+            if let Some(pct) = v.as_f64() {
+                format!("{} `{:>3}%`", progress_bar(pct), pct.round() as i64)
+            } else {
+                value_str
+            }
+        } else {
+            value_str
+        };
+
+        out = out.replace(&placeholder, &replacement);
+    }
+
+    out
+}
+
+fn progress_bar(pct: f64) -> String {
+    let pct = pct.clamp(0.0, 100.0);
+    let filled = (pct / 10.0).round() as usize;
+    let filled = filled.min(10);
+    let empty = 10 - filled;
+    format!("{}{}", "█".repeat(filled), "░".repeat(empty))
+}
+
+fn err(runner: &UsageRunnerConfig, reason: String) -> RunnerResult {
+    warn!(runner = %runner.name, reason = %reason, "usage runner failed");
+    RunnerResult::Err {
+        name: runner.name.clone(),
+        label: runner.label.clone(),
+        reason,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_progress_bar_50pct() {
+        assert_eq!(progress_bar(50.0), "█████░░░░░");
+    }
+
+    #[test]
+    fn test_progress_bar_clamped() {
+        assert_eq!(progress_bar(150.0), "██████████");
+        assert_eq!(progress_bar(-10.0), "░░░░░░░░░░");
+    }
+
+    #[test]
+    fn test_render_simple() {
+        let data: Value = serde_json::from_str(r#"{"pct": 42, "name": "test"}"#).unwrap();
+        let out = render_template("value={{ pct }}% name={{ name }}", &data, &[]);
+        assert_eq!(out, "value=42% name=test");
+    }
+
+    #[test]
+    fn test_render_with_progress() {
+        let data: Value = serde_json::from_str(r#"{"pct": 30}"#).unwrap();
+        let out = render_template("{{ pct }}", &data, &["pct".into()]);
+        assert!(out.contains("███░░░░░░░"));
+        assert!(out.contains("30%"));
+    }
+}


### PR DESCRIPTION
## What problem does this solve?

Users can manage MCP servers via Discord slash commands such as `/mcp-add`, `/mcp-remove`, and `/mcp-list`, but those profile entries are never injected into ACP sessions. The profile JSON is written, but the backend session still starts without `mcpServers`, so `/mcp-add` is a dead-end UI.

This change closes the loop from Discord MCP profile management to runtime MCP activation.

## At a Glance

```text
Discord user
  |
  | /mcp-add mempalace http://...
  v
profile JSON: data/mcp-profiles/{bot}/{user_id}.json
  |
  v
message / slash command
  |
  v
discord.rs -> mcp_servers_for_user(user_id)
  |
  v
pool.get_or_create(thread, mcp_servers)
  |
  v
connection.session_new/session_load(..., mcp_servers)
  |
  v
ACP JSON-RPC session/new | session/load
  { cwd, mcpServers: [{ name, type, url, headers }] }
  |
  v
Claude / Copilot / Gemini / Codex session loads MCP tools
```

## Prior Art

**OpenClaw**

OpenClaw merges MCP config from bundle defaults plus global config and injects it at session/runtime creation. For CLI backends it relies on backend-specific config/CLI arg injection such as `--mcp-config`, not ACP `session/new`.

Relevant difference:
- Scope is global, not per user.
- Injection is backend-specific.
- Good reference for runtime lifecycle and config invalidation, but not for Discord multi-user isolation.

**Hermes Agent**

Hermes supports `mcp_servers` on ACP session creation, but tools are registered into a process-wide registry rather than isolated per Discord user/session.

Relevant difference:
- Uses ACP-style injection similar to this PR.
- Registry is global, so one user's MCP setup can affect others.
- Better fit for ACP transport shape, weaker fit for Discord multi-user isolation.

## Comparison

| Aspect | OpenClaw | Hermes Agent | OpenAB in this PR |
|---|---|---|---|
| MCP config scope | Global | Global/process-wide | Per-user per-bot |
| Injection point | Config merge + CLI args | ACP session params | ACP session params |
| User isolation | No | No | Yes |
| Management surface | Chat / CLI | CLI | Discord slash commands |
| Activation timing | Runtime/config reload | Session/runtime | Next session / `/new-session` |

## Proposed Solution

1. Add `McpServerEntry` and `read_mcp_profile()` in `src/config.rs` to read `{mcp_profiles_dir}/{user_id}.json`.
2. Extend `session_new()` / `session_load()` in `src/acp/connection.rs` to accept `mcp_servers` and send them through ACP.
3. Extend `SessionPool::get_or_create()` in `src/acp/pool.rs` to thread `mcp_servers` into new or resumed sessions.
4. In `src/discord.rs`, resolve the calling user's MCP profile and inject it into message handling and session-creating slash commands.
5. Keep diagnostic commands on `&[]` so health/status flows do not depend on user MCP state.

Profile JSON stays in the existing Discord-managed format:

```json
{
  "discord_user_id": "844236700611379200",
  "mcpServers": {
    "mempalace": {
      "type": "http",
      "url": "http://127.0.0.1:18793/mcp",
      "headers": []
    }
  },
  "enabled": true
}
```

Converted at runtime to ACP format:

```json
[
  {
    "name": "mempalace",
    "type": "http",
    "url": "http://127.0.0.1:18793/mcp",
    "headers": []
  }
]
```

## Why this approach?

- ACP-native: all target backends accept `mcpServers` on session creation.
- Per-user isolation: MCP config is keyed by Discord user ID, not global process state.
- Per-bot isolation: each bot keeps its own `mcp_profiles_dir`.
- Graceful fallback: missing or invalid profile returns an empty list.
- No backend-specific config mutation: avoids touching `~/.claude*`, Copilot config files, or other local machine state.

## Alternatives Considered

1. Backend-specific config file mutation.
   Rejected because it is fragile, backend-specific, and risks overwriting user-managed config.

2. Global singleton MCP registry.
   Rejected because OpenAB is a shared Discord bot process and would leak one user's MCP tools into another user's sessions.

3. In-session hot reload.
   Deferred because the current ACP/session model is simpler and the UX is already covered by “next session” plus `/new-session`.

## Validation

Current branch validation:

- [x] `cargo check`
- [x] `cargo build --release`
- [x] `cargo test` (`42 passed, 0 failed`)
- [x] `cargo fmt --check`
- [x] Branch diff excludes personal `bat` / local profile / runtime script files

Previously validated during the implementation session:

- [x] Claude ACP E2E: profile -> `session/new(mcpServers)` -> tool discovery -> `mempalace_search`
- [x] Backend format verification for Claude / Copilot / Gemini / Codex
- [x] `/mcp-add` UX updated to note that changes apply on next session and `/new-session` can apply immediately

## Notes

This PR branch also includes a small follow-up cleanup to remove dead-code warnings in the model picker path so the branch stays warning-free during review.
