### PR TITLE
docs(copilot): document split auth — subscription PAT + scoped gh CLI user

### DIFF
--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -52,7 +52,7 @@ Generate a [fine-grained personal access token](https://github.com/settings/pers
 - Expiration: as needed
 - **Account permissions → Copilot Requests: Read-only** (this is the only permission required)
 
-Inject it as an env var in your Helm chart:
+Inject it as an env var in your Helm chart (add the last line):
 
 ```bash
 helm install openab-copilot openab/openab \
@@ -65,10 +65,10 @@ helm install openab-copilot openab/openab \
   --set 'agents.copilot.args={--acp,--stdio}' \
   --set agents.copilot.persistence.enabled=true \
   --set agents.copilot.workingDir=/home/node \
-  --set 'agents.copilot.env.COPILOT_GITHUB_TOKEN=github_pat_YOUR_TOKEN_HERE'
+  --set 'agents.copilot.env.COPILOT_GITHUB_TOKEN=github_pat_YOUR_TOKEN_HERE'  # optional
 ```
 
-Copilot CLI reads `COPILOT_GITHUB_TOKEN` automatically — no interactive login needed.
+> **Note**: `COPILOT_GITHUB_TOKEN` is only required if you want to authenticate the Copilot subscription via a fine-grained PAT without running `copilot login`, or if you plan to use `gh auth login` with a different user for git operations. If you only have one GitHub account, you can skip this and use `copilot login` instead (see below).
 
 ### Step 2: `gh` CLI Auth (scoped user)
 
@@ -110,7 +110,7 @@ helm install openab-copilot openab/openab \
   --set 'agents.copilot.args={--acp,--stdio}' \
   --set agents.copilot.persistence.enabled=true \
   --set agents.copilot.workingDir=/home/node \
-  --set 'agents.copilot.env.COPILOT_GITHUB_TOKEN=github_pat_YOUR_TOKEN_HERE'
+  --set 'agents.copilot.env.COPILOT_GITHUB_TOKEN=github_pat_YOUR_TOKEN_HERE'  # optional, see Authentication
 ```
 
 ## Model Selection

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -113,6 +113,8 @@ Scenario 2: Different users (split auth)
 └─────────────────────────────────────────────────────────┘
 ```
 
+> **Recommendation**: If your Copilot subscription is on a privileged human account (e.g. org admin), we strongly recommend Scenario 2 — use a fine-grained PAT for the subscription and a scoped bot user for git operations. This limits the blast radius of the agent's git access.
+
 | Auth Layer | Purpose | Account | Method |
 |---|---|---|---|
 | `COPILOT_GITHUB_TOKEN` | Copilot subscription (models) | Subscription owner | Fine-grained PAT env var |

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -38,40 +38,80 @@ docker build -f Dockerfile.copilot -t openab-copilot .
 
 ## Authentication
 
-Copilot CLI uses GitHub OAuth (same as `gh` CLI). In a headless container, use device flow:
+Copilot CLI has two independent auth layers that can use **different** GitHub accounts:
+
+1. **Copilot subscription auth** — authenticates your Copilot subscription (model access)
+2. **`gh` CLI auth** — authenticates git operations (clone, push, PR creation)
+
+This separation lets you use a subscription owner's token for Copilot while scoping git operations to a different GitHub user (e.g. a bot account).
+
+### Step 1: Copilot Subscription (fine-grained PAT)
+
+Generate a [fine-grained personal access token](https://github.com/settings/personal-access-tokens/new) from the GitHub account that owns the Copilot subscription:
+
+- Token name: e.g. `openab-copilot`
+- Expiration: as needed
+- **Account permissions → Copilot Requests: Read-only** (this is the only permission required)
+
+Inject it as an env var in your Helm chart:
 
 ```bash
-# 1. Exec into the running pod/container
-kubectl exec -it deployment/openab-copilot -- bash
-
-# 2. Authenticate via device flow
-gh auth login --hostname github.com --git-protocol https -p https -w
-
-# 3. Follow the device code flow in your browser
-
-# 4. Verify
-gh auth status
-
-# 5. Restart the pod (token is persisted via PVC)
-kubectl rollout restart deployment/openab-copilot
+helm install openab-copilot openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.copilot.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.copilot.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.copilot.discord.enabled=true \
+  --set agents.copilot.image=ghcr.io/openabdev/openab-copilot \
+  --set agents.copilot.command=copilot \
+  --set 'agents.copilot.args={--acp,--stdio}' \
+  --set agents.copilot.persistence.enabled=true \
+  --set agents.copilot.workingDir=/home/node \
+  --set 'agents.copilot.env.COPILOT_GITHUB_TOKEN=github_pat_YOUR_TOKEN_HERE'
 ```
 
-The OAuth token is stored under `~/.config/gh/` and persisted across pod restarts via PVC.
+Copilot CLI reads `COPILOT_GITHUB_TOKEN` automatically — no interactive login needed.
 
-> **Note**: See [docs/gh-auth-device-flow.md](gh-auth-device-flow.md) for details on device flow in headless environments.
+### Step 2: `gh` CLI Auth (scoped user)
+
+After deployment, authenticate `gh` as a separate user for git operations:
+
+```bash
+kubectl exec -it deployment/openab-copilot-copilot -- gh auth login -p https -w
+```
+
+Follow the device flow in your browser, authorizing with the desired GitHub account (e.g. a bot user like `thepagent`).
+
+Verify:
+
+```bash
+kubectl exec deployment/openab-copilot-copilot -- gh auth status
+```
+
+The `gh` token is stored under `~/.config/gh/` on the PVC and persists across pod restarts.
+
+### Summary
+
+| Auth Layer | Purpose | Account | Method |
+|---|---|---|---|
+| `COPILOT_GITHUB_TOKEN` | Copilot subscription (models) | Subscription owner | Fine-grained PAT env var |
+| `gh auth` | Git operations (clone, push) | Bot / scoped user | Device flow (`gh auth login`) |
+
+> **Note**: Classic personal access tokens (`ghp_`) are **not supported** for Copilot. Use a fine-grained PAT (`github_pat_`) with the "Copilot Requests" permission.
 
 ## Helm Install
 
 ```bash
-helm install openab openab/openab \
+helm install openab-copilot openab/openab \
   --set agents.kiro.enabled=false \
+  --set agents.copilot.discord.enabled=true \
   --set agents.copilot.discord.botToken="$DISCORD_BOT_TOKEN" \
   --set-string 'agents.copilot.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
-  --set agents.copilot.image=ghcr.io/openabdev/openab-copilot:latest \
+  --set agents.copilot.image=ghcr.io/openabdev/openab-copilot \
   --set agents.copilot.command=copilot \
   --set 'agents.copilot.args={--acp,--stdio}' \
   --set agents.copilot.persistence.enabled=true \
-  --set agents.copilot.workingDir=/home/node
+  --set agents.copilot.workingDir=/home/node \
+  --set 'agents.copilot.env.COPILOT_GITHUB_TOKEN=github_pat_YOUR_TOKEN_HERE'
 ```
 
 ## Model Selection
@@ -87,6 +127,6 @@ Model selection is controlled by Copilot CLI itself (via `/model` in interactive
 ## Known Limitations
 
 - ⚠️ ACP support is in **public preview** — behavior may change
-- ⚠️ Headless auth with `GITHUB_TOKEN` env var has not been fully validated; device flow via `gh auth login` is the recommended path
+- Classic personal access tokens (`ghp_`) are not supported — use fine-grained PATs (`github_pat_`)
 - Copilot CLI requires an active Copilot subscription per user/org
 - For Copilot Business/Enterprise, an admin must enable Copilot CLI from the Policies page

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -24,8 +24,7 @@ OpenAB spawns `copilot --acp --stdio` as a child process and communicates via st
 [agent]
 command = "copilot"
 args = ["--acp", "--stdio"]
-working_dir = "/home/agent"
-# Auth via: kubectl exec -it <pod> -- gh auth login -p https -w
+working_dir = "/home/node"
 ```
 
 ## Docker

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -90,6 +90,29 @@ The `gh` token is stored under `~/.config/gh/` on the PVC and persists across po
 
 ### Summary
 
+```
+Scenario 1: Same user for both (simple)
+┌─────────────────────────────────────────────────────────┐
+│  copilot login (as @alice)                              │
+│    ├─ Copilot subscription ── @alice's plan ✅          │
+│    └─ gh operations ───────── @alice ✅                 │
+│                                                         │
+│  No env var needed. One login covers everything.        │
+└─────────────────────────────────────────────────────────┘
+
+Scenario 2: Different users (split auth)
+┌─────────────────────────────────────────────────────────┐
+│  COPILOT_GITHUB_TOKEN=github_pat_... (from @alice)      │
+│    └─ Copilot subscription ── @alice's plan ✅          │
+│                                                         │
+│  gh auth login (as @bot-user)                           │
+│    └─ gh operations ───────── @bot-user ✅              │
+│                                                         │
+│  Use when subscription owner ≠ git operations user.     │
+│  e.g. @alice owns Copilot Pro, @bot-user pushes code.   │
+└─────────────────────────────────────────────────────────┘
+```
+
 | Auth Layer | Purpose | Account | Method |
 |---|---|---|---|
 | `COPILOT_GITHUB_TOKEN` | Copilot subscription (models) | Subscription owner | Fine-grained PAT env var |


### PR DESCRIPTION
### Description

Document that Copilot CLI auth and `gh` CLI auth are independent and can use different GitHub accounts.

### Use Case

Users who want to run Copilot with a subscription owner's token while scoping git operations to a bot account (e.g. `thepagent`). Previously the docs only showed `gh auth login` which conflates both auth layers.

Key changes:
- Add fine-grained PAT setup for Copilot subscription (only needs "Copilot Requests" permission)
- Add `gh auth login` as a separate step for scoped git operations
- Update Helm install example with `discord.enabled=true` and `COPILOT_GITHUB_TOKEN` env var
- Note that classic PATs (`ghp_`) are not supported
- Remove outdated note about image not being published