### PR TITLE
feat: auto-label new PRs with pending-screening

### DIFF
--- a/.github/workflows/pending-screening.yml
+++ b/.github/workflows/pending-screening.yml
@@ -1,0 +1,48 @@
+name: PR Pending Screening
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to add pending-screening label"
+        required: true
+        type: number
+
+permissions: {}
+
+jobs:
+  add-label:
+    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request?.number || ${{ github.event.inputs.pr_number || 0 }};
+            if (!prNumber) {
+              core.setFailed('No PR number found');
+              return;
+            }
+
+            // Ensure label exists
+            try {
+              await github.rest.issues.createLabel({
+                ...context.repo,
+                name: 'pending-screening',
+                color: 'fbca04',
+                description: 'PR awaiting automated screening'
+              });
+              core.info('Created pending-screening label');
+            } catch (e) {
+              if (e.status !== 422) throw e; // 422 = already exists
+            }
+
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: prNumber,
+              labels: ['pending-screening']
+            });
+            core.info(`Added pending-screening to #${prNumber}`);


### PR DESCRIPTION
## What
Auto-label all new PRs with `pending-screening` as the first step of the triage pipeline.

## How
- GitHub Actions workflow triggered on `pull_request_target` (opened, reopened)
- Skips draft PRs
- Auto-creates the `pending-screening` label if it doesn't exist (avoids 404)
- Supports `workflow_dispatch` for manual use
- Uses `github-script` (no checkout needed)
- Least privilege: top-level `permissions: {}`, job-level `pull-requests: write`

## Next step
Agent picks up PRs with `pending-screening` label, runs automated review, then swaps to `screened` label.

Co-authored-by: 普渡法師 <普渡法師@users.noreply.github.com>