### PR TITLE
feat(helm): add per-agent nameOverride for custom deployment names

### DIFF
--- a/charts/openab/templates/_helpers.tpl
+++ b/charts/openab/templates/_helpers.tpl
@@ -36,9 +36,13 @@ app.kubernetes.io/instance: {{ .ctx.Release.Name }}
 app.kubernetes.io/component: {{ .agent }}
 {{- end }}
 
-{{/* Per-agent resource name: <fullname>-<agentKey> */}}
+{{/* Per-agent resource name: nameOverride > <fullname>-<agentKey> */}}
 {{- define "openab.agentFullname" -}}
+{{- if and .cfg.nameOverride (ne .cfg.nameOverride "") }}
+{{- .cfg.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
 {{- printf "%s-%s" (include "openab.fullname" .ctx) .agent | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{/* Resolve image: agent-level string override → global default (repository:tag, tag defaults to appVersion).

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -38,6 +38,8 @@ agents:
     #     # trustedBotIds: []  # empty = any bot (mode permitting)
     #     trustedBotIds: []
     #   workingDir: /home/agent
+    #   # nameOverride: custom deployment name (default: <release>-<agentKey>)
+    #   nameOverride: ""
     #   env: {}
     #   envFrom: []
     #   pool:


### PR DESCRIPTION
### Description

Add `nameOverride` field to per-agent config. When set, it overrides the default `<release>-<agentKey>` deployment naming convention.

### Use Case

When the agent YAML key does not match the actual backend, the default naming is confusing:

```
release: openab-pudu, key: kiro, backend: claude-code
→ deployment name: openab-pudu-kiro  ← misleading
```

With `nameOverride`:

```yaml
agents:
  pudu:
    nameOverride: "openab-pudu"
    command: claude-agent-acp
```

→ deployment name: `openab-pudu` ✅

### Changes

- `_helpers.tpl`: `openab.agentFullname` checks `cfg.nameOverride` before falling back to `<fullname>-<agentKey>`
- `values.yaml`: documented the new field in the commented example