### PR TITLE
fix(discord): add AllowUsers thread gating (owner check + participation check)

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -7,6 +7,9 @@ allowed_channels = ["1234567890"]       # empty or omitted = allow all channels
 # allow_bot_messages = "off"  # "off" (default) | "mentions" | "all"
                                # "mentions" is recommended for multi-agent collaboration
 # trusted_bot_ids = []         # empty = any bot (mode permitting); set to restrict
+# allow_user_messages = "involved"  # "involved" (default) | "mentions"
+                                     # "involved" = reply in threads bot owns or has participated in
+                                     # "mentions" = always require @mention
 
 # [slack]
 # bot_token = "${SLACK_BOT_TOKEN}"     # Bot User OAuth Token (xoxb-...)

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,6 +86,8 @@ pub struct DiscordConfig {
     /// ignored when `"off"` since all bot messages are rejected before this check.
     #[serde(default)]
     pub trusted_bot_ids: Vec<String>,
+    #[serde(default)]
+    pub allow_user_messages: AllowUsers,
 }
 
 /// Controls whether the bot responds to user messages in threads without @mention.

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,6 +1,6 @@
 use crate::acp::ContentBlock;
 use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, MessageRef, SenderContext};
-use crate::config::{AllowBots, SttConfig};
+use crate::config::{AllowBots, AllowUsers, SttConfig};
 use crate::format;
 use crate::media;
 use async_trait::async_trait;
@@ -12,13 +12,16 @@ use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, MessageId, UserId};
 use serenity::model::user::User;
 use serenity::prelude::*;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 use tracing::{debug, error, info};
 
 /// Hard cap on consecutive bot messages in a channel or thread.
 /// Prevents runaway loops between multiple bots in "all" mode.
 const MAX_CONSECUTIVE_BOT_TURNS: u8 = 10;
+
+/// Maximum entries in the participation cache before eviction.
+const PARTICIPATION_CACHE_MAX: usize = 1000;
 
 // --- DiscordAdapter: implements ChatAdapter for Discord via serenity ---
 
@@ -124,6 +127,74 @@ pub struct Handler {
     pub adapter: OnceLock<Arc<dyn ChatAdapter>>,
     pub allow_bot_messages: AllowBots,
     pub trusted_bot_ids: HashSet<u64>,
+    pub allow_user_messages: AllowUsers,
+    /// Positive-only cache: thread channel_id → cached_at for threads where bot has participated.
+    pub participated_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
+    /// TTL for participation cache entries (from pool.session_ttl_hours).
+    pub session_ttl: std::time::Duration,
+}
+
+impl Handler {
+    /// Check if the bot has participated in a Discord thread.
+    /// Returns true if any message in the thread is from the bot.
+    /// Fail-closed: returns false on API error.
+    /// Only caches positive results (participation is irreversible).
+    async fn bot_participated_in_thread(
+        &self,
+        http: &Http,
+        channel_id: ChannelId,
+        bot_id: UserId,
+    ) -> bool {
+        let key = channel_id.to_string();
+
+        // Check positive cache
+        {
+            let cache = self.participated_threads.lock().await;
+            if let Some(cached_at) = cache.get(&key) {
+                if cached_at.elapsed() < self.session_ttl {
+                    return true;
+                }
+            }
+        }
+
+        // Fetch recent messages and check if bot posted any
+        let messages = match channel_id
+            .messages(http, serenity::builder::GetMessages::new().limit(200))
+            .await
+        {
+            Ok(msgs) => msgs,
+            Err(e) => {
+                tracing::warn!(
+                    channel_id = %channel_id,
+                    error = %e,
+                    "failed to fetch thread messages for participation check, rejecting (fail-closed)"
+                );
+                return false;
+            }
+        };
+
+        let involved = messages.iter().any(|m| m.author.id == bot_id);
+
+        if involved {
+            let mut cache = self.participated_threads.lock().await;
+            cache.insert(key, tokio::time::Instant::now());
+
+            // Evict if over capacity
+            if cache.len() > PARTICIPATION_CACHE_MAX {
+                cache.retain(|_, ts| ts.elapsed() < self.session_ttl);
+                if cache.len() > PARTICIPATION_CACHE_MAX {
+                    let mut entries: Vec<_> = cache.iter().map(|(k, v)| (k.clone(), *v)).collect();
+                    entries.sort_by_key(|(_, ts)| *ts);
+                    let evict_count = entries.len() / 2;
+                    for (k, _) in entries.into_iter().take(evict_count) {
+                        cache.remove(&k);
+                    }
+                }
+            }
+        }
+
+        involved
+    }
 }
 
 #[serenity::async_trait]
@@ -201,33 +272,63 @@ impl EventHandler for Handler {
             }
         }
 
-        let in_thread = if !in_allowed_channel {
+        // Thread detection: check if the message is in a thread whose parent
+        // is an allowed channel, and whether the bot owns that thread.
+        let (in_thread, bot_owns_thread) = if !in_allowed_channel {
             match msg.channel_id.to_channel(&ctx.http).await {
                 Ok(serenity::model::channel::Channel::Guild(gc)) => {
-                    let result = gc
+                    let parent_allowed = gc
                         .parent_id
                         .is_some_and(|pid| self.allowed_channels.contains(&pid.get()));
-                    tracing::debug!(channel_id = %msg.channel_id, parent_id = ?gc.parent_id, result, "thread check");
-                    result
+                    let owned = gc.owner_id.is_some_and(|oid| oid == bot_id);
+                    tracing::debug!(
+                        channel_id = %msg.channel_id,
+                        parent_id = ?gc.parent_id,
+                        owner_id = ?gc.owner_id,
+                        parent_allowed,
+                        bot_owns = owned,
+                        "thread check"
+                    );
+                    (parent_allowed, owned)
                 }
                 Ok(other) => {
                     tracing::debug!(channel_id = %msg.channel_id, kind = ?other, "not a guild channel");
-                    false
+                    (false, false)
                 }
                 Err(e) => {
                     tracing::debug!(channel_id = %msg.channel_id, error = %e, "to_channel failed");
-                    false
+                    (false, false)
                 }
             }
         } else {
-            false
+            (false, false)
         };
 
         if !in_allowed_channel && !in_thread {
             return;
         }
-        if !in_thread && !is_mentioned {
-            return;
+
+        // User message gating (mirrors Slack's AllowUsers logic).
+        // Mentions: always require @mention, even in bot's own threads.
+        // Involved (default): skip @mention if the bot owns the thread
+        //   (Option A) OR has previously posted in it (Option B).
+        if !is_mentioned {
+            match self.allow_user_messages {
+                AllowUsers::Mentions => return,
+                AllowUsers::Involved => {
+                    if !in_thread {
+                        return;
+                    }
+                    let involved = bot_owns_thread
+                        || self
+                            .bot_participated_in_thread(&ctx.http, msg.channel_id, bot_id)
+                            .await;
+                    if !involved {
+                        tracing::debug!(channel_id = %msg.channel_id, "bot not involved in thread, ignoring");
+                        return;
+                    }
+                }
+            }
         }
 
         if !self.allowed_users.is_empty() && !self.allowed_users.contains(&msg.author.id.get()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,7 @@ async fn main() -> anyhow::Result<()> {
                     users = allowed_users.len(),
                     trusted_bots = trusted_bot_ids.len(),
                     allow_bot_messages = ?discord_cfg.allow_bot_messages,
+                    allow_user_messages = ?discord_cfg.allow_user_messages,
                     "starting discord adapter"
                 );
 
@@ -166,6 +167,9 @@ async fn main() -> anyhow::Result<()> {
                     adapter: std::sync::OnceLock::new(),
                     allow_bot_messages: discord_cfg.allow_bot_messages,
                     trusted_bot_ids,
+                    allow_user_messages: discord_cfg.allow_user_messages,
+                    participated_threads: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+                    session_ttl: std::time::Duration::from_secs(ttl_secs),
                 };
 
                 let intents = GatewayIntents::GUILD_MESSAGES


### PR DESCRIPTION
## Summary

Add `allow_user_messages` config to the Discord adapter with two complementary thread-involvement checks, achieving full parity with the Slack adapter's `AllowUsers::Involved` behavior.

## Problem

The Discord adapter bypasses the `@mention` requirement for **all** messages in threads whose parent channel is in `allowed_channels`. When Bot-A creates a thread, Bot-B and Bot-C also respond to every message — even though nobody mentioned them. This is equivalent to `AllowUsers::All`, which was intentionally removed from the Slack adapter.

## Solution

Two complementary checks (not mutually exclusive):

**Option A — thread owner check (zero-cost):**
Uses Discord's native `GuildChannel.owner_id` to detect threads created by the bot. No API calls, no state. Covers the primary flow: user @mentions bot → bot creates thread → bot responds to follow-ups.

**Option B — participation check (cached API call):**
Fetches last 50 messages in the thread via `ChannelId.messages()` to check if the bot has posted. Positive-only cache with TTL (4h) and eviction (max 1000 entries), matching the Slack adapter's pattern. Covers: user creates thread → @mentions bot inside → bot replies → user continues without @mention.

**New config:**
```toml
[discord]
allow_user_messages = "involved"  # "involved" (default) | "mentions"
```

## Behavior change

| Scenario | Before | After (involved) | After (mentions) |
|---|---|---|---|
| Message in bot's own thread (no @mention) | ✅ Processed | ✅ Processed (owner check) | ❌ Ignored |
| Message in thread where bot has replied (no @mention) | ✅ Processed (bug — all bots) | ✅ Processed (participation check) | ❌ Ignored |
| Message in unrelated thread (no @mention) | ✅ Processed (bug) | ❌ Ignored | ❌ Ignored |
| Message in any thread with @mention | ✅ Processed | ✅ Processed | ✅ Processed |
| Message in allowed channel with @mention | ✅ Processed | ✅ Processed | ✅ Processed |

## Files changed

- `src/config.rs` — add `allow_user_messages: AllowUsers` to `DiscordConfig`
- `src/discord.rs` — thread owner check, `bot_participated_in_thread()` with cache, `AllowUsers` match in message handler
- `src/main.rs` — wire new config field + participation cache
- `config.toml.example` — document new option

## Design notes

- **Fail-closed**: API errors in participation check → message ignored (consistent with Slack)
- **Owner check runs first**: avoids the API call when the bot created the thread
- **Cache is positive-only**: once involved, always involved (participation is irreversible within TTL)
- **Default is `"involved"`**: no config change needed for existing deployments, but behavior improves

Closes #407