### PR TITLE
test: verify pending-screening label auto-apply

### DIFF
--- a/test-pending-screening.md
+++ b/test-pending-screening.md
@@ -1,0 +1,5 @@
+# Test: Verify pending-screening label
+
+This PR exists only to verify that the `pending-screening` label is auto-applied on new PRs.
+
+Delete this file after verification.


### PR DESCRIPTION
Testing that the `pending-screening` workflow correctly auto-labels new PRs.

**Close after verification** — no real changes.