### PR TITLE
fix(helm): decouple [discord] section from botToken presence

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "openab.labels" $d | nindent 4 }}
 data:
   config.toml: |
-    {{- if and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken }}
+    {{- if ($cfg.discord).enabled }}
     [discord]
     bot_token = "${DISCORD_BOT_TOKEN}"
     {{- range $cfg.discord.allowedChannels }}

--- a/charts/openab/tests/adapter-enablement_test.yaml
+++ b/charts/openab/tests/adapter-enablement_test.yaml
@@ -1,0 +1,70 @@
+suite: adapter enablement gating
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: renders [discord] with placeholder token when enabled=true without botToken
+    set:
+      agents.kiro.discord.enabled: true
+      agents.kiro.discord.botToken: ""
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: "\\[discord\\]"
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'bot_token = "\$\{DISCORD_BOT_TOKEN\}"'
+
+  - it: omits [discord] when enabled=false
+    set:
+      agents.kiro.discord.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: "\\[discord\\]"
+
+  - it: omits [discord] when discord is not set
+    set:
+      agents.kiro.discord: null
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: "\\[discord\\]"
+
+  - it: renders [slack] when enabled=true
+    set:
+      agents.kiro.slack.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: "\\[slack\\]"
+
+  - it: omits [slack] when enabled=false
+    set:
+      agents.kiro.slack.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: "\\[slack\\]"
+
+  - it: renders [slack] with placeholder tokens when enabled=true
+    set:
+      agents.kiro.slack.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'bot_token = "\$\{SLACK_BOT_TOKEN\}"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'app_token = "\$\{SLACK_APP_TOKEN\}"'
+
+  - it: renders both [discord] and [slack] when both enabled
+    set:
+      agents.kiro.discord.enabled: true
+      agents.kiro.slack.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: "\\[discord\\]"
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: "\\[slack\\]"

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -24,7 +24,7 @@ agents:
     #   command: claude-agent-acp
     #   args: []
     #   discord:
-    #     botToken: ""
+    #     enabled: true
     #     # ⚠️ Use --set-string for channel IDs to avoid float64 precision loss
     #     allowedChannels:
     #       - "YOUR_CHANNEL_ID"
@@ -60,7 +60,7 @@ agents:
     #   args:
     #     - acp
     #   discord:
-    #     botToken: ""
+    #     enabled: true
     #     allowedChannels:
     #       - "YOUR_CHANNEL_ID"
     #     allowedUsers: []
@@ -91,7 +91,7 @@ agents:
     #     - --workspace
     #     - /home/agent
     #   discord:
-    #     botToken: ""
+    #     enabled: true
     #     allowedChannels:
     #       - "YOUR_CHANNEL_ID"
     #     allowedUsers: []
@@ -115,8 +115,9 @@ agents:
       - acp
       - --trust-all-tools
     discord:
-      enabled: true      # set to false to disable; enabled with empty botToken is treated as disabled
-      botToken: ""
+      enabled: true      # set to false to disable the discord adapter
+      # botToken is no longer required at render time; the actual token
+      # is injected at runtime via the DISCORD_BOT_TOKEN env var.
       # ⚠️ Use --set-string for channel IDs to avoid float64 precision loss
       allowedChannels:
         - "YOUR_CHANNEL_ID"


### PR DESCRIPTION
### Issue

Closes #392.
Supersedes #393 (rebased onto current `main`, removed stale/duplicate Slack section, updated `values.yaml`).

### Reason for this change

The `[discord]` block in `config.toml` is conditionally rendered only when `($cfg.discord).botToken` is non-empty. This forces users who manage secrets at runtime (e.g., AWS Secrets Manager → K8s Secret → env var) to either:
1. Pass a dummy token to Helm (confusing)
2. Pass the real token to Helm (stored in Helm release history — security risk)

The template already hardcodes `bot_token = "${DISCORD_BOT_TOKEN}"` as a placeholder for runtime expansion, so requiring `botToken` in Helm values serves no purpose other than gating the block.

### Description of changes

**configmap.yaml** (one-line change):
```diff
- {{- if and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken }}
+ {{- if ($cfg.discord).enabled }}
```

**values.yaml**:
- Removed `botToken` from the kiro agent discord section (no longer needed at render time)
- Updated comment to explain runtime token injection via `DISCORD_BOT_TOKEN` env var
- Added `enabled: true` to all commented-out agent examples (claude, opencode, cursor) so users see the correct pattern

### ⚠️ Breaking Change

This changes the discord condition from **opt-out** (`enabled` defaults to true unless `"false"`) to **opt-in** (`enabled` must be explicitly `true`).

**Who is affected**: Users who have `discord.botToken` set but never explicitly set `discord.enabled: true`. After this change, their `[discord]` block will not render.

**Migration**: Add `discord.enabled: true` to your agent's discord values.

### Context
- Discord discussion: https://discord.com/channels/1491295327620169908/1491365162869985283
- Reference: #380