### PR TITLE
fix: gate bot turn warning behind allowed_channels check

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -276,7 +276,33 @@ impl EventHandler for Handler {
                                 "soft bot turn limit reached",
                             ),
                         }
-                        if msg.author.id != bot_id {
+                        // Only post the warning if this bot is allowed in the channel/thread.
+                        // Bot turn counting intentionally runs before channel gating so ALL
+                        // bot messages are counted, but the *warning message* must respect
+                        // channel permissions — otherwise bots that never participated in a
+                        // thread will spam it with warnings.
+                        //
+                        // Must match the full thread allowlist semantics: a thread is allowed
+                        // if its own channel_id OR its parent_id is in allowed_channels.
+                        let ch = msg.channel_id.get();
+                        let mut allowed_here = self.allow_all_channels
+                            || self.allowed_channels.contains(&ch);
+                        if !allowed_here {
+                            // Thread channel_id won't be in allowed_channels directly —
+                            // check parent_id via to_channel(). Only called on the
+                            // WarnAndStop path (once per soft/hard limit hit), not on
+                            // every bot message.
+                            if let Ok(serenity::model::channel::Channel::Guild(gc)) =
+                                msg.channel_id.to_channel(&ctx.http).await
+                            {
+                                if gc.parent_id.is_some_and(|pid| {
+                                    self.allowed_channels.contains(&pid.get())
+                                }) {
+                                    allowed_here = true;
+                                }
+                            }
+                        }
+                        if msg.author.id != bot_id && allowed_here {
                             let _ = msg.channel_id.say(&ctx.http, &user_message).await;
                         }
                         return;


### PR DESCRIPTION
## Problem

Fixes #529

Bot turn counting runs before channel gating (`allowed_channels` check) in `discord.rs`. When a thread hits the soft limit (20/20), the `WarnAndStop` branch calls `msg.channel_id.say()` **before** the handler reaches the channel permission check — then immediately `return`s.

This means bots that are **not allowed** in a channel/thread still post `⚠️ Bot turn limit reached (20/20)` warnings there, because they receive all Discord gateway events regardless of their `allowed_channels` config.

```
message() execution order:

  ① Bot turn counting + say(warning)   ← runs first, no channel check
  ② Channel gating (allowed_channels)  ← too late, ① already returned
```

## Fix

Add an `allowed_here` check before `say()` in the `WarnAndStop` branch:

```rust
let ch = msg.channel_id.get();
let allowed_here = self.allow_all_channels
    || self.allowed_channels.contains(&ch);
if msg.author.id != bot_id && allowed_here {
    let _ = msg.channel_id.say(&ctx.http, &user_message).await;
}
```

**What stays the same:**
- Bot turn counting is unchanged — ALL bot messages still count toward the per-thread limit (preserves #483 invariant)
- `SilentStop` / `return` behavior unchanged
- `allow_all_channels = true` bots are unaffected

**What changes:**
- Bots not allowed in a channel no longer post warning messages there

## Out of scope

Dedup (multiple allowed bots each posting their own warning in the same thread) is a separate issue to track independently.