### PR TITLE
fix(slack): expose thread_ts in sender_json so agents reply in thread

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -110,7 +110,7 @@ impl AdapterRouter {
         &self,
         adapter: &Arc<dyn ChatAdapter>,
         thread_channel: &ChannelRef,
-        sender: &SenderContext,
+        sender_json: &str,
         prompt: &str,
         extra_blocks: Vec<ContentBlock>,
         trigger_msg: &MessageRef,
@@ -118,7 +118,6 @@ impl AdapterRouter {
         tracing::debug!(platform = adapter.platform(), "processing message");
 
         // Build content blocks: sender context + prompt text, then extra (images, transcripts)
-        let sender_json = serde_json::to_string(sender).unwrap();
         let prompt_with_sender = format!(
             "<sender_context>\n{}\n</sender_context>\n\n{}",
             sender_json, prompt

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -413,8 +413,9 @@ impl EventHandler for Handler {
 
         let router = self.router.clone();
         tokio::spawn(async move {
+            let sender_json = serde_json::to_string(&sender).unwrap();
             if let Err(e) = router
-                .handle_message(&adapter, &thread_channel, &sender, &prompt, extra_blocks, &trigger_msg)
+                .handle_message(&adapter, &thread_channel, &sender_json, &prompt, extra_blocks, &trigger_msg)
                 .await
             {
                 error!("handle_message error: {e}");

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -931,9 +931,21 @@ async fn handle_message(
         parent_id: None,
     };
 
+    // Serialize sender context with Slack-native key names so agents calling
+    // the Slack API directly see "thread_ts" rather than the generic "thread_id".
+    let sender_json = {
+        let mut v = serde_json::to_value(&sender).unwrap();
+        if let Some(obj) = v.as_object_mut() {
+            if let Some(tid) = obj.remove("thread_id") {
+                obj.insert("thread_ts".to_string(), tid);
+            }
+        }
+        v.to_string()
+    };
+
     let adapter_dyn: Arc<dyn ChatAdapter> = adapter.clone();
     if let Err(e) = router
-        .handle_message(&adapter_dyn, &thread_channel, &sender, &prompt, extra_blocks, &trigger_msg)
+        .handle_message(&adapter_dyn, &thread_channel, &sender_json, &prompt, extra_blocks, &trigger_msg)
         .await
     {
         error!("Slack handle_message error: {e}");


### PR DESCRIPTION
## Problem

When an agent calls `chat.postMessage` directly via the Slack API, it needs to pass `thread_ts` to keep replies in the correct thread. Previously, `SenderContext` serialized the thread identifier as `\"thread_id\"` — a generic platform-agnostic name that agents could not reliably map to Slack's `thread_ts` parameter. As a result, messages were posted to channel root instead of the thread.

This is a Slack-only issue. Discord threads are separate channels, so `channel_id` already identifies the thread — no separate `thread_ts` concept exists.

Discussion: https://discord.com/channels/1491295327620169908/1494739741600387204/1494944277694775457

## Solution

Change `AdapterRouter::handle_message` to accept a pre-serialized `sender_json: &str` so each platform adapter controls its own serialization format:

- **`slack.rs`**: renames `\"thread_id\"` → `\"thread_ts\"` before passing to `handle_message`
- **`discord.rs`**: serializes as-is (no change in behavior)
- **`adapter.rs`**: removes internal `serde_json::to_string(sender)` call

Agent now receives:
\`\`\`json
{
  "channel": "slack",
  "channel_id": "C99999",
  "thread_ts": "1234567890.123456"
}
\`\`\`

No shared layer is polluted with Slack-specific logic.

## Files Changed

- `src/adapter.rs` — signature change only
- `src/slack.rs` — custom serialization with `thread_ts` key
- `src/discord.rs` — standard serialization, no behavior change

## Test Plan

- [ ] `cargo clippy -- -D warnings` passes
- [ ] Slack: agent replies with `thread_ts` → message stays in thread
- [ ] Discord: behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)