### PR TITLE
fix: bump CLI versions — codex 0.121.0, gemini 0.38.1, copilot 1.0.30, cursor 2026.04.15

### DIFF
--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
-ARG CODEX_VERSION=0.120.0
+ARG CODEX_VERSION=0.121.0
 RUN npm install -g @zed-industries/codex-acp@0.9.5 @openai/codex@${CODEX_VERSION} --retry 3
 
 # Install gh CLI

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
-ARG COPILOT_VERSION=1.0.25
+ARG COPILOT_VERSION=1.0.30
 RUN npm install -g @github/copilot@${COPILOT_VERSION} --retry 3
 
 # Install gh CLI (for auth and token management)

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # URL scheme scraped from Cursor's official downloads page — no apt/yum package exists.
 # If Cursor changes this pattern, the build fails with curl 404. Monitor
 # https://cursor.com/cli or https://docs.cursor.com/cli for version/URL updates.
-ARG CURSOR_VERSION=2026.04.14-ee4b43a
+ARG CURSOR_VERSION=2026.04.15-dccdccd
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
     curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
-ARG GEMINI_CLI_VERSION=0.37.2
+ARG GEMINI_CLI_VERSION=0.38.1
 RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} --retry 3
 
 # Install gh CLI


### PR DESCRIPTION
## Summary

Bump pinned CLI versions in Dockerfiles after investigating latest releases and upstream bug trackers.

## Changes

| Dockerfile | CLI | Old | New | Notes |
|---|---|---|---|---|
| `Dockerfile.codex` | `@openai/codex` | 0.120.0 | **0.121.0** | No CLI-specific regressions; open bugs are VS Code extension/desktop app only |
| `Dockerfile.gemini` | `@google/gemini-cli` | 0.37.2 | **0.38.1** | Clean — zero open bugs with `bug` label |
| `Dockerfile.copilot` | `@github/copilot` | 1.0.25 | **1.0.30** | No public issue tracker (repo 404); low risk |
| `Dockerfile.cursor` | Cursor Agent CLI | 2026.04.14-ee4b43a | **2026.04.15-dccdccd** | Version from official install script; ships with Cursor 3.1 (Apr 13) |

## NOT updated (intentionally)

| Dockerfile | CLI | Pinned | Latest | Why |
|---|---|---|---|---|
| `Dockerfile` | `kiro-cli` | 2.0.0 | 2.0.0 | Already latest |
| `Dockerfile.claude` | `@anthropic-ai/claude-code` | 2.1.104 | 2.1.112 | ⚠️ **Too risky for container workloads** — see below |
| `Dockerfile.opencode` | `opencode-ai` | 1.4.6 | 1.4.6 | Already latest |

### claude-code risk assessment

- **[#49512](https://github.com/anthropics/claude-code/issues/49512)** (2.1.112): ENOENT race condition on `mkdir` of per-session tasks dir when running parallel sessions — labeled `regression` + `platform:linux`. Directly impacts openab which runs containers with concurrent sessions.
- **[#49503](https://github.com/anthropics/claude-code/issues/49503)** (2.1.111): `settings.json` model preference silently ignored — sessions default to Opus 4.7 instead of pinned model.
- **[#47648](https://github.com/anthropics/claude-code/issues/47648)** (2.1.105+): Auth token paste broken on Linux — closed as "not planned" (the original issue that triggered PR #333 revert to 2.1.104).

Recommendation: stay on 2.1.104 until upstream resolves the parallel session race condition.

## How to verify

```bash
# Check latest versions
curl -fsSL https://prod.download.cli.kiro.dev/stable/latest/manifest.json | jq -r .version
npm view @openai/codex version
npm view @anthropic-ai/claude-code version
npm view @google/gemini-cli version
npm view @github/copilot version
curl -fsSL https://cursor.com/install | grep "CURSOR_VERSION\|DOWNLOAD_URL" | head -2
npm view opencode-ai version
```

Ref: #326, #333