### PR TITLE
ci: add Docker smoke test with ACP handshake validation

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,57 @@
+name: Docker Smoke Test
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile*'
+      - 'src/**'
+      - 'Cargo.*'
+
+jobs:
+  smoke-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - { dockerfile: Dockerfile, suffix: "", agent: "kiro-cli", agent_args: "acp --trust-all-tools" }
+          - { dockerfile: Dockerfile.claude, suffix: "-claude", agent: "claude-agent-acp", agent_args: "" }
+          - { dockerfile: Dockerfile.codex, suffix: "-codex", agent: "codex-acp", agent_args: "" }
+          - { dockerfile: Dockerfile.gemini, suffix: "-gemini", agent: "gemini", agent_args: "--acp" }
+          - { dockerfile: Dockerfile.copilot, suffix: "-copilot", agent: "copilot", agent_args: "--acp" }
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build image
+        run: docker build -t openab-test${{ matrix.variant.suffix }} -f ${{ matrix.variant.dockerfile }} .
+
+      - name: Verify openab CMD does not crash
+        run: |
+          OUTPUT=$(docker run --rm openab-test${{ matrix.variant.suffix }} 2>&1 || true)
+          if echo "$OUTPUT" | grep -q "unrecognized subcommand"; then
+            echo "❌ CMD regression: $OUTPUT"
+            exit 1
+          fi
+          echo "✅ openab CMD ok"
+
+      - name: Verify agent CLI exists
+        run: docker run --rm --entrypoint which openab-test${{ matrix.variant.suffix }} ${{ matrix.variant.agent }}
+
+      - name: ACP initialize handshake
+        run: |
+          INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{},"clientInfo":{"name":"ci-test","version":"0.0.1"}}}'
+
+          RESPONSE=$(echo "$INIT" | timeout 30 docker run --rm -i \
+            --entrypoint ${{ matrix.variant.agent }} \
+            openab-test${{ matrix.variant.suffix }} \
+            ${{ matrix.variant.agent_args }} 2>/dev/null | head -1)
+
+          echo "Response: $RESPONSE"
+
+          if ! echo "$RESPONSE" | jq -e '.result.agentInfo.name' > /dev/null 2>&1; then
+            echo "❌ ACP initialize failed — no agentInfo in response"
+            exit 1
+          fi
+
+          AGENT_NAME=$(echo "$RESPONSE" | jq -r '.result.agentInfo.name')
+          echo "✅ ACP handshake ok — agent=$AGENT_NAME"


### PR DESCRIPTION
Closes #347

Adds a CI workflow that runs on PRs touching Dockerfiles or source code. Tests 3 layers for each of the 5 image variants:

1. **openab CMD regression check** — runs container with default CMD, asserts no `unrecognized subcommand` error (would have caught #334)
2. **Agent CLI exists** — `which <agent>` verifies the binary is in PATH (would have caught the `github-copilot` vs `copilot` naming issue)
3. **ACP initialize handshake** — sends a real JSON-RPC `initialize` request over stdio and validates the response contains `agentInfo`. No API keys needed — `initialize` is unauthenticated.

Test matrix: kiro, claude, codex, gemini, copilot