### PR TITLE
fix(opencode): add missing NOTES.txt and RELEASING.md updates

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -140,13 +140,14 @@ release-pr.yml 在 Release PR 中自動更新以下檔案的版本：
 
 ## Image Variants
 
-每次 build 產出 4 個 multi-arch image (linux/amd64 + linux/arm64)：
+每次 build 產出 5 個 multi-arch image (linux/amd64 + linux/arm64)：
 
 ```
 ghcr.io/openabdev/openab          # default (kiro-cli)
 ghcr.io/openabdev/openab-codex    # codex
 ghcr.io/openabdev/openab-claude   # claude
 ghcr.io/openabdev/openab-gemini   # gemini
+ghcr.io/openabdev/openab-opencode # opencode
 ```
 
 Image tags 依 release 類型不同：

--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -24,6 +24,9 @@ Agents deployed:
 {{- else if eq $cfg.command "gemini" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- gemini
+{{- else if eq $cfg.command "opencode" }}
+    Authenticate:
+    kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- opencode auth login
 {{- end }}
 
     Restart after auth:


### PR DESCRIPTION
## Summary

PR #258 (feat: add OpenCode as ACP agent backend) was merged without updating two files that other agent PRs (e.g. Cursor #301) correctly include:

### Changes

- **`charts/openab/templates/NOTES.txt`** — added `opencode auth login` branch in the agent auth instructions (matching the pattern for kiro, claude, gemini, etc.)
- **`RELEASING.md`** — bumped image variant count from 4 → 5 and added `ghcr.io/openabdev/openab-opencode` to the list

### Reference
- Issue: #367
- PR that introduced OpenCode: #258
- Cursor PR used as reference for the pattern: #301

Closes #367