### PR TITLE
feat: add stale pending-contributor → closing-soon workflow

### DIFF
--- a/.github/workflows/stale-contributor.yml
+++ b/.github/workflows/stale-contributor.yml
@@ -1,0 +1,56 @@
+name: Label stale pending-contributor PRs
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # hourly
+  workflow_dispatch:
+
+jobs:
+  check-stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const CONTRIBUTOR = 'pending-contributor';
+            const CLOSING = 'closing-soon';
+            const STALE_DAYS = 2;
+            const cutoff = new Date(Date.now() - STALE_DAYS * 24 * 60 * 60 * 1000);
+
+            const prs = await github.rest.pulls.list({
+              ...context.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            for (const pr of prs.data) {
+              const labels = pr.labels.map(l => l.name);
+              if (!labels.includes(CONTRIBUTOR)) continue;
+              if (labels.includes(CLOSING)) continue;
+
+              // Find when pending-contributor was last applied
+              const { data: events } = await github.rest.issues.listEvents({
+                ...context.repo,
+                issue_number: pr.number,
+                per_page: 100
+              });
+
+              const labelEvent = events
+                .filter(e => e.event === 'labeled' && e.label?.name === CONTRIBUTOR)
+                .pop();
+
+              if (!labelEvent) continue;
+
+              const labeledAt = new Date(labelEvent.created_at);
+              if (labeledAt > cutoff) continue;
+
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: pr.number,
+                labels: [CLOSING]
+              });
+              console.log(`#${pr.number} — ${CONTRIBUTOR} since ${labeledAt.toISOString()}, added ${CLOSING}`);
+            }


### PR DESCRIPTION
## Summary

Adds a workflow that automatically applies `closing-soon` to open PRs where `pending-contributor` has been applied for more than 2 days without action.

## Behavior

- Runs **hourly** + manual `workflow_dispatch`
- Scans open PRs matching: `is:pr is:open label:pending-contributor -label:closing-soon`
- Checks when `pending-contributor` was last applied via issue events timeline
- If **≥ 2 days** since label was applied → adds `closing-soon`

## Lifecycle

This completes the PR label lifecycle:

1. **#450** `needs-rebase` — hourly conflict detection → adds `needs-rebase` + `pending-contributor`
2. **#451** `pending-maintainer` — flips to `pending-maintainer` when all conditions met
3. **This PR** — escalates stale `pending-contributor` → `closing-soon` after 2 days
4. **Existing** `close-stale-prs.yml` — auto-closes `closing-soon` PRs after 3 more days

## Files Changed

- `.github/workflows/stale-contributor.yml` (new)