### PR TITLE
feat(discord): add `multibot-mentions` mode for allow_user_messages

### DIFF
--- a/docs/discord.md
+++ b/docs/discord.md
@@ -103,6 +103,24 @@ Controls whether the bot requires @mention in threads.
 |---|---|
 | `"involved"` (default) | Respond in threads the bot owns or has participated in without @mention. Main channel always requires @mention. |
 | `"mentions"` | Always require @mention, even in the bot's own threads. |
+| `"multibot-mentions"` | Same as `involved` in single-bot threads. In threads where other bots have also posted, requires @mention — prevents all bots from responding to every message. |
+
+#### Comparison
+
+| Scenario | `involved` | `mentions` | `multibot-mentions` |
+|---|---|---|---|
+| Main channel (no @mention) | ❌ | ❌ | ❌ |
+| Main channel (with @mention) | ✅ | ✅ | ✅ |
+| Single-bot thread (no @mention) | ✅ | ❌ | ✅ |
+| Single-bot thread (with @mention) | ✅ | ✅ | ✅ |
+| Multi-bot thread (no @mention) | ✅ | ❌ | ❌ |
+| Multi-bot thread (with @mention) | ✅ | ✅ | ✅ |
+
+#### When to use which
+
+- **`involved`** — Single-bot setup, or you want all bots to respond freely in shared threads.
+- **`mentions`** — Strict control. Every message must explicitly @mention the bot. Best for high-traffic channels where accidental triggers are a concern.
+- **`multibot-mentions`** — Multi-bot setup. Natural conversation in single-bot threads, explicit @mention control in multi-bot threads. Recommended for most multi-bot deployments.
 
 ### `trusted_bot_ids`
 
@@ -171,6 +189,18 @@ helm install openab openab/openab \
 
 - **One thread per message:** when you @mention both bots in a single message, only the first bot creates a thread. The second bot's thread creation fails and the message is dropped. Workaround: @mention each bot in separate messages.
 - **Thread ownership:** a bot only responds in threads it owns or has participated in (`involved` mode). To have Bot B respond in Bot A's thread, use `mentions` mode and explicitly @mention Bot B.
+
+### Recommended: `multibot-mentions` mode
+
+In multi-bot channels, use `multibot-mentions` to get the best of both worlds:
+
+```toml
+[discord]
+allow_user_messages = "multibot-mentions"
+```
+
+- **Single-bot threads:** natural conversation, no @mention needed (same as `involved`)
+- **Multi-bot threads:** requires @mention so only the addressed bot responds
 
 ### Bot-to-bot communication
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,20 +96,24 @@ pub struct DiscordConfig {
 ///   in the thread (posted at least one message, or the thread parent @mentions the bot).
 ///   Channel/MPDM messages always require @mention. DMs always process (implicit mention).
 /// - `Mentions`: always require @mention, even in threads the bot is participating in.
+/// - `MultibotMentions`: same as `Involved` in single-bot threads; falls back to `Mentions`
+///   when other bots have also posted in the thread.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum AllowUsers {
     #[default]
     Involved,
     Mentions,
+    MultibotMentions,
 }
 
 impl<'de> Deserialize<'de> for AllowUsers {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
-        match s.to_lowercase().as_str() {
+        match s.to_lowercase().replace('-', "_").as_str() {
             "involved" => Ok(Self::Involved),
             "mentions" => Ok(Self::Mentions),
-            other => Err(serde::de::Error::unknown_variant(other, &["involved", "mentions"])),
+            "multibot_mentions" => Ok(Self::MultibotMentions),
+            other => Err(serde::de::Error::unknown_variant(other, &["involved", "mentions", "multibot-mentions"])),
         }
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -116,34 +116,47 @@ pub struct Handler {
     pub allow_user_messages: AllowUsers,
     /// Positive-only cache: thread channel_id → cached_at for threads where bot has participated.
     pub participated_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
+    /// Positive-only cache: thread channel_id → cached_at for threads where other bots have posted.
+    /// Like participation, a thread becoming multi-bot is irreversible (bot messages don't disappear).
+    pub multibot_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
     /// TTL for participation cache entries (from pool.session_ttl_hours).
     pub session_ttl: std::time::Duration,
 }
 
 impl Handler {
-    /// Check if the bot has participated in a Discord thread.
-    /// Returns true if any message in the thread is from the bot.
-    /// Fail-closed: returns false on API error.
-    /// Only caches positive results (participation is irreversible).
+    /// Check if the bot has participated in a Discord thread, and whether
+    /// other bots have also posted in it.
+    /// Returns `(involved, other_bot_present)`.
+    /// Fail-closed: returns `(false, false)` on API error.
+    /// Caches positive results only (both participation and multi-bot status are irreversible).
     async fn bot_participated_in_thread(
         &self,
         http: &Http,
         channel_id: ChannelId,
         bot_id: UserId,
-    ) -> bool {
+    ) -> (bool, bool) {
         let key = channel_id.to_string();
 
-        // Check positive cache
-        {
+        // Check positive caches
+        let cached_involved = {
             let cache = self.participated_threads.lock().await;
-            if let Some(cached_at) = cache.get(&key) {
-                if cached_at.elapsed() < self.session_ttl {
-                    return true;
-                }
-            }
+            cache.get(&key).is_some_and(|ts| ts.elapsed() < self.session_ttl)
+        };
+        let cached_multibot = {
+            let cache = self.multibot_threads.lock().await;
+            cache.get(&key).is_some_and(|ts| ts.elapsed() < self.session_ttl)
+        };
+
+        // Both cached → skip fetch entirely
+        if cached_involved && cached_multibot {
+            return (true, true);
+        }
+        // Involved cached + not MultibotMentions mode → don't need other_bot info
+        if cached_involved && self.allow_user_messages != AllowUsers::MultibotMentions {
+            return (true, false);
         }
 
-        // Fetch recent messages and check if bot posted any
+        // Fetch recent messages
         let messages = match channel_id
             .messages(http, serenity::builder::GetMessages::new().limit(200))
             .await
@@ -155,15 +168,16 @@ impl Handler {
                     error = %e,
                     "failed to fetch thread messages for participation check, rejecting (fail-closed)"
                 );
-                return false;
+                return (false, false);
             }
         };
 
-        let involved = messages.iter().any(|m| m.author.id == bot_id);
+        let involved = cached_involved || messages.iter().any(|m| m.author.id == bot_id);
+        let other_bot_present = cached_multibot || messages.iter().any(|m| m.author.bot && m.author.id != bot_id);
 
-        if involved {
+        if involved && !cached_involved {
             let mut cache = self.participated_threads.lock().await;
-            cache.insert(key, tokio::time::Instant::now());
+            cache.insert(key.clone(), tokio::time::Instant::now());
 
             // Evict if over capacity
             if cache.len() > PARTICIPATION_CACHE_MAX {
@@ -179,7 +193,24 @@ impl Handler {
             }
         }
 
-        involved
+        if other_bot_present && !cached_multibot {
+            let mut cache = self.multibot_threads.lock().await;
+            cache.insert(key, tokio::time::Instant::now());
+
+            if cache.len() > PARTICIPATION_CACHE_MAX {
+                cache.retain(|_, ts| ts.elapsed() < self.session_ttl);
+                if cache.len() > PARTICIPATION_CACHE_MAX {
+                    let mut entries: Vec<_> = cache.iter().map(|(k, v)| (k.clone(), *v)).collect();
+                    entries.sort_by_key(|(_, ts)| *ts);
+                    let evict_count = entries.len() / 2;
+                    for (k, _) in entries.into_iter().take(evict_count) {
+                        cache.remove(&k);
+                    }
+                }
+            }
+        }
+
+        (involved, other_bot_present)
     }
 }
 
@@ -294,6 +325,8 @@ impl EventHandler for Handler {
         // Mentions: always require @mention, even in bot's own threads.
         // Involved (default): skip @mention if the bot owns the thread
         //   (Option A) OR has previously posted in it (Option B).
+        // MultibotMentions: same as Involved, but if other bots are also
+        //   in the thread, require @mention to avoid all bots responding.
         if !is_mentioned {
             match self.allow_user_messages {
                 AllowUsers::Mentions => return,
@@ -301,12 +334,37 @@ impl EventHandler for Handler {
                     if !in_thread {
                         return;
                     }
-                    let involved = bot_owns_thread
-                        || self
-                            .bot_participated_in_thread(&ctx.http, msg.channel_id, bot_id)
-                            .await;
+                    let (involved, _) = if bot_owns_thread {
+                        (true, false) // other_bot_present not needed for Involved mode
+                    } else {
+                        self.bot_participated_in_thread(&ctx.http, msg.channel_id, bot_id)
+                            .await
+                    };
                     if !involved {
                         tracing::debug!(channel_id = %msg.channel_id, "bot not involved in thread, ignoring");
+                        return;
+                    }
+                }
+                AllowUsers::MultibotMentions => {
+                    if !in_thread {
+                        return;
+                    }
+                    let (involved, other_bot) = if bot_owns_thread {
+                        // Still need to check for other bots
+                        let (_, other) = self
+                            .bot_participated_in_thread(&ctx.http, msg.channel_id, bot_id)
+                            .await;
+                        (true, other)
+                    } else {
+                        self.bot_participated_in_thread(&ctx.http, msg.channel_id, bot_id)
+                            .await
+                    };
+                    if !involved {
+                        tracing::debug!(channel_id = %msg.channel_id, "bot not involved in thread, ignoring");
+                        return;
+                    }
+                    if other_bot {
+                        tracing::debug!(channel_id = %msg.channel_id, "multi-bot thread, requiring @mention");
                         return;
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,7 @@ async fn main() -> anyhow::Result<()> {
                     trusted_bot_ids,
                     allow_user_messages: discord_cfg.allow_user_messages,
                     participated_threads: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+                    multibot_threads: tokio::sync::Mutex::new(std::collections::HashMap::new()),
                     session_ttl: std::time::Duration::from_secs(ttl_secs),
                 };
 

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -664,7 +664,7 @@ pub async fn run_slack_adapter(
                                                             AllowUsers::Mentions => {
                                                                 if !mentions_bot { continue; }
                                                             }
-                                                            AllowUsers::Involved => {
+                                                            AllowUsers::Involved | AllowUsers::MultibotMentions => {
                                                                 if !has_thread {
                                                                     // Non-thread channel message: require mention
                                                                     // (app_mention handles this, but DMs don't get app_mention)


### PR DESCRIPTION
## Summary

Closes #463

Add a third mode for `allow_user_messages` that combines the best of `involved` and `mentions`:

- **Single-bot threads:** natural conversation, no `@mention` needed (same as `involved`)
- **Multi-bot threads:** requires `@mention` so only the addressed bot responds (same as `mentions`)

```toml
[discord]
allow_user_messages = "multibot-mentions"
```

## Changes

### `src/config.rs`
- Add `MultibotMentions` variant to `AllowUsers` enum
- Accept `"multibot-mentions"` or `"multibot_mentions"` in config deserialization

### `src/discord.rs`
- Refactor `bot_participated_in_thread()` to return `(involved, other_bot_present)` tuple
  - Reuses the existing message fetch (up to 200 messages) — zero additional API calls
  - Checks `m.author.bot && m.author.id != bot_id` to detect other bots
  - For `Involved` mode with a cache hit, skips the fetch entirely (no regression)
- Add `multibot_threads` positive-only cache (same pattern as `participated_threads`)
  - Once a thread is detected as multi-bot, the result is cached — subsequent messages skip the fetch
  - Both caches hit → `return (true, true)`, zero API call
  - Same eviction strategy (session TTL + capacity cap)
- Add `MultibotMentions` branch in the gating logic:
  - Not in thread → return (same as other modes)
  - Not involved → return
  - Other bot present → return (require `@mention`)

### `src/main.rs`
- Initialize `multibot_threads` cache in Handler construction

### `docs/discord.md`
- Add `multibot-mentions` to the `allow_user_messages` config table
- Add "Recommended: multibot-mentions mode" section under Multi-Bot Setup

## Design decisions

**Positive-only caching for `other_bot_present`:** Like participation, a thread becoming multi-bot is irreversible — bot messages don't disappear. So we use the same positive-only cache pattern: once detected, cached for the session TTL. This avoids per-message API calls in active multi-bot threads.

**Detection uses `m.author.bot`:** Checks any bot author, not just `trusted_bot_ids`. This is intentional — even untrusted bots in a thread indicate a multi-bot scenario where `@mention` gating is desirable.

**First message in new thread:** No other bot messages exist yet → behaves as `involved`. Correct, since it is not yet a multi-bot thread.