### PR TITLE
docs: warn that agentsMd ConfigMap shadows PVC files

### DIFF
--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -47,6 +47,8 @@ agents:
     #     enabled: true
     #     storageClass: ""
     #     size: 1Gi
+    #   # ⚠️ When set, this ConfigMap mount shadows any file at the same path on the PVC.
+    #   # The PVC file is NOT deleted but becomes invisible to the agent. Remove agentsMd to restore.
     #   agentsMd: ""
     #   resources: {}
     #   nodeSelector: {}
@@ -77,6 +79,8 @@ agents:
     #     enabled: true
     #     storageClass: ""
     #     size: 1Gi
+    #   # ⚠️ When set, this ConfigMap mount shadows any file at the same path on the PVC.
+    #   # The PVC file is NOT deleted but becomes invisible to the agent. Remove agentsMd to restore.
     #   agentsMd: ""
     #   resources: {}
     #   image: "ghcr.io/openabdev/openab-opencode:latest"
@@ -115,6 +119,8 @@ agents:
       enabled: true
       storageClass: ""
       size: 1Gi  # defaults to 1Gi if not set
+    # ⚠️ When set, this ConfigMap mount shadows any file at the same path on the PVC.
+    # The PVC file is NOT deleted but becomes invisible to the agent. Remove agentsMd to restore.
     agentsMd: ""
     resources: {}
     nodeSelector: {}

--- a/docs/openab-upgrade-sop.md
+++ b/docs/openab-upgrade-sop.md
@@ -48,6 +48,8 @@
 
 > ⚠️ **Data loss warning:** `helm uninstall` **deletes the PVC** and all persistent data (steering files, auth database, agent config) unless the chart has an explicit resource policy annotation. Always use `helm rollback` instead of uninstall + reinstall. If you need to uninstall, back up the PVC data first.
 
+> ⚠️ **`agentsMd` shadows PVC files:** When `agentsMd` is set in Helm values, the resulting ConfigMap volumeMount shadows any existing file at the same path on the PVC (e.g. `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`). The PVC file is not deleted but becomes invisible to the agent. Remove `agentsMd` from your values to restore PVC files. See [#360](https://github.com/openabdev/openab/issues/360).
+
 ---
 
 ## Upgrade Process Overview


### PR DESCRIPTION
## Summary

When `agentsMd` is set in Helm values, the ConfigMap volumeMount shadows any existing file at the same path on the PVC (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`). The PVC file is not deleted but becomes invisible to the agent. No warning was documented.

## Changes

- **`charts/openab/values.yaml`** — Added ⚠️ warning comments next to all 3 `agentsMd` fields (claude preset, opencode preset, default preset) explaining the shadow behavior
- **`docs/openab-upgrade-sop.md`** — Added `agentsMd` shadow warning in the PVC warnings section, alongside the existing data loss warning

## Context

This is standard Kubernetes volumeMount behavior — when a ConfigMap is mounted at a path, it shadows whatever is on the underlying volume at that path. Since `agentsMd` defaults to `""`, this only affects users who explicitly set it. Removing `agentsMd` restores the PVC files.

Introduced by #240. Fixes #360.