### PR TITLE
fix(docker): add procps to all Dockerfiles for HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps unzip && rm -rf /var/lib/apt/lists/*
 
 # Install kiro-cli (auto-detect arch, copy binary directly)
 ARG KIRO_CLI_VERSION=2.0.0

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
 
 # Install claude-agent-acp adapter and Claude Code CLI
 ARG CLAUDE_CODE_VERSION=2.1.104

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
 ARG CODEX_VERSION=0.120.0

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
 ARG COPILOT_VERSION=1.0.25

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
 ARG GEMINI_CLI_VERSION=0.37.2


### PR DESCRIPTION
## Problem

All five Dockerfiles use `pgrep -x openab` in their `HEALTHCHECK`, but `procps` (which provides `pgrep`) is not included in the `node:22-bookworm-slim` base image. This means health checks have been silently failing across all container variants.

## Solution

Add `procps` to the existing `apt-get install` line in the runtime stage of every Dockerfile.

## Files Changed

- `Dockerfile`
- `Dockerfile.claude`
- `Dockerfile.codex`
- `Dockerfile.copilot`
- `Dockerfile.gemini`

Minimal, focused fix — only addresses the missing `pgrep` dependency.