### PR TITLE
feat: add ripgrep to all Dockerfile variants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep unzip && rm -rf /var/lib/apt/lists/*
 
 # Install kiro-cli (auto-detect arch, copy binary directly)
 ARG KIRO_CLI_VERSION=2.0.0

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
 
 # Install claude-agent-acp adapter and Claude Code CLI
 ARG CLAUDE_CODE_VERSION=2.1.104

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
 ARG CODEX_VERSION=0.120.0

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
 ARG COPILOT_VERSION=1.0.25

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
 
 # Install Cursor Agent CLI (pinned version)
 # Tarball source: https://downloads.cursor.com/lab/<version>/linux/<arch>/agent-cli-package.tar.gz

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
 ARG GEMINI_CLI_VERSION=0.37.2

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -23,7 +23,7 @@ RUN touch src/main.rs && cargo build --release
 # Note: opencode does not publish SHA256 checksums for its releases,
 # so checksum verification is not possible at this time.
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
 
 # Install opencode
 ARG OPENCODE_VERSION=1.4.6


### PR DESCRIPTION
## Summary

Install `ripgrep` (`rg`) in the runtime stage of all Dockerfile variants to provide fast recursive search capabilities for coding agents.

Closes #250

## Changes

Added `ripgrep` to `apt-get install` in:
- `Dockerfile`
- `Dockerfile.claude`
- `Dockerfile.codex`
- `Dockerfile.copilot`
- `Dockerfile.cursor`
- `Dockerfile.gemini`
- `Dockerfile.opencode`

Packages are kept in alphabetical order.