### PR TITLE
feat(chart): add extraInitContainers, extraContainers, extraVolumeMounts, extraVolumes support

### DIFF
--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $cfg.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: openab
           image: {{ include "openab.agentImage" $d | quote }}
@@ -101,6 +105,12 @@ spec:
             {{- end }}
             - name: tmp
               mountPath: /tmp
+            {{- with $cfg.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- with $cfg.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $cfg.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -124,5 +134,8 @@ spec:
         {{- end }}
         - name: tmp
           emptyDir: {}
+        {{- with $cfg.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -170,3 +170,11 @@ agents:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    # extraInitContainers adds init containers to the pod (runs before the main container)
+    extraInitContainers: []
+    # extraContainers adds sidecar containers to the pod
+    extraContainers: []
+    # extraVolumeMounts adds additional volume mounts to the main container
+    extraVolumeMounts: []
+    # extraVolumes adds additional volumes to the pod
+    extraVolumes: []


### PR DESCRIPTION
## Summary

This PR adds four extension points to the Helm chart deployment template, allowing users to inject custom resources without modifying the chart itself.

## Key Changes

- **`extraInitContainers`** — inject init containers that run before the main `openab` container (e.g., fetch secrets from Vault, pull config from S3, wait for dependencies)
- **`extraContainers`** — add sidecar containers alongside the main container (e.g., MCP tool servers, log forwarders, token refreshers)
- **`extraVolumeMounts`** — mount additional volumes into the main container (e.g., Secret-based credentials, shared config)
- **`extraVolumes`** — declare additional volumes for the pod (PVC, Secret, ConfigMap, emptyDir)

## Example Usage

```yaml
agents:
  kiro:
    extraVolumes:
      - name: mcp-socket
        emptyDir: {}
    extraVolumeMounts:
      - name: mcp-socket
        mountPath: /tmp/mcp
    extraContainers:
      - name: my-mcp-server
        image: ghcr.io/myorg/my-mcp-tools:latest
        volumeMounts:
          - name: mcp-socket
            mountPath: /tmp/mcp
```

## Design

- Follows the standard Helm `extra*` pattern (`with` + `toYaml` + `nindent`)
- All four fields default to `[]` — zero impact on existing deployments
- Per-agent scoped (under `agents.<name>`), so each agent can have its own extensions
- Placement in deployment.yaml:
  - `extraInitContainers`: before `containers:`
  - `extraVolumeMounts`: after the `tmp` mount in the main container
  - `extraContainers`: after the main container
  - `extraVolumes`: after the `tmp` emptyDir volume