### PR TITLE
fix: add tini as init process to all Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install kiro-cli (auto-detect arch, copy binary directly)
 ARG KIRO_CLI_VERSION=2.0.0
@@ -40,5 +40,5 @@ COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENTRYPOINT ["openab"]
-CMD ["run", "/etc/openab/config.toml"]
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "/etc/openab/config.toml"]

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install claude-agent-acp adapter and Claude Code CLI.
 # Without CLAUDE_CODE_EXECUTABLE the adapter uses its own bundled SDK cli.js,
@@ -33,5 +33,5 @@ COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bi
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENTRYPOINT ["openab"]
-CMD ["run", "/etc/openab/config.toml"]
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "/etc/openab/config.toml"]

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
 ARG CODEX_VERSION=0.121.0
@@ -30,5 +30,5 @@ COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bi
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENTRYPOINT ["openab"]
-CMD ["run", "/etc/openab/config.toml"]
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "/etc/openab/config.toml"]

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
 ARG COPILOT_VERSION=1.0.30
@@ -30,5 +30,5 @@ COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bi
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENTRYPOINT ["openab"]
-CMD ["run", "/etc/openab/config.toml"]
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "/etc/openab/config.toml"]

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install Cursor Agent CLI (pinned version)
 # Tarball source: https://downloads.cursor.com/lab/<version>/linux/<arch>/agent-cli-package.tar.gz
@@ -42,5 +42,5 @@ COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENTRYPOINT ["openab"]
-CMD ["run", "/etc/openab/config.toml"]
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "/etc/openab/config.toml"]

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
 ARG GEMINI_CLI_VERSION=0.38.1
@@ -30,6 +30,6 @@ COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bi
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENTRYPOINT ["openab"]
-CMD ["run", "/etc/openab/config.toml"]
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "/etc/openab/config.toml"]
 

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -23,7 +23,7 @@ RUN touch src/main.rs && cargo build --release
 # Note: opencode does not publish SHA256 checksums for its releases,
 # so checksum verification is not possible at this time.
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install opencode
 ARG OPENCODE_VERSION=1.4.6
@@ -45,5 +45,5 @@ COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bi
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENTRYPOINT ["openab"]
-CMD ["run", "/etc/openab/config.toml"]
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "/etc/openab/config.toml"]


### PR DESCRIPTION
## Summary

Fixes #290 — `openab` running as PID 1 in containers does not reap zombie processes from agent grandchildren (shell tool calls like `git`, `grep`, `next build`, etc.). After ~85 minutes of normal usage, 44 zombies were observed accumulating at ~30/hour, eventually leading to PID exhaustion.

## Changes

Added [`tini`](https://github.com/krallin/tini) as the init process to all 7 Dockerfiles:

| Dockerfile | Base Image |
|---|---|
| `Dockerfile` | `debian:bookworm-slim` |
| `Dockerfile.cursor` | `debian:bookworm-slim` |
| `Dockerfile.codex` | `node:22-bookworm-slim` |
| `Dockerfile.claude` | `node:22-bookworm-slim` |
| `Dockerfile.gemini` | `node:22-bookworm-slim` |
| `Dockerfile.copilot` | `node:22-bookworm-slim` |
| `Dockerfile.opencode` | `node:22-bookworm-slim` |

For each Dockerfile:
1. Added `tini` to the existing `apt-get install` line
2. Changed `ENTRYPOINT ["openab"]` → `ENTRYPOINT ["tini", "--"]`
3. Changed `CMD ["run", "/etc/openab/config.toml"]` → `CMD ["openab", "run", "/etc/openab/config.toml"]`

## Why tini

`tini` is a minimal init process (~30KB) that:
- **Reaps zombie processes** — calls `waitpid()` on `SIGCHLD`, preventing zombie accumulation
- **Forwards signals** — properly delivers `SIGTERM`/`SIGINT` to child processes for graceful shutdown

This is the standard container best practice, used by:
- Docker (`docker run --init`)
- AWS ECS (`initProcessEnabled: true`)
- Jenkins, GitLab Runner official images

## Why all Dockerfiles (not just codex)

The issue was observed on `openab-codex`, but the root cause (`openab` as PID 1 not reaping children) affects every agent that spawns subprocesses. All agents do this via shell tool calls.

## Testing

- Verified the diff is consistent across all 7 files
- No functional change to `openab` itself — tini is transparent, just wraps the existing process