### PR TITLE
fix: strip @(role) and @(user) placeholders in shorten_thread_name()

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -821,9 +821,11 @@ fn resolve_mentions(content: &str, bot_id: UserId, mentions: &[User]) -> String 
 }
 
 fn shorten_thread_name(prompt: &str) -> String {
+    // Strip @(role) and @(user) placeholders left by resolve_mentions()
+    let cleaned = prompt.replace("@(role)", "").replace("@(user)", "");
     // Shorten GitHub URLs: https://github.com/owner/repo/issues/123 → owner/repo#123
     let re = regex::Regex::new(r"https?://github\.com/([^/]+/[^/]+)/(issues|pull)/(\d+)").unwrap();
-    let shortened = re.replace_all(prompt, "$1#$3");
+    let shortened = re.replace_all(cleaned.trim(), "$1#$3");
     let name: String = shortened.chars().take(40).collect();
     if name.len() < shortened.len() {
         format!("{name}...")


### PR DESCRIPTION
## Problem

Thread titles leak literal `@(role)` / `@(user)` placeholders from `resolve_mentions()`.

Example: `@(role) HIHI intro yourself` instead of `HIHI intro yourself`.

## Fix

Strip `@(role)` and `@(user)` in `shorten_thread_name()` before shortening, then `.trim()` to clean up leading/trailing whitespace.

Fixes #372