### PR TITLE
feat(discord): bot turn limits (soft + hard) for bot-to-bot loops

### DIFF
--- a/docs/discord.md
+++ b/docs/discord.md
@@ -212,6 +212,18 @@ To enable bots to collaborate (e.g. code review → deploy handoff):
 allow_bot_messages = "mentions"
 ```
 
+### Bot turn limits
+
+To prevent runaway bot-to-bot loops, OpenAB enforces two layers of protection:
+
+- **Soft limit** (`max_bot_turns`, default: 20) — consecutive bot turns without human intervention. When reached, the bot sends a warning and stops responding. A human message in the thread resets the counter.
+- **Hard limit** (100, not configurable) — absolute cap on total bot turns per thread. When reached, bot-to-bot conversation is permanently stopped in that thread.
+
+```toml
+[discord]
+max_bot_turns = 30  # default is 20
+```
+
 ### Ice-breaking: teaching bots who's in the room
 
 Since user mentions are preserved as raw `<@UID>`, bots need a UID→name mapping to know who is who. Add an ice-breaking greeting to each bot's system prompt or context entry:

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,7 +88,13 @@ pub struct DiscordConfig {
     pub trusted_bot_ids: Vec<String>,
     #[serde(default)]
     pub allow_user_messages: AllowUsers,
+    /// Max consecutive bot turns (without human intervention) before throttling.
+    /// Human message resets the counter. Default: 20.
+    #[serde(default = "default_max_bot_turns")]
+    pub max_bot_turns: u32,
 }
+
+fn default_max_bot_turns() -> u32 { 20 }
 
 /// Controls whether the bot responds to user messages in threads without @mention.
 ///

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -19,6 +19,9 @@ use tracing::{debug, error, info};
 /// Prevents runaway loops between multiple bots in "all" mode.
 const MAX_CONSECUTIVE_BOT_TURNS: u8 = 10;
 
+/// Absolute per-thread cap on bot turns. Cannot be overridden by config or human intervention.
+const HARD_BOT_TURN_LIMIT: u32 = 100;
+
 /// Maximum entries in the participation cache before eviction.
 const PARTICIPATION_CACHE_MAX: usize = 1000;
 
@@ -121,6 +124,10 @@ pub struct Handler {
     pub multibot_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
     /// TTL for participation cache entries (from pool.session_ttl_hours).
     pub session_ttl: std::time::Duration,
+    /// Configurable soft limit on bot turns per thread (reset by human message).
+    pub max_bot_turns: u32,
+    /// Per-thread counters: (soft_turns, hard_turns). Soft resets on human msg, hard never resets.
+    pub bot_turn_counts: tokio::sync::Mutex<HashMap<String, (u32, u32)>>,
 }
 
 impl Handler {
@@ -385,6 +392,41 @@ impl EventHandler for Handler {
         }
 
         let prompt = resolve_mentions(&msg.content, bot_id);
+
+        // Bot turn limiting: track consecutive bot turns per thread.
+        // Placed after all gating so only messages that will actually be
+        // processed count toward the limit.
+        // Human message resets soft counter; hard counter never resets.
+        {
+            let thread_key = msg.channel_id.to_string();
+            let mut counts = self.bot_turn_counts.lock().await;
+            if msg.author.bot {
+                let (soft, hard) = counts.entry(thread_key).or_insert((0, 0));
+                *soft += 1;
+                *hard += 1;
+                if *hard >= HARD_BOT_TURN_LIMIT {
+                    tracing::warn!(channel_id = %msg.channel_id, hard = *hard, "hard bot turn limit reached");
+                    let _ = msg.channel_id.say(
+                        &ctx.http,
+                        format!("🛑 Hard limit reached ({HARD_BOT_TURN_LIMIT}). Bot-to-bot conversation in this thread has been permanently stopped."),
+                    ).await;
+                    return;
+                }
+                if *soft >= self.max_bot_turns {
+                    tracing::info!(channel_id = %msg.channel_id, soft = *soft, max = self.max_bot_turns, "soft bot turn limit reached");
+                    let _ = msg.channel_id.say(
+                        &ctx.http,
+                        format!("⚠️ Bot turn limit reached ({}/{}). A human must reply in this thread to continue bot-to-bot conversation.", *soft, self.max_bot_turns),
+                    ).await;
+                    return;
+                }
+            } else {
+                // Human message: reset soft counter
+                if let Some((soft, _)) = counts.get_mut(&thread_key) {
+                    *soft = 0;
+                }
+            }
+        }
 
         // No text and no attachments → skip
         if prompt.is_empty() && msg.attachments.is_empty() {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -148,12 +148,10 @@ impl Handler {
         };
 
         // Both cached → skip fetch entirely
-        if cached_involved && cached_multibot {
-            return (true, true);
-        }
-        // Involved cached + not MultibotMentions mode → don't need other_bot info
-        if cached_involved && self.allow_user_messages != AllowUsers::MultibotMentions {
-            return (true, false);
+        // With early detection from msg.author, multibot_threads is populated
+        // eagerly — no need to fetch just to check for other bots.
+        if cached_involved {
+            return (true, cached_multibot);
         }
 
         // Fetch recent messages
@@ -319,6 +317,14 @@ impl EventHandler for Handler {
 
         if !in_allowed_channel && !in_thread {
             return;
+        }
+
+        // Early multibot detection: if the current message is from another bot,
+        // this thread is multi-bot. Cache it now — no fetch needed.
+        if in_thread && msg.author.bot && msg.author.id != bot_id {
+            let key = msg.channel_id.to_string();
+            let mut cache = self.multibot_threads.lock().await;
+            cache.entry(key).or_insert_with(tokio::time::Instant::now);
         }
 
         // User message gating (mirrors Slack's AllowUsers logic).

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,8 @@ async fn main() -> anyhow::Result<()> {
                     participated_threads: tokio::sync::Mutex::new(std::collections::HashMap::new()),
                     multibot_threads: tokio::sync::Mutex::new(std::collections::HashMap::new()),
                     session_ttl: std::time::Duration::from_secs(ttl_secs),
+                    max_bot_turns: discord_cfg.max_bot_turns,
+                    bot_turn_counts: tokio::sync::Mutex::new(std::collections::HashMap::new()),
                 };
 
                 let intents = GatewayIntents::GUILD_MESSAGES


### PR DESCRIPTION
## Summary

Closes #466

Add two-layer protection against runaway bot-to-bot mention loops. The existing `MAX_CONSECUTIVE_BOT_TURNS` is ineffective when bots interleave messages (each bot's own reply breaks the `take_while` chain, so the counter never reaches the cap).

## Design

### Soft limit (`max_bot_turns`, configurable)

- Default: 20 consecutive bot turns without human intervention
- When reached: sends warning message, stops responding
- Human message resets the counter
- Configurable via `max_bot_turns` in `[discord]` config

```
⚠️ Bot turn limit reached (20/20). A human must reply in this thread to continue bot-to-bot conversation.
```

### Hard limit (`HARD_BOT_TURN_LIMIT = 100`, not configurable)

- Absolute cap on bot turns between human interventions
- Human message resets the counter (same as soft)
- When reached: sends stop message

```
🛑 Hard limit reached (100). Bot-to-bot conversation in this thread has been permanently stopped.
```

### How it works

```
Bot A: @BotB ...     ← soft=1, hard=1
Bot B: @BotA ...     ← soft=2, hard=2
...
Bot B: @BotA ...     ← soft=20 → ⚠️ throttled
Human: continue      ← soft=0, hard=0 (both reset)
Bot A: @BotB ...     ← soft=1, hard=1 (fresh start)
```

The difference: soft is configurable (default 20), hard is fixed at 100. If someone sets `max_bot_turns = 100` or higher, the hard limit is the safety net.

## Changes (+63/-0)

- `src/config.rs`: add `max_bot_turns` field (default 20) to `DiscordConfig`
- `src/discord.rs`: add `HARD_BOT_TURN_LIMIT = 100` const, `bot_turn_counts` per-thread `(soft, hard)` counters, counting + throttle logic (placed after all gating)
- `src/main.rs`: initialize `bot_turn_counts` and `max_bot_turns`
- `docs/discord.md`: document bot turn limits

## Why not fix `MAX_CONSECUTIVE_BOT_TURNS`?

The existing check counts consecutive messages from *other* bots using `take_while`. When Bot A and Bot B alternate, each bot's own reply breaks the chain — the counter never exceeds 1. The fundamental issue is the counting method, not the cap value. Our approach counts *all* bot turns regardless of interleaving.

## Related

- #464 — `multibot-mentions` mode
- #465 — eager multibot detection