### PR TITLE
fix(discord): spawn handle_message to unblock event loop

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -427,13 +427,15 @@ impl EventHandler for Handler {
 
         let trigger_msg = discord_msg_ref(&msg);
 
-        if let Err(e) = self
-            .router
-            .handle_message(&adapter, &thread_channel, &sender, &prompt, extra_blocks, &trigger_msg)
-            .await
-        {
-            error!("handle_message error: {e}");
-        }
+        let router = self.router.clone();
+        tokio::spawn(async move {
+            if let Err(e) = router
+                .handle_message(&adapter, &thread_channel, &sender, &prompt, extra_blocks, &trigger_msg)
+                .await
+            {
+                error!("handle_message error: {e}");
+            }
+        });
     }
 
     async fn ready(&self, _ctx: Context, ready: Ready) {


### PR DESCRIPTION
## Problem

When one session is streaming a long response, all other incoming Discord messages are blocked until the streaming completes. The serenity event handler awaits `handle_message()` directly, which runs the entire streaming loop (30s+) before returning. This serializes all concurrent sessions behind one active response.

Reported in #429.

## Fix

Wrap the `handle_message()` call in `tokio::spawn` so the event handler returns immediately. The router is `Arc<AdapterRouter>`, so cloning is cheap. All other variables (`adapter`, `thread_channel`, `sender`, `prompt`, `extra_blocks`, `trigger_msg`) are moved into the spawned task.

```
Before:  msg A → handle_message().await (30s) → msg B → handle_message().await → ...
After:   msg A → spawn(handle_message) → return → msg B → spawn(handle_message) → return
```

## Changes

- `src/discord.rs`: Clone `self.router` (Arc) and spawn `handle_message` as a detached tokio task instead of awaiting it inline.

Fixes #429