### PR TITLE
fix(acp): persist thread→session mapping to survive pod restarts

### DIFF
--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -3,6 +3,7 @@ use crate::acp::protocol::ConfigOption;
 use crate::config::AgentConfig;
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::Instant;
@@ -28,6 +29,7 @@ pub struct SessionPool {
     state: RwLock<PoolState>,
     config: AgentConfig,
     max_sessions: usize,
+    mapping_path: PathBuf,
 }
 
 type EvictionCandidate = (
@@ -63,15 +65,47 @@ fn get_or_insert_gate(
 
 impl SessionPool {
     pub fn new(config: AgentConfig, max_sessions: usize) -> Self {
+        let openab_dir = std::env::var("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("/tmp"))
+            .join(".openab");
+        let _ = std::fs::create_dir_all(&openab_dir);
+        let mapping_path = openab_dir.join("thread_map.json");
+        let suspended = Self::load_mapping(&mapping_path);
         Self {
             state: RwLock::new(PoolState {
                 active: HashMap::new(),
                 cancel_handles: HashMap::new(),
-                suspended: HashMap::new(),
+                suspended,
                 creating: HashMap::new(),
             }),
             config,
             max_sessions,
+            mapping_path,
+        }
+    }
+
+    fn load_mapping(path: &Path) -> HashMap<String, String> {
+        match std::fs::read_to_string(path) {
+            Ok(data) => serde_json::from_str(&data).unwrap_or_else(|e| {
+                warn!(path = %path.display(), error = %e, "corrupt thread_map.json, starting fresh");
+                HashMap::new()
+            }),
+            Err(_) => HashMap::new(),
+        }
+    }
+
+    fn save_mapping(&self, suspended: &HashMap<String, String>) {
+        let data = match serde_json::to_string_pretty(suspended) {
+            Ok(d) => d,
+            Err(e) => {
+                warn!(error = %e, "failed to serialize thread mapping");
+                return;
+            }
+        };
+        let tmp = self.mapping_path.with_extension("json.tmp");
+        if let Err(e) = std::fs::write(&tmp, &data).and_then(|_| std::fs::rename(&tmp, &self.mapping_path)) {
+            warn!(path = %self.mapping_path.display(), error = %e, "failed to persist thread mapping");
         }
     }
 
@@ -213,6 +247,7 @@ impl SessionPool {
 
         state.suspended.remove(thread_id);
         state.active.insert(thread_id.to_string(), new_conn);
+        self.save_mapping(&state.suspended);
         if !cancel_session_id.is_empty() {
             state.cancel_handles.insert(thread_id.to_string(), (cancel_handle, cancel_session_id));
         }
@@ -322,6 +357,7 @@ impl SessionPool {
         state.cancel_handles.remove(thread_id);
         state.suspended.remove(thread_id);
         state.creating.remove(thread_id);
+        self.save_mapping(&state.suspended);
         if had_active {
             info!(thread_id, "session reset");
             Ok(())
@@ -368,12 +404,33 @@ impl SessionPool {
                 }
             }
         }
+        self.save_mapping(&state.suspended);
     }
 
     pub async fn shutdown(&self) {
+        // Snapshot active handles, then drop state lock before awaiting
+        // per-connection mutexes (lock ordering: never hold state while
+        // awaiting a connection lock).
+        let snapshot: Vec<(String, Arc<Mutex<AcpConnection>>)> = {
+            let state = self.state.read().await;
+            state.active.iter().map(|(k, v)| (k.clone(), Arc::clone(v))).collect()
+        };
+
+        let mut session_ids: Vec<(String, String)> = Vec::new();
+        for (key, conn) in snapshot {
+            let conn = conn.lock().await;
+            if let Some(sid) = conn.acp_session_id.clone() {
+                session_ids.push((key, sid));
+            }
+        }
+
         let mut state = self.state.write().await;
+        for (key, sid) in session_ids {
+            state.suspended.insert(key, sid);
+        }
+        self.save_mapping(&state.suspended);
         let count = state.active.len();
-        state.active.clear(); // Drop impl kills process groups
+        state.active.clear();
         info!(count, "pool shutdown complete");
     }
 }

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -302,14 +302,16 @@ impl SessionPool {
 
     pub async fn shutdown(&self) {
         let mut state = self.state.write().await;
-        // Persist active sessions so they can be resumed after restart.
-        let keys: Vec<String> = state.active.keys().cloned().collect();
-        for key in keys {
-            if let Some(conn) = state.active.get(&key) {
-                let conn = conn.lock().await;
-                if let Some(sid) = conn.acp_session_id.clone() {
-                    state.suspended.insert(key, sid);
-                }
+        // Collect handles before borrowing suspended mutably.
+        let handles: Vec<(String, Arc<Mutex<AcpConnection>>)> = state
+            .active
+            .iter()
+            .map(|(k, v)| (k.clone(), Arc::clone(v)))
+            .collect();
+        for (key, conn) in handles {
+            let conn = conn.lock().await;
+            if let Some(sid) = conn.acp_session_id.clone() {
+                state.suspended.insert(key, sid);
             }
         }
         self.save_mapping(&state.suspended);

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -2,6 +2,7 @@ use crate::acp::connection::AcpConnection;
 use crate::config::AgentConfig;
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::Instant;
@@ -24,6 +25,7 @@ pub struct SessionPool {
     state: RwLock<PoolState>,
     config: AgentConfig,
     max_sessions: usize,
+    mapping_path: PathBuf,
 }
 
 type EvictionCandidate = (
@@ -59,14 +61,33 @@ fn get_or_insert_gate(
 
 impl SessionPool {
     pub fn new(config: AgentConfig, max_sessions: usize) -> Self {
+        let mapping_path = PathBuf::from(&config.working_dir).join("thread_map.json");
+        let suspended = Self::load_mapping(&mapping_path);
         Self {
             state: RwLock::new(PoolState {
                 active: HashMap::new(),
-                suspended: HashMap::new(),
+                suspended,
                 creating: HashMap::new(),
             }),
             config,
             max_sessions,
+            mapping_path,
+        }
+    }
+
+    fn load_mapping(path: &PathBuf) -> HashMap<String, String> {
+        match std::fs::read_to_string(path) {
+            Ok(data) => serde_json::from_str(&data).unwrap_or_else(|e| {
+                warn!(path = %path.display(), error = %e, "corrupt thread_map.json, starting fresh");
+                HashMap::new()
+            }),
+            Err(_) => HashMap::new(),
+        }
+    }
+
+    fn save_mapping(&self, suspended: &HashMap<String, String>) {
+        if let Err(e) = std::fs::write(&self.mapping_path, serde_json::to_string(suspended).unwrap_or_default()) {
+            warn!(path = %self.mapping_path.display(), error = %e, "failed to persist thread mapping");
         }
     }
 
@@ -206,6 +227,7 @@ impl SessionPool {
 
         state.suspended.remove(thread_id);
         state.active.insert(thread_id.to_string(), new_conn);
+        self.save_mapping(&state.suspended);
         Ok(())
     }
 
@@ -267,12 +289,22 @@ impl SessionPool {
                 }
             }
         }
+        self.save_mapping(&state.suspended);
     }
 
     pub async fn shutdown(&self) {
         let mut state = self.state.write().await;
+        // Persist active sessions so they can be resumed after restart.
+        for (key, conn) in state.active.iter() {
+            if let Ok(conn) = conn.try_lock() {
+                if let Some(sid) = conn.acp_session_id.clone() {
+                    state.suspended.insert(key.clone(), sid);
+                }
+            }
+        }
+        self.save_mapping(&state.suspended);
         let count = state.active.len();
-        state.active.clear(); // Drop impl kills process groups
+        state.active.clear();
         info!(count, "pool shutdown complete");
     }
 }

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -2,7 +2,7 @@ use crate::acp::connection::AcpConnection;
 use crate::config::AgentConfig;
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::Instant;
@@ -75,7 +75,7 @@ impl SessionPool {
         }
     }
 
-    fn load_mapping(path: &PathBuf) -> HashMap<String, String> {
+    fn load_mapping(path: &Path) -> HashMap<String, String> {
         match std::fs::read_to_string(path) {
             Ok(data) => serde_json::from_str(&data).unwrap_or_else(|e| {
                 warn!(path = %path.display(), error = %e, "corrupt thread_map.json, starting fresh");
@@ -86,7 +86,15 @@ impl SessionPool {
     }
 
     fn save_mapping(&self, suspended: &HashMap<String, String>) {
-        if let Err(e) = std::fs::write(&self.mapping_path, serde_json::to_string(suspended).unwrap_or_default()) {
+        let data = match serde_json::to_string_pretty(suspended) {
+            Ok(d) => d,
+            Err(e) => {
+                warn!(error = %e, "failed to serialize thread mapping");
+                return;
+            }
+        };
+        let tmp = self.mapping_path.with_extension("json.tmp");
+        if let Err(e) = std::fs::write(&tmp, &data).and_then(|_| std::fs::rename(&tmp, &self.mapping_path)) {
             warn!(path = %self.mapping_path.display(), error = %e, "failed to persist thread mapping");
         }
     }
@@ -295,17 +303,14 @@ impl SessionPool {
     pub async fn shutdown(&self) {
         let mut state = self.state.write().await;
         // Persist active sessions so they can be resumed after restart.
-        let to_save: Vec<(String, String)> = state
-            .active
-            .iter()
-            .filter_map(|(key, conn)| {
-                let conn = conn.try_lock().ok()?;
-                let sid = conn.acp_session_id.clone()?;
-                Some((key.clone(), sid))
-            })
-            .collect();
-        for (key, sid) in to_save {
-            state.suspended.insert(key, sid);
+        let keys: Vec<String> = state.active.keys().cloned().collect();
+        for key in keys {
+            if let Some(conn) = state.active.get(&key) {
+                let conn = conn.lock().await;
+                if let Some(sid) = conn.acp_session_id.clone() {
+                    state.suspended.insert(key, sid);
+                }
+            }
         }
         self.save_mapping(&state.suspended);
         let count = state.active.len();

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -295,12 +295,17 @@ impl SessionPool {
     pub async fn shutdown(&self) {
         let mut state = self.state.write().await;
         // Persist active sessions so they can be resumed after restart.
-        for (key, conn) in state.active.iter() {
-            if let Ok(conn) = conn.try_lock() {
-                if let Some(sid) = conn.acp_session_id.clone() {
-                    state.suspended.insert(key.clone(), sid);
-                }
-            }
+        let to_save: Vec<(String, String)> = state
+            .active
+            .iter()
+            .filter_map(|(key, conn)| {
+                let conn = conn.try_lock().ok()?;
+                let sid = conn.acp_session_id.clone()?;
+                Some((key.clone(), sid))
+            })
+            .collect();
+        for (key, sid) in to_save {
+            state.suspended.insert(key, sid);
         }
         self.save_mapping(&state.suspended);
         let count = state.active.len();


### PR DESCRIPTION
## Context

Closes #456

After a pod restart, all Discord thread-to-session mappings are lost because the `suspended` HashMap in `SessionPool` is purely in-memory. Even though kiro-cli correctly persists session state to PVC, OpenAB cannot associate returning threads with their previous sessions — every thread gets a brand-new session instead of resuming.

## Design

```
                        SessionPool (in-memory)
                    ┌─────────────────────────────┐
                    │  active: thread→connection   │
                    │  suspended: thread→session_id │──┐
                    └─────────────────────────────┘  │
                                                      │ save_mapping()
                         ┌────────────────────────────┘
                         │  atomic write (tmp + rename)
                         ▼
                    $HOME/.openab/thread_map.json   ◄── PVC
                         │
                         │ load_mapping() on startup
                         ▼
                    ┌─────────────────────────────┐
                    │  SessionPool::new()          │
                    │  suspended = loaded map      │
                    └─────────────────────────────┘

Save points (4):
  ┌──────────────────┬──────────────────────────────────┐
  │ get_or_create    │ after eviction inserts + remove   │
  │ reset_session    │ after suspended.remove            │
  │ cleanup_idle     │ after idle sessions → suspended   │
  │ shutdown         │ active sessions → suspended       │
  └──────────────────┴──────────────────────────────────┘

Lock ordering in shutdown():
  1. state.read()   → snapshot active handles
  2. drop state lock
  3. conn.lock()    → collect session IDs (no state held)
  4. state.write()  → insert into suspended + save to disk
  (follows: "never await per-connection mutex while holding state")
```

## Changes

- Added `mapping_path: PathBuf` field to `SessionPool`, set to `$HOME/.openab/thread_map.json`
- `load_mapping()`: reads `thread_map.json` on startup; falls back to empty map if file is missing or corrupt
- `save_mapping()`: atomic write (tmp + rename) after every suspended map mutation (4 save points)
- `shutdown()` now snapshots active sessions with correct lock ordering before persisting

## Design Decisions

- **`$HOME/.openab/` on PVC** — dedicated OpenAB state directory, separate from agent working_dir. `create_dir_all` on startup, fallback to `/tmp` if `$HOME` is unset.
- **Atomic write** — write to `.json.tmp` then `rename` to prevent corruption on crash mid-write.
- **Save on every mutation** — ensures mapping is always up-to-date even on ungraceful shutdown. Write frequency is low (only on eviction, idle cleanup, reset, or shutdown).
- **Graceful degradation** — corrupt or missing `thread_map.json` logs a warning and starts fresh. Failed writes warn without panicking.
- **Lock ordering** — `shutdown()` follows the codebase rule: snapshot with read lock, drop it, collect session IDs by locking connections individually, then re-acquire write lock.
- **No cleanup of stale entries** — out of scope. Stale mappings pointing to deleted session files are harmless: `session/load` will fail and fall back to `session/new`.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1495245278205182093