### PR TITLE
fix(discord/slack/helm): empty allowed_channels denies all channels (secure by default)

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -11,6 +11,9 @@ metadata:
 data:
   config.toml: |
     {{- if ($cfg.discord).enabled }}
+    {{- if not $cfg.discord.allowedChannels }}
+    {{- fail (printf "agents.%s.discord.allowedChannels is required — empty means the bot will not respond to any messages. Add at least one channel ID." $name) }}
+    {{- end }}
     [discord]
     bot_token = "${DISCORD_BOT_TOKEN}"
     {{- range $cfg.discord.allowedChannels }}
@@ -52,6 +55,9 @@ data:
     {{- end }}
 
     {{- if and ($cfg.slack).enabled }}
+    {{- if not (($cfg.slack).allowedChannels) }}
+    {{- fail (printf "agents.%s.slack.allowedChannels is required — empty means the bot will not respond to any messages. Add at least one channel ID." $name) }}
+    {{- end }}
     [slack]
     bot_token = "${SLACK_BOT_TOKEN}"
     app_token = "${SLACK_APP_TOKEN}"

--- a/charts/openab/tests/adapter-enablement_test.yaml
+++ b/charts/openab/tests/adapter-enablement_test.yaml
@@ -33,6 +33,8 @@ tests:
   - it: renders [slack] when enabled=true
     set:
       agents.kiro.slack.enabled: true
+      agents.kiro.slack.allowedChannels:
+        - "C0123456789"
     asserts:
       - matchRegex:
           path: data["config.toml"]
@@ -49,6 +51,8 @@ tests:
   - it: renders [slack] with placeholder tokens when enabled=true
     set:
       agents.kiro.slack.enabled: true
+      agents.kiro.slack.allowedChannels:
+        - "C0123456789"
     asserts:
       - matchRegex:
           path: data["config.toml"]
@@ -61,6 +65,8 @@ tests:
     set:
       agents.kiro.discord.enabled: true
       agents.kiro.slack.enabled: true
+      agents.kiro.slack.allowedChannels:
+        - "C0123456789"
     asserts:
       - matchRegex:
           path: data["config.toml"]

--- a/charts/openab/tests/configmap_test.yaml
+++ b/charts/openab/tests/configmap_test.yaml
@@ -92,8 +92,27 @@ tests:
   - it: renders slack allow_user_messages = "multibot-mentions"
     set:
       agents.kiro.slack.enabled: true
+      agents.kiro.slack.allowedChannels:
+        - "C0123456789"
       agents.kiro.slack.allowUserMessages: multibot-mentions
     asserts:
       - matchRegex:
           path: data["config.toml"]
           pattern: 'allow_user_messages = "multibot-mentions"'
+
+  - it: rejects empty discord allowedChannels
+    set:
+      agents.kiro.discord.enabled: true
+      agents.kiro.discord.allowedChannels: []
+    asserts:
+      - failedTemplate:
+          errorPattern: "discord.allowedChannels is required"
+
+  - it: rejects empty slack allowedChannels
+    set:
+      agents.kiro.discord.enabled: false
+      agents.kiro.slack.enabled: true
+      agents.kiro.slack.allowedChannels: []
+    asserts:
+      - failedTemplate:
+          errorPattern: "slack.allowedChannels is required"

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -135,7 +135,7 @@ agents:
       enabled: false
       botToken: ""       # Bot User OAuth Token (xoxb-...)
       appToken: ""       # App-Level Token (xapp-...) for Socket Mode
-      allowedChannels: []  # empty = allow all channels
+      allowedChannels: []  # required — empty = deny all channels (secure by default)
       allowedUsers: []     # empty = allow all users
       # allowBotMessages: "off" (default) | "mentions" | "all"
       allowBotMessages: "off"

--- a/config.toml.example
+++ b/config.toml.example
@@ -2,7 +2,7 @@
 
 [discord]
 bot_token = "${DISCORD_BOT_TOKEN}"
-allowed_channels = ["1234567890"]       # empty or omitted = allow all channels
+allowed_channels = ["1234567890"]       # required — empty or omitted = deny all channels (secure by default)
 # allowed_users = ["<YOUR_DISCORD_USER_ID>"]  # empty or omitted = allow all users
 # allow_bot_messages = "off"  # "off" (default) | "mentions" | "all"
                                # "mentions" is recommended for multi-agent collaboration

--- a/config.toml.example
+++ b/config.toml.example
@@ -14,7 +14,7 @@ allowed_channels = ["1234567890"]       # required — empty or omitted = deny a
 # [slack]
 # bot_token = "${SLACK_BOT_TOKEN}"     # Bot User OAuth Token (xoxb-...)
 # app_token = "${SLACK_APP_TOKEN}"     # App-Level Token (xapp-...) for Socket Mode
-# allowed_channels = ["C0123456789"]   # empty or omitted = allow all channels
+# allowed_channels = ["C0123456789"]   # required — empty or omitted = deny all channels (secure by default)
 # allowed_users = ["U0123456789"]      # empty or omitted = allow all users
 # allow_bot_messages = "off"           # "off" (default) | "mentions" | "all"
 # trusted_bot_ids = []                 # empty = any bot (mode permitting); set to restrict

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -64,7 +64,7 @@ Complete guide to setting up, configuring, and running OpenAB with Discord.
 ```toml
 [discord]
 bot_token = "${DISCORD_BOT_TOKEN}"
-allowed_channels = ["123456789"]      # channel ID allowlist (empty = all)
+allowed_channels = ["123456789"]      # channel ID allowlist (empty = deny all)
 allowed_users = ["987654321"]         # user ID allowlist (empty = all)
 allow_bot_messages = "off"            # off | mentions | all
 allow_user_messages = "involved"      # involved | mentions
@@ -75,11 +75,12 @@ trusted_bot_ids = []                  # bot user IDs allowed through (empty = an
 
 | `allowed_channels` | `allowed_users` | Result |
 |---|---|---|
-| empty | empty | All users, all channels (default) |
+| empty | empty | **No channels, no users — bot ignores all messages** |
 | set | empty | Only these channels, all users |
-| empty | set | All channels, only these users |
+| empty | set | **Bot ignores all messages** (channels must be configured first) |
 | set | set | **AND** — must be in allowed channel AND allowed user |
 
+- Empty `allowed_channels` = bot will not respond anywhere (secure by default)
 - Empty `allowed_users` (default) = no user filtering
 - Denied users get a 🚫 reaction and no reply
 

--- a/docs/slack-bot-howto.md
+++ b/docs/slack-bot-howto.md
@@ -63,9 +63,21 @@ Add the `[slack]` section to your `config.toml`:
 [slack]
 bot_token = "${SLACK_BOT_TOKEN}"
 app_token = "${SLACK_APP_TOKEN}"
-allowed_channels = []                # empty = allow all channels
+allowed_channels = ["C0123456789"]    # required — empty = deny all channels (secure by default)
 # allowed_users = ["U0123456789"]    # empty = allow all users
 ```
+
+### Access control behavior
+
+| `allowed_channels` | `allowed_users` | Result |
+|---|---|---|
+| empty | empty | **No channels, no users — bot ignores all messages** |
+| set | empty | Only these channels, all users |
+| empty | set | **Bot ignores all messages** (channels must be configured first) |
+| set | set | **AND** — must be in allowed channel AND allowed user |
+
+- Empty `allowed_channels` = bot will not respond anywhere (secure by default)
+- Empty `allowed_users` (default) = no user filtering
 
 Set the environment variables:
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -234,8 +234,11 @@ impl EventHandler for Handler {
         }).clone();
 
         let channel_id = msg.channel_id.get();
-        let in_allowed_channel =
-            self.allowed_channels.is_empty() || self.allowed_channels.contains(&channel_id);
+        if self.allowed_channels.is_empty() {
+            debug!("allowed_channels is empty — ignoring message in channel {}", channel_id);
+            return;
+        }
+        let in_allowed_channel = self.allowed_channels.contains(&channel_id);
 
         let is_mentioned = msg.mentions_user_id(bot_id)
             || msg.content.contains(&format!("<@{}>", bot_id));

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use serenity::prelude::*;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 #[derive(Parser)]
 #[command(name = "openab")]
@@ -111,6 +111,9 @@ async fn main() -> anyhow::Result<()> {
 
             // Spawn Slack adapter (background task)
             let slack_handle = if let Some(slack_cfg) = cfg.slack {
+                if slack_cfg.allowed_channels.is_empty() {
+                    warn!("no allowed_channels configured for Slack — bot will not respond to any messages. Add at least one channel ID to [slack] allowed_channels.");
+                }
                 info!(
                     channels = slack_cfg.allowed_channels.len(),
                     users = slack_cfg.allowed_users.len(),
@@ -148,6 +151,9 @@ async fn main() -> anyhow::Result<()> {
             if let Some(discord_cfg) = cfg.discord {
                 let allowed_channels =
                     parse_id_set(&discord_cfg.allowed_channels, "discord.allowed_channels")?;
+                if allowed_channels.is_empty() {
+                    warn!("no allowed_channels configured — bot will not respond to any messages. Add at least one channel ID to [discord] allowed_channels.");
+                }
                 let allowed_users = parse_id_set(&discord_cfg.allowed_users, "discord.allowed_users")?;
                 let trusted_bot_ids = parse_id_set(&discord_cfg.trusted_bot_ids, "discord.trusted_bot_ids")?;
                 info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ async fn main() -> anyhow::Result<()> {
                 let allowed_channels =
                     parse_id_set(&discord_cfg.allowed_channels, "discord.allowed_channels")?;
                 if allowed_channels.is_empty() {
-                    warn!("no allowed_channels configured — bot will not respond to any messages. Add at least one channel ID to [discord] allowed_channels.");
+                    warn!("no allowed_channels configured for Discord — bot will not respond to any messages. Add at least one channel ID to [discord] allowed_channels.");
                 }
                 let allowed_users = parse_id_set(&discord_cfg.allowed_users, "discord.allowed_users")?;
                 let trusted_bot_ids = parse_id_set(&discord_cfg.trusted_bot_ids, "discord.trusted_bot_ids")?;

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -803,8 +803,12 @@ async fn handle_message(
     };
     let thread_ts = event["thread_ts"].as_str().map(|s| s.to_string());
 
-    // Check allowed channels (empty = allow all)
-    if !allowed_channels.is_empty() && !allowed_channels.contains(&channel_id) {
+    // Check allowed channels (empty = deny all)
+    if allowed_channels.is_empty() {
+        tracing::debug!("allowed_channels is empty — ignoring message in channel {}", channel_id);
+        return;
+    }
+    if !allowed_channels.contains(&channel_id) {
         return;
     }
 


### PR DESCRIPTION
## Context

Empty `allowed_channels` (or omitted) currently makes the bot respond in **all channels** — an insecure default that risks session pool exhaustion and sensitive content leaking to unintended channels.

Closes #91

## Summary

Change the default behavior of empty `allowed_channels` from "allow all" to "deny all" (secure by default) for **both Discord and Slack adapters**. When no channels are configured, the bot silently ignores all messages and logs a `warn!` at startup.

## Changes

| File | Change |
|------|--------|
| `src/discord.rs` | Empty `allowed_channels` → `debug!` log + early return (deny all) |
| `src/slack.rs` | Same fix — empty `allowed_channels` → `debug!` log + early return (deny all) |
| `src/main.rs` | Log `warn!` at startup when `allowed_channels` is empty (both adapters) |
| `config.toml.example` | Updated comments for both `[discord]` and `[slack]` sections |
| `docs/discord.md` | Updated access control behavior table |
| `docs/slack-bot-howto.md` | Added access control behavior table (matches Discord) |

## ⚠️ Breaking Change

**Both Discord and Slack adapters are affected.**

| Before | After |
|--------|-------|
| Empty `allowed_channels` = bot responds in **all** channels | Empty `allowed_channels` = bot responds in **no** channels |

### Who is affected

Any deployment that relies on empty or omitted `allowed_channels` to respond everywhere — the bot will **silently stop responding** after this update.

### How to fix

Add at least one channel ID to `allowed_channels` in your `config.toml`:

```toml
[discord]
allowed_channels = ["YOUR_CHANNEL_ID"]

[slack]
allowed_channels = ["C0123456789"]
```

### Why this is the right default

- Forgetting to configure `allowed_channels` should fail **closed**, not open
- Prevents accidental session pool exhaustion across many channels
- Prevents sensitive content leaking to unintended channels
- The bot still starts successfully — it just won't respond until channels are configured
- A clear `warn!` log at startup tells operators exactly what to do

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1494273220759523398