### PR TITLE
fix(docker): use ARG for opencode version + bump to 1.4.6

### DIFF
--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -26,7 +26,8 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
 
 # Install opencode
-RUN npm install -g opencode-ai@1.4.3 --retry 3
+ARG OPENCODE_VERSION=1.4.6
+RUN npm install -g opencode-ai@${OPENCODE_VERSION} --retry 3
 
 # Install gh CLI (matches Dockerfile.claude / Dockerfile.gemini / Dockerfile.codex)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
Mirrors the `ARG CURSOR_VERSION` pattern from PR #301.

- Introduces `ARG OPENCODE_VERSION=1.4.6` so version can be overridden at build time without editing the Dockerfile
- Bumps `1.4.3` → `1.4.6` (latest on npm as of 2026-04-15)

```bash
# override at build time
docker build --build-arg OPENCODE_VERSION=1.4.7 -f Dockerfile.opencode .
```