### PR TITLE
fix(discord): move multibot detection + bot turn tracker before gating

### DIFF
--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -214,3 +214,125 @@ pub fn classify_notification(msg: &JsonRpcMessage) -> Option<AcpEvent> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_standard_config_options() {
+        let result = json!({
+            "configOptions": [{
+                "id": "model",
+                "name": "Model",
+                "type": "enum",
+                "currentValue": "claude-sonnet-4",
+                "options": [
+                    {"value": "claude-sonnet-4", "name": "Sonnet 4"},
+                    {"value": "claude-opus-4", "name": "Opus 4"}
+                ]
+            }]
+        });
+        let opts = parse_config_options(&result);
+        assert_eq!(opts.len(), 1);
+        assert_eq!(opts[0].id, "model");
+        assert_eq!(opts[0].current_value, "claude-sonnet-4");
+        assert_eq!(opts[0].options.len(), 2);
+    }
+
+    #[test]
+    fn parse_kiro_models_fallback() {
+        let result = json!({
+            "models": {
+                "currentModelId": "m1",
+                "availableModels": [
+                    {"modelId": "m1", "name": "Model One"},
+                    {"modelId": "m2", "name": "Model Two"}
+                ]
+            }
+        });
+        let opts = parse_config_options(&result);
+        assert_eq!(opts.len(), 1);
+        assert_eq!(opts[0].id, "model");
+        assert_eq!(opts[0].category.as_deref(), Some("model"));
+        assert_eq!(opts[0].current_value, "m1");
+        assert_eq!(opts[0].options.len(), 2);
+    }
+
+    #[test]
+    fn parse_kiro_modes_fallback() {
+        let result = json!({
+            "modes": {
+                "currentModeId": "default",
+                "availableModes": [
+                    {"id": "default", "name": "Default"},
+                    {"id": "planner", "name": "Planner"}
+                ]
+            }
+        });
+        let opts = parse_config_options(&result);
+        assert_eq!(opts.len(), 1);
+        assert_eq!(opts[0].id, "agent");
+        assert_eq!(opts[0].category.as_deref(), Some("agent"));
+        assert_eq!(opts[0].current_value, "default");
+    }
+
+    #[test]
+    fn parse_kiro_models_and_modes() {
+        let result = json!({
+            "models": {
+                "currentModelId": "m1",
+                "availableModels": [{"modelId": "m1", "name": "M1"}]
+            },
+            "modes": {
+                "currentModeId": "default",
+                "availableModes": [{"id": "default", "name": "Default"}]
+            }
+        });
+        let opts = parse_config_options(&result);
+        assert_eq!(opts.len(), 2);
+        assert_eq!(opts[0].id, "model");
+        assert_eq!(opts[1].id, "agent");
+    }
+
+    #[test]
+    fn parse_standard_takes_precedence_over_kiro() {
+        let result = json!({
+            "configOptions": [{
+                "id": "model",
+                "name": "Model",
+                "type": "enum",
+                "currentValue": "standard",
+                "options": [{"value": "standard", "name": "Standard"}]
+            }],
+            "models": {
+                "currentModelId": "kiro",
+                "availableModels": [{"modelId": "kiro", "name": "Kiro"}]
+            }
+        });
+        let opts = parse_config_options(&result);
+        assert_eq!(opts.len(), 1);
+        assert_eq!(opts[0].current_value, "standard");
+    }
+
+    #[test]
+    fn parse_empty_result() {
+        let opts = parse_config_options(&json!({}));
+        assert!(opts.is_empty());
+    }
+
+    #[test]
+    fn parse_empty_config_options_falls_through_to_kiro() {
+        let result = json!({
+            "configOptions": [],
+            "models": {
+                "currentModelId": "m1",
+                "availableModels": [{"modelId": "m1", "name": "M1"}]
+            }
+        });
+        let opts = parse_config_options(&result);
+        assert_eq!(opts.len(), 1);
+        assert_eq!(opts[0].id, "model");
+    }
+}

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -244,6 +244,15 @@ impl EventHandler for Handler {
         let is_mentioned = msg.mentions_user_id(bot_id)
             || msg.content.contains(&format!("<@{}>", bot_id));
 
+        // Early multibot detection: cache that another bot is present in this
+        // channel/thread. Runs BEFORE bot message gating so we detect other
+        // bots even when their messages are filtered out. (#481)
+        if msg.author.bot && msg.author.id != bot_id {
+            let key = msg.channel_id.to_string();
+            let mut cache = self.multibot_threads.lock().await;
+            cache.entry(key).or_insert_with(tokio::time::Instant::now);
+        }
+
         // Bot message gating (from upstream #321)
         if msg.author.bot {
             match self.allow_bot_messages {
@@ -328,14 +337,6 @@ impl EventHandler for Handler {
 
         if !in_allowed_channel && !in_thread {
             return;
-        }
-
-        // Early multibot detection: if the current message is from another bot,
-        // this thread is multi-bot. Cache it now — no fetch needed.
-        if in_thread && msg.author.bot && msg.author.id != bot_id {
-            let key = msg.channel_id.to_string();
-            let mut cache = self.multibot_threads.lock().await;
-            cache.entry(key).or_insert_with(tokio::time::Instant::now);
         }
 
         // User message gating (mirrors Slack's AllowUsers logic).
@@ -818,10 +819,39 @@ fn resolve_mentions(content: &str, bot_id: UserId) -> String {
     out.trim().to_string()
 }
 
+/// Pure decision function: should this message be processed or ignored?
+/// Returns `true` if the message should be processed (bot responds).
+/// Extracted from the EventHandler::message gating logic for testability.
+#[cfg(test)]
+fn should_process_user_message(
+    mode: AllowUsers,
+    is_mentioned: bool,
+    in_thread: bool,
+    involved: bool,
+    other_bot_present: bool,
+) -> bool {
+    if is_mentioned {
+        return true;
+    }
+    match mode {
+        AllowUsers::Mentions => false,
+        AllowUsers::Involved => in_thread && involved,
+        AllowUsers::MultibotMentions => {
+            if !in_thread || !involved {
+                return false;
+            }
+            !other_bot_present
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // --- Bot turn tracker tests ---
+
+    /// Basic increment: bot messages below the soft limit return Ok.
     #[test]
     fn bot_turns_increment() {
         let mut t = BotTurnTracker::new(5);
@@ -829,6 +859,7 @@ mod tests {
         assert_eq!(t.on_bot_message("t1"), TurnResult::Ok);
     }
 
+    /// Soft limit: after N consecutive bot turns, returns SoftLimit.
     #[test]
     fn soft_limit_triggers() {
         let mut t = BotTurnTracker::new(3);
@@ -837,6 +868,7 @@ mod tests {
         assert_eq!(t.on_bot_message("t1"), TurnResult::SoftLimit(3));
     }
 
+    /// Human message resets both soft and hard counters, allowing bots to continue.
     #[test]
     fn human_resets_both_counters() {
         let mut t = BotTurnTracker::new(3);
@@ -849,6 +881,7 @@ mod tests {
         assert_eq!(t.on_bot_message("t1"), TurnResult::SoftLimit(3));
     }
 
+    /// Hard limit: absolute cap on bot turns, triggers after HARD_BOT_TURN_LIMIT.
     #[test]
     fn hard_limit_triggers() {
         let mut t = BotTurnTracker::new(HARD_BOT_TURN_LIMIT + 1);
@@ -858,6 +891,7 @@ mod tests {
         assert_eq!(t.on_bot_message("t1"), TurnResult::HardLimit);
     }
 
+    /// Hard limit resets on human message, allowing bots to continue.
     #[test]
     fn hard_limit_resets_on_human() {
         let mut t = BotTurnTracker::new(HARD_BOT_TURN_LIMIT + 1);
@@ -869,6 +903,7 @@ mod tests {
         assert_eq!(t.on_bot_message("t1"), TurnResult::Ok);
     }
 
+    /// When soft and hard limits are equal, hard limit takes precedence.
     #[test]
     fn hard_before_soft_when_equal() {
         let mut t = BotTurnTracker::new(HARD_BOT_TURN_LIMIT);
@@ -879,6 +914,7 @@ mod tests {
         assert_eq!(t.on_bot_message("t1"), TurnResult::HardLimit);
     }
 
+    /// Turn counters are per-thread — one thread hitting the limit doesn't affect others.
     #[test]
     fn threads_are_independent() {
         let mut t = BotTurnTracker::new(3);
@@ -889,9 +925,157 @@ mod tests {
         assert_eq!(t.on_bot_message("t2"), TurnResult::Ok);
     }
 
+    /// Human message on an unknown thread is a no-op (should not panic).
     #[test]
     fn human_on_unknown_thread_is_noop() {
         let mut t = BotTurnTracker::new(5);
         t.on_human_message("unknown"); // should not panic
+    }
+
+    // --- resolve_mentions tests ---
+
+    /// Bot's own <@UID> mention is stripped from the prompt.
+    #[test]
+    fn resolve_mentions_strips_bot_mention() {
+        let bot_id = UserId::new(111);
+        let result = resolve_mentions("hello <@111> world", bot_id);
+        assert_eq!(result, "hello  world");
+    }
+
+    /// Bot's own legacy <@!UID> mention is also stripped.
+    #[test]
+    fn resolve_mentions_strips_bot_mention_legacy() {
+        let bot_id = UserId::new(111);
+        let result = resolve_mentions("hello <@!111> world", bot_id);
+        assert_eq!(result, "hello  world");
+    }
+
+    /// Other users' <@UID> mentions are preserved so the LLM can mention them back.
+    #[test]
+    fn resolve_mentions_preserves_other_user_mentions() {
+        let bot_id = UserId::new(111);
+        let result = resolve_mentions("<@111> say hi to <@222>", bot_id);
+        assert_eq!(result, "say hi to <@222>");
+    }
+
+    /// Role mentions <@&UID> are replaced with @(role) placeholder.
+    #[test]
+    fn resolve_mentions_replaces_role_mentions() {
+        let bot_id = UserId::new(111);
+        let result = resolve_mentions("hello <@&999>", bot_id);
+        assert_eq!(result, "hello @(role)");
+    }
+
+    /// Message containing only the bot mention results in empty string.
+    #[test]
+    fn resolve_mentions_empty_after_strip() {
+        let bot_id = UserId::new(111);
+        let result = resolve_mentions("<@111>", bot_id);
+        assert_eq!(result, "");
+    }
+
+    // --- should_process_user_message tests (GIVEN/WHEN/THEN) ---
+    // Tests the multibot-mentions gating logic extracted from EventHandler::message.
+    // The bug in #481 was that other bots' messages were filtered by bot gating
+    // before multibot detection could run, so the bot never learned the thread
+    // was multi-bot and responded without @mention.
+
+    /// GIVEN: multibot-mentions mode, single-bot thread, bot is involved
+    /// WHEN:  human sends message without @mention
+    /// THEN:  bot responds (natural conversation)
+    #[test]
+    fn multibot_mentions_single_bot_thread_no_mention() {
+        assert!(should_process_user_message(
+            AllowUsers::MultibotMentions,
+            false,          // is_mentioned
+            true,           // in_thread
+            true,           // involved
+            false,          // other_bot_present
+        ));
+    }
+
+    /// GIVEN: multibot-mentions mode, multi-bot thread (other bot has posted)
+    /// WHEN:  human sends message without @mention
+    /// THEN:  bot does NOT respond (requires @mention in multi-bot thread)
+    /// This is the exact scenario from bug #481.
+    #[test]
+    fn multibot_mentions_multi_bot_thread_no_mention() {
+        assert!(!should_process_user_message(
+            AllowUsers::MultibotMentions,
+            false,          // is_mentioned
+            true,           // in_thread
+            true,           // involved
+            true,           // other_bot_present ← another bot posted
+        ));
+    }
+
+    /// GIVEN: multibot-mentions mode, multi-bot thread
+    /// WHEN:  human sends message WITH @mention
+    /// THEN:  bot responds (explicit @mention always works)
+    #[test]
+    fn multibot_mentions_multi_bot_thread_with_mention() {
+        assert!(should_process_user_message(
+            AllowUsers::MultibotMentions,
+            true,           // is_mentioned
+            true,           // in_thread
+            true,           // involved
+            true,           // other_bot_present
+        ));
+    }
+
+    /// GIVEN: multibot-mentions mode, not in a thread (main channel)
+    /// WHEN:  human sends message without @mention
+    /// THEN:  bot does NOT respond (main channel always requires @mention)
+    #[test]
+    fn multibot_mentions_main_channel_no_mention() {
+        assert!(!should_process_user_message(
+            AllowUsers::MultibotMentions,
+            false,          // is_mentioned
+            false,          // in_thread (main channel)
+            false,          // involved
+            false,          // other_bot_present
+        ));
+    }
+
+    /// GIVEN: multibot-mentions mode, in thread but bot is NOT involved
+    /// WHEN:  human sends message without @mention
+    /// THEN:  bot does NOT respond (not participating in this thread)
+    #[test]
+    fn multibot_mentions_not_involved() {
+        assert!(!should_process_user_message(
+            AllowUsers::MultibotMentions,
+            false,          // is_mentioned
+            true,           // in_thread
+            false,          // involved ← bot hasn't posted here
+            false,          // other_bot_present
+        ));
+    }
+
+    /// GIVEN: involved mode, multi-bot thread
+    /// WHEN:  human sends message without @mention
+    /// THEN:  bot responds (involved mode ignores multi-bot status)
+    #[test]
+    fn involved_mode_ignores_multibot() {
+        assert!(should_process_user_message(
+            AllowUsers::Involved,
+            false,          // is_mentioned
+            true,           // in_thread
+            true,           // involved
+            true,           // other_bot_present ← ignored in involved mode
+        ));
+    }
+
+    /// GIVEN: mentions mode
+    /// WHEN:  human sends message without @mention (even in own thread)
+    /// THEN:  bot does NOT respond (always requires @mention)
+    #[test]
+    fn mentions_mode_always_requires_mention() {
+        assert!(!should_process_user_message(
+            AllowUsers::Mentions,
+            false,          // is_mentioned
+            true,           // in_thread
+            true,           // involved
+            false,          // other_bot_present
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Closes #481, closes #483

Move eager multibot detection **before** bot message gating so other bots' messages are detected even when filtered by `allow_bot_messages = "mentions"`.

## The Bug

```
AgentBroker event handler — message processing order
═════════════════════════════════════════════════════

  ① Human: @AgentBroker HIHI
     → Broker creates thread, responds
     → participated_threads cache: { thread: ✅ }
     → multibot_threads cache:     { }  ← empty

  ② Human: @AgentDealer 你來
     → Broker responds (involved in thread)

  ③ AgentDealer: 來了來了！
     │
     ▼
  ┌─────────────────────────────────────────────────┐
  │ Line 248: Bot message gating                    │
  │                                                 │
  │ allow_bot_messages = "mentions"                  │
  │ Dealer did NOT @mention Broker                   │
  │ → return ❌  message discarded                  │
  └─────────────────────────────────────────────────┘
     │
     │  ⛔ NEVER REACHES ⛔
     │
     ▼
  ┌─────────────────────────────────────────────────┐
  │ Line 335: Eager multibot detection              │
  │                                                 │
  │ if msg.author.bot && msg.author.id != bot_id    │
  │   → multibot_threads.insert(thread)             │
  │                                                 │
  │ 💀 Dead code for filtered bot messages          │
  └─────────────────────────────────────────────────┘

  ④ Human: nice (no @mention)
     → Broker checks: involved=✅, multibot=❌ (cache empty)
     → Thinks single-bot thread → responds ← BUG
```

## The Fix

```
BEFORE:                              AFTER:
─────────────────────────            ─────────────────────────
                                     Multibot detection  ← NEW
                                       if msg.author.bot
                                         cache it
                                              │
                                              ▼
Bot message gating                   Bot message gating
  allow_bot_messages check             allow_bot_messages check
  → return if filtered                 → return if filtered
         │                                    │
         ▼                                    ▼
Multibot detection  ← TOO LATE      (removed — already done)
  never reached for
  filtered messages
```

Move the `if msg.author.bot` cache check **before** gating. Drop the `in_thread` guard — caching by `channel_id` is harmless for non-thread channels.

## Tests Added (20 new, 70 total)

Extracted `should_process_user_message()` as a pure decision function from the EventHandler gating logic, enabling GIVEN/WHEN/THEN style assertions:

### Multibot gating (7 tests)

| Test | GIVEN | WHEN | THEN |
|------|-------|------|------|
| `multibot_mentions_single_bot_thread_no_mention` | multibot-mentions, single-bot thread, involved | no @mention | ✅ responds |
| **`multibot_mentions_multi_bot_thread_no_mention`** | **multibot-mentions, multi-bot thread, involved** | **no @mention** | **❌ silent (bug #481)** |
| `multibot_mentions_multi_bot_thread_with_mention` | multibot-mentions, multi-bot thread | with @mention | ✅ responds |
| `multibot_mentions_main_channel_no_mention` | multibot-mentions, main channel | no @mention | ❌ silent |
| `multibot_mentions_not_involved` | multibot-mentions, thread, not involved | no @mention | ❌ silent |
| `involved_mode_ignores_multibot` | involved mode, multi-bot thread | no @mention | ✅ responds |
| `mentions_mode_always_requires_mention` | mentions mode, own thread | no @mention | ❌ silent |

### resolve_mentions (5 tests)

| Test | What it verifies |
|------|-----------------|
| `strips_bot_mention` | Bot's own `<@UID>` removed from prompt |
| `strips_bot_mention_legacy` | Legacy `<@!UID>` format also removed |
| `preserves_other_user_mentions` | Other users' `<@UID>` kept for LLM mention-back |
| `replaces_role_mentions` | `<@&UID>` → `@(role)` placeholder |
| `empty_after_strip` | Bot-only mention → empty string |

### parse_config_options (7 tests)

| Test | What it verifies |
|------|-----------------|
| `parse_standard_config_options` | Standard ACP `configOptions` array |
| `parse_kiro_models_fallback` | Kiro `models` format → model ConfigOption |
| `parse_kiro_modes_fallback` | Kiro `modes` format → agent ConfigOption |
| `parse_kiro_models_and_modes` | Both models + modes → 2 ConfigOptions |
| `parse_standard_takes_precedence` | Standard format wins over kiro fallback |
| `parse_empty_result` | Empty JSON → empty vec |
| `parse_empty_config_options_falls_through` | Empty `configOptions: []` → kiro fallback |

+314/-8 lines. Zero API calls. Zero fetch.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365162869985283/1495640437371965560