### PR TITLE
fix(helm): default discord.enabled to true when botToken is present

### DIFF
--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -6,13 +6,14 @@ Agents deployed:
 {{- range $name, $cfg := .Values.agents }}
 {{- if ne (include "openab.agentEnabled" $cfg) "false" }}
   • {{ $name }} ({{ $cfg.command }})
-{{- if not (or (and ($cfg.discord).enabled ($cfg.discord).botToken) (and ($cfg.slack).enabled ($cfg.slack).botToken)) }}
-    ⚠️  No bot token provided. Create the secret manually:
+{{- if not (or (and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken) (and ($cfg.slack).enabled ($cfg.slack).botToken)) }}
+    ⚠️  No bot token provided. Set one via Helm values or create the secret manually:
     kubectl create secret generic {{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} \
-      --from-literal=discord-bot-token="YOUR_DISCORD_TOKEN"
+      --from-literal=discord-bot-token="YOUR_TOKEN"   # for Discord
+    # --from-literal=slack-bot-token="YOUR_TOKEN"      # for Slack
 {{- end }}
 
-{{- if and ($cfg.discord).enabled ($cfg.discord).botToken }}
+{{- if and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken }}
     Discord: ✅ configured
 {{- end }}
 {{- if and ($cfg.slack).enabled ($cfg.slack).botToken }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "openab.labels" $d | nindent 4 }}
 data:
   config.toml: |
-    {{- if and ($cfg.discord).enabled ($cfg.discord).botToken }}
+    {{- if and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken }}
     [discord]
     bot_token = "${DISCORD_BOT_TOKEN}"
     {{- range $cfg.discord.allowedChannels }}

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- if and ($cfg.discord).enabled ($cfg.discord).botToken }}
+            {{- if and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken }}
             - name: DISCORD_BOT_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/openab/templates/secret.yaml
+++ b/charts/openab/templates/secret.yaml
@@ -1,6 +1,6 @@
 {{- range $name, $cfg := .Values.agents }}
 {{- if ne (include "openab.agentEnabled" $cfg) "false" }}
-{{- $hasDiscord := and ($cfg.discord).enabled ($cfg.discord).botToken }}
+{{- $hasDiscord := and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken }}
 {{- $hasSlack := and ($cfg.slack).enabled (or ($cfg.slack).botToken ($cfg.slack).appToken) }}
 {{- $hasStt := and ($cfg.stt).enabled ($cfg.stt).apiKey }}
 {{- if or $hasDiscord $hasSlack $hasStt }}


### PR DESCRIPTION
## Problem

Upgrading from 0.7.6 → 0.7.7-beta.1 causes `CrashLoopBackOff` because the new `discord.enabled` guard in configmap.yaml and secret.yaml requires the field to be explicitly set. Existing deployments from 0.7.6 don't have `discord.enabled` in their values, so the `[discord]` section and `discord-bot-token` secret entry are silently omitted.

```
Error: failed to parse /etc/openab/config.toml: missing field `discord`
```

## Root Cause

The 0.7.7-beta.1 Slack adapter PR added this guard:
```yaml
{{- if and ($cfg.discord).enabled ($cfg.discord).botToken }}
```

When `discord.enabled` is absent (not set), Go templates evaluate it as falsy → entire `[discord]` block is skipped.

## Fix

Change the guard to only skip when `enabled` is explicitly `"false"`:
```yaml
{{- if and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken }}
```

This preserves backwards compatibility with 0.7.6 values (no `enabled` field) while still allowing explicit `discord.enabled: false` for Slack-only setups.

## Verified

- Tested locally: upgrade from 0.7.6 → 0.7.7-beta.1 with unmodified 0.7.6 values — pod starts, config.toml has `[discord]` section, secret has `discord-bot-token`.

Fixes #383