### PR TITLE
docs: add k8s CronJob reference architecture guide

### DIFF
--- a/docs/CronJob.md
+++ b/docs/CronJob.md
@@ -1,0 +1,361 @@
+# CronJob
+
+This document explains how OpenAB sets up the project-screening CronJob that polls the GitHub project board, claims new items, runs `codex exec`, and delivers the report back to Discord.
+
+## Why We Used A CronJob
+
+We deliberately chose a Kubernetes `CronJob` instead of:
+
+- installing `cron` inside the app container
+- running an always-on sleep loop in the main pod
+- reusing a long-lived ACP session for scheduled screening
+
+This shape fits Kubernetes better:
+
+- the scheduler is owned by the cluster
+- each run gets a fresh pod
+- failures are isolated per run
+- logs are attached to each job
+- `concurrencyPolicy: Forbid` prevents overlapping claimers
+
+The model is:
+
+```text
+GitHub Project Incoming
+        |
+        v
+Kubernetes CronJob
+        |
+        v
+ephemeral job pod
+        |
+        v
+screen_once.sh
+  - find Incoming item
+  - move it to PR-Screening
+  - build prompt
+  - run codex exec
+  - post Discord summary
+  - create Discord thread
+  - post full report
+```
+
+## High-Level Architecture
+
+```text
+GitHub Project Board
+  Incoming
+     |
+     v
+CronJob: openab-project-screening
+  schedule: every 30 minutes
+     |
+     v
+Job Pod
+  image: ghcr.io/openabdev/openab-codex:latest
+  script: /opt/openab-project-screening/screen_once.sh
+     |
+     +--> GitHub API via gh
+     +--> Codex via codex exec
+     +--> Discord API via curl
+     |
+     v
+PR-Screening
+     |
+     v
+Masami / Pahud follow-up
+```
+
+## Credential Model
+
+The job is intentionally stateless.
+
+- `GH_TOKEN` comes from the `openab-project-screening` Secret
+- `auth.json` comes from the same Secret and is copied into `$HOME/.codex/auth.json`
+- `DISCORD_BOT_TOKEN` comes from the existing `openab-kiro-codex` Secret
+- the script and prompt are mounted from a ConfigMap
+- the pod uses `/tmp` via `emptyDir`
+- no shared PVC is required
+
+This avoids coupling the scheduled workflow to a long-lived interactive pod.
+
+## CronJob Manifest
+
+The raw manifest lives at:
+
+- `k8s/project-screening-cronjob.yaml`
+
+Key parts:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: openab-project-screening
+spec:
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: project-screening
+              image: ghcr.io/openabdev/openab-codex:latest
+              command:
+                - bash
+                - /opt/openab-project-screening/screen_once.sh
+              env:
+                - name: GH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: openab-project-screening
+                      key: gh-token
+                - name: CODEX_AUTH_JSON_SOURCE
+                  value: /opt/openab-project-screening-auth/auth.json
+                - name: DISCORD_BOT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: openab-kiro-codex
+                      key: discord-bot-token
+                - name: DISCORD_REPORT_CHANNEL_ID
+                  value: "1494378525640097921"
+```
+
+Security settings were kept tight on purpose:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+Container hardening:
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+```
+
+## ConfigMap And Script
+
+The mounted ConfigMap lives at:
+
+- `k8s/project-screening-configmap.yaml`
+
+It carries:
+
+- `screen_once.sh`
+- `screening_prompt.md`
+
+The core runtime flow in `screen_once.sh` is:
+
+```bash
+item_id="$(incoming_item_jq '.items[0].id // empty')"
+
+if [[ -z "$item_id" ]]; then
+  log "no Incoming items found"
+  exit 0
+fi
+
+gh project item-edit \
+  --id "$item_id" \
+  --project-id "$project_id" \
+  --field-id "$status_field_id" \
+  --single-select-option-id "$screening_option_id" >/dev/null
+
+generate_report "$prompt_file" "$report_file"
+post_report_to_discord "$item_number" "$item_title" "$item_url" "$report_file"
+```
+
+That gives us the exact one-shot behavior we want:
+
+1. no-op when `Incoming` is empty
+2. claim the first item when work exists
+3. generate the report once
+4. deliver it once
+5. exit
+
+## Codex Execution
+
+The report is generated with `codex exec`, not with a long-lived ACP daemon:
+
+```bash
+codex exec \
+  --skip-git-repo-check \
+  --cd "$WORK_DIR" \
+  --sandbox read-only \
+  --ephemeral \
+  --color never \
+  --output-last-message "$report_file" \
+  - <"$prompt_file" >/dev/null
+```
+
+Why `codex exec`:
+
+- this workflow is scheduled and one-shot
+- each run should start clean
+- we do not need a persistent interactive session
+- job logs map naturally to one execution
+
+## Discord Delivery
+
+After the report is generated, the script posts a summary message, creates a thread on that message, and then sends the full report into the thread.
+
+Summary message:
+
+```text
+PR Screening - #<number>
+<title>
+Status: moved to PR-Screening
+```
+
+Actual implementation:
+
+```bash
+starter_content="🔍 **PR Screening** — [#${item_number}](${item_url})
+${item_title}
+Status: moved to ${SCREENING_STATUS_NAME}"
+```
+
+Thread naming:
+
+```bash
+const base = `Screening: #${number}${title ? ` ${title}` : ""}`.trim();
+process.stdout.write(base.slice(0, 100) || `Screening: #${number}`);
+```
+
+Discord API flow:
+
+```bash
+# 1. post summary message
+POST /channels/{channel_id}/messages
+
+# 2. create thread on that message
+POST /channels/{channel_id}/messages/{message_id}/threads
+
+# 3. post report chunks
+POST /channels/{thread_id}/messages
+```
+
+The script also retries on Discord `429` rate limits before continuing.
+
+## Secrets
+
+Raw secret for screening job inputs:
+
+- `k8s/project-screening-secret.yaml`
+
+It contains:
+
+```yaml
+stringData:
+  gh-token: "REPLACE_WITH_GITHUB_TOKEN_WITH_PROJECT_SCOPE"
+  auth.json: |
+    REPLACE_WITH_CONTENTS_OF_CODEX_AUTH_JSON
+```
+
+Discord is intentionally not duplicated there. The CronJob reads the bot token from the existing:
+
+```text
+Secret name: openab-kiro-codex
+Key: discord-bot-token
+```
+
+## Raw Kubernetes Install
+
+Create or update the screening secret:
+
+```bash
+kubectl -n default create secret generic openab-project-screening \
+  --from-literal=gh-token='YOUR_GITHUB_TOKEN_WITH_PROJECT_SCOPE' \
+  --from-file=auth.json="$HOME/.codex/auth.json" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Verify the shared Discord token secret exists:
+
+```bash
+kubectl -n default get secret openab-kiro-codex
+kubectl -n default get secret openab-kiro-codex -o jsonpath='{.data.discord-bot-token}' | grep -q .
+```
+
+Apply the ConfigMap and CronJob:
+
+```bash
+kubectl -n default apply -f k8s/project-screening-configmap.yaml
+kubectl -n default apply -f k8s/project-screening-cronjob.yaml
+```
+
+Run one manual test:
+
+```bash
+kubectl -n default create job \
+  --from=cronjob/openab-project-screening \
+  openab-project-screening-manual-$(date +%s)
+```
+
+Inspect the logs:
+
+```bash
+LATEST_JOB=$(kubectl -n default get jobs \
+  --sort-by=.metadata.creationTimestamp \
+  -o jsonpath='{.items[-1:].metadata.name}')
+
+kubectl -n default logs -f job/"$LATEST_JOB"
+```
+
+## Helm Values
+
+Helm values are wired under `projectScreening`:
+
+```yaml
+projectScreening:
+  enabled: true
+  schedule: "*/30 * * * *"
+  image: ghcr.io/openabdev/openab-codex:latest
+  githubToken: "<token with project scope>"
+  codexAuthJson: |
+    PASTE_THE_CONTENTS_OF_YOUR__HOME__CODEX__AUTH_JSON_HERE
+  discordReport:
+    enabled: true
+    secretName: "openab-kiro-codex"
+    secretKey: "discord-bot-token"
+    channelId: "1494378525640097921"
+```
+
+Relevant Helm files:
+
+- `charts/openab/values.yaml`
+- `charts/openab/templates/project-screening-configmap.yaml`
+- `charts/openab/templates/project-screening-cronjob.yaml`
+- `charts/openab/templates/project-screening-secret.yaml`
+- `charts/openab/files/project-screening/screen_once.sh`
+
+## Operational Notes
+
+- This pod cannot install the CronJob from inside itself without broader RBAC.
+- The correct install path is a cluster-admin shell or CI/CD pipeline.
+- Once the CronJob is live, stop any older in-pod watcher so only one claimer remains.
+
+## Design Summary
+
+The elegant part of this setup is that each concern is separated cleanly:
+
+- Kubernetes owns the schedule
+- GitHub Projects remains the source of truth
+- `codex exec` is used as a disposable analysis engine
+- Discord is only the reporting surface
+- the handoff queue is `PR-Screening`
+
+That separation is why this design works well in Kubernetes.

--- a/docs/cronjob_k8s_refarch.md
+++ b/docs/cronjob_k8s_refarch.md
@@ -1,8 +1,43 @@
-# CronJob
+# Kubernetes CronJob Reference Architecture
 
-This document explains how OpenAB sets up the project-screening CronJob that polls the GitHub project board, claims new items, runs `codex exec`, and delivers the report back to Discord.
+This document is a reference architecture for how we set up the project-screening CronJob around `codex exec`, GitHub Projects, and Discord delivery.
 
-## Why We Used A CronJob
+It is not meant to be framed as the one official OpenAB recommendation. The intent is narrower: when someone asks how to do scheduled screening work in Kubernetes, we can hand this document to their Kiro or Codex-style agent as a concrete starting point and let that agent adapt the pattern to their environment.
+
+## ASCII Flow
+
+```text
+GitHub Project Board
+  Incoming
+     |
+     v
+Kubernetes CronJob
+  schedule: every 30 minutes
+  concurrencyPolicy: Forbid
+     |
+     v
+Ephemeral Job Pod
+  image: ghcr.io/openabdev/openab-codex:latest
+  command: bash /opt/openab-project-screening/screen_once.sh
+     |
+     +--> read GitHub Project state via gh
+     +--> claim first Incoming item
+     +--> build prompt from PR/issue metadata
+     +--> run codex exec
+     +--> post summary to Discord
+     +--> create Discord thread
+     +--> post full report
+     |
+     v
+Project Board
+  PR-Screening
+     |
+     v
+Masami / Pahud
+  human or agent follow-up
+```
+
+## What This Document Covers
 
 We deliberately chose a Kubernetes `CronJob` instead of:
 
@@ -17,28 +52,6 @@ This shape fits Kubernetes better:
 - failures are isolated per run
 - logs are attached to each job
 - `concurrencyPolicy: Forbid` prevents overlapping claimers
-
-The model is:
-
-```text
-GitHub Project Incoming
-        |
-        v
-Kubernetes CronJob
-        |
-        v
-ephemeral job pod
-        |
-        v
-screen_once.sh
-  - find Incoming item
-  - move it to PR-Screening
-  - build prompt
-  - run codex exec
-  - post Discord summary
-  - create Discord thread
-  - post full report
-```
 
 ## High-Level Architecture
 
@@ -78,6 +91,8 @@ The job is intentionally stateless.
 - no shared PVC is required
 
 This avoids coupling the scheduled workflow to a long-lived interactive pod.
+
+If another team wants the same behavior, they should treat the specific secret names, project names, and channel IDs in this document as implementation examples and swap in their own values.
 
 ## CronJob Manifest
 
@@ -121,7 +136,7 @@ spec:
                       name: openab-kiro-codex
                       key: discord-bot-token
                 - name: DISCORD_REPORT_CHANNEL_ID
-                  value: "1494378525640097921"
+                  value: "<your_channel_id>"
 ```
 
 Security settings were kept tight on purpose:
@@ -331,7 +346,7 @@ projectScreening:
     enabled: true
     secretName: "openab-kiro-codex"
     secretKey: "discord-bot-token"
-    channelId: "1494378525640097921"
+    channelId: "<your_channel_id>"
 ```
 
 Relevant Helm files:
@@ -359,3 +374,5 @@ The elegant part of this setup is that each concern is separated cleanly:
 - the handoff queue is `PR-Screening`
 
 That separation is why this design works well in Kubernetes.
+
+The more opinionated design discussion, including alternatives we considered and why we ultimately chose this route, should live in a separate architecture note. This document is intentionally the operational reference version.


### PR DESCRIPTION
## Summary
- rename the doc to `docs/cronjob_k8s_refarch.md`
- add an ASCII architecture flow near the top for faster scanning
- reframe the note as a Kubernetes reference architecture rather than an official OpenAB recommendation
- replace the example Discord channel value with `<your_channel_id>` in the reusable config examples

## Problem

The first version of this doc was too text-heavy and read more like an official recommendation than a reusable reference pattern.

For this topic, the intended use is different: when someone asks how to do scheduled CronJob-based screening in Kubernetes, we want a shareable reference doc that their Kiro or Codex-style agent can adapt to their own environment.

## Changes

This update changes the documentation shape in three ways:

- adds an ASCII flow diagram at the start so the architecture is understandable on a quick scan
- renames the file to `docs/cronjob_k8s_refarch.md`
- changes the Helm `channelId` example to `<your_channel_id>` so the doc reads as a portable pattern rather than a hardcoded internal setup

The document also now explicitly says it is a reference architecture note and that a more opinionated design discussion should live separately.

## Out Of Scope

- changing the CronJob implementation itself
- changing the installed cluster state
- writing the later design-rationale essay about alternatives and final selection

## Test Plan

- verified the renamed document content locally after the edit
- confirmed the ASCII flow, filename, and channel placeholder updates are present
- no code-path tests were needed because this PR remains documentation only

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1494860860408201286
