### PR TITLE
fix: wire CLAUDE_CODE_EXECUTABLE so adapter uses pinned claude-code

### DIFF
--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -10,9 +10,12 @@ RUN touch src/main.rs && cargo build --release
 FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
 
-# Install claude-agent-acp adapter and Claude Code CLI
+# Install claude-agent-acp adapter and Claude Code CLI.
+# Without CLAUDE_CODE_EXECUTABLE the adapter uses its own bundled SDK cli.js,
+# ignoring the globally installed claude-code binary (see #418).
 ARG CLAUDE_CODE_VERSION=2.1.104
 RUN npm install -g @agentclientprotocol/claude-agent-acp@0.25.0 @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} --retry 3
+ENV CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude
 
 # Install gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Summary

Set `ENV CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude` in `Dockerfile.claude` so `claude-agent-acp` actually uses the globally installed (and version-pinned) `@anthropic-ai/claude-code` binary instead of its own bundled SDK `cli.js`.

## Problem

As documented in #418, `claude-agent-acp` never invokes the globally installed `/usr/local/bin/claude`. The adapter resolves its CLI path via `claudeCliPath()` which, for non-static npm installs, always falls through to the SDK-bundled `cli.js`. This means:

- `CLAUDE_CODE_VERSION=2.1.104` pinning in the Dockerfile has **no effect** on what actually runs in sessions
- PR #333 (revert to 2.1.104) and PR #412 (stay on 2.1.104) were based on a false premise — the adapter never ran the global binary

## Fix

The adapter checks `CLAUDE_CODE_EXECUTABLE` env var first (since `claude-agent-acp@0.6.0`). Setting it to `/usr/local/bin/claude` makes the pinned version load-bearing.

## Changes

```diff
-# Install claude-agent-acp adapter and Claude Code CLI
+# Install claude-agent-acp adapter and Claude Code CLI.
+# Without CLAUDE_CODE_EXECUTABLE the adapter uses its own bundled SDK cli.js,
+# ignoring the globally installed claude-code binary (see #418).
 ARG CLAUDE_CODE_VERSION=2.1.104
 RUN npm install -g @agentclientprotocol/claude-agent-acp@0.25.0 @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} --retry 3
+ENV CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude
```

## How to verify

```bash
docker build -f Dockerfile.claude -t openab-claude:test .
docker run --rm --entrypoint sh openab-claude:test -c '
  echo "CLAUDE_CODE_EXECUTABLE=$CLAUDE_CODE_EXECUTABLE"
  claude --version
'
```

Then confirm the adapter uses the global binary:
```bash
# In a running container with a session:
lsof -p $(pgrep -f claude-agent-acp) | grep cli.js
# Should show /usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js
```

Fixes #418

Discord Discussion URL: https://discord.com/channels/1490282656913559670/1495058349241405522