### PR TITLE
build(docker): bump codex-acp to 0.11.1

### DIFF
--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -11,8 +11,9 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
+ARG CODEX_ACP_VERSION=0.11.1
 ARG CODEX_VERSION=0.121.0
-RUN npm install -g @zed-industries/codex-acp@0.11.1 @openai/codex@${CODEX_VERSION} --retry 3
+RUN npm install -g @zed-industries/codex-acp@${CODEX_ACP_VERSION} @openai/codex@${CODEX_VERSION} --retry 3
 
 # Install gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 
 # Pre-install codex-acp and codex CLI globally
 ARG CODEX_VERSION=0.121.0
-RUN npm install -g @zed-industries/codex-acp@0.9.5 @openai/codex@${CODEX_VERSION} --retry 3
+RUN npm install -g @zed-industries/codex-acp@0.11.1 @openai/codex@${CODEX_VERSION} --retry 3
 
 # Install gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Summary

Bump `@zed-industries/codex-acp` from `0.9.5` to `0.11.1` in `Dockerfile.codex`.

## Notes for review

This is the remaining useful part of #250. Runtime utilities such as `procps`, `ripgrep`, and `tini` are already present on `main`, and this keeps the current `ARG CODEX_VERSION=0.121.0` pinning pattern for `@openai/codex`.

Upstream changelog highlights from `0.9.5` to `0.11.1`:

- `0.10.0`: forwards warning messages and `/compact` notifications to the client; sanitizes MCP server names containing whitespace; updates Codex upstream.
- `0.11.0`: updates to Codex `v0.117`; fixes mode/permission matching for trusted workspace configs; adds logout support.
- `0.11.1`: fixes MCP approval flow after Codex started routing MCP calls through elicitation calls.

Risk: low. This only changes the globally installed adapter package version in the Codex image.

## Validation

Not run: Docker build would need to download apt/npm dependencies.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404/1496103969770967090

References:
- https://github.com/openabdev/openab/pull/250
- https://github.com/zed-industries/codex-acp/releases/tag/v0.11.1
- https://github.com/zed-industries/codex-acp/releases
