### PR TITLE
feat: add RFC issue template and improve issue-check workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,0 +1,10 @@
+name: RFC
+description: Propose a design or architectural change
+labels: [rfc, needs-triage]
+body:
+  - type: textarea
+    attributes:
+      label: Proposal
+      description: Describe your proposal freely
+    validations:
+      required: true

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -29,6 +29,9 @@ jobs:
               guidance: ['Question']
             };
 
+            // RFC is free-form — skip check entirely
+            if (labels.includes('rfc')) return;
+
             const type = Object.keys(rules).find(k => labels.includes(k));
 
             // Find old check comment
@@ -42,7 +45,7 @@ jobs:
               // No template label — skip if already flagged
               if (old && labels.includes('incomplete')) return;
 
-              const msg = `${marker}\n⚠️ Could not detect an issue template. Please make sure this issue was created using one of the available templates and that the corresponding label (\`bug\`, \`feature\`, \`documentation\`, \`guidance\`) is present.\n\nAvailable templates: Bug Report, Feature Request, Documentation, Guidance`;
+              const msg = `${marker}\nThanks for the report! It looks like this issue was created without a template and is missing some required fields. Please add one of the following labels: \`bug\`, \`feature\`, \`documentation\`, or \`guidance\`, then edit this issue to include the matching template fields — the \`incomplete\` label will be removed automatically.`;
 
               if (old) {
                 await github.rest.issues.deleteComment({


### PR DESCRIPTION
## Description

This PR adds an RFC issue template for proposing design or architectural changes, and improves the issue-check workflow with better messaging and RFC support.

Currently, contributors who want to propose larger changes don't have a dedicated template. Additionally, the no-template warning message is unclear and doesn't guide users on how to fix the issue.

## Changes

### Issue Templates
* **rfc.yml**: New minimal RFC template with a single free-form `Proposal` field — no structured format required

### GitHub Action
* **issue-check.yml**:
  * Skip completeness check entirely for issues with `rfc` label (free-form by design)
  * Update no-template warning to a friendlier, actionable message that tells users to add the appropriate label and edit the issue to match the template fields — instead of the previous unclear error message

### Before vs After (no-template message)

**Before:**
> ⚠️ Could not detect an issue template. Please make sure this issue was created using one of the available templates and that the corresponding label (`bug`, `feature`, `documentation`, `guidance`) is present.

**After:**
> Thanks for the report! It looks like this issue was created without a template and is missing some required fields. Please add one of the following labels: `bug`, `feature`, `documentation`, or `guidance`, then edit this issue to include the matching template fields — the `incomplete` label will be removed automatically.