### PR TITLE
feat(helm): add pod extensibility controls

### DIFF
--- a/charts/openab/templates/_helpers.tpl
+++ b/charts/openab/templates/_helpers.tpl
@@ -71,9 +71,17 @@ app.kubernetes.io/component: {{ .agent }}
 {{- end }}
 {{- end }}
 
-{{/* Resolve serviceAccountName: per-agent only, empty by default (uses namespace default SA) */}}
+{{/*
+Resolve serviceAccountName:
+- If serviceAccount.create is true: use serviceAccount.name or fallback to <agentFullname>
+- Else: use serviceAccountName (for referencing externally-created SAs), or empty (namespace default)
+*/}}
 {{- define "openab.agentServiceAccountName" -}}
-{{- default "" .cfg.serviceAccountName }}
+{{- if (.cfg.serviceAccount).create -}}
+{{- default (include "openab.agentFullname" .) .cfg.serviceAccount.name -}}
+{{- else -}}
+{{- default "" .cfg.serviceAccountName -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/openab/templates/_helpers.tpl
+++ b/charts/openab/templates/_helpers.tpl
@@ -113,3 +113,8 @@ duplicate YAML keys AND break Deployment→Pod selector matching.
 {{- define "openab.persistenceEnabled" -}}
 {{- if and . .persistence (eq (.persistence.enabled | toString) "false") }}false{{ else }}true{{ end }}
 {{- end }}
+
+{{/* Discord adapter enabled: default true unless explicitly set to false; returns false when discord config is absent */}}
+{{- define "openab.discordEnabled" -}}
+{{- if and . .discord (ne (.discord.enabled | toString) "false") }}true{{ else }}false{{ end }}
+{{- end }}

--- a/charts/openab/templates/_helpers.tpl
+++ b/charts/openab/templates/_helpers.tpl
@@ -63,7 +63,11 @@ app.kubernetes.io/component: {{ .agent }}
 {{- $pullSecrets = .cfg.imagePullSecrets -}}
 {{- end }}
 {{- range $pullSecrets }}
+{{- if kindIs "map" . }}
+- name: {{ .name | quote }}
+{{- else }}
 - name: {{ . | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -92,11 +96,7 @@ labels merged last so users cannot hijack them. Hijacking would produce
 duplicate YAML keys AND break Deployment→Pod selector matching.
 */}}
 {{- define "openab.agentPodLabels" -}}
-{{- $reserved := dict
-    "app.kubernetes.io/name" (include "openab.name" .ctx)
-    "app.kubernetes.io/instance" .ctx.Release.Name
-    "app.kubernetes.io/component" .agent
--}}
+{{- $reserved := include "openab.selectorLabels" . | fromYaml -}}
 {{- $labels := mergeOverwrite (dict)
     (.ctx.Values.podLabels | default (dict))
     (.cfg.podLabels | default (dict))

--- a/charts/openab/templates/_helpers.tpl
+++ b/charts/openab/templates/_helpers.tpl
@@ -51,9 +51,57 @@ app.kubernetes.io/component: {{ .agent }}
 {{- end }}
 {{- end }}
 
-{{/* Resolve imagePullPolicy: global default (per-agent image string has no pullPolicy) */}}
+{{/* Resolve imagePullPolicy: per-agent override or global default */}}
 {{- define "openab.agentImagePullPolicy" -}}
-{{- .ctx.Values.image.pullPolicy }}
+{{- default .ctx.Values.image.pullPolicy .cfg.imagePullPolicy }}
+{{- end }}
+
+{{/* Resolve imagePullSecrets: per-agent override (if explicitly set, including empty list) or global default */}}
+{{- define "openab.agentImagePullSecrets" -}}
+{{- $pullSecrets := .ctx.Values.imagePullSecrets -}}
+{{- if hasKey .cfg "imagePullSecrets" -}}
+{{- $pullSecrets = .cfg.imagePullSecrets -}}
+{{- end }}
+{{- range $pullSecrets }}
+- name: {{ . | quote }}
+{{- end }}
+{{- end }}
+
+{{/* Resolve serviceAccountName: per-agent only, empty by default (uses namespace default SA) */}}
+{{- define "openab.agentServiceAccountName" -}}
+{{- default "" .cfg.serviceAccountName }}
+{{- end }}
+
+{{/*
+Pod annotations: global baseline + per-agent override, with reserved
+chart-managed annotations (checksum/config) merged last so users cannot
+clobber them and produce duplicate YAML keys.
+*/}}
+{{- define "openab.agentPodAnnotations" -}}
+{{- $reserved := dict "checksum/config" (.cfg | toJson | sha256sum) -}}
+{{- $annotations := mergeOverwrite (dict)
+    (.ctx.Values.podAnnotations | default (dict))
+    (.cfg.podAnnotations | default (dict))
+    $reserved -}}
+{{- toYaml $annotations }}
+{{- end }}
+
+{{/*
+Pod labels: global baseline + per-agent override, with reserved selector
+labels merged last so users cannot hijack them. Hijacking would produce
+duplicate YAML keys AND break Deployment→Pod selector matching.
+*/}}
+{{- define "openab.agentPodLabels" -}}
+{{- $reserved := dict
+    "app.kubernetes.io/name" (include "openab.name" .ctx)
+    "app.kubernetes.io/instance" .ctx.Release.Name
+    "app.kubernetes.io/component" .agent
+-}}
+{{- $labels := mergeOverwrite (dict)
+    (.ctx.Values.podLabels | default (dict))
+    (.cfg.podLabels | default (dict))
+    $reserved -}}
+{{- toYaml $labels }}
 {{- end }}
 
 {{/* Agent enabled: default true unless explicitly set to false */}}

--- a/charts/openab/templates/clusterrole.yaml
+++ b/charts/openab/templates/clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- range $name, $cfg := .Values.agents }}
+{{- if ne (include "openab.agentEnabled" $cfg) "false" }}
+{{- if ($cfg.rbac).createClusterRole }}
+{{- $d := dict "ctx" $ "agent" $name "cfg" $cfg }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "openab.agentFullname" $d }}
+  labels:
+    {{- include "openab.labels" $d | nindent 4 }}
+{{- with $cfg.rbac.clusterRules }}
+rules:
+  {{- toYaml . | nindent 2 }}
+{{- else }}
+rules: []
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openab/templates/clusterrolebinding.yaml
+++ b/charts/openab/templates/clusterrolebinding.yaml
@@ -1,0 +1,22 @@
+{{- range $name, $cfg := .Values.agents }}
+{{- if ne (include "openab.agentEnabled" $cfg) "false" }}
+{{- if ($cfg.rbac).createClusterRole }}
+{{- $d := dict "ctx" $ "agent" $name "cfg" $cfg }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "openab.agentFullname" $d }}
+  labels:
+    {{- include "openab.labels" $d | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "openab.agentFullname" $d }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "openab.agentServiceAccountName" $d }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -83,12 +83,14 @@ data:
     working_dir = "{{ $cfg.workingDir | default "/home/agent" }}"
     {{- $stringEnv := dict }}
     {{- range $k, $v := $cfg.env }}
-    {{- if not (kindIs "map" $v) }}
+    {{- if kindIs "slice" $v }}
+    {{- fail (printf "env.%s is a list — env values must be strings or maps (valueFrom)" $k) }}
+    {{- else if not (kindIs "map" $v) }}
     {{- $_ := set $stringEnv $k $v }}
     {{- end }}
     {{- end }}
     {{- if $stringEnv }}
-    env = { {{ $first := true }}{{ range $k, $v := $stringEnv }}{{ if not $first }}, {{ end }}{{ $k }} = "{{ $v }}"{{ $first = false }}{{ end }} }
+    env = { {{ $first := true }}{{ range $k, $v := $stringEnv }}{{ if not $first }}, {{ end }}{{ $k }} = {{ $v | toJson }}{{ $first = false }}{{ end }} }
     {{- end }}
 
     [pool]

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "openab.labels" $d | nindent 4 }}
 data:
   config.toml: |
-    {{- if ($cfg.discord).enabled }}
+    {{- if ne (include "openab.discordEnabled" $cfg) "false" }}
     [discord]
     bot_token = "${DISCORD_BOT_TOKEN}"
     {{- range $cfg.discord.allowedChannels }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -81,8 +81,14 @@ data:
     command = "{{ $cfg.command }}"
     args = {{ if $cfg.args }}{{ $cfg.args | toJson }}{{ else }}[]{{ end }}
     working_dir = "{{ $cfg.workingDir | default "/home/agent" }}"
-    {{- if $cfg.env }}
-    env = { {{ $first := true }}{{ range $k, $v := $cfg.env }}{{ if not $first }}, {{ end }}{{ $k }} = "{{ $v }}"{{ $first = false }}{{ end }} }
+    {{- $stringEnv := dict }}
+    {{- range $k, $v := $cfg.env }}
+    {{- if not (kindIs "map" $v) }}
+    {{- $_ := set $stringEnv $k $v }}
+    {{- end }}
+    {{- end }}
+    {{- if $stringEnv }}
+    env = { {{ $first := true }}{{ range $k, $v := $stringEnv }}{{ if not $first }}, {{ end }}{{ $k }} = "{{ $v }}"{{ $first = false }}{{ end }} }
     {{- end }}
 
     [pool]

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- if and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken }}
+            {{- if and (ne (include "openab.discordEnabled" $cfg) "false") ($cfg.discord).botToken }}
             - name: DISCORD_BOT_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -82,6 +82,9 @@ spec:
             - name: HOME
               value: {{ $cfg.workingDir | default "/home/agent" }}
             {{- range $k, $v := $cfg.env }}
+            {{- if kindIs "slice" $v }}
+            {{- fail (printf "env.%s is a list — env values must be strings or maps (valueFrom)" $k) }}
+            {{- end }}
             - name: {{ $k }}
               {{- if kindIs "map" $v }}
               {{- toYaml $v | nindent 14 }}

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
             {{- with $cfg.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-        {{- with $cfg.sidecars }}
+        {{- with $cfg.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with $cfg.nodeSelector }}

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -21,12 +21,25 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ $cfg | toJson | sha256sum }}
+        {{- include "openab.agentPodAnnotations" $d | nindent 8 }}
       labels:
-        {{- include "openab.selectorLabels" $d | nindent 8 }}
+        {{- include "openab.agentPodLabels" $d | nindent 8 }}
     spec:
+      {{- $imagePullSecrets := include "openab.agentImagePullSecrets" $d | trim }}
+      {{- if $imagePullSecrets }}
+      imagePullSecrets:
+        {{- $imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- $serviceAccountName := include "openab.agentServiceAccountName" $d | trim }}
+      {{- if $serviceAccountName }}
+      serviceAccountName: {{ $serviceAccountName }}
+      {{- end }}
       {{- with $.Values.podSecurityContext }}
       securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $cfg.initContainers }}
+      initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
@@ -80,6 +93,22 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with $cfg.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $cfg.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $cfg.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $cfg.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/openab
@@ -99,6 +128,12 @@ spec:
               mountPath: {{ $cfg.workingDir | default "/home/agent" }}/GEMINI.md
               subPath: AGENTS.md
             {{- end }}
+            {{- with $cfg.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with $cfg.sidecars }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with $cfg.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -119,6 +154,9 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "openab.agentFullname" $d }}
+        {{- end }}
+        {{- with $cfg.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -83,7 +83,11 @@ spec:
               value: {{ $cfg.workingDir | default "/home/agent" }}
             {{- range $k, $v := $cfg.env }}
             - name: {{ $k }}
+              {{- if kindIs "map" $v }}
+              {{- toYaml $v | nindent 14 }}
+              {{- else }}
               value: {{ $v | quote }}
+              {{- end }}
             {{- end }}
           {{- with $cfg.envFrom }}
           envFrom:

--- a/charts/openab/templates/pdb.yaml
+++ b/charts/openab/templates/pdb.yaml
@@ -1,0 +1,29 @@
+{{- range $name, $cfg := .Values.agents }}
+{{- if ne (include "openab.agentEnabled" $cfg) "false" }}
+{{- if ($cfg.podDisruptionBudget).enabled }}
+{{- $d := dict "ctx" $ "agent" $name "cfg" $cfg }}
+{{- $pdb := $cfg.podDisruptionBudget }}
+{{- if and (hasKey $pdb "minAvailable") (hasKey $pdb "maxUnavailable") (ne $pdb.minAvailable nil) (ne $pdb.maxUnavailable nil) }}
+{{- fail (printf "agents.%s.podDisruptionBudget: cannot set both minAvailable and maxUnavailable" $name) }}
+{{- end }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "openab.agentFullname" $d }}
+  labels:
+    {{- include "openab.labels" $d | nindent 4 }}
+spec:
+  {{- if ne ($pdb.minAvailable | toString) "<nil>" }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- else if ne ($pdb.maxUnavailable | toString) "<nil>" }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- else }}
+  {{- fail (printf "agents.%s.podDisruptionBudget: must set either minAvailable or maxUnavailable" $name) }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "openab.selectorLabels" $d | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openab/templates/role.yaml
+++ b/charts/openab/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- range $name, $cfg := .Values.agents }}
+{{- if ne (include "openab.agentEnabled" $cfg) "false" }}
+{{- if ($cfg.rbac).create }}
+{{- $d := dict "ctx" $ "agent" $name "cfg" $cfg }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "openab.agentFullname" $d }}
+  labels:
+    {{- include "openab.labels" $d | nindent 4 }}
+{{- with $cfg.rbac.rules }}
+rules:
+  {{- toYaml . | nindent 2 }}
+{{- else }}
+rules: []
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openab/templates/rolebinding.yaml
+++ b/charts/openab/templates/rolebinding.yaml
@@ -1,0 +1,22 @@
+{{- range $name, $cfg := .Values.agents }}
+{{- if ne (include "openab.agentEnabled" $cfg) "false" }}
+{{- if ($cfg.rbac).create }}
+{{- $d := dict "ctx" $ "agent" $name "cfg" $cfg }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "openab.agentFullname" $d }}
+  labels:
+    {{- include "openab.labels" $d | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "openab.agentFullname" $d }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "openab.agentServiceAccountName" $d }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openab/templates/secret.yaml
+++ b/charts/openab/templates/secret.yaml
@@ -1,6 +1,6 @@
 {{- range $name, $cfg := .Values.agents }}
 {{- if ne (include "openab.agentEnabled" $cfg) "false" }}
-{{- $hasDiscord := and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken }}
+{{- $hasDiscord := and (ne (include "openab.discordEnabled" $cfg) "false") ($cfg.discord).botToken }}
 {{- $hasSlack := and ($cfg.slack).enabled (or ($cfg.slack).botToken ($cfg.slack).appToken) }}
 {{- $hasStt := and ($cfg.stt).enabled ($cfg.stt).apiKey }}
 {{- if or $hasDiscord $hasSlack $hasStt }}

--- a/charts/openab/templates/serviceaccount.yaml
+++ b/charts/openab/templates/serviceaccount.yaml
@@ -1,0 +1,23 @@
+{{- range $name, $cfg := .Values.agents }}
+{{- if ne (include "openab.agentEnabled" $cfg) "false" }}
+{{- if ($cfg.serviceAccount).create }}
+{{- $d := dict "ctx" $ "agent" $name "cfg" $cfg }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openab.agentServiceAccountName" $d }}
+  labels:
+    {{- include "openab.labels" $d | nindent 4 }}
+  {{- with $cfg.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if hasKey $cfg.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ $cfg.serviceAccount.automountServiceAccountToken }}
+{{- else }}
+automountServiceAccountToken: true
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openab/tests/deployment_test.yaml
+++ b/charts/openab/tests/deployment_test.yaml
@@ -186,10 +186,14 @@ tests:
     set:
       agents.kiro.podLabels:
         app.kubernetes.io/name: hacked
+        app.kubernetes.io/component: evil
     asserts:
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: openab
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: kiro
 
   - it: podAnnotations cannot hijack checksum/config
     set:

--- a/charts/openab/tests/deployment_test.yaml
+++ b/charts/openab/tests/deployment_test.yaml
@@ -1,0 +1,215 @@
+suite: pod extensibility controls
+templates:
+  - templates/deployment.yaml
+tests:
+  # -- imagePullSecrets --
+
+  - it: renders global imagePullSecrets (string shorthand)
+    set:
+      imagePullSecrets:
+        - regcred
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: "regcred"
+
+  - it: renders global imagePullSecrets (K8s native object format)
+    set:
+      imagePullSecrets:
+        - name: regcred
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: "regcred"
+
+  - it: per-agent imagePullSecrets=[] opts out of global
+    set:
+      imagePullSecrets:
+        - global-secret
+      agents.kiro.imagePullSecrets: []
+    asserts:
+      - isNull:
+          path: spec.template.spec.imagePullSecrets
+
+  # -- imagePullPolicy --
+
+  - it: per-agent imagePullPolicy overrides global default
+    set:
+      image.pullPolicy: IfNotPresent
+      agents.kiro.imagePullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  # -- initContainers --
+
+  - it: renders initContainers
+    set:
+      agents.kiro.initContainers:
+        - name: setup
+          image: busybox:1.36
+          command: ["sh", "-c", "echo setup"]
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: setup
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox:1.36
+
+  # -- extraContainers --
+
+  - it: renders extraContainers into pod spec
+    set:
+      agents.kiro.extraContainers:
+        - name: logtail
+          image: busybox:1.36
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: logtail
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: busybox:1.36
+
+  # -- extraVolumes / extraVolumeMounts --
+
+  - it: renders extra volumes and mounts
+    set:
+      agents.kiro.extraVolumes:
+        - name: scratch
+          emptyDir: {}
+      agents.kiro.extraVolumeMounts:
+        - name: scratch
+          mountPath: /scratch
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: scratch
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: scratch
+            mountPath: /scratch
+
+  # -- probes, lifecycle, serviceAccountName --
+
+  - it: renders serviceAccountName
+    set:
+      agents.kiro.serviceAccountName: openab-agent
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: openab-agent
+
+  - it: renders livenessProbe
+    set:
+      agents.kiro.livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 8080
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+
+  - it: renders readinessProbe
+    set:
+      agents.kiro.readinessProbe:
+        httpGet:
+          path: /readyz
+          port: 8080
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+
+  - it: renders startupProbe
+    set:
+      agents.kiro.startupProbe:
+        exec:
+          command: ["pgrep", "openab"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          value: ["pgrep", "openab"]
+
+  - it: renders lifecycle hooks
+    set:
+      agents.kiro.lifecycle:
+        preStop:
+          exec:
+            command: ["sh", "-c", "sleep 1"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["sh", "-c", "sleep 1"]
+
+  # -- podAnnotations / podLabels --
+
+  - it: renders global and per-agent pod annotations
+    set:
+      podAnnotations:
+        team: platform
+      agents.kiro.podAnnotations:
+        trace: enabled
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.team
+          value: platform
+      - equal:
+          path: spec.template.metadata.annotations.trace
+          value: enabled
+
+  - it: renders global and per-agent pod labels
+    set:
+      podLabels:
+        tier: agents
+      agents.kiro.podLabels:
+        agent: kiro
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.tier
+          value: agents
+      - equal:
+          path: spec.template.metadata.labels.agent
+          value: kiro
+
+  # -- reserved key protection --
+
+  - it: podLabels cannot hijack reserved selector labels
+    set:
+      agents.kiro.podLabels:
+        app.kubernetes.io/name: hacked
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: openab
+
+  - it: podAnnotations cannot hijack checksum/config
+    set:
+      agents.kiro.podAnnotations:
+        checksum/config: pwned
+    asserts:
+      - notEqual:
+          path: spec.template.metadata.annotations["checksum/config"]
+          value: pwned
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: "^[a-f0-9]{64}$"
+
+  - it: per-agent podLabels override global for same non-reserved key
+    set:
+      podLabels:
+        tier: GLOBAL
+      agents.kiro.podLabels:
+        tier: PERAGENT
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.tier
+          value: PERAGENT

--- a/charts/openab/tests/env_test.yaml
+++ b/charts/openab/tests/env_test.yaml
@@ -1,0 +1,83 @@
+suite: env polymorphic rendering
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: renders simple string env as value
+    set:
+      agents.kiro.env:
+        MY_VAR: hello
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_VAR
+            value: "hello"
+
+  - it: renders valueFrom env (fieldRef)
+    set:
+      agents.kiro.env:
+        MY_POD_NAME:
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
+  - it: renders mixed string and valueFrom env
+    set:
+      agents.kiro.env:
+        SIMPLE_VAR: simple
+        POD_NAME:
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIMPLE_VAR
+            value: "simple"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
+  - it: rejects list-typed env values
+    set:
+      agents.kiro.env:
+        BAD:
+          - item1
+          - item2
+    asserts:
+      - failedTemplate:
+          errorPattern: "env.BAD is a list"
+
+---
+suite: env configmap filtering
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: filters map-typed env from config.toml
+    set:
+      agents.kiro.env:
+        KEEP_THIS: hello
+        SKIP_THIS:
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'KEEP_THIS = "hello"'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: "SKIP_THIS"

--- a/charts/openab/tests/pdb_test.yaml
+++ b/charts/openab/tests/pdb_test.yaml
@@ -1,0 +1,56 @@
+suite: PodDisruptionBudget
+templates:
+  - templates/pdb.yaml
+tests:
+  - it: does not create PDB by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates PDB with minAvailable when enabled
+    set:
+      agents.kiro.podDisruptionBudget.enabled: true
+      agents.kiro.podDisruptionBudget.minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: kiro
+
+  - it: creates PDB with maxUnavailable
+    set:
+      agents.kiro.podDisruptionBudget.enabled: true
+      agents.kiro.podDisruptionBudget.maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: supports percentage values
+    set:
+      agents.kiro.podDisruptionBudget.enabled: true
+      agents.kiro.podDisruptionBudget.minAvailable: 50%
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 50%
+
+  - it: fails when both minAvailable and maxUnavailable are set
+    set:
+      agents.kiro.podDisruptionBudget.enabled: true
+      agents.kiro.podDisruptionBudget.minAvailable: 1
+      agents.kiro.podDisruptionBudget.maxUnavailable: 1
+    asserts:
+      - failedTemplate:
+          errorPattern: "cannot set both minAvailable and maxUnavailable"
+
+  - it: fails when neither minAvailable nor maxUnavailable are set
+    set:
+      agents.kiro.podDisruptionBudget.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "must set either minAvailable or maxUnavailable"

--- a/charts/openab/tests/rbac_test.yaml
+++ b/charts/openab/tests/rbac_test.yaml
@@ -1,0 +1,140 @@
+suite: RBAC (Role + ClusterRole)
+release:
+  name: test
+templates:
+  - templates/role.yaml
+  - templates/rolebinding.yaml
+  - templates/clusterrole.yaml
+  - templates/clusterrolebinding.yaml
+tests:
+  - it: creates no RBAC resources by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates Role when rbac.create=true
+    template: templates/role.yaml
+    set:
+      agents.kiro.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Role
+
+  - it: creates RoleBinding when rbac.create=true
+    template: templates/rolebinding.yaml
+    set:
+      agents.kiro.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: RoleBinding
+
+  - it: Role renders rules correctly
+    template: templates/role.yaml
+    set:
+      agents.kiro.rbac.create: true
+      agents.kiro.rbac.rules:
+        - apiGroups: [""]
+          resources: ["configmaps"]
+          verbs: ["get", "list"]
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: test-openab-kiro
+      - equal:
+          path: rules[0].apiGroups
+          value: [""]
+      - equal:
+          path: rules[0].resources
+          value: ["configmaps"]
+      - equal:
+          path: rules[0].verbs
+          value: ["get", "list"]
+
+  - it: Role with empty rules still renders
+    template: templates/role.yaml
+    set:
+      agents.kiro.rbac.create: true
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: rules
+          value: []
+
+  - it: RoleBinding references the Role and ServiceAccount
+    template: templates/rolebinding.yaml
+    set:
+      agents.kiro.serviceAccount.create: true
+      agents.kiro.rbac.create: true
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - equal:
+          path: roleRef.name
+          value: test-openab-kiro
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: test-openab-kiro
+
+  - it: creates ClusterRole when rbac.createClusterRole=true
+    template: templates/clusterrole.yaml
+    set:
+      agents.kiro.rbac.createClusterRole: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+
+  - it: creates ClusterRoleBinding when rbac.createClusterRole=true
+    template: templates/clusterrolebinding.yaml
+    set:
+      agents.kiro.rbac.createClusterRole: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRoleBinding
+
+  - it: ClusterRole renders clusterRules correctly
+    template: templates/clusterrole.yaml
+    set:
+      agents.kiro.rbac.createClusterRole: true
+      agents.kiro.rbac.clusterRules:
+        - apiGroups: [""]
+          resources: ["nodes"]
+          verbs: ["get"]
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: rules[0].resources
+          value: ["nodes"]
+
+  - it: rbac.create=false does not create Role
+    template: templates/role.yaml
+    set:
+      agents.kiro.rbac.createClusterRole: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rbac.createClusterRole=false does not create ClusterRole
+    template: templates/clusterrole.yaml
+    set:
+      agents.kiro.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/openab/tests/serviceaccount_test.yaml
+++ b/charts/openab/tests/serviceaccount_test.yaml
@@ -1,0 +1,87 @@
+suite: ServiceAccount creation
+release:
+  name: test
+templates:
+  - templates/serviceaccount.yaml
+  - templates/deployment.yaml
+tests:
+  - it: does not create SA by default
+    template: templates/serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates SA when serviceAccount.create=true
+    template: templates/serviceaccount.yaml
+    set:
+      agents.kiro.serviceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: test-openab-kiro
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+
+  - it: uses custom SA name when set
+    template: templates/serviceaccount.yaml
+    set:
+      agents.kiro.serviceAccount.create: true
+      agents.kiro.serviceAccount.name: my-custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-custom-sa
+
+  - it: renders IRSA annotations
+    template: templates/serviceaccount.yaml
+    set:
+      agents.kiro.serviceAccount.create: true
+      agents.kiro.serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123:role/my-role
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123:role/my-role
+
+  - it: supports disabling automountServiceAccountToken
+    template: templates/serviceaccount.yaml
+    set:
+      agents.kiro.serviceAccount.create: true
+      agents.kiro.serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: deployment uses created SA name
+    template: templates/deployment.yaml
+    set:
+      agents.kiro.serviceAccount.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: test-openab-kiro
+
+  - it: deployment still supports external serviceAccountName for backward compat
+    template: templates/deployment.yaml
+    set:
+      agents.kiro.serviceAccountName: external-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: external-sa
+
+  - it: serviceAccount.create=true overrides external serviceAccountName
+    template: templates/deployment.yaml
+    set:
+      agents.kiro.serviceAccountName: external-sa
+      agents.kiro.serviceAccount.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: test-openab-kiro

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -4,6 +4,9 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+# Both formats supported:
+#   - name: regcred          # K8s native format
+#   - my-secret              # shorthand string format
 imagePullSecrets: []
 
 podAnnotations: {}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -194,6 +194,28 @@ agents:
     extraContainers: []
     extraVolumes: []
     extraVolumeMounts: []
+    # -- ServiceAccount, RBAC, PodDisruptionBudget
+    # serviceAccountName (above) still supported for referencing externally-created SAs.
+    # When serviceAccount.create is true, the chart creates a new SA named <agentFullname>
+    # (or serviceAccount.name if set), overriding serviceAccountName.
+    serviceAccount:
+      create: false
+      name: ""                            # empty = use <agentFullname>
+      automountServiceAccountToken: true  # set false if agent does not need K8s API access
+      annotations: {}                     # e.g. eks.amazonaws.com/role-arn for IRSA
+    rbac:
+      # namespaced Role + RoleBinding
+      create: false
+      rules: []
+      # cluster-scope ClusterRole + ClusterRoleBinding
+      createClusterRole: false
+      clusterRules: []
+    # ⚠️ PDB with minAvailable: 1 combined with the hardcoded replicas: 1 will prevent
+    # node drains. Use maxUnavailable: 1 instead if you need drain support.
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: null
+      maxUnavailable: null
     nodeSelector: {}
     tolerations: []
     affinity: {}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -179,15 +179,16 @@ agents:
     # The PVC file is NOT deleted but becomes invisible to the agent. Remove agentsMd to restore.
     agentsMd: ""
     resources: {}
+    # -- Pod extensibility
     serviceAccountName: ""
     podAnnotations: {}
     podLabels: {}
-    livenessProbe: {}
-    readinessProbe: {}
-    startupProbe: {}
-    lifecycle: {}
+    livenessProbe: {}   # {} = disabled
+    readinessProbe: {}  # {} = disabled
+    startupProbe: {}    # {} = disabled
+    lifecycle: {}       # {} = disabled
     initContainers: []
-    sidecars: []
+    extraContainers: []
     extraVolumes: []
     extraVolumeMounts: []
     nodeSelector: {}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -40,7 +40,14 @@ agents:
     #     # trustedBotIds: []  # empty = any bot (mode permitting)
     #     trustedBotIds: []
     #   workingDir: /home/agent
-    #   env: {}
+    #   env:
+    #     # simple key-value
+    #     MY_VAR: "hello"
+    #     # valueFrom (fieldRef, secretKeyRef, configMapKeyRef, etc.)
+    #     MY_POD_NAME:
+    #       valueFrom:
+    #         fieldRef:
+    #           fieldPath: metadata.name
     #   envFrom: []
     #   pool:
     #     maxSessions: 10

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -4,6 +4,11 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
+podAnnotations: {}
+podLabels: {}
+
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000
@@ -110,6 +115,9 @@ agents:
     #     size: 1Gi
     #   image: "ghcr.io/openabdev/openab-cursor:latest"
     image: ""
+    imagePullPolicy: ""
+    # imagePullSecrets: unset inherits global; set to [] to opt out.
+    # imagePullSecrets: []
     command: kiro-cli
     args:
       - acp
@@ -164,6 +172,17 @@ agents:
     # The PVC file is NOT deleted but becomes invisible to the agent. Remove agentsMd to restore.
     agentsMd: ""
     resources: {}
+    serviceAccountName: ""
+    podAnnotations: {}
+    podLabels: {}
+    livenessProbe: {}
+    readinessProbe: {}
+    startupProbe: {}
+    lifecycle: {}
+    initContainers: []
+    sidecars: []
+    extraVolumes: []
+    extraVolumeMounts: []
     nodeSelector: {}
     tolerations: []
     affinity: {}


### PR DESCRIPTION
## What problem does this solve?

OpenAB's Helm chart is currently strong on the minimal install path, but it is too thin for many real Kubernetes deployments.

It does not currently expose several common deployment controls that operators typically expect from a reusable open-source chart, including:

- `imagePullSecrets`
- probes (`livenessProbe`, `readinessProbe`, `startupProbe`)
- `lifecycle`
- `initContainers`
- `extraContainers`
- extra volumes / volume mounts
- `serviceAccountName` binding
- chart-managed `ServiceAccount` with IRSA support
- `Role` / `ClusterRole` RBAC
- `PodDisruptionBudget`
- other pod-level and cluster-level deployment settings that are common in production clusters

This leaves users with a few unattractive options:

1. rebuild a custom image for relatively minor deployment-specific needs
2. patch rendered manifests after `helm template`
3. fork the chart just to add standard Kubernetes fields

A concrete example: operators who need agents to access AWS resources (via IRSA) or the Kubernetes API currently have to fork the chart to add ServiceAccount annotations and RBAC rules.

Closes: #397

Discord Discussion URL: https://discordapp.com/channels/1491295327620169908/1493841502529523732

## At a Glance

```text
┌─────────────────────────────────────┐
│ Current OpenAB Helm Chart           │
│ minimal install path                │
└──────────────┬──────────────────────┘
               │
               ▼
┌─────────────────────────────────────┐
│ Missing common chart hooks          │
│ - imagePullSecrets                  │
│ - probes / lifecycle                │
│ - initContainers / extraContainers  │
│ - extra volumes / mounts            │
│ - ServiceAccount + RBAC             │
│ - PodDisruptionBudget               │
│ - polymorphic env (valueFrom)       │
└──────────────┬──────────────────────┘
               │
               ▼
┌─────────────────────────────────────┐
│ This PR                             │
│ pod extensibility + SA/RBAC/PDB     │
│ + env + template fixes              │
└─────────────────────────────────────┘
```

## Prior Art & Industry Research

**OpenClaw:**

I reviewed the local OpenClaw repository and its Kubernetes deployment manifests. While OpenClaw does not currently ship a Helm chart in this repo, it does treat startup bootstrap as a first-class deployment concern. In particular, it uses an `initContainer` to prepare configuration and workspace state before the main container starts.

This suggests:

- `initContainers` are a reasonable place for startup preparation
- bootstrap logic should be treated as deployment design, not an ad hoc workaround
- a hardened main container can stay simpler when initialization is separated

Reference:

- `scripts/k8s/manifests/deployment.yaml`

**Hermes Agent:**

I reviewed Hermes Agent's Docker and deployment documentation. Hermes takes a clearer stance on tool installation: stable toolchains should primarily be handled through custom images or clearly defined mutable runtime environments, not by stretching the chart into a package manager.

This suggests:

- serious toolchains should prefer custom images
- runtime bootstrap can exist, but it should stay lightweight and bounded
- Helm should expose deployment extension points, not replace image design

References:

- `Dockerfile`
- `website/docs/user-guide/docker.md`
- `website/docs/getting-started/nix-setup.md`

**Other references:**

I reviewed Bitnami charts and Helm / Kubernetes best practices. Bitnami's more mature charts commonly expose `imagePullSecrets`, `serviceAccount`, probes, `lifecycle`, `initContainers`, `extraContainers`, `extraVolumes`, `extraVolumeMounts`, `extraEnvVarsCM`, `extraEnvVarsSecret`, `extraDeploy`, and `pdb`. This PR adopts the subset of that surface area that fits under `Deployment.spec.template` plus the essential cluster-level resources (ServiceAccount, Role, ClusterRole, PDB).

Relevant upstream guidance also supports this direction:

- Helm chart values and template best practices
- Kubernetes guidance for `initContainers`
- Kubernetes guidance for private registry pulls via `imagePullSecrets`
- Kubernetes RBAC best practices for namespaced vs cluster-scoped access

## Proposed Solution

This PR implements full pod / deployment extensibility plus chart-managed `ServiceAccount`, RBAC, and `PodDisruptionBudget`. Discord feedback from @tonylee led to expanding beyond the original Phase 1 scope to cover AWS IRSA + K8s API access scenarios.

| File | Purpose |
|---|---|
| `charts/openab/values.yaml` | Helm values for pod extensibility, serviceAccount, rbac, and podDisruptionBudget |
| `charts/openab/templates/_helpers.tpl` | Helpers for per-agent image pull policy/secrets, ServiceAccount name resolution (create + external fallback), reserved-key-safe pod metadata merging, and unified discord.enabled gate |
| `charts/openab/templates/deployment.yaml` | Render pod-level extensibility controls into `Deployment.spec.template` |
| `charts/openab/templates/configmap.yaml` | Filter map-typed env from config.toml, escape string env via `toJson`, use unified discord gate |
| `charts/openab/templates/secret.yaml` | Use unified discord gate helper |
| `charts/openab/templates/serviceaccount.yaml` | Per-agent ServiceAccount (opt-in), with annotations + automount control |
| `charts/openab/templates/role.yaml` | Per-agent namespaced Role (opt-in) |
| `charts/openab/templates/rolebinding.yaml` | Per-agent RoleBinding (opt-in) |
| `charts/openab/templates/clusterrole.yaml` | Per-agent ClusterRole (opt-in) |
| `charts/openab/templates/clusterrolebinding.yaml` | Per-agent ClusterRoleBinding (opt-in) |
| `charts/openab/templates/pdb.yaml` | Per-agent PodDisruptionBudget (opt-in) |
| `charts/openab/tests/deployment_test.yaml` | Pod extensibility coverage (17 tests) |
| `charts/openab/tests/env_test.yaml` | Env polymorphic rendering + configmap filtering (5 tests) |
| `charts/openab/tests/serviceaccount_test.yaml` | ServiceAccount creation coverage (8 tests) |
| `charts/openab/tests/rbac_test.yaml` | RBAC coverage (9 tests) |
| `charts/openab/tests/pdb_test.yaml` | PodDisruptionBudget coverage (6 tests) |

Implemented scope:

**Pod / Deployment extensibility**
- `imagePullSecrets` (global + per-agent, with explicit opt-out, supports both K8s native and shorthand formats)
- per-agent `imagePullPolicy` (global default + per-agent override)
- per-agent `serviceAccountName` binding (for referencing externally-created SAs)
- `livenessProbe`, `readinessProbe`, `startupProbe`, `lifecycle`
- `initContainers`, `extraContainers`
- `extraVolumes`, `extraVolumeMounts`
- `podAnnotations`, `podLabels` (global + per-agent, merged with reserved-key protection)
- polymorphic `env` rendering (string values + `valueFrom` maps via `kindIs "map"`)
- TOML env value escaping via `toJson` (fixes pre-existing injection risk)

**Chart-managed resources (Phase 2)**
- `ServiceAccount` (opt-in via `serviceAccount.create`, with annotations for IRSA and `automountServiceAccountToken` control)
- namespaced `Role` + `RoleBinding` (opt-in via `rbac.create`)
- cluster-scoped `ClusterRole` + `ClusterRoleBinding` (opt-in via `rbac.createClusterRole`)
- `PodDisruptionBudget` (opt-in via `podDisruptionBudget.enabled`, supports both `minAvailable` and `maxUnavailable`)

**Template consistency**
- unified `discord.enabled` gate via `openab.discordEnabled` helper (consistent behavior across configmap, deployment, secret)

Explicitly out of scope:

- extra ConfigMap / Secret creation — already covered by existing `extraVolumes`/`extraVolumeMounts`/`envFrom`, operators create their own K8s resources and reference them
- generic extra objects such as `extraDeploy` — deferred

For the "install tools" question specifically, the implementation keeps two clear paths:

1. **Custom image** — the preferred path for stable, repeatable, production-grade toolchains
2. **`initContainers` + shared volume** — a lightweight bootstrap path for small binaries or startup initialization

### Safety & correctness

Three design decisions are load-bearing for correctness.

**Reserved pod-metadata keys cannot be hijacked.** `agentPodLabels` and `agentPodAnnotations` use `mergeOverwrite(dict, global, per-agent, reserved)`, where the reserved key set is merged **last**. This guarantees:

- `checksum/config` annotation is always the chart-computed hash — users cannot accidentally pin it or disable rollout-on-config-change
- `app.kubernetes.io/{name,instance,component}` labels on the pod template always match `spec.selector.matchLabels`, so `Deployment` → `Pod` selector matching can never be broken by a user-supplied `podLabels` entry

Without this protection, a user who set `podLabels.app.kubernetes.io/name: custom` would silently produce duplicate YAML keys **and** a Deployment whose ReplicaSet could no longer match its own Pods.

**Per-agent `imagePullSecrets: []` explicitly opts out of the global list.** The helper uses `hasKey` instead of a truthy check, so three states are distinguishable per agent:

- key omitted → inherit `.Values.imagePullSecrets`
- `imagePullSecrets: []` → opt out (no pull secrets, even if global is set)
- `imagePullSecrets: [foo]` → replace with per-agent list

**All new resources are opt-in with safe defaults.** `serviceAccount.create`, `rbac.create`, `rbac.createClusterRole`, and `podDisruptionBudget.enabled` all default to `false`. Existing deployments see no behavioral change on upgrade — only new resources are created when operators explicitly opt in.

**Backward compatibility for ServiceAccount binding.** The existing `agents.<x>.serviceAccountName` field still works for referencing externally-created SAs. When `serviceAccount.create: true` is set, the chart-created SA takes precedence over the external reference.

## Why this approach?

I do not think OpenAB should model every Kubernetes field at once, and I do not think Helm should become the primary mechanism for packaging arbitrary tools.

At the same time, the current chart is thin enough that users are pushed toward forking it for fairly normal deployment requirements. That creates unnecessary friction for a public chart.

This approach takes the middle path:

- keep the default chart simple — all new controls are opt-in
- expose the extension points that operators commonly expect
- keep custom images as the primary answer for serious tool installation
- treat `initContainers` bootstrap as a lightweight complement, not the main packaging model
- make chart-managed RBAC available for teams who need agents to access cloud resources or the K8s API, without requiring a fork

Tradeoffs and limitations:

- the chart surface will grow
- pod-metadata merge rules must be unambiguous and predictable — addressed by the reserved-last `mergeOverwrite` pattern
- `PodDisruptionBudget` combined with the hardcoded `replicas: 1` has a known edge case (minAvailable: 1 prevents node drains) — documented with a comment in values.yaml

## Alternatives Considered

### 1. Pod extensibility only; defer SA/RBAC/PDB — initially chosen, then expanded

The first iteration of this PR scoped to `Deployment.spec.template` only, deferring SA/RBAC/PDB. After Discord feedback (specifically operators needing IRSA + K8s API access), the scope was expanded to include chart-managed resources since those are the exact gaps that otherwise force a fork.

### 2. Implement everything at once — chosen

Including SA/RBAC/PDB in the same PR keeps related extensibility changes together. All new resources follow the existing per-agent multi-resource loop pattern and share the same helpers (e.g. `agentFullname`, `selectorLabels`). All defaults are opt-in, so the risk profile is no higher than the Phase 1 changes.

### 3. Extra ConfigMap / Secret creation — rejected

The existing `extraVolumes`/`extraVolumeMounts`/`envFrom` fields already cover this use case. Users create their own ConfigMaps/Secrets (with their preferred lifecycle management) and reference them. Adding chart-managed extras would duplicate functionality without clear benefit.

## Validation

- [x] `helm lint charts/openab` passes
- [x] Rendering coverage added for:
  - `imagePullSecrets` (global + per-agent, both K8s native and shorthand formats)
  - per-agent `imagePullPolicy`
  - `initContainers`, `extraContainers`
  - `extraVolumes` / `extraVolumeMounts`
  - probes (`livenessProbe`, `readinessProbe`, `startupProbe`), `lifecycle`
  - `serviceAccountName` + chart-managed ServiceAccount
  - ServiceAccount `automountServiceAccountToken` + IRSA annotations
  - Role + RoleBinding + ClusterRole + ClusterRoleBinding
  - PodDisruptionBudget (`minAvailable`, `maxUnavailable`, percentage values)
  - pod annotations and labels (global + per-agent merged)
  - polymorphic `env` rendering (string, valueFrom, mixed)
- [x] Hardening coverage added for:
  - reserved selector labels (`app.kubernetes.io/{name,component}`) cannot be hijacked by user `podLabels`
  - `checksum/config` annotation cannot be overridden by user `podAnnotations`
  - per-agent `imagePullSecrets: []` opts out of the global list
  - per-agent `podLabels` override global for the same non-reserved key
  - list-typed env values rejected with clear error message
  - map-typed env values filtered from `config.toml` (TOML cannot represent `valueFrom`)
  - PDB fails loudly when both `minAvailable` and `maxUnavailable` are set
  - PDB fails loudly when neither is set
- [x] Backward compatibility:
  - existing `serviceAccountName` still resolves to external SA
  - `serviceAccount.create: true` overrides external reference when both are set
- [ ] Manual deploy-oriented verification on a real cluster

Validation command:

```bash
helm unittest charts/openab
```

Result: **61 passed, 0 failed** (across 8 suites)

DC: https://discord.com/channels/1491295327620169908/1493841502529523732/1494148867380219956
