### PR TITLE
fix(discord): detect threads when allow_all_channels=true

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -344,6 +344,8 @@ impl EventHandler for Handler {
 
         // Thread detection: check if the message is in a thread whose parent
         // is an allowed channel, and whether the bot owns that thread.
+        // When in_allowed_channel is true, we still need to detect threads
+        // so that MultibotMentions/Involved modes work correctly (#504).
         let (in_thread, bot_owns_thread) = if !in_allowed_channel {
             match msg.channel_id.to_channel(&ctx.http).await {
                 Ok(serenity::model::channel::Channel::Guild(gc)) => {
@@ -371,7 +373,13 @@ impl EventHandler for Handler {
                 }
             }
         } else {
-            (false, false)
+            match msg.channel_id.to_channel(&ctx.http).await {
+                Ok(serenity::model::channel::Channel::Guild(gc)) if gc.parent_id.is_some() => {
+                    let owned = gc.owner_id.is_some_and(|oid| oid == bot_id);
+                    (true, owned)
+                }
+                _ => (false, false),
+            }
         };
 
         if !in_allowed_channel && !in_thread {


### PR DESCRIPTION
### Description

When `allow_all_channels = true`, thread detection was skipped entirely, setting `in_thread = false` for all messages. This caused `MultibotMentions` and `Involved` modes to ignore thread follow-ups — the bot would respond to the initial @mention but not to any subsequent messages in the thread.

### Root Cause

The `else` branch of `if !in_allowed_channel` returned `(false, false)` unconditionally, skipping the `to_channel()` call needed to detect threads.

### Fix

When `in_allowed_channel = true`, still call `to_channel()` to check if the message is in a thread (has `parent_id`).

### Validation

- `cargo check` ✅
- `cargo test` — 75/75 passed ✅
- Tested on OrbStack: `allow_all_channels=false` with explicit channels responds to thread follow-ups; same bot with `allow_all_channels=true` did not — this fix resolves it.

Closes #504