### PR TITLE
fix(gemini): seed ~/.gemini/projects.json with registry schema on startup

### DIFF
--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -26,10 +26,12 @@ ENV HOME=/home/node
 WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+COPY --chown=node:node docker-entrypoint-gemini.sh /usr/local/bin/docker-entrypoint-gemini.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-gemini.sh
 
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENTRYPOINT ["openab"]
+ENTRYPOINT ["docker-entrypoint-gemini.sh"]
 CMD ["run", "/etc/openab/config.toml"]
 

--- a/docker-entrypoint-gemini.sh
+++ b/docker-entrypoint-gemini.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Seed ~/.gemini/projects.json with the required registry schema if missing or empty
+PROJECTS_JSON="${HOME}/.gemini/projects.json"
+mkdir -p "${HOME}/.gemini"
+if [ ! -f "$PROJECTS_JSON" ] || [ "$(cat "$PROJECTS_JSON" 2>/dev/null)" = "{}" ] || [ ! -s "$PROJECTS_JSON" ]; then
+  echo '{"projects":{}}' > "$PROJECTS_JSON"
+fi
+
+exec openab "$@"


### PR DESCRIPTION
Fixes #389

## Changes
- Add `docker-entrypoint-gemini.sh` that seeds `~/.gemini/projects.json` with `{"projects":{}}` before launching `openab`
- Update `Dockerfile.gemini` to use the new entrypoint script

## Why
Gemini CLI expects `~/.gemini/projects.json` to contain a registry object. If the file is missing or contains `{}`, it exits during ACP startup. The entrypoint script ensures the correct schema is always present before `openab` runs.

## Related
https://discord.com/channels/1491295327620169908/1491365162869985283/1494669467546943839