### PR TITLE
fix: exempt bot-authored PRs from Discord discussion URL check

### DIFF
--- a/.github/workflows/pr-discussion-check.yml
+++ b/.github/workflows/pr-discussion-check.yml
@@ -24,6 +24,18 @@ jobs:
             const marker = '<!-- openab-pr-discussion-check -->';
             const label = 'closing-soon';
 
+            // Exempt bot-authored PRs (e.g. openab-app release PRs)
+            if (pr.user.type === 'Bot') {
+              console.log(`Skipping discussion check for bot PR by ${pr.user.login}`);
+              if (old) {
+                await github.rest.issues.deleteComment({ ...context.repo, comment_id: old.id });
+              }
+              if (labels.includes(label)) {
+                try { await github.rest.issues.removeLabel({ ...context.repo, issue_number: pr.number, name: label }); } catch (e) { if (e.status !== 404) throw e; }
+              }
+              return;
+            }
+
             const hasDiscordUrl = /https:\/\/discord\.com\/channels\/\d+\/\d+/.test(body);
 
             const comments = await github.rest.issues.listComments({


### PR DESCRIPTION
Closes the issue where `openab-app` release PRs (e.g. #346) get flagged by the Discord Discussion URL check and labeled `closing-soon`.

## Problem

The `pr-discussion-check.yml` workflow requires every PR to include a Discord discussion URL. Bot-authored release PRs (created by `openab-app[bot]`) don't have one and shouldn't need one — they're automated version bumps.

PR #346 (`release: v0.7.5-beta.1`) was flagged and will be auto-closed in 3 days by `close-stale-prs.yml`.

## Fix

Skip the check when `pr.user.type === 'Bot'`. Also cleans up any existing warning comment and `closing-soon` label if the workflow re-runs on a bot PR.

Discord Discussion URL: https://discord.com/channels/1352702813/1493128598654029996