### PR TITLE
fix(discord): restore edit_message and use_streaming in ChatAdapter

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -81,9 +81,9 @@ pub trait ChatAdapter: Send + Sync + 'static {
     }
 
     /// Whether this adapter should use streaming edit (true) or send-once (false).
-    fn use_streaming(&self) -> bool {
-        false
-    }
+    /// Required: each adapter must explicitly declare its streaming capability
+    /// to prevent silent regression if the trait default changes.
+    fn use_streaming(&self) -> bool;
 }
 
 // --- AdapterRouter ---

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -6,7 +6,7 @@ use crate::format;
 use crate::media;
 use async_trait::async_trait;
 use std::sync::LazyLock;
-use serenity::builder::{CreateActionRow, CreateCommand, CreateInteractionResponse, CreateInteractionResponseMessage, CreateSelectMenu, CreateSelectMenuKind, CreateSelectMenuOption, CreateThread};
+use serenity::builder::{CreateActionRow, CreateCommand, CreateInteractionResponse, CreateInteractionResponseMessage, CreateSelectMenu, CreateSelectMenuKind, CreateSelectMenuOption, CreateThread, EditMessage};
 use serenity::http::Http;
 use serenity::model::application::{ComponentInteractionDataKind, Interaction};
 use serenity::model::channel::{AutoArchiveDuration, Message, ReactionType};
@@ -56,6 +56,23 @@ impl ChatAdapter for DiscordAdapter {
             channel: channel.clone(),
             message_id: msg.id.to_string(),
         })
+    }
+
+    async fn edit_message(&self, msg: &MessageRef, content: &str) -> anyhow::Result<()> {
+        let ch_id: u64 = msg.channel.channel_id.parse()?;
+        let msg_id: u64 = msg.message_id.parse()?;
+        ChannelId::new(ch_id)
+            .edit_message(
+                &self.http,
+                MessageId::new(msg_id),
+                EditMessage::new().content(content),
+            )
+            .await?;
+        Ok(())
+    }
+
+    fn use_streaming(&self) -> bool {
+        true
     }
 
     async fn create_thread(


### PR DESCRIPTION
## Summary

Restores two methods that were accidentally dropped from the Discord `ChatAdapter` impl during the 0.8.0 refactor, breaking streaming replies.

## The Problem

```
┌─────────────────────────────────────────────────────────┐
│  0.7.7 (working)                                        │
│                                                         │
│  User: "explain this code"                              │
│                                                         │
│  Bot msg #1:  "Let me look..."                          │
│       ↓ edit_message()                                  │
│  Bot msg #1:  "Let me look... The function takes..."    │
│       ↓ edit_message()                                  │
│  Bot msg #1:  "Let me look... The function takes a      │
│               struct and returns a Result<T>..."        │
│                                                         │
│  ✅ Single message, updated in-place (streaming)        │
└─────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────┐
│  0.8.0 (broken)                                         │
│                                                         │
│  User: "explain this code"                              │
│                                                         │
│  Bot msg #1:  "Let me look..."                          │
│  Bot msg #2:  "Let me look... The function takes..."    │
│  Bot msg #3:  "Let me look... The function takes a      │
│               struct and returns a Result<T>..."        │
│                                                         │
│  ❌ New message every tick — floods the channel         │
│  ❌ use_streaming() defaults to false — no edits        │
│  ❌ edit_message() missing — even if enabled, crashes   │
└─────────────────────────────────────────────────────────┘
```

## The Fix

```
  impl ChatAdapter for DiscordAdapter {
      send_message()     ✅ existed
      create_thread()    ✅ existed
+     edit_message()     🔧 restored  ← was dropped in 0.8.0 refactor
+     use_streaming()    🔧 added     ← trait default flipped to false
  }
```

```
┌─────────────────────────────────────────────────────────┐
│  0.8.0 + this patch                                     │
│                                                         │
│  User: "explain this code"                              │
│                                                         │
│  Bot msg #1:  "Let me look..."                          │
│       ↓ edit_message()  ← restored!                     │
│  Bot msg #1:  "The function takes a struct and..."      │
│                                                         │
│  ✅ Streaming works again                               │
└─────────────────────────────────────────────────────────┘
```

## Testing

- Built and deployed as `0.8.0-patched` on 4 production containers
- Streaming replies confirmed working on Discord

Fixes #502

Discord Discussion: https://discord.com/channels/1488041051187974246/1496042954274639943