### PR TITLE
fix(helm): handle nil cfg in agentFullname for NOTES.txt compatibility

### DIFF
--- a/charts/openab/templates/_helpers.tpl
+++ b/charts/openab/templates/_helpers.tpl
@@ -38,7 +38,7 @@ app.kubernetes.io/component: {{ .agent }}
 
 {{/* Per-agent resource name: nameOverride > <fullname>-<agentKey> */}}
 {{- define "openab.agentFullname" -}}
-{{- if and .cfg.nameOverride (ne .cfg.nameOverride "") }}
+{{- if and .cfg (.cfg.nameOverride) (ne .cfg.nameOverride "") }}
 {{- .cfg.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- printf "%s-%s" (include "openab.fullname" .ctx) .agent | trunc 63 | trimSuffix "-" }}


### PR DESCRIPTION
### Description

Fix nil pointer panic in `openab.agentFullname` when called without `cfg` in the template dict (e.g. from NOTES.txt).

### Steps to Reproduce

`helm install` with `nameOverride` set — NOTES.txt calls `agentFullname` with `dict "ctx" $ "agent" $name` (no `cfg`), causing a nil dereference.

### Fix

Guard `.cfg.nameOverride` with a nil check on `.cfg` first:

```
{{- if and .cfg (.cfg.nameOverride) (ne .cfg.nameOverride "") }}
```