### PR TITLE
docs: warn that agentsMd shadows PVC files at the same path

### DIFF
--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -47,7 +47,7 @@ agents:
     #     enabled: true
     #     storageClass: ""
     #     size: 1Gi
-    #   agentsMd: ""
+    #   agentsMd: ""  # when set, shadows any existing file at the same path on the PVC
     #   resources: {}
     #   nodeSelector: {}
     #   tolerations: []
@@ -77,7 +77,7 @@ agents:
     #     enabled: true
     #     storageClass: ""
     #     size: 1Gi
-    #   agentsMd: ""
+    #   agentsMd: ""  # when set, shadows any existing file at the same path on the PVC
     #   resources: {}
     #   image: "ghcr.io/openabdev/openab-opencode:latest"
     image: ""
@@ -115,6 +115,9 @@ agents:
       enabled: true
       storageClass: ""
       size: 1Gi  # defaults to 1Gi if not set
+    # agentsMd: when set, the ConfigMap volumeMount takes precedence over any existing file
+    # at the same path on the PVC (e.g. AGENTS.md, CLAUDE.md, GEMINI.md). The PVC file is
+    # not deleted but becomes invisible to the agent. Remove agentsMd to restore PVC files.
     agentsMd: ""
     resources: {}
     nodeSelector: {}

--- a/docs/openab-upgrade-sop.md
+++ b/docs/openab-upgrade-sop.md
@@ -264,6 +264,12 @@ Pay special attention to:
 - Added or deprecated environment variables
 - Any migration steps
 
+> ⚠️ **`agentsMd` takes precedence over PVC files:** If you have `agentsMd` set in your Helm
+> values, the ConfigMap volumeMount will shadow any existing file at the same path on the PVC
+> (e.g. `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`). The PVC file is not deleted but becomes
+> invisible to the agent. If you rely on PVC-managed agent instruction files, either leave
+> `agentsMd` empty or migrate its content to the PVC file before upgrading.
+
 ### 3. Check Node Resources
 
 ```bash


### PR DESCRIPTION
## Summary

Fixes #360

When `agentsMd` is set in Helm values, the ConfigMap volumeMount silently shadows any existing file at the same path on the PVC (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, etc.). The PVC file is not deleted but becomes invisible to the agent. This is standard Kubernetes behaviour but there was no documentation warning about it.

## Changes

### `charts/openab/values.yaml`
Added an inline comment next to `agentsMd` in the active agent block and both commented-out example blocks explaining the shadowing behaviour and how to restore PVC files.

### `docs/openab-upgrade-sop.md`
Added a callout under "Pay special attention to" in Section I (Read the Release Notes) so operators are reminded to check their `agentsMd` setting before upgrading.

## No code changes
This is a documentation-only fix. No logic, templates, or chart behaviour was modified.