### PR TITLE
fix: resolve mentions instead of stripping all (#363)

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -791,8 +791,11 @@ fn compose_display(tool_lines: &[ToolEntry], text: &str, streaming: bool) -> Str
     out
 }
 
-static MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r"<@[!&]?\d+>").unwrap()
+static ROLE_MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"<@&\d+>").unwrap()
+});
+static USER_MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"<@!?\d+>").unwrap()
 });
 
 fn resolve_mentions(content: &str, bot_id: UserId, mentions: &[User]) -> String {
@@ -811,8 +814,9 @@ fn resolve_mentions(content: &str, bot_id: UserId, mentions: &[User]) -> String 
             .replace(&format!("<@{}>", user.id), &display)
             .replace(&format!("<@!{}>", user.id), &display);
     }
-    // 3. Fallback: replace any remaining unresolved mentions (including role mentions)
-    let out = MENTION_RE.replace_all(&out, "@unknown").to_string();
+    // 3. Fallback: replace any remaining unresolved mentions
+    let out = ROLE_MENTION_RE.replace_all(&out, "@(role)");
+    let out = USER_MENTION_RE.replace_all(&out, "@(user)").to_string();
     out.trim().to_string()
 }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -791,17 +791,28 @@ fn compose_display(tool_lines: &[ToolEntry], text: &str, streaming: bool) -> Str
     out
 }
 
+static MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"<@[!&]?\d+>").unwrap()
+});
+
 fn resolve_mentions(content: &str, bot_id: UserId, mentions: &[User]) -> String {
-    let bot_re = regex::Regex::new(&format!(r"<@!?{}>", bot_id)).unwrap();
-    let mut out = bot_re.replace_all(content, "").to_string();
+    // 1. Strip the bot's own trigger mention
+    let mut out = content
+        .replace(&format!("<@{}>", bot_id), "")
+        .replace(&format!("<@!{}>", bot_id), "");
+    // 2. Resolve known user mentions to @DisplayName
     for user in mentions {
         if user.id == bot_id {
             continue;
         }
         let label = user.global_name.as_deref().unwrap_or(&user.name);
-        let re = regex::Regex::new(&format!(r"<@!?{}>", user.id)).unwrap();
-        out = re.replace_all(&out, format!("@{}", label)).to_string();
+        let display = format!("@{}", label);
+        out = out
+            .replace(&format!("<@{}>", user.id), &display)
+            .replace(&format!("<@!{}>", user.id), &display);
     }
+    // 3. Fallback: replace any remaining unresolved mentions (including role mentions)
+    let out = MENTION_RE.replace_all(&out, "@unknown").to_string();
     out.trim().to_string()
 }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -11,7 +11,8 @@ use std::sync::LazyLock;
 use serenity::async_trait;
 use serenity::model::channel::{Message, ReactionType};
 use serenity::model::gateway::Ready;
-use serenity::model::id::{ChannelId, MessageId};
+use serenity::model::id::{ChannelId, MessageId, UserId};
+use serenity::model::user::User;
 use serenity::prelude::*;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -167,7 +168,7 @@ impl EventHandler for Handler {
         }
 
         let prompt = if is_mentioned {
-            strip_mention(&msg.content)
+            resolve_mentions(&msg.content, bot_id, &msg.mentions)
         } else {
             msg.content.trim().to_string()
         };
@@ -790,12 +791,18 @@ fn compose_display(tool_lines: &[ToolEntry], text: &str, streaming: bool) -> Str
     out
 }
 
-static MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r"<@[!&]?\d+>").unwrap()
-});
-
-fn strip_mention(content: &str) -> String {
-    MENTION_RE.replace_all(content, "").trim().to_string()
+fn resolve_mentions(content: &str, bot_id: UserId, mentions: &[User]) -> String {
+    let bot_re = regex::Regex::new(&format!(r"<@!?{}>", bot_id)).unwrap();
+    let mut out = bot_re.replace_all(content, "").to_string();
+    for user in mentions {
+        if user.id == bot_id {
+            continue;
+        }
+        let label = user.global_name.as_deref().unwrap_or(&user.name);
+        let re = regex::Regex::new(&format!(r"<@!?{}>", user.id)).unwrap();
+        out = re.replace_all(&out, format!("@{}", label)).to_string();
+    }
+    out.trim().to_string()
 }
 
 fn shorten_thread_name(prompt: &str) -> String {


### PR DESCRIPTION
## Summary

Fixes #363.

`strip_mention` used a blanket regex (`<@[!&]?\d+>`) that removed **all** Discord mention tokens from the prompt — including references to other bots/users. This broke bot-to-bot collaboration introduced in v0.7.4.

## Changes

Replace `strip_mention` with `resolve_mentions(content, bot_id, mentions)`:

1. **Strip only the bot's own trigger mention** — `<@BOT_ID>` is removed
2. **Resolve all other `<@ID>` to `@DisplayName`** — using `msg.mentions` from serenity

### Before
```
"<@超渡ID> you can see <@普渡ID> right?"
  → strip_mention → "you can see  right?"   ❌ @普渡法師 erased
```

### After
```
"<@超渡ID> you can see <@普渡ID> right?"
  → resolve_mentions → "you can see @普渡法師 right?"   ✅
```

## Approach

Follows the same pattern as [OpenClaw's `resolveDiscordMentions`](https://github.com/openclaw/openclaw/blob/main/src/discord/monitor/message-utils.ts) — **never strip, always resolve**.

https://discord.com/channels/1491295327620169908/1494031440482926706