### PR TITLE
fix(acp): close notify channel on EOF to prevent stream hang

### DIFF
--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -253,9 +253,9 @@ impl AcpConnection {
                         params: None,
                     });
                 }
-                // Signal subscriber
-                let sub = notify_tx.lock().await;
-                drop(sub);
+                // Close the notify channel so rx.recv() returns None
+                let mut sub = notify_tx.lock().await;
+                *sub = None;
             })
         };
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -273,7 +273,16 @@ impl AdapterRouter {
 
                     // Process ACP notifications
                     let mut response_error: Option<String> = None;
-                    while let Some(notification) = rx.recv().await {
+                    let recv_timeout = std::time::Duration::from_secs(600);
+                    loop {
+                        let notification = match tokio::time::timeout(recv_timeout, rx.recv()).await {
+                            Ok(Some(n)) => n,
+                            Ok(None) => break, // channel closed
+                            Err(_) => {
+                                response_error = Some("Agent stopped responding".into());
+                                break;
+                            }
+                        };
                         if notification.id.is_some() {
                             if let Some(ref err) = notification.error {
                                 response_error = Some(format_coded_error(err.code, &err.message));


### PR DESCRIPTION
## Summary

Closes #295

When the ACP child process dies (EOF on stdout), the reader task in `connection.rs` fails to close the notify channel. This causes `rx.recv()` in the streaming loop to hang forever, holding the per-connection mutex and permanently leaking the pool slot.

## Changes

| File | Change |
|------|--------|
| `src/acp/connection.rs` | Fix EOF handler: `*sub = None` instead of `drop(sub)` — drops the `UnboundedSender`, closing the channel |
| `src/adapter.rs` | Add 10-minute timeout to `rx.recv()` as defense-in-depth |

## Root Cause

In the reader task EOF handler:

```rust
// Before (bug)
let sub = notify_tx.lock().await;
drop(sub);  // drops MutexGuard, NOT the Option<Sender> inside
```

`drop(sub)` only drops the `MutexGuard<Option<UnboundedSender>>`. The `Option` remains `Some(sender)`, so the `UnboundedSender` is never dropped and `rx.recv()` never returns `None`.

```rust
// After (fix)
let mut sub = notify_tx.lock().await;
*sub = None;  // drops the Sender → channel closes → rx.recv() returns None
```

## Defense-in-Depth

Added a 10-minute timeout around `rx.recv()` in the streaming loop (`adapter.rs`). If no notification arrives within 10 minutes, the loop breaks with an "Agent stopped responding" error. This prevents indefinite hangs even if other channel-closing bugs exist.

## Scope Note

Issue #295 also describes a global write lock problem in `with_connection`. That was already fixed in a prior refactor — `with_connection` now uses a read lock + per-connection mutex. See [validation comment](https://github.com/openabdev/openab/issues/295#issuecomment-4276043728) for details. This PR only addresses the remaining confirmed bug (notify channel EOF).

## Validation

- Code-level verification: `*sub = None` drops the `UnboundedSender`, which is the standard tokio `mpsc` channel close mechanism
- `tokio::time::timeout` wrapping `rx.recv()` is a well-established pattern for stall detection