### PR TITLE
fix(helm): escape all user-supplied TOML string values with toJson

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
     {{- if not (has $cfg.discord.allowBotMessages (list "off" "mentions" "all")) }}
     {{- fail (printf "agents.%s.discord.allowBotMessages must be one of: off, mentions, all — got: %s" $name $cfg.discord.allowBotMessages) }}
     {{- end }}
-    allow_bot_messages = "{{ $cfg.discord.allowBotMessages }}"
+    allow_bot_messages = {{ $cfg.discord.allowBotMessages | toJson }}
     {{- end }}
     {{- range $cfg.discord.trustedBotIds }}
     {{- if regexMatch "e\\+|E\\+" (toString .) }}
@@ -64,7 +64,7 @@ data:
     {{- if not (has ($cfg.slack).allowBotMessages (list "off" "mentions" "all")) }}
     {{- fail (printf "agents.%s.slack.allowBotMessages must be one of: off, mentions, all — got: %s" $name ($cfg.slack).allowBotMessages) }}
     {{- end }}
-    allow_bot_messages = "{{ ($cfg.slack).allowBotMessages }}"
+    allow_bot_messages = {{ ($cfg.slack).allowBotMessages | toJson }}
     {{- end }}
     {{- if ($cfg.slack).trustedBotIds }}
     trusted_bot_ids = {{ ($cfg.slack).trustedBotIds | toJson }}
@@ -73,16 +73,16 @@ data:
     {{- if not (has ($cfg.slack).allowUserMessages (list "involved" "mentions")) }}
     {{- fail (printf "agents.%s.slack.allowUserMessages must be one of: involved, mentions — got: %s" $name ($cfg.slack).allowUserMessages) }}
     {{- end }}
-    allow_user_messages = "{{ ($cfg.slack).allowUserMessages }}"
+    allow_user_messages = {{ ($cfg.slack).allowUserMessages | toJson }}
     {{- end }}
     {{- end }}
 
     [agent]
-    command = "{{ $cfg.command }}"
+    command = {{ $cfg.command | toJson }}
     args = {{ if $cfg.args }}{{ $cfg.args | toJson }}{{ else }}[]{{ end }}
-    working_dir = "{{ $cfg.workingDir | default "/home/agent" }}"
+    working_dir = {{ $cfg.workingDir | default "/home/agent" | toJson }}
     {{- if $cfg.env }}
-    env = { {{ $first := true }}{{ range $k, $v := $cfg.env }}{{ if not $first }}, {{ end }}{{ $k }} = "{{ $v }}"{{ $first = false }}{{ end }} }
+    env = { {{ $first := true }}{{ range $k, $v := $cfg.env }}{{ if not $first }}, {{ end }}{{ $k }} = {{ $v | toJson }}{{ $first = false }}{{ end }} }
     {{- end }}
 
     [pool]
@@ -100,8 +100,8 @@ data:
     [stt]
     enabled = true
     api_key = "${STT_API_KEY}"
-    model = "{{ ($cfg.stt).model | default "whisper-large-v3-turbo" }}"
-    base_url = "{{ ($cfg.stt).baseUrl | default "https://api.groq.com/openai/v1" }}"
+    model = {{ ($cfg.stt).model | default "whisper-large-v3-turbo" | toJson }}
+    base_url = {{ ($cfg.stt).baseUrl | default "https://api.groq.com/openai/v1" | toJson }}
     {{- end }}
   {{- if $cfg.agentsMd }}
   AGENTS.md: |


### PR DESCRIPTION
## What problem does this solve?

The configmap template renders user-supplied string values with raw interpolation:

```
{{ $k }} = "{{ $v }}"
```

If a value contains double quotes or backslashes, the rendered TOML is malformed. For example, `MY_VAR: 'say "hello"'` produces:

```toml
env = { MY_VAR = "say "hello"" }
```

This breaks TOML parsing at runtime. A crafted value could also inject arbitrary TOML keys.

The same unsafe pattern exists in 8 fields across the template: `env` values, `command`, `working_dir`, `allow_bot_messages` (Discord/Slack), `allow_user_messages` (Slack), and STT `model`/`base_url`.

Related: #425 (Helm chart analysis report)

## Credit

This issue was originally identified and fixed by @thekkagent in #380 as part of a larger Helm chart extensibility PR. This PR extracts the TOML escaping fix as a standalone security patch, and extends it to cover all remaining string fields in the template.

## Proposed Solution

Replace all `"{{ $v }}"` patterns with `{{ $v | toJson }}`.

`toJson` outputs a valid JSON string (with surrounding quotes and proper escaping). TOML basic string syntax is compatible with JSON strings, so the output is valid TOML.

| Input value | Before (broken) | After (correct) |
|---|---|---|
| `hello` | `"hello"` | `"hello"` |
| `say "hi"` | `"say "hi""` ❌ | `"say \"hi\""` ✅ |
| `path\to\file` | `"path\to\file"` ❌ | `"path\\to\\file"` ✅ |

### Fields changed

| Field | Risk level | Notes |
|---|---|---|
| `env` values | **High** — arbitrary user input | Primary fix target |
| `command` | Low — CLI binary path | Defense in depth |
| `working_dir` | Low — file path | Defense in depth |
| `allow_bot_messages` (Discord) | Low — has enum validation | Defense in depth |
| `allow_bot_messages` (Slack) | Low — has enum validation | Defense in depth |
| `allow_user_messages` (Slack) | Low — has enum validation | Defense in depth |
| `model` (STT) | Low — has default value | Defense in depth |
| `base_url` (STT) | Low — has default value | Defense in depth |

### Fields NOT changed (no user input)

| Field | Reason |
|---|---|
| `bot_token`, `app_token`, `api_key` | Use env var placeholders (`${...}`), not user values |
| `allowed_channels`, `allowed_users`, `trusted_bot_ids` | Already use `toJson` |
| `args` | Already uses `toJson` |

## Why this approach?

`toJson` is already used elsewhere in this template (for `args`, `allowed_channels`, etc.), so this is consistent with the existing escaping strategy. It produces output identical to the original for values without special characters, making it fully backward compatible.

## Alternatives Considered

### 1. Fix only `env` values — rejected

The `env` field has the highest risk since it accepts arbitrary user input. However, applying the same fix to all string fields is trivial (same one-line pattern) and eliminates the entire vulnerability class from the template. Leaving some fields unfixed would be inconsistent.

### 2. Use Helm `quote` function — rejected

`quote` wraps a value in double quotes but does not escape internal quotes or backslashes. It would not fix the injection.

### 3. Use TOML literal strings (`'...'`) — rejected

TOML literal strings don't process escape sequences, but they also can't contain single quotes. This would trade one injection vector for another.

## Validation

- [x] `helm lint charts/openab` — passed (0 failures)
- [x] Default values render identically to `main` (no behavioral change)
- [x] Special characters (double quotes, backslashes) render correctly escaped TOML
- [x] All affected fields tested: env, command, working_dir, allow_bot_messages, allow_user_messages, model, base_url

```bash
# Test env with special characters
helm template test charts/openab \
  --set agents.kiro.discord.botToken="test" \
  --set-string 'agents.kiro.discord.allowedChannels[0]=123456789' \
  --set 'agents.kiro.env.NORMAL=hello' \
  --set 'agents.kiro.env.QUOTES=say "hi"' \
  --set 'agents.kiro.env.BACKSLASH=path\\to\\file' \
  -s templates/configmap.yaml
```

Output:
```toml
env = { BACKSLASH = "path\\to\\file", NORMAL = "hello", QUOTES = "say \"hi\"" }
```

```bash
# Test all other fields with features enabled
helm template test charts/openab \
  --set agents.kiro.discord.botToken="test" \
  --set-string 'agents.kiro.discord.allowedChannels[0]=123456789' \
  --set agents.kiro.discord.allowBotMessages="mentions" \
  --set agents.kiro.slack.enabled=true \
  --set agents.kiro.slack.botToken="xoxb-test" \
  --set agents.kiro.slack.appToken="xapp-test" \
  --set agents.kiro.slack.allowBotMessages="all" \
  --set agents.kiro.slack.allowUserMessages="involved" \
  --set agents.kiro.stt.enabled=true \
  --set agents.kiro.stt.apiKey="sk-test" \
  -s templates/configmap.yaml
```

All fields render correctly with proper quoting.

## Scope

One file changed, 8 lines modified. No new features, no new values fields, no template logic changes. Pure security fix.

DC: https://discord.com/channels/1491295327620169908/1493841502529523732