### PR TITLE
docs: remove outdated 'image not published' notes

### DIFF
--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -62,8 +62,6 @@ The OAuth token is stored under `~/.config/gh/` and persisted across pod restart
 
 ## Helm Install
 
-> **Note**: The `ghcr.io/openabdev/openab-copilot` image is not published yet. You must build it locally first with `docker build -f Dockerfile.copilot -t openab-copilot .` and push to your own registry, or use a local image.
-
 ```bash
 helm install openab openab/openab \
   --set agents.kiro.enabled=false \

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -59,8 +59,6 @@ The auth token is stored under `~/.cursor/` and persisted across pod restarts vi
 
 ## Helm Install
 
-> **Note**: The `ghcr.io/openabdev/openab-cursor` image is not published yet. You must build it locally first with `docker build -f Dockerfile.cursor -t openab-cursor .` and push to your own registry, or use a local image.
-
 ```bash
 helm install openab openab/openab \
   --set agents.kiro.enabled=false \


### PR DESCRIPTION
## Summary

Remove stale notes in `docs/copilot.md` and `docs/cursor.md` that incorrectly state the container images are not published yet.

Both images are already available on ghcr.io:
- `ghcr.io/openabdev/openab-copilot`
- `ghcr.io/openabdev/openab-cursor`

## Changes
- Remove the outdated `> **Note**: The image is not published yet...` block from `docs/copilot.md`
- Remove the same block from `docs/cursor.md`