### PR TITLE
feat(discord): preserve user mention UIDs for LLM mention-back

### DIFF
--- a/docs/discord.md
+++ b/docs/discord.md
@@ -127,6 +127,16 @@ Empty (default) = any bot can pass through (subject to the mode check).
 
 Role mentions are ignored because they are shared across bots and cause false positives in multi-bot setups. This is intentional since v0.7.8-beta.3 (#420, #440).
 
+### User mention UIDs
+
+When a user mentions another user (e.g. `@SomeUser`) in a message to the bot, the raw Discord mention `<@UID>` is preserved in the prompt sent to the LLM. This means:
+
+- The LLM can copy `<@UID>` into its reply to produce a clickable Discord mention
+- The bot's own mention is stripped (so the bot doesn't see itself being triggered)
+- Role mentions are replaced with `@(role)` placeholder
+
+To help the LLM know who each UID refers to, provide a UID→name mapping via system prompt or context entry (see [Multi-Bot Setup](#multi-bot-setup) below).
+
 ---
 
 ## Thread Behavior
@@ -171,6 +181,22 @@ To enable bots to collaborate (e.g. code review → deploy handoff):
 [discord]
 allow_bot_messages = "mentions"
 ```
+
+### Ice-breaking: teaching bots who's in the room
+
+Since user mentions are preserved as raw `<@UID>`, bots need a UID→name mapping to know who is who. Add an ice-breaking greeting to each bot's system prompt or context entry:
+
+```
+We have 3 participants in this room:
+
+MY_NICIKNAME    <@MY_NAME>
+BOT1_NICKNAME   <@BOT1>
+BOT2_NICKNAME   <@BOT2>
+
+Always use <@UID> format to mention someone in your messages.
+```
+
+This lets each bot build the mapping in its own context from the start and correctly mention others using `<@UID>`.
 
 See [multi-agent.md](multi-agent.md) for detailed examples.
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -10,7 +10,6 @@ use serenity::http::Http;
 use serenity::model::channel::{AutoArchiveDuration, Message, ReactionType};
 use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, MessageId, UserId};
-use serenity::model::user::User;
 use serenity::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
@@ -321,11 +320,7 @@ impl EventHandler for Handler {
             return;
         }
 
-        let prompt = if is_mentioned {
-            resolve_mentions(&msg.content, bot_id, &msg.mentions)
-        } else {
-            msg.content.trim().to_string()
-        };
+        let prompt = resolve_mentions(&msg.content, bot_id);
 
         // No text and no attachments → skip
         if prompt.is_empty() && msg.attachments.is_empty() {
@@ -474,28 +469,14 @@ async fn get_or_create_thread(
 static ROLE_MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
     regex::Regex::new(r"<@&\d+>").unwrap()
 });
-static USER_MENTION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r"<@!?\d+>").unwrap()
-});
 
-fn resolve_mentions(content: &str, bot_id: UserId, mentions: &[User]) -> String {
+fn resolve_mentions(content: &str, bot_id: UserId) -> String {
     // 1. Strip the bot's own trigger mention
-    let mut out = content
+    let out = content
         .replace(&format!("<@{}>", bot_id), "")
         .replace(&format!("<@!{}>", bot_id), "");
-    // 2. Resolve known user mentions to @DisplayName
-    for user in mentions {
-        if user.id == bot_id {
-            continue;
-        }
-        let label = user.global_name.as_deref().unwrap_or(&user.name);
-        let display = format!("@{}", label);
-        out = out
-            .replace(&format!("<@{}>", user.id), &display)
-            .replace(&format!("<@!{}>", user.id), &display);
-    }
-    // 3. Fallback: replace any remaining unresolved mentions
-    let out = ROLE_MENTION_RE.replace_all(&out, "@(role)");
-    let out = USER_MENTION_RE.replace_all(&out, "@(user)").to_string();
+    // 2. Other user mentions: keep <@UID> as-is so the LLM can mention back
+    // 3. Fallback: replace role mentions only (user mentions are preserved)
+    let out = ROLE_MENTION_RE.replace_all(&out, "@(role)").to_string();
     out.trim().to_string()
 }


### PR DESCRIPTION
## Summary

Closes #460

Simplify `resolve_mentions()` to keep other-user `<@UID>` mentions as-is instead of resolving them to `@DisplayName` (which discards the UID). This lets the LLM copy `<@UID>` into its reply for correct Discord mention rendering — no outbound transformation needed.

## Changes (`src/discord.rs`, +6/-24)

- **Remove step 2** — no longer resolves `<@UID>` → `@DisplayName`. User mentions pass through as raw `<@UID>`.
- **Remove `USER_MENTION_RE`** — no longer needed since user mentions are preserved.
- **Remove `mentions` parameter** — `resolve_mentions` no longer needs the serenity `User` list.
- **Call unconditionally** — not just when `is_mentioned`, so thread follow-ups also get bot-mention stripping.

### What stays the same

- Bot own mention: stripped
- Role mentions: `@(role)` fallback
- `send_message` / outbound: untouched

## Why preserve raw `<@UID>` instead of `<@UID|DisplayName>`

We explored `<@UID|DisplayName>` (Slack-style) but LLMs don't reliably preserve token formats — the model might respond with `@Name`, `<@Name>`, or `<@UID|Name>`. Only raw `<@UID>` is safe:

- LLM copies `<@UID>` → Discord renders clickable mention ✅
- LLM writes `@Name` → plain text, no worse than before ⚠️
- No outbound regex needed — zero risk of mangling

## Recommended usage: ice-breaking in multi-bot chatrooms

Since `<@UID>` is now preserved, bots need a UID→name mapping to know who is who. The recommended approach is to send an ice-breaking greeting at the start of a multi-bot chatroom (via system prompt or context entry):

```
We have 3 people in this room:

ME @MY_NAME
BOT_A_NAME @BOT_A
BOT_B_NAME @BOT_B

Make sure to use <@UID> to mention someone in the messages.
```

This lets each bot build the UID→name mapping in its own context from the very beginning and learn how to mention others correctly.

## Design notes

**Slack isolation:** Slack has its own independent mention handling in `src/slack.rs`. Not touched.

**Thread title:** `shorten_thread_name()` will show raw `<@UID>` in thread titles. Pre-existing gap (old code stripped mentions entirely), can be addressed separately.


DC: https://discord.com/channels/1491295327620169908/1494739741600387204/1495368292146217071