### PR TITLE
test: add regression tests for adapter streaming capability

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -475,3 +475,40 @@ fn compose_display(tool_lines: &[ToolEntry], text: &str, streaming: bool) -> Str
     out.push_str(text.trim_end());
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile-time regression guard: use_streaming() is a required trait method
+    /// (no default). Any adapter that forgets to implement it will fail to compile.
+    /// This test documents the contract — see PR #503 / issue #502 for context.
+    #[test]
+    fn use_streaming_is_required_method() {
+        // If use_streaming() had a default impl, this test module would still
+        // compile even if an adapter forgot to override it. The real guard is
+        // the trait definition itself — this test exists as documentation and
+        // to catch if someone re-adds a default.
+        struct TestAdapter;
+
+        #[async_trait]
+        impl ChatAdapter for TestAdapter {
+            fn platform(&self) -> &'static str { "test" }
+            fn message_limit(&self) -> usize { 2000 }
+            async fn send_message(&self, _: &ChannelRef, _: &str) -> Result<MessageRef> {
+                unimplemented!()
+            }
+            async fn create_thread(&self, _: &ChannelRef, _: &MessageRef, _: &str) -> Result<ChannelRef> {
+                unimplemented!()
+            }
+            async fn add_reaction(&self, _: &MessageRef, _: &str) -> Result<()> { Ok(()) }
+            async fn remove_reaction(&self, _: &MessageRef, _: &str) -> Result<()> { Ok(()) }
+            // use_streaming() MUST be declared — removing this line should fail compilation
+            fn use_streaming(&self) -> bool { false }
+        }
+
+        let adapter = TestAdapter;
+        // Verify the method is callable and returns the declared value
+        assert!(!adapter.use_streaming());
+    }
+}

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -990,3 +990,26 @@ fn markdown_to_mrkdwn(text: &str) -> String {
     let text = CODE_BLOCK_LANG_RE.replace_all(&text, "```\n"); // ```rust → ```
     text.into_owned()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::ChatAdapter;
+
+    /// Regression test: Slack streaming depends on allow_bot_messages config.
+    /// Off → stream (better human UX), Mentions/All → send-once (avoids bot-to-bot interference).
+    /// See PR #420 for design rationale.
+    #[test]
+    fn streaming_enabled_only_when_bots_off() {
+        let ttl = std::time::Duration::from_secs(300);
+
+        let off = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Off);
+        assert!(off.use_streaming(), "should stream when allow_bot_messages=Off");
+
+        let mentions = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions);
+        assert!(!mentions.use_streaming(), "should NOT stream when allow_bot_messages=Mentions");
+
+        let all = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::All);
+        assert!(!all.use_streaming(), "should NOT stream when allow_bot_messages=All");
+    }
+}


### PR DESCRIPTION
### Description

Adds regression tests for the streaming capability contract, following up on the Discord streaming regression (#502, fixed in PR #503).

### Tests Added

**`src/adapter.rs`** — Trait contract test
- Creates a `TestAdapter` that must implement `use_streaming()` (required method, no default)
- If someone re-adds a default impl, this test documents the expected contract
- Compile-time guard: any adapter missing `use_streaming()` fails to build

**`src/slack.rs`** — Slack conditional streaming
- `allow_bot_messages=Off` → `use_streaming()` returns `true` (streaming for human UX)
- `allow_bot_messages=Mentions` → returns `false` (send-once for bot-to-bot safety)
- `allow_bot_messages=All` → returns `false`

### Why no Discord runtime test?

`DiscordAdapter` requires `Arc<Http>` (serenity HTTP client) which cannot be constructed without a real bot token. The required trait method provides compile-time enforcement instead — if Discord ever loses its `use_streaming()` override, the build fails.

### Context

- Root cause: PR #420 refactored streaming, Discord was never opted in
- Bug: #502 | Fix: PR #503 | Hardening: `use_streaming()` made required

Closes #507

Discord Discussion: https://discord.com/channels/1488041051187974246/1496042954274639943