### PR TITLE
fix(helm): auto-append appVersion tag to agent images without explicit tag

### DIFF
--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -1,5 +1,7 @@
 openab {{ .Chart.AppVersion }} has been installed!
 
+💡 Agent images without an explicit tag (no ":") auto-append {{ .Chart.AppVersion }}.
+
 ⚠️  Channel/user IDs must be set with --set-string (not --set) to avoid float64 precision loss.
 
 Agents deployed:

--- a/charts/openab/templates/_helpers.tpl
+++ b/charts/openab/templates/_helpers.tpl
@@ -41,7 +41,9 @@ app.kubernetes.io/component: {{ .agent }}
 {{- printf "%s-%s" (include "openab.fullname" .ctx) .agent | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/* Resolve image: agent-level string override → global default (repository:tag, tag defaults to appVersion) */}}
+{{/* Resolve image: agent-level string override → global default (repository:tag, tag defaults to appVersion).
+    Caveat: "contains :" treats registry ports (e.g. my-registry:5000/img) as tagged.
+    Not an issue for ghcr.io / Docker Hub; revisit if custom registries with ports are needed. */}}
 {{- define "openab.agentImage" -}}
 {{- if and .cfg.image (kindIs "string" .cfg.image) (ne .cfg.image "") }}
 {{- if contains ":" .cfg.image }}

--- a/charts/openab/templates/_helpers.tpl
+++ b/charts/openab/templates/_helpers.tpl
@@ -44,7 +44,11 @@ app.kubernetes.io/component: {{ .agent }}
 {{/* Resolve image: agent-level string override → global default (repository:tag, tag defaults to appVersion) */}}
 {{- define "openab.agentImage" -}}
 {{- if and .cfg.image (kindIs "string" .cfg.image) (ne .cfg.image "") }}
+{{- if contains ":" .cfg.image }}
 {{- .cfg.image }}
+{{- else }}
+{{- printf "%s:%s" .cfg.image (default .ctx.Chart.AppVersion .ctx.Values.image.tag) }}
+{{- end }}
 {{- else }}
 {{- $tag := default .ctx.Chart.AppVersion .ctx.Values.image.tag }}
 {{- printf "%s:%s" .ctx.Values.image.repository $tag }}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -57,7 +57,7 @@ agents:
     #   nodeSelector: {}
     #   tolerations: []
     #   affinity: {}
-    #   image: "ghcr.io/openabdev/openab-claude:latest"
+    #   image: "ghcr.io/openabdev/openab-claude"  # tag omitted → auto-appends appVersion
     # opencode:
     #   command: opencode
     #   args:


### PR DESCRIPTION
## Context

Closes #433

When upgrading the Helm chart, agent-specific images (e.g. `openab-claude`, `openab-copilot`) do not automatically follow the chart's `appVersion`. Users must manually specify the full image with tag for each agent on every upgrade, because the `openab.agentImage` helper treats the agent `image` field as a raw string with no tag logic.

## Summary

Added a `contains ":"` check in the `openab.agentImage` helper — if the agent image string has no tag (no colon), auto-append `appVersion` (or `image.tag` override). Fully backward compatible.

## Changes

- Modified `openab.agentImage` in `charts/openab/templates/_helpers.tpl`
- Added inner `contains ":"` branch: if colon present → use as-is (explicit pin); if no colon → auto-append tag
- Tag source is identical to existing logic: `default .ctx.Chart.AppVersion .ctx.Values.image.tag`

## Behavior

| Input | Result |
|-------|--------|
| `image: ghcr.io/.../openab-claude` | → `ghcr.io/.../openab-claude:<appVersion>` |
| `image: ghcr.io/.../openab-claude:custom` | → `ghcr.io/.../openab-claude:custom` (unchanged) |
| No `image` set | → `<global repository>:<appVersion>` (unchanged) |

Discord Discussion URL: https://discord.com/channels/1488041051187974246/1494843603103645737