### PR TITLE
feat(discord): inline text/plain attachments into prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +289,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +407,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -394,6 +429,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -502,6 +548,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +592,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -568,6 +639,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,9 +654,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -947,6 +1026,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,7 +1049,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openab"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -983,6 +1072,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -2480,6 +2570,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 unicode-width = "0.2"
 libc = "0.2"
 tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
+
+[dev-dependencies]
+wiremock = "0.6"

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -458,7 +458,7 @@ impl EventHandler for Handler {
             is_bot: msg.author.bot,
         };
 
-        // Build extra content blocks from attachments (images, audio)
+        // Build extra content blocks from attachments (images, audio, text)
         let mut extra_blocks = Vec::new();
         for attachment in &msg.attachments {
             let mime = attachment.content_type.as_deref().unwrap_or("");
@@ -482,6 +482,21 @@ impl EventHandler for Handler {
                     tracing::warn!(filename = %attachment.filename, "skipping audio attachment (STT disabled)");
                     let msg_ref = discord_msg_ref(&msg);
                     let _ = adapter.add_reaction(&msg_ref, "🎤").await;
+                }
+            } else if media::is_text_mime(mime) {
+                if let Some(text) = media::download_text_attachment(
+                    &attachment.url,
+                    &attachment.filename,
+                    u64::from(attachment.size),
+                    None,
+                ).await {
+                    debug!(filename = %attachment.filename, chars = text.len(), "text attachment inlined");
+                    extra_blocks.insert(0, ContentBlock::Text {
+                        text: format!(
+                            "[Attached text: {} ({} bytes)]\n{}",
+                            attachment.filename, attachment.size, text
+                        ),
+                    });
                 }
             } else if let Some(block) = media::download_and_encode_image(
                 &attachment.url,

--- a/src/media.rs
+++ b/src/media.rs
@@ -2,6 +2,7 @@ use crate::acp::ContentBlock;
 use crate::config::SttConfig;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
+use futures_util::StreamExt;
 use image::ImageReader;
 use std::io::Cursor;
 use std::sync::LazyLock;
@@ -182,6 +183,85 @@ pub fn is_audio_mime(mime: &str) -> bool {
     mime.starts_with("audio/")
 }
 
+/// Check if a MIME type is `text/plain` (Discord's auto-convert for long messages).
+pub fn is_text_mime(mime: &str) -> bool {
+    mime.starts_with("text/plain")
+}
+
+/// Download a `text/plain` attachment and return its UTF-8 contents.
+///
+/// Discord auto-converts messages longer than 2000 characters into a `.txt` file
+/// attachment; inlining the bytes lets the agent see the full content instead of
+/// receiving an empty prompt. Capped at 128 KB to avoid blowing the context window.
+pub async fn download_text_attachment(
+    url: &str,
+    filename: &str,
+    size: u64,
+    auth_token: Option<&str>,
+) -> Option<String> {
+    // Discord auto-converts any message body over 2000 characters into a
+    // .txt attachment. 128 KB covers ~20× that threshold — plenty for pasted
+    // logs and stack traces, while keeping a bounded share of the agent's
+    // context window.
+    const MAX_SIZE: u64 = 128 * 1024;
+
+    // Discord metadata hint. Only a hint — cheap fail-fast to skip the HTTP
+    // round-trip when the attachment is obviously oversized. The
+    // authoritative cap is enforced on the response body below; metadata
+    // and Content-Length are not trusted on their own.
+    if size > MAX_SIZE {
+        tracing::warn!(filename, size, "text attachment exceeds 128KB (metadata), skipping");
+        return None;
+    }
+
+    let mut req = HTTP_CLIENT.get(url);
+    if let Some(token) = auth_token {
+        req = req.header("Authorization", format!("Bearer {token}"));
+    }
+
+    let resp = req.send().await.ok()?;
+    if !resp.status().is_success() {
+        error!(url, status = %resp.status(), "text download failed");
+        return None;
+    }
+
+    // Single source of truth for the cap: stream chunks and abort the moment
+    // the running total would exceed MAX_SIZE. This is the authoritative
+    // guard — Content-Length and metadata are untrusted. Pre-size the
+    // buffer against the metadata hint so the common path (valid small
+    // attachment) avoids repeated reallocations.
+    let mut stream = resp.bytes_stream();
+    let mut buf: Vec<u8> = Vec::with_capacity(size.min(MAX_SIZE) as usize);
+    while let Some(chunk) = stream.next().await {
+        let chunk = match chunk {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(filename, error = %e, "text attachment stream error");
+                return None;
+            }
+        };
+        if buf.len().saturating_add(chunk.len()) > MAX_SIZE as usize {
+            tracing::warn!(
+                filename,
+                streamed = buf.len(),
+                chunk_size = chunk.len(),
+                "text attachment body exceeds 128KB, aborting"
+            );
+            return None;
+        }
+        buf.extend_from_slice(&chunk);
+    }
+
+    // `String::from_utf8` consumes the Vec — no extra copy.
+    match String::from_utf8(buf) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            tracing::warn!(filename, error = %e, "text attachment is not valid UTF-8, skipping");
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -262,5 +342,83 @@ mod tests {
     fn invalid_data_returns_error() {
         let garbage = vec![0x00, 0x01, 0x02, 0x03];
         assert!(resize_and_compress(&garbage).is_err());
+    }
+
+    // --- download_text_attachment tests ---
+    //
+    // The implementation has exactly two gates: a metadata hint short-
+    // circuit (no network traffic), and the streaming cap on the response
+    // body (authoritative). Each gate gets one test, plus a happy-path
+    // sanity check. No regression fence is needed because there is no
+    // second defense layer that could silently absorb a failure of the
+    // streaming cap — if the streaming check is removed, oversized bodies
+    // pass through and the oversized-body test fails directly.
+
+    use wiremock::matchers::{method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn download_text_returns_content_when_body_small() {
+        let server = MockServer::start().await;
+        let body = "hello\nworld";
+        Mock::given(method("GET"))
+            .and(wm_path("/a.txt"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/a.txt", server.uri());
+        let result =
+            download_text_attachment(&url, "a.txt", body.len() as u64, None).await;
+        assert_eq!(result, Some(body.to_string()));
+    }
+
+    #[tokio::test]
+    async fn download_text_rejects_when_metadata_over_cap() {
+        // Metadata guard must short-circuit before any network call. We
+        // stand up a MockServer with `.expect(0)` so the test fails if any
+        // HTTP request reaches the server — a regression that dropped the
+        // metadata guard and delegated rejection to the streaming cap
+        // would be caught here as unnecessary outbound traffic, even
+        // though it would still return `None` at the end.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/does-not-matter", server.uri());
+        let result = download_text_attachment(
+            &url,
+            "big.txt",
+            200 * 1024, // > 128 KB cap
+            None,
+        )
+        .await;
+        assert_eq!(result, None);
+        // MockServer verifies `.expect(0)` on drop; leaving this explicit
+        // so the intent survives a copy-paste by future maintainers.
+        drop(server);
+    }
+
+    #[tokio::test]
+    async fn download_text_rejects_body_over_cap() {
+        // Metadata declares 1 KB (bypasses the metadata guard), body is
+        // 200 KB. Only the streaming cap can catch this — there is no
+        // other layer in the implementation that could reject it. A
+        // regression that removes the streaming cap would let the full
+        // body buffer and return `Some(...)`, failing this test directly.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/big.txt"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![b'A'; 200 * 1024]))
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/big.txt", server.uri());
+        let result =
+            download_text_attachment(&url, "big.txt", 1024, None).await;
+        assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
## Summary

Adds text/plain attachment inline support for Discord. When Discord
auto-converts a message longer than 2,000 characters into a .txt
attachment (the single most common non-image attachment in practice),
the broker now downloads the content, UTF-8 decodes it, and injects
it as a text content block tagged
`[Attached text: <filename> (<size> bytes)]` at the front of
`content_blocks`. The agent (`claude-agent-acp` and any other
ACP-compatible CLI) processes it identically to inline chat text.

Reopens #287.

## Problem

Before this change, messages over 2,000 characters silently vanished:
Discord packaged the content as a `.txt` attachment, the broker's
attachment dispatcher had no `text/plain` branch, and the agent saw
an empty prompt. Pasted logs, stack traces, and long-form articles
just disappeared.

## Design

- New `download_text_attachment(url, filename, size, auth_token) -> Option<String>`
  in `src/media.rs`, structurally parallel to the existing
  `download_and_transcribe` (STT audio) and `download_and_encode_image`
  (image) entry points.
- Dispatched from `src/discord.rs` when `content_type.starts_with("text/")`.
- Body size capped at 128 KB. Rationale: ~20× the 2,000-char Discord
  threshold, generous for logs and stack traces, while keeping a
  bounded share of the agent's context window.

## Why a single streaming gate (no Content-Length check)

An earlier revision had a three-layer defense (metadata →
Content-Length → streaming). During internal adversarial review, the
extra layers surfaced as test-matrix complexity (a "which layer
caught it?" distinction) without materially improving safety: the
streaming cap alone handles honest origins, hostile origins that lie
about `size`, and chunked/unknown-Content-Length responses. Simplified
to a single authoritative body-size gate.

The Discord metadata `size` hint is still checked first — purely as a
cheap fail-fast to skip the HTTP round-trip for obviously oversized
attachments — but it is not trusted as the enforcement layer.

## Tests (new `[dev-dependencies]` entry: `wiremock = "0.6"`)

Three cases:

1. **Happy path**: body < 128 KB returns `Some(content)`.
2. **Metadata short-circuit**: `size > 128 KB` short-circuits before
   any HTTP call. Verified with a `MockServer` + `Mock::expect(0)` so
   any regression that drops the metadata guard and delegates to the
   streaming cap is caught as unwanted outbound traffic — even though
   it would still return `None`.
3. **Oversized body**: metadata claims 1 KB, server serves 200 KB →
   returns `None`. The streaming cap is the only production
   body-size gate, so a regression that removes it fails this test
   directly.

Local results: `cargo test --release` 89 pass, `cargo clippy
--all-targets -- -D warnings` clean.

## Scope notes

- **Discord only**. Slack's attachment handler in `src/slack.rs`
  currently has no text-attachment branch either. This PR does not
  wire Slack — happy to leave that to a Slack-using contributor as a
  separate feature PR.
- `download_and_transcribe` (STT audio, no body-level cap at all)
  and `download_and_encode_image` (image, post-download check only —
  already buffered before rejecting) share the same
  metadata-trust-then-full-buffer pattern fixed here. Happy to follow
  up with dedicated PRs to apply the same streaming pattern to those
  if there's interest.

## Behavior on edge cases

- Non-UTF-8 bytes → log `tracing::warn`, skip.
- HTTP non-2xx → log `tracing::error`, skip.
- Body > 128 KB → log `tracing::warn`, skip.
- No hard failures; all skips preserve the user's regular prompt if
  there is one.