### PR TITLE
feat: add pending-maintainer label workflow

### DIFF
--- a/.github/workflows/pending-maintainer.yml
+++ b/.github/workflows/pending-maintainer.yml
@@ -1,0 +1,105 @@
+name: Label pending-maintainer PRs
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+
+jobs:
+  check-pending:
+    if: github.event_name == 'workflow_dispatch' || github.event.issue.pull_request != null || github.event.pull_request != null
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      checks: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const MAINTAINER = 'pending-maintainer';
+            const CONTRIBUTOR = 'pending-contributor';
+
+            let prNumbers = [];
+
+            if (context.eventName === 'workflow_dispatch') {
+              const prs = await github.rest.pulls.list({
+                ...context.repo,
+                state: 'open',
+                per_page: 100
+              });
+              prNumbers = prs.data.map(pr => pr.number);
+            } else if (context.eventName === 'issue_comment') {
+              prNumbers = [context.payload.issue.number];
+            } else if (context.eventName === 'pull_request_review') {
+              prNumbers = [context.payload.pull_request.number];
+            }
+
+            for (const prNumber of prNumbers) {
+              const { data: pr } = await github.rest.pulls.get({
+                ...context.repo,
+                pull_number: prNumber
+              });
+
+              const labels = pr.labels.map(l => l.name);
+
+              // Skip drafts — not ready for maintainer review
+              if (pr.draft) {
+                console.log(`#${prNumber} — draft, skipping`);
+                continue;
+              }
+
+              // Skip if has merge conflicts — ball is on contributor
+              if (pr.mergeable === false) {
+                console.log(`#${prNumber} — has conflicts, skipping`);
+                continue;
+              }
+
+              // Check CI status on head commit
+              const { data: status } = await github.rest.repos.getCombinedStatusForRef({
+                ...context.repo,
+                ref: pr.head.sha
+              });
+              const { data: checks } = await github.rest.checks.listForRef({
+                ...context.repo,
+                ref: pr.head.sha,
+                per_page: 100
+              });
+              const ciRed = status.state === 'failure'
+                || checks.check_runs.some(c => c.conclusion === 'failure');
+              if (ciRed) {
+                console.log(`#${prNumber} — CI failing, skipping`);
+                continue;
+              }
+
+              // Check last comment is from PR author
+              const { data: comments } = await github.rest.issues.listComments({
+                ...context.repo,
+                issue_number: prNumber,
+                per_page: 1,
+                direction: 'desc'
+              });
+              if (comments.length === 0) continue;
+
+              const lastCommenter = comments[0].user.login;
+              if (lastCommenter !== pr.user.login) continue;
+
+              // All conditions met: not draft, no conflicts, CI green, author replied
+              if (!labels.includes(MAINTAINER)) {
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: prNumber,
+                  labels: [MAINTAINER]
+                });
+              }
+              if (labels.includes(CONTRIBUTOR)) {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: prNumber,
+                  name: CONTRIBUTOR
+                }).catch(() => {});
+              }
+              console.log(`#${prNumber} — all clear, set ${MAINTAINER}`);
+            }

--- a/.github/workflows/pending-maintainer.yml
+++ b/.github/workflows/pending-maintainer.yml
@@ -1,6 +1,8 @@
 name: Label pending-maintainer PRs
 
 on:
+  schedule:
+    - cron: '0 * * * *'  # hourly safety net
   issue_comment:
     types: [created]
   pull_request_review:
@@ -9,7 +11,7 @@ on:
 
 jobs:
   check-pending:
-    if: github.event_name == 'workflow_dispatch' || github.event.issue.pull_request != null || github.event.pull_request != null
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.issue.pull_request != null || github.event.pull_request != null
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -24,7 +26,7 @@ jobs:
 
             let prNumbers = [];
 
-            if (context.eventName === 'workflow_dispatch') {
+            if (context.eventName === 'workflow_dispatch' || context.eventName === 'schedule') {
               const prs = await github.rest.pulls.list({
                 ...context.repo,
                 state: 'open',

--- a/.github/workflows/pending-maintainer.yml
+++ b/.github/workflows/pending-maintainer.yml
@@ -51,6 +51,12 @@ jobs:
                 continue;
               }
 
+              // Skip if closing-soon — contributor has incomplete work
+              if (labels.includes('closing-soon')) {
+                console.log(`#${prNumber} — closing-soon, skipping`);
+                continue;
+              }
+
               // Skip if has merge conflicts — ball is on contributor
               if (pr.mergeable === false) {
                 console.log(`#${prNumber} — has conflicts, skipping`);

--- a/.github/workflows/pending-maintainer.yml
+++ b/.github/workflows/pending-maintainer.yml
@@ -57,9 +57,15 @@ jobs:
                 continue;
               }
 
-              // Skip if has merge conflicts — ball is on contributor
-              if (pr.mergeable === false) {
-                console.log(`#${prNumber} — has conflicts, skipping`);
+              // Skip if has merge conflicts or already labeled needs-rebase
+              if (pr.mergeable === false || labels.includes('needs-rebase')) {
+                console.log(`#${prNumber} — has conflicts or needs-rebase, skipping`);
+                continue;
+              }
+
+              // Skip if wontfix or not-planned
+              if (labels.includes('wontfix') || labels.includes('not-planned')) {
+                console.log(`#${prNumber} — wontfix/not-planned, skipping`);
                 continue;
               }
 
@@ -80,16 +86,16 @@ jobs:
                 continue;
               }
 
-              // Check last comment is from PR author
-              const { data: comments } = await github.rest.issues.listComments({
+              // Check last comment from a human (skip bot comments) is from PR author
+              const { data: allComments } = await github.rest.issues.listComments({
                 ...context.repo,
                 issue_number: prNumber,
-                per_page: 1,
-                direction: 'desc'
+                per_page: 100
               });
-              if (comments.length === 0) continue;
+              const humanComments = allComments.filter(c => !c.user.type || c.user.type !== 'Bot');
+              if (humanComments.length === 0) continue;
 
-              const lastCommenter = comments[0].user.login;
+              const lastCommenter = humanComments[humanComments.length - 1].user.login;
               if (lastCommenter !== pr.user.login) continue;
 
               // All conditions met: not draft, no conflicts, CI green, author replied


### PR DESCRIPTION
## Summary

Adds a workflow that automatically flips `pending-contributor` → `pending-maintainer` when all conditions are met.

## Guard Conditions (all must pass to flip)

1. **Not a draft PR**
2. **No `closing-soon` label** — PR has incomplete work
3. **No merge conflicts** and **no `needs-rebase` label**
4. **No `wontfix` / `not-planned` label**
5. **CI is green** — no failed status checks or check runs
6. **Last human comment is from PR author** — bot comments are filtered out

If any condition fails, the label stays as-is (ball remains on contributor).

## Triggers

- **`issue_comment`** — fires immediately when a comment is posted on a PR
- **`pull_request_review`** — fires when a review is submitted
- **`schedule` (hourly)** — safety net to catch edge cases (CI turns green, rebase completed, `needs-rebase` removed by #450)
- **`workflow_dispatch`** — manual trigger scans all open PRs

## Label Behavior

- Adds `pending-maintainer`
- Removes `pending-contributor` if present

## Files Changed

- `.github/workflows/pending-maintainer.yml` (new)