### PR TITLE
perf(discord): eager multibot detection from msg.author

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -148,12 +148,10 @@ impl Handler {
         };
 
         // Both cached → skip fetch entirely
-        if cached_involved && cached_multibot {
-            return (true, true);
-        }
-        // Involved cached + not MultibotMentions mode → don't need other_bot info
-        if cached_involved && self.allow_user_messages != AllowUsers::MultibotMentions {
-            return (true, false);
+        // With early detection from msg.author, multibot_threads is populated
+        // eagerly — no need to fetch just to check for other bots.
+        if cached_involved {
+            return (true, cached_multibot);
         }
 
         // Fetch recent messages
@@ -319,6 +317,14 @@ impl EventHandler for Handler {
 
         if !in_allowed_channel && !in_thread {
             return;
+        }
+
+        // Early multibot detection: if the current message is from another bot,
+        // this thread is multi-bot. Cache it now — no fetch needed.
+        if in_thread && msg.author.bot && msg.author.id != bot_id {
+            let key = msg.channel_id.to_string();
+            let mut cache = self.multibot_threads.lock().await;
+            cache.entry(key).or_insert_with(tokio::time::Instant::now);
         }
 
         // User message gating (mirrors Slack's AllowUsers logic).


### PR DESCRIPTION
## Summary

Builds on #464. Eliminates unnecessary API fetches in `multibot-mentions` mode.

## Problem

In #464, `bot_participated_in_thread()` fetches up to 200 messages on every unmentioned message in `MultibotMentions` mode — even in single-bot threads where no other bot will ever be found. This is because `cached_involved = true` could not short-circuit without knowing `other_bot_present`.

## Solution

Detect multi-bot threads eagerly from `msg.author` instead of fetching history:

```rust
// Before gating logic — zero API call
if in_thread && msg.author.bot && msg.author.id != bot_id {
    cache multibot_threads[thread_id] = now
}
```

When a bot message arrives in a thread, we already know it is multi-bot. No fetch needed.

This allows `bot_participated_in_thread()` to short-circuit on `cached_involved` alone:

```rust
// Before (fetched every time for MultibotMentions):
if cached_involved && cached_multibot { return (true, true); }
if cached_involved && mode != MultibotMentions { return (true, false); }
// ↑ MultibotMentions with cached_involved but !cached_multibot → fetch

// After (always short-circuits):
if cached_involved { return (true, cached_multibot); }
// ↑ cached_multibot is populated eagerly from msg.author
```

## Impact

| Scenario | Before | After |
|---|---|---|
| Single-bot thread, unmentioned msg | Fetch 200 msgs every time | Zero fetch (cache hit) |
| Multi-bot thread, after detection | Zero fetch (cache hit) | Zero fetch (cache hit) |
| First bot message in thread | Fetch (to check involvement) | Fetch (same) + cache multibot |

## Cold-start note

After bot restart, both caches are empty. If a thread is already multi-bot but the next message is from a user (not a bot), early detection won't trigger and `cached_multibot = false`. However, `cached_involved` is also false (cleared on restart), so `bot_participated_in_thread` will fetch — and the fetch includes `other_bot_present` detection, which repopulates the cache. This is safe and consistent with #464 behavior — just one fallback fetch on the first message after restart.

## Changes (`src/discord.rs`, +12/-6)

- Add early multibot detection from `msg.author` before gating logic
- Simplify `bot_participated_in_thread`: `cached_involved` → return `(true, cached_multibot)` immediately, no mode-specific branching