### PR TITLE
feat(slack): AllowUsers/AllowBots gating, DM support, participation cache

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -60,6 +60,21 @@ data:
     {{- end }}
     {{- end }}
     allowed_users = {{ ($cfg.slack).allowedUsers | default list | toJson }}
+    {{- if ($cfg.slack).allowBotMessages }}
+    {{- if not (has ($cfg.slack).allowBotMessages (list "off" "mentions" "all")) }}
+    {{- fail (printf "agents.%s.slack.allowBotMessages must be one of: off, mentions, all — got: %s" $name ($cfg.slack).allowBotMessages) }}
+    {{- end }}
+    allow_bot_messages = "{{ ($cfg.slack).allowBotMessages }}"
+    {{- end }}
+    {{- if ($cfg.slack).trustedBotIds }}
+    trusted_bot_ids = {{ ($cfg.slack).trustedBotIds | toJson }}
+    {{- end }}
+    {{- if ($cfg.slack).allowUserMessages }}
+    {{- if not (has ($cfg.slack).allowUserMessages (list "involved" "mentions")) }}
+    {{- fail (printf "agents.%s.slack.allowUserMessages must be one of: involved, mentions — got: %s" $name ($cfg.slack).allowUserMessages) }}
+    {{- end }}
+    allow_user_messages = "{{ ($cfg.slack).allowUserMessages }}"
+    {{- end }}
     {{- end }}
 
     [agent]

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -133,6 +133,14 @@ agents:
       appToken: ""       # App-Level Token (xapp-...) for Socket Mode
       allowedChannels: []  # empty = allow all channels
       allowedUsers: []     # empty = allow all users
+      # allowBotMessages: "off" (default) | "mentions" | "all"
+      allowBotMessages: "off"
+      # trustedBotIds: Bot User IDs (U...) — find via Slack UI: click bot profile → Copy member ID
+      trustedBotIds: []
+      # allowUserMessages: "involved" (default) | "mentions"
+      # "involved" = respond to thread follow-ups without @mention if bot has participated
+      # "mentions" = always require @mention
+      allowUserMessages: "involved"
     workingDir: /home/agent
     env: {}
     envFrom: []

--- a/config.toml.example
+++ b/config.toml.example
@@ -13,6 +13,11 @@ allowed_channels = ["1234567890"]       # empty or omitted = allow all channels
 # app_token = "${SLACK_APP_TOKEN}"     # App-Level Token (xapp-...) for Socket Mode
 # allowed_channels = ["C0123456789"]   # empty or omitted = allow all channels
 # allowed_users = ["U0123456789"]      # empty or omitted = allow all users
+# allow_bot_messages = "off"           # "off" (default) | "mentions" | "all"
+# trusted_bot_ids = []                 # empty = any bot (mode permitting); set to restrict
+# allow_user_messages = "involved"     # "involved" (default) | "mentions"
+                                        # "involved" = reply in threads bot has participated in
+                                        # "mentions" = always require @mention
 
 [agent]
 command = "kiro-cli"

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,30 @@ pub struct DiscordConfig {
     pub trusted_bot_ids: Vec<String>,
 }
 
+/// Controls whether the bot responds to user messages in threads without @mention.
+///
+/// - `Involved` (default): respond to thread messages only if the bot has participated
+///   in the thread (posted at least one message, or the thread parent @mentions the bot).
+///   Channel/MPDM messages always require @mention. DMs always process (implicit mention).
+/// - `Mentions`: always require @mention, even in threads the bot is participating in.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AllowUsers {
+    #[default]
+    Involved,
+    Mentions,
+}
+
+impl<'de> Deserialize<'de> for AllowUsers {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        match s.to_lowercase().as_str() {
+            "involved" => Ok(Self::Involved),
+            "mentions" => Ok(Self::Mentions),
+            other => Err(serde::de::Error::unknown_variant(other, &["involved", "mentions"])),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct SlackConfig {
     pub bot_token: String,
@@ -96,6 +120,15 @@ pub struct SlackConfig {
     pub allowed_channels: Vec<String>,
     #[serde(default)]
     pub allowed_users: Vec<String>,
+    #[serde(default)]
+    pub allow_bot_messages: AllowBots,
+    /// Bot User IDs (U...) allowed to interact when allow_bot_messages is
+    /// "mentions" or "all". Find via Slack UI: click bot profile → Copy member ID.
+    /// Empty = allow any bot (mode permitting).
+    #[serde(default)]
+    pub trusted_bot_ids: Vec<String>,
+    #[serde(default)]
+    pub allow_user_messages: AllowUsers,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -164,7 +164,7 @@ impl EventHandler for Handler {
                                 .filter(|(mid, _)| **mid < msg.id)
                                 .map(|(_, m)| m.clone())
                                 .collect();
-                            recent.sort_unstable_by(|a, b| b.id.cmp(&a.id));
+                            recent.sort_unstable_by_key(|m| std::cmp::Reverse(m.id));
                             recent.truncate(cap);
                             recent
                         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,16 +114,23 @@ async fn main() -> anyhow::Result<()> {
                 info!(
                     channels = slack_cfg.allowed_channels.len(),
                     users = slack_cfg.allowed_users.len(),
+                    allow_bot_messages = ?slack_cfg.allow_bot_messages,
+                    allow_user_messages = ?slack_cfg.allow_user_messages,
                     "starting slack adapter"
                 );
                 let router = router.clone();
                 let stt = cfg.stt.clone();
+                let session_ttl = std::time::Duration::from_secs(ttl_secs);
                 Some(tokio::spawn(async move {
                     if let Err(e) = slack::run_slack_adapter(
                         slack_cfg.bot_token,
                         slack_cfg.app_token,
                         slack_cfg.allowed_channels.into_iter().collect(),
                         slack_cfg.allowed_users.into_iter().collect(),
+                        slack_cfg.allow_bot_messages,
+                        slack_cfg.trusted_bot_ids.into_iter().collect(),
+                        slack_cfg.allow_user_messages,
+                        session_ttl,
                         stt,
                         router,
                         shutdown_rx,

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -522,28 +522,35 @@ pub async fn run_slack_adapter(
                                                             if !mentions_bot { continue; }
                                                         }
                                                         AllowBots::All => {
-                                                            // Loop protection: count consecutive bot msgs
+                                                            // Loop protection: count consecutive bot msgs (fail-closed)
                                                             if let Some(thread_ts) = event["thread_ts"].as_str() {
                                                                 let limit_str = (MAX_CONSECUTIVE_BOT_TURNS + 1).to_string();
-                                                                if let Ok(resp) = adapter.api_get(
+                                                                match adapter.api_get(
                                                                     "conversations.replies",
                                                                     &[
                                                                         ("channel", channel_id),
                                                                         ("ts", thread_ts),
                                                                         ("limit", &limit_str),
+                                                                        ("inclusive", "true"),
                                                                     ],
                                                                 ).await {
-                                                                    if let Some(msgs) = resp["messages"].as_array() {
-                                                                        let consecutive = msgs.iter().rev()
-                                                                            .take_while(|m| {
-                                                                                m["bot_id"].is_string()
-                                                                                    || m["subtype"].as_str() == Some("bot_message")
-                                                                            })
-                                                                            .count();
-                                                                        if consecutive >= MAX_CONSECUTIVE_BOT_TURNS {
-                                                                            warn!("bot turn cap reached ({MAX_CONSECUTIVE_BOT_TURNS}), ignoring");
-                                                                            continue;
+                                                                    Ok(resp) => {
+                                                                        if let Some(msgs) = resp["messages"].as_array() {
+                                                                            let consecutive = msgs.iter().rev()
+                                                                                .take_while(|m| {
+                                                                                    m["bot_id"].is_string()
+                                                                                        || m["subtype"].as_str() == Some("bot_message")
+                                                                                })
+                                                                                .count();
+                                                                            if consecutive >= MAX_CONSECUTIVE_BOT_TURNS {
+                                                                                warn!("bot turn cap reached ({MAX_CONSECUTIVE_BOT_TURNS}), ignoring");
+                                                                                continue;
+                                                                            }
                                                                         }
+                                                                    }
+                                                                    Err(e) => {
+                                                                        warn!(channel_id, thread_ts, error = %e, "failed to fetch thread for bot loop check, rejecting (fail-closed)");
+                                                                        continue;
                                                                     }
                                                                 }
                                                             }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,6 +1,6 @@
 use crate::acp::ContentBlock;
 use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, MessageRef, SenderContext};
-use crate::config::SttConfig;
+use crate::config::{AllowBots, AllowUsers, SttConfig};
 use crate::media;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -39,6 +39,7 @@ fn unicode_to_slack_emoji(unicode: &str) -> &str {
         "✅" => "white_check_mark",
         "❌" => "x",
         "🔧" => "wrench",
+        "🎤" => "microphone",
         _ => "grey_question",
     }
 }
@@ -48,20 +49,32 @@ fn unicode_to_slack_emoji(unicode: &str) -> &str {
 /// TTL for cached user display names (5 minutes).
 const USER_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(300);
 
+/// Maximum entries in the participation cache before eviction.
+const PARTICIPATION_CACHE_MAX: usize = 1000;
+
 pub struct SlackAdapter {
     client: reqwest::Client,
     bot_token: String,
     bot_user_id: tokio::sync::OnceCell<String>,
     user_cache: tokio::sync::Mutex<HashMap<String, (String, tokio::time::Instant)>>,
+    /// Cache: Bot ID (B...) → Bot User ID (U...) for trusted_bot_ids matching.
+    bot_id_cache: tokio::sync::Mutex<HashMap<String, String>>,
+    /// Positive-only cache: thread_ts → cached_at for threads where bot has participated.
+    participated_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
+    /// TTL for participation cache entries (matches session_ttl_hours from config).
+    session_ttl: std::time::Duration,
 }
 
 impl SlackAdapter {
-    pub fn new(bot_token: String) -> Self {
+    pub fn new(bot_token: String, session_ttl: std::time::Duration) -> Self {
         Self {
             client: reqwest::Client::new(),
             bot_token,
             bot_user_id: tokio::sync::OnceCell::new(),
             user_cache: tokio::sync::Mutex::new(HashMap::new()),
+            bot_id_cache: tokio::sync::Mutex::new(HashMap::new()),
+            participated_threads: tokio::sync::Mutex::new(HashMap::new()),
+            session_ttl,
         }
     }
 
@@ -84,6 +97,25 @@ impl SlackAdapter {
             .header("Authorization", format!("Bearer {}", self.bot_token))
             .header("Content-Type", "application/json; charset=utf-8")
             .json(&body)
+            .send()
+            .await?;
+
+        let json: serde_json::Value = resp.json().await?;
+        if json["ok"].as_bool() != Some(true) {
+            let err = json["error"].as_str().unwrap_or("unknown error");
+            return Err(anyhow!("Slack API {method}: {err}"));
+        }
+        Ok(json)
+    }
+
+    /// Call a Slack API method using GET with query parameters.
+    /// Required for read methods like conversations.replies that don't accept JSON body.
+    async fn api_get(&self, method: &str, params: &[(&str, &str)]) -> Result<serde_json::Value> {
+        let resp = self
+            .client
+            .get(format!("{SLACK_API}/{method}"))
+            .header("Authorization", format!("Bearer {}", self.bot_token))
+            .query(params)
             .send()
             .await?;
 
@@ -137,6 +169,118 @@ impl SlackAdapter {
         );
 
         Some(resolved)
+    }
+
+    /// Resolve a Bot ID (B...) to Bot User ID (U...) via bots.info API.
+    /// Cached permanently (bot IDs don't change).
+    async fn resolve_bot_user_id(&self, bot_id: &str) -> Option<String> {
+        {
+            let cache = self.bot_id_cache.lock().await;
+            if let Some(user_id) = cache.get(bot_id) {
+                return Some(user_id.clone());
+            }
+        }
+
+        let resp = self
+            .api_post("bots.info", serde_json::json!({ "bot": bot_id }))
+            .await
+            .ok()?;
+        let user_id = resp.get("bot")?
+            .get("user_id")?
+            .as_str()?
+            .to_string();
+
+        self.bot_id_cache.lock().await.insert(
+            bot_id.to_string(),
+            user_id.clone(),
+        );
+
+        Some(user_id)
+    }
+
+    /// Check if the bot has participated in a Slack thread.
+    /// Returns true if: parent message @mentions the bot, OR any message in thread is from the bot.
+    /// Fail-closed: returns false on API error (consistent with Discord's approach).
+    /// Only caches positive results (involved=true is irreversible).
+    async fn bot_participated_in_thread(&self, channel: &str, thread_ts: &str) -> bool {
+        // Check positive cache first
+        {
+            let cache = self.participated_threads.lock().await;
+            if let Some(cached_at) = cache.get(thread_ts) {
+                if cached_at.elapsed() < self.session_ttl {
+                    return true;
+                }
+            }
+        }
+
+        let bot_id = match self.get_bot_user_id().await {
+            Some(id) => id,
+            None => {
+                warn!("cannot resolve bot user ID, rejecting (fail-closed)");
+                return false;
+            }
+        };
+
+        let resp = self
+            .api_get(
+                "conversations.replies",
+                &[
+                    ("channel", channel),
+                    ("ts", thread_ts),
+                    ("limit", "200"),
+                    ("inclusive", "true"),
+                ],
+            )
+            .await;
+
+        let json = match resp {
+            Ok(json) => json,
+            Err(e) => {
+                warn!(channel, thread_ts, error = %e, "failed to fetch thread replies, rejecting (fail-closed)");
+                return false;
+            }
+        };
+        let Some(messages) = json["messages"].as_array() else { return false };
+
+        // Check if parent message @mentions the bot
+        let parent_mentions_bot = messages
+            .first()
+            .and_then(|m| m["text"].as_str())
+            .is_some_and(|text| text.contains(&format!("<@{bot_id}>")));
+
+        // Check if any message in thread is from the bot
+        let bot_posted = messages.iter().any(|m| m["user"].as_str() == Some(bot_id));
+
+        let involved = parent_mentions_bot || bot_posted;
+
+        if involved {
+            self.cache_participation(thread_ts).await;
+        }
+
+        involved
+    }
+
+    /// Insert a positive participation entry, enforcing cache bounds.
+    async fn cache_participation(&self, thread_ts: &str) {
+        let mut cache = self.participated_threads.lock().await;
+        let now = tokio::time::Instant::now();
+
+        cache.insert(thread_ts.to_string(), now);
+
+        if cache.len() > PARTICIPATION_CACHE_MAX {
+            // Evict expired entries first
+            cache.retain(|_, ts| ts.elapsed() < self.session_ttl);
+
+            // If still over, evict oldest half
+            if cache.len() > PARTICIPATION_CACHE_MAX {
+                let mut entries: Vec<_> = cache.iter().map(|(k, v)| (k.clone(), *v)).collect();
+                entries.sort_by_key(|(_, ts)| *ts);
+                let evict_count = entries.len() / 2;
+                for (key, _) in entries.into_iter().take(evict_count) {
+                    cache.remove(&key);
+                }
+            }
+        }
     }
 }
 
@@ -242,18 +386,26 @@ impl ChatAdapter for SlackAdapter {
 
 // --- Socket Mode event loop ---
 
+/// Hard cap on consecutive bot messages in a thread. Prevents runaway loops.
+const MAX_CONSECUTIVE_BOT_TURNS: usize = 10;
+
 /// Run the Slack adapter using Socket Mode (persistent WebSocket, no public URL needed).
 /// Reconnects automatically on disconnect.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_slack_adapter(
     bot_token: String,
     app_token: String,
     allowed_channels: HashSet<String>,
     allowed_users: HashSet<String>,
+    allow_bot_messages: AllowBots,
+    trusted_bot_ids: HashSet<String>,
+    allow_user_messages: AllowUsers,
+    session_ttl: std::time::Duration,
     stt_config: SttConfig,
     router: Arc<AdapterRouter>,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> Result<()> {
-    let adapter = Arc::new(SlackAdapter::new(bot_token.clone()));
+    let adapter = Arc::new(SlackAdapter::new(bot_token.clone(), session_ttl));
 
     loop {
         // Check for shutdown before (re)connecting
@@ -325,56 +477,140 @@ pub async fn run_slack_adapter(
                                                 });
                                             }
                                             "message" => {
-                                                // Handle thread follow-ups without @mention.
-                                                // Skip bot messages and subtypes that aren't real user messages.
+                                                let channel_id = event["channel"].as_str().unwrap_or("");
                                                 let has_thread = event["thread_ts"].is_string();
                                                 let is_bot = event["bot_id"].is_string()
                                                     || event["subtype"].as_str() == Some("bot_message");
                                                 let subtype = event["subtype"].as_str().unwrap_or("");
-                                                let has_files = event["files"].is_array();
-                                                // Skip messages that @mention the bot — app_mention handles those
                                                 let msg_text = event["text"].as_str().unwrap_or("");
-                                                let mentions_bot = if let Some(bot_id) = adapter.get_bot_user_id().await {
-                                                    msg_text.contains(&format!("<@{bot_id}>"))
+                                                let mentions_bot = if let Some(bot_uid) = adapter.get_bot_user_id().await {
+                                                    msg_text.contains(&format!("<@{bot_uid}>"))
                                                 } else {
                                                     false
                                                 };
+                                                let is_dm = channel_id.starts_with('D');
+
                                                 debug!(
+                                                    channel_id,
                                                     has_thread,
                                                     is_bot,
+                                                    is_dm,
                                                     subtype,
-                                                    has_files,
                                                     mentions_bot,
                                                     text = msg_text,
                                                     "message event received"
                                                 );
+
+                                                // Skip non-message subtypes
                                                 let skip_subtype = matches!(subtype,
                                                     "message_changed" | "message_deleted" |
                                                     "channel_join" | "channel_leave" |
                                                     "channel_topic" | "channel_purpose"
                                                 );
-                                                if has_thread && !is_bot && !skip_subtype && !mentions_bot {
-                                                    let event = event.clone();
-                                                    let adapter = adapter.clone();
-                                                    let bot_token = bot_token.clone();
-                                                    let allowed_channels = allowed_channels.clone();
-                                                    let allowed_users = allowed_users.clone();
-                                                    let stt_config = stt_config.clone();
-                                                    let router = router.clone();
-                                                    tokio::spawn(async move {
-                                                        handle_message(
-                                                            &event,
-                                                            false,
-                                                            &adapter,
-                                                            &bot_token,
-                                                            &allowed_channels,
-                                                            &allowed_users,
-                                                            &stt_config,
-                                                            &router,
-                                                        )
-                                                        .await;
-                                                    });
+                                                if skip_subtype { continue; }
+
+                                                // Skip messages that @mention the bot — app_mention handles those
+                                                // (except in DMs where app_mention doesn't fire)
+                                                if mentions_bot && !is_dm { continue; }
+
+                                                // --- Bot message gating ---
+                                                if is_bot {
+                                                    let event_bot_id = event["bot_id"].as_str().unwrap_or("");
+                                                    match allow_bot_messages {
+                                                        AllowBots::Off => { continue; }
+                                                        AllowBots::Mentions => {
+                                                            if !mentions_bot { continue; }
+                                                        }
+                                                        AllowBots::All => {
+                                                            // Loop protection: count consecutive bot msgs
+                                                            if let Some(thread_ts) = event["thread_ts"].as_str() {
+                                                                let limit_str = (MAX_CONSECUTIVE_BOT_TURNS + 1).to_string();
+                                                                if let Ok(resp) = adapter.api_get(
+                                                                    "conversations.replies",
+                                                                    &[
+                                                                        ("channel", channel_id),
+                                                                        ("ts", thread_ts),
+                                                                        ("limit", &limit_str),
+                                                                    ],
+                                                                ).await {
+                                                                    if let Some(msgs) = resp["messages"].as_array() {
+                                                                        let consecutive = msgs.iter().rev()
+                                                                            .take_while(|m| {
+                                                                                m["bot_id"].is_string()
+                                                                                    || m["subtype"].as_str() == Some("bot_message")
+                                                                            })
+                                                                            .count();
+                                                                        if consecutive >= MAX_CONSECUTIVE_BOT_TURNS {
+                                                                            warn!("bot turn cap reached ({MAX_CONSECUTIVE_BOT_TURNS}), ignoring");
+                                                                            continue;
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                    // Check trusted_bot_ids
+                                                    if !trusted_bot_ids.is_empty() {
+                                                        let resolved = adapter.resolve_bot_user_id(event_bot_id).await;
+                                                        let is_trusted = resolved
+                                                            .as_ref()
+                                                            .is_some_and(|uid| trusted_bot_ids.contains(uid.as_str()));
+                                                        if !is_trusted {
+                                                            debug!(event_bot_id, resolved = ?resolved, "bot not in trusted_bot_ids, ignoring");
+                                                            continue;
+                                                        }
+                                                    }
+                                                    // Bot messages must be in a thread (no top-level bot processing)
+                                                    if !has_thread { continue; }
                                                 }
+
+                                                // --- User message gating ---
+                                                if !is_bot {
+                                                    if is_dm {
+                                                        // DM: implicit mention — always process
+                                                    } else {
+                                                        match allow_user_messages {
+                                                            AllowUsers::Mentions => {
+                                                                if !mentions_bot { continue; }
+                                                            }
+                                                            AllowUsers::Involved => {
+                                                                if !has_thread {
+                                                                    // Non-thread channel message: require mention
+                                                                    // (app_mention handles this, but DMs don't get app_mention)
+                                                                    continue;
+                                                                }
+                                                                // Thread message: check bot participation
+                                                                let thread_ts = event["thread_ts"].as_str().unwrap_or("");
+                                                                if !adapter.bot_participated_in_thread(channel_id, thread_ts).await {
+                                                                    debug!(channel_id, thread_ts, "bot not involved in thread, ignoring");
+                                                                    continue;
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+
+                                                // Dispatch to handle_message
+                                                let event = event.clone();
+                                                let adapter = adapter.clone();
+                                                let bot_token = bot_token.clone();
+                                                let allowed_channels = allowed_channels.clone();
+                                                let allowed_users = allowed_users.clone();
+                                                let stt_config = stt_config.clone();
+                                                let router = router.clone();
+                                                tokio::spawn(async move {
+                                                    handle_message(
+                                                        &event,
+                                                        is_dm,
+                                                        &adapter,
+                                                        &bot_token,
+                                                        &allowed_channels,
+                                                        &allowed_users,
+                                                        &stt_config,
+                                                        &router,
+                                                    )
+                                                    .await;
+                                                });
                                             }
                                             _ => {}
                                         }
@@ -435,7 +671,7 @@ async fn get_socket_mode_url(app_token: &str) -> Result<String> {
 #[allow(clippy::too_many_arguments)]
 async fn handle_message(
     event: &serde_json::Value,
-    is_mention: bool,
+    strip_mentions: bool,
     adapter: &Arc<SlackAdapter>,
     bot_token: &str,
     allowed_channels: &HashSet<String>,
@@ -447,10 +683,13 @@ async fn handle_message(
         Some(ch) => ch.to_string(),
         None => return,
     };
-    let user_id = match event["user"].as_str() {
+    // Bot messages may lack "user" field — fall back to "bot_id" as sender identifier
+    let user_id = match event["user"].as_str().or_else(|| event["bot_id"].as_str()) {
         Some(u) => u.to_string(),
         None => return,
     };
+    let is_bot_msg = event["bot_id"].is_string()
+        || event["subtype"].as_str() == Some("bot_message");
     let text = match event["text"].as_str() {
         Some(t) => t.to_string(),
         None => return,
@@ -466,8 +705,8 @@ async fn handle_message(
         return;
     }
 
-    // Check allowed users
-    if !allowed_users.is_empty() && !allowed_users.contains(&user_id) {
+    // Check allowed users — skip for bot messages (they go through trusted_bot_ids instead)
+    if !is_bot_msg && !allowed_users.is_empty() && !allowed_users.contains(&user_id) {
         tracing::info!(user_id, "denied Slack user, ignoring");
         let msg_ref = MessageRef {
             channel: ChannelRef {
@@ -482,17 +721,10 @@ async fn handle_message(
         return;
     }
 
-    // Strip bot mention from text only for @mention events
-    let prompt = if is_mention {
+    // Strip bot mention from text for @mention events; DMs and thread follow-ups pass through as-is
+    let prompt = if strip_mentions {
         strip_slack_mention(&text)
     } else {
-        // Thread follow-up: check for bot loop before processing
-        if let Some(ref tts) = thread_ts {
-            if is_bot_loop(adapter, &channel_id, tts).await {
-                tracing::warn!(channel_id, thread_ts = tts, "bot loop detected, ignoring");
-                return;
-            }
-        }
         text.trim().to_string()
     };
 
@@ -537,6 +769,16 @@ async fn handle_message(
                     }
                 } else {
                     debug!(filename, "skipping audio attachment (STT disabled)");
+                    let msg_ref = MessageRef {
+                        channel: ChannelRef {
+                            platform: "slack".into(),
+                            channel_id: channel_id.clone(),
+                            thread_id: thread_ts.clone(),
+                            parent_id: None,
+                        },
+                        message_id: ts.clone(),
+                    };
+                    let _ = adapter.add_reaction(&msg_ref, "🎤").await;
                 }
             } else if let Some(block) = media::download_and_encode_image(
                 url,
@@ -564,7 +806,7 @@ async fn handle_message(
         display_name,
         channel: "slack".into(),
         channel_id: channel_id.clone(),
-        is_bot: false,
+        is_bot: is_bot_msg,
     };
 
     let trigger_msg = MessageRef {
@@ -596,39 +838,6 @@ async fn handle_message(
 
 static SLACK_MENTION_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"<@[A-Z0-9]+>").unwrap());
-
-/// Hard cap on consecutive bot messages in a thread.
-/// Mirrors Discord's MAX_CONSECUTIVE_BOT_TURNS to prevent runaway loops.
-const MAX_CONSECUTIVE_BOT_TURNS: usize = 10;
-
-/// Check if the last N messages in a Slack thread are all from bots.
-async fn is_bot_loop(adapter: &SlackAdapter, channel: &str, thread_ts: &str) -> bool {
-    let resp = adapter
-        .api_post(
-            "conversations.replies",
-            serde_json::json!({
-                "channel": channel,
-                "ts": thread_ts,
-                "limit": MAX_CONSECUTIVE_BOT_TURNS + 1,
-                "inclusive": true,
-            }),
-        )
-        .await;
-
-    let Ok(json) = resp else { return false }; // fail-open on API error
-    let Some(messages) = json["messages"].as_array() else { return false };
-
-    // Skip the first message (thread parent), count consecutive bot messages from the end
-    let recent: Vec<_> = messages.iter().skip(1).rev().collect();
-    if recent.len() < MAX_CONSECUTIVE_BOT_TURNS {
-        return false;
-    }
-
-    recent
-        .iter()
-        .take(MAX_CONSECUTIVE_BOT_TURNS)
-        .all(|m| m["bot_id"].is_string() || m["subtype"].as_str() == Some("bot_message"))
-}
 
 fn strip_slack_mention(text: &str) -> String {
     SLACK_MENTION_RE.replace_all(text, "").trim().to_string()


### PR DESCRIPTION
## What problem does this solve?

The Slack adapter has three gaps compared to Discord:

1. **Thread follow-up bug** — bot replies to *any* thread message, even threads it was never mentioned in ([reported in Discord](https://discord.com/channels/1491295327620169908/1491969620754567270/1494205732562800771))
2. **No bot-to-bot gating** — Discord has `allow_bot_messages` + `trusted_bot_ids`; Slack ignores all bot messages with no way to enable collaboration
3. **No DM support** — Slack DMs (`message.im`) are silently dropped because the event handler requires `thread_ts` (fixes #396)

Part of #382 (Slack adapter stabilization for 0.7.7 GA).

## Prior art

**Discord adapter** (`src/discord.rs`) already implements:
- `AllowBots` enum (Off/Mentions/All) with consecutive bot turn cap (fail-closed)
- `trusted_bot_ids` allowlist
- Thread-aware message gating (only respond in threads created by mention)

**OpenClaw** uses a similar "involved" concept — bots only respond in conversations they've been invited into.

**Hermes Agent** inspired the original `AllowBots` 3-value design (see `config.rs` doc comment).

## What's in this PR

| File | Purpose |
|---|---|
| `src/config.rs` | New `AllowUsers` enum (Involved/Mentions), `AllowBots` + `trusted_bot_ids` added to `SlackConfig` |
| `src/slack.rs` | Event handler rewrite: DM detection, AllowUsers gating, AllowBots gating, participation cache, `api_get()` for read methods, STT reaction |
| `src/main.rs` | Wire new config params to `run_slack_adapter()` |
| `charts/openab/templates/configmap.yaml` | Helm template for new Slack config options with validation |
| `charts/openab/values.yaml` | Default values for new options |
| `config.toml.example` | Document new Slack options |

## Key decisions

### `AllowUsers` enum (Involved / Mentions)

| Mode | Channel/MPDM (non-thread) | Thread (bot NOT involved) | Thread (bot involved) |
|------|---------------------------|---------------------------|----------------------|
| `involved` (default) | @mention required | ignored | reply without @mention |
| `mentions` | @mention required | @mention required | @mention required |

- **DMs** (`D` prefix channel ID): always processed (implicit mention) — `AllowUsers` does not apply
- **"Involved" definition**: bot posted at least one message in the thread, OR thread parent @mentions the bot

### Participation cache

- **Positive-only**: only caches `true` (involved is irreversible — bot can't un-post)
- **`false` never cached**: next message re-queries API (bot may have replied since)
- **TTL = `session_ttl_hours`**: cache entries expire with ACP sessions
- **Bounded at 1000 entries**: evicts expired first, then oldest half

### Fail-closed on API errors

Consistent with Discord adapter (`discord.rs:182`: *"rejecting (fail-closed)"*). If `conversations.replies` fails, the message is dropped. User can always @mention to retry.

### `api_get()` for Slack read methods

`conversations.replies` is a GET method that does not accept JSON body POST. The previous `api_post()` call silently failed with `invalid_arguments`. Added `api_get()` with query parameters.

### `tokio::spawn` preserved

The old `feat/generalize-discord-features` branch removed `tokio::spawn` for `handle_message`, which would block the WebSocket read loop and cause Slack to disconnect on slow agent responses. This PR keeps `tokio::spawn`.

## Alternatives considered

1. **`AllowUsers::All`** (respond to all thread messages) — rejected as impractical; bot would reply in unrelated threads
2. **Fail-open for participation check** — rejected for consistency with Discord; silent message drops are preferable to replying in unrelated threads (user can @mention to retry)
3. **Caching negative results** — rejected because thread state changes with every message; stale `false` would permanently prevent bot from responding in a thread it later joins

## Test plan

- [ ] **Channel (involved mode)**: post without mention → no reply; @mention → reply in thread; thread follow-up without mention → reply
- [ ] **Channel (mentions mode)**: thread follow-up without mention → no reply even in bot-involved threads
- [ ] **DM**: send message without mention → reply; thread follow-up → reply
- [ ] **Bot gating**: set `allow_bot_messages = "all"` → bot responds to other bot messages; loop protection caps at 10 consecutive bot turns
- [ ] `cargo check` + `cargo clippy` — clean
- [ ] Helm: `helm template` renders new config options correctly