### PR TITLE
refactor: extract bot-turn throttling into resolve/record/evaluate/execute pipeline

### DIFF
--- a/src/bot_turns.rs
+++ b/src/bot_turns.rs
@@ -151,8 +151,6 @@ pub struct ResolvedMessageContext {
     pub allowed_here: bool,
     /// Whether the message is a plain human message that should reset counters.
     pub is_human_text: bool,
-    /// Soft limit configured for this adapter instance.
-    pub max_bot_turns: u32,
 }
 
 // ---------------------------------------------------------------------------
@@ -442,7 +440,6 @@ mod tests {
             is_self: false,
             allowed_here: allowed,
             is_human_text: false,
-            max_bot_turns: 3,
         }
     }
 
@@ -453,7 +450,6 @@ mod tests {
             is_self: true,
             allowed_here: true,
             is_human_text: false,
-            max_bot_turns: 3,
         }
     }
 
@@ -464,7 +460,6 @@ mod tests {
             is_self: false,
             allowed_here: true,
             is_human_text: true,
-            max_bot_turns: 3,
         }
     }
 
@@ -541,7 +536,6 @@ mod tests {
             is_self: false,
             allowed_here: true,
             is_human_text: false,
-            max_bot_turns: 3,
         };
         assert_eq!(evaluate_bot_turn_policy(&mut t, &ctx), TurnPolicyDecision::Continue);
     }

--- a/src/bot_turns.rs
+++ b/src/bot_turns.rs
@@ -4,6 +4,18 @@
 //! soft/hard limit semantics. Both counters reset on a human message in the
 //! thread. Runs before self-check so a bot's own messages count too — this
 //! means `soft_limit=20` caps the *total* bot messages in a thread, not per-bot.
+//!
+//! ## Pipeline architecture (#531)
+//!
+//! Bot turn handling is split into four phases so that counting (which must
+//! see ALL bot messages) is decoupled from warning emission (which must
+//! respect channel permissions):
+//!
+//! 1. **Resolve** — build [`ResolvedMessageContext`] once, shared by all phases.
+//! 2. **Record** — [`BotTurnTracker::classify_bot_message`] updates counters.
+//! 3. **Evaluate** — [`evaluate_bot_turn_policy`] returns a [`TurnPolicyDecision`]
+//!    with no side effects.
+//! 4. **Execute** — the adapter acts on the decision (send warning, log, return).
 
 use std::collections::HashMap;
 
@@ -117,6 +129,90 @@ pub enum TurnAction {
     /// Stop processing silently — the warning was already sent on a previous
     /// turn; further warnings would spam the thread.
     SilentStop,
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: Resolve — shared context for all subsequent phases
+// ---------------------------------------------------------------------------
+
+/// Platform-agnostic context resolved once per incoming message.
+/// Both Discord and Slack adapters build this, then pass it to
+/// [`evaluate_bot_turn_policy`] so the decision logic is shared.
+#[derive(Debug, Clone)]
+pub struct ResolvedMessageContext {
+    /// Per-thread key used for turn counting (Discord: channel_id, Slack: thread_ts).
+    pub thread_key: String,
+    /// Whether the message author is a bot.
+    pub is_bot: bool,
+    /// Whether the message is from our own bot.
+    pub is_self: bool,
+    /// Whether this bot is allowed in the channel/thread (full allowlist semantics,
+    /// including parent_id for Discord threads).
+    pub allowed_here: bool,
+    /// Whether the message is a plain human message that should reset counters.
+    pub is_human_text: bool,
+    /// Soft limit configured for this adapter instance.
+    pub max_bot_turns: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Evaluate — pure decision, no side effects
+// ---------------------------------------------------------------------------
+
+/// Decision returned by [`evaluate_bot_turn_policy`]. The adapter executes
+/// the decision without re-evaluating any conditions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TurnPolicyDecision {
+    /// Message is fine, continue processing.
+    Continue,
+    /// Bot message counted, under limits, continue processing.
+    BotContinue,
+    /// Stop processing silently (already warned on a previous turn).
+    SilentStop,
+    /// Stop processing and post a warning to the thread.
+    WarnAndStop {
+        severity: TurnSeverity,
+        turns: u32,
+        user_message: String,
+    },
+    /// Stop processing — warning would be sent but bot is not allowed here.
+    /// Log only, no message posted.
+    WarnAndStopSuppressed {
+        severity: TurnSeverity,
+        turns: u32,
+    },
+    /// Human message reset the counter. Continue processing.
+    HumanReset,
+}
+
+/// Evaluate the bot turn policy for a message. This is the shared
+/// cross-adapter decision function (#531).
+///
+/// **Phase 2 (record)** happens inside this function — the tracker is mutated.
+/// **Phase 3 (evaluate)** is the return value — a pure decision.
+/// **Phase 4 (execute)** is the caller's responsibility.
+pub fn evaluate_bot_turn_policy(
+    tracker: &mut BotTurnTracker,
+    ctx: &ResolvedMessageContext,
+) -> TurnPolicyDecision {
+    if ctx.is_bot {
+        match tracker.classify_bot_message(&ctx.thread_key) {
+            TurnAction::Continue => TurnPolicyDecision::BotContinue,
+            TurnAction::SilentStop => TurnPolicyDecision::SilentStop,
+            TurnAction::WarnAndStop { severity, turns, user_message } => {
+                if ctx.is_self || !ctx.allowed_here {
+                    TurnPolicyDecision::WarnAndStopSuppressed { severity, turns }
+                } else {
+                    TurnPolicyDecision::WarnAndStop { severity, turns, user_message }
+                }
+            }
+        }
+    } else if ctx.is_human_text {
+        tracker.on_human_message(&ctx.thread_key);
+        TurnPolicyDecision::HumanReset
+    } else {
+        TurnPolicyDecision::Continue
+    }
 }
 
 #[cfg(test)]
@@ -335,5 +431,118 @@ mod tests {
             t.classify_bot_message("t1"),
             TurnAction::WarnAndStop { severity: TurnSeverity::Soft, turns: 2, .. },
         ));
+    }
+
+    // --- evaluate_bot_turn_policy tests ---
+
+    fn bot_ctx(thread_key: &str, allowed: bool) -> ResolvedMessageContext {
+        ResolvedMessageContext {
+            thread_key: thread_key.to_string(),
+            is_bot: true,
+            is_self: false,
+            allowed_here: allowed,
+            is_human_text: false,
+            max_bot_turns: 3,
+        }
+    }
+
+    fn self_bot_ctx(thread_key: &str) -> ResolvedMessageContext {
+        ResolvedMessageContext {
+            thread_key: thread_key.to_string(),
+            is_bot: true,
+            is_self: true,
+            allowed_here: true,
+            is_human_text: false,
+            max_bot_turns: 3,
+        }
+    }
+
+    fn human_ctx(thread_key: &str) -> ResolvedMessageContext {
+        ResolvedMessageContext {
+            thread_key: thread_key.to_string(),
+            is_bot: false,
+            is_self: false,
+            allowed_here: true,
+            is_human_text: true,
+            max_bot_turns: 3,
+        }
+    }
+
+    #[test]
+    fn policy_bot_continue() {
+        let mut t = BotTurnTracker::new(3);
+        let ctx = bot_ctx("t1", true);
+        assert_eq!(evaluate_bot_turn_policy(&mut t, &ctx), TurnPolicyDecision::BotContinue);
+    }
+
+    #[test]
+    fn policy_bot_warn_and_stop_when_allowed() {
+        let mut t = BotTurnTracker::new(3);
+        let ctx = bot_ctx("t1", true);
+        let _ = evaluate_bot_turn_policy(&mut t, &ctx);
+        let _ = evaluate_bot_turn_policy(&mut t, &ctx);
+        assert!(matches!(
+            evaluate_bot_turn_policy(&mut t, &ctx),
+            TurnPolicyDecision::WarnAndStop { severity: TurnSeverity::Soft, turns: 3, .. },
+        ));
+    }
+
+    #[test]
+    fn policy_bot_warn_suppressed_when_not_allowed() {
+        let mut t = BotTurnTracker::new(3);
+        let ctx = bot_ctx("t1", false);
+        let _ = evaluate_bot_turn_policy(&mut t, &ctx);
+        let _ = evaluate_bot_turn_policy(&mut t, &ctx);
+        assert_eq!(
+            evaluate_bot_turn_policy(&mut t, &ctx),
+            TurnPolicyDecision::WarnAndStopSuppressed { severity: TurnSeverity::Soft, turns: 3 },
+        );
+    }
+
+    #[test]
+    fn policy_bot_warn_suppressed_when_self() {
+        let mut t = BotTurnTracker::new(3);
+        let ctx = self_bot_ctx("t1");
+        let _ = evaluate_bot_turn_policy(&mut t, &ctx);
+        let _ = evaluate_bot_turn_policy(&mut t, &ctx);
+        assert_eq!(
+            evaluate_bot_turn_policy(&mut t, &ctx),
+            TurnPolicyDecision::WarnAndStopSuppressed { severity: TurnSeverity::Soft, turns: 3 },
+        );
+    }
+
+    #[test]
+    fn policy_silent_stop_after_warn() {
+        let mut t = BotTurnTracker::new(2);
+        let ctx = bot_ctx("t1", true);
+        let _ = evaluate_bot_turn_policy(&mut t, &ctx);
+        let _ = evaluate_bot_turn_policy(&mut t, &ctx); // WarnAndStop
+        assert_eq!(evaluate_bot_turn_policy(&mut t, &ctx), TurnPolicyDecision::SilentStop);
+    }
+
+    #[test]
+    fn policy_human_resets() {
+        let mut t = BotTurnTracker::new(3);
+        let bot = bot_ctx("t1", true);
+        let human = human_ctx("t1");
+        let _ = evaluate_bot_turn_policy(&mut t, &bot);
+        let _ = evaluate_bot_turn_policy(&mut t, &bot);
+        assert_eq!(evaluate_bot_turn_policy(&mut t, &human), TurnPolicyDecision::HumanReset);
+        assert_eq!(evaluate_bot_turn_policy(&mut t, &bot), TurnPolicyDecision::BotContinue);
+    }
+
+    #[test]
+    fn policy_non_bot_non_human_continues() {
+        let mut t = BotTurnTracker::new(3);
+        // System message: not bot, not human text
+        let ctx = ResolvedMessageContext {
+            thread_key: "t1".to_string(),
+            is_bot: false,
+            is_self: false,
+            allowed_here: true,
+            is_human_text: false,
+            max_bot_turns: 3,
+        };
+        assert_eq!(evaluate_bot_turn_policy(&mut t, &ctx), TurnPolicyDecision::Continue);
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,7 +1,7 @@
 use crate::acp::ContentBlock;
 use crate::acp::protocol::ConfigOption;
 use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, MessageRef, SenderContext};
-use crate::bot_turns::{BotTurnTracker, TurnAction, TurnSeverity};
+use crate::bot_turns::{BotTurnTracker, TurnAction, TurnSeverity, ResolvedMessageContext, TurnPolicyDecision, evaluate_bot_turn_policy};
 use crate::config::{AllowBots, AllowUsers, SttConfig};
 use crate::format;
 use crate::media;
@@ -251,67 +251,93 @@ impl EventHandler for Handler {
             cache.entry(key).or_insert_with(tokio::time::Instant::now);
         }
 
-        // Bot turn counting: runs before self-check so ALL bot messages
-        // (including own) count toward the per-thread limit. This means
-        // soft_limit=20 = 20 total bot messages in the thread (~10 per bot
-        // in a two-bot ping-pong). (#483)
-        {
-            let thread_key = msg.channel_id.to_string();
-            let mut tracker = self.bot_turns.lock().await;
-            if msg.author.bot {
-                match tracker.classify_bot_message(&thread_key) {
-                    TurnAction::Continue => {}
-                    TurnAction::SilentStop => return,
-                    TurnAction::WarnAndStop { severity, turns, user_message } => {
-                        match severity {
-                            TurnSeverity::Hard => tracing::warn!(
-                                channel_id = %msg.channel_id,
-                                turns,
-                                "hard bot turn limit reached",
-                            ),
-                            TurnSeverity::Soft => tracing::info!(
-                                channel_id = %msg.channel_id,
-                                turns,
-                                max = self.max_bot_turns,
-                                "soft bot turn limit reached",
-                            ),
-                        }
-                        // Only post the warning if this bot is allowed in the channel/thread.
-                        // Bot turn counting intentionally runs before channel gating so ALL
-                        // bot messages are counted, but the *warning message* must respect
-                        // channel permissions — otherwise bots that never participated in a
-                        // thread will spam it with warnings.
-                        //
-                        // Must match the full thread allowlist semantics: a thread is allowed
-                        // if its own channel_id OR its parent_id is in allowed_channels.
-                        let ch = msg.channel_id.get();
-                        let mut allowed_here = self.allow_all_channels
-                            || self.allowed_channels.contains(&ch);
-                        if !allowed_here {
-                            // Thread channel_id won't be in allowed_channels directly —
-                            // check parent_id via to_channel(). Only called on the
-                            // WarnAndStop path (once per soft/hard limit hit), not on
-                            // every bot message.
-                            if let Ok(serenity::model::channel::Channel::Guild(gc)) =
-                                msg.channel_id.to_channel(&ctx.http).await
-                            {
-                                if gc.parent_id.is_some_and(|pid| {
-                                    self.allowed_channels.contains(&pid.get())
-                                }) {
-                                    allowed_here = true;
-                                }
-                            }
-                        }
-                        if msg.author.id != bot_id && allowed_here {
-                            let _ = msg.channel_id.say(&ctx.http, &user_message).await;
-                        }
-                        return;
+        // --- Phase 1: Resolve message context (#531) ---
+        // Build shared context once; used by turn counting and gating.
+        let is_bot = msg.author.bot;
+        let is_self = msg.author.id == bot_id;
+        let is_human_text = !is_bot
+            && matches!(msg.kind, MessageType::Regular | MessageType::InlineReply)
+            && !msg.content.is_empty();
+
+        // Channel allowlist (full thread semantics: own id OR parent_id).
+        // The to_channel() call only happens for bot messages — human messages
+        // are gated later in the normal flow. This matches #528 behavior:
+        // to_channel() was already called on the WarnAndStop path; we now call
+        // it slightly earlier (on all bot messages) so the resolved context is
+        // available to the policy function. In practice this is cheap because
+        // serenity caches channel lookups, and bot messages that hit Continue
+        // return immediately after the policy check anyway.
+        let allowed_here = if is_bot {
+            let ch = msg.channel_id.get();
+            let mut allowed = self.allow_all_channels
+                || self.allowed_channels.contains(&ch);
+            if !allowed {
+                if let Ok(serenity::model::channel::Channel::Guild(gc)) =
+                    msg.channel_id.to_channel(&ctx.http).await
+                {
+                    if gc.parent_id.is_some_and(|pid| {
+                        self.allowed_channels.contains(&pid.get())
+                    }) {
+                        allowed = true;
                     }
                 }
-            } else if matches!(msg.kind, MessageType::Regular | MessageType::InlineReply)
-                && !msg.content.is_empty()
-            {
-                tracker.on_human_message(&thread_key);
+            }
+            allowed
+        } else {
+            true // non-bot: gating happens later in the normal flow
+        };
+
+        let turn_ctx = ResolvedMessageContext {
+            thread_key: msg.channel_id.to_string(),
+            is_bot,
+            is_self,
+            allowed_here,
+            is_human_text,
+            max_bot_turns: self.max_bot_turns,
+        };
+
+        // --- Phase 2+3: Record turns & evaluate policy (#531) ---
+        {
+            let mut tracker = self.bot_turns.lock().await;
+            match evaluate_bot_turn_policy(&mut tracker, &turn_ctx) {
+                TurnPolicyDecision::Continue
+                | TurnPolicyDecision::BotContinue
+                | TurnPolicyDecision::HumanReset => {}
+                TurnPolicyDecision::SilentStop => return,
+                TurnPolicyDecision::WarnAndStop { severity, turns, user_message } => {
+                    // --- Phase 4: Execute effects ---
+                    match severity {
+                        TurnSeverity::Hard => tracing::warn!(
+                            channel_id = %msg.channel_id,
+                            turns,
+                            "hard bot turn limit reached",
+                        ),
+                        TurnSeverity::Soft => tracing::info!(
+                            channel_id = %msg.channel_id,
+                            turns,
+                            max = self.max_bot_turns,
+                            "soft bot turn limit reached",
+                        ),
+                    }
+                    let _ = msg.channel_id.say(&ctx.http, &user_message).await;
+                    return;
+                }
+                TurnPolicyDecision::WarnAndStopSuppressed { severity, turns } => {
+                    match severity {
+                        TurnSeverity::Hard => tracing::warn!(
+                            channel_id = %msg.channel_id,
+                            turns,
+                            "hard bot turn limit reached (warning suppressed)",
+                        ),
+                        TurnSeverity::Soft => tracing::info!(
+                            channel_id = %msg.channel_id,
+                            turns,
+                            max = self.max_bot_turns,
+                            "soft bot turn limit reached (warning suppressed)",
+                        ),
+                    }
+                    return;
+                }
             }
         }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,7 +1,7 @@
 use crate::acp::ContentBlock;
 use crate::acp::protocol::ConfigOption;
 use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, MessageRef, SenderContext};
-use crate::bot_turns::{BotTurnTracker, TurnAction, TurnSeverity, ResolvedMessageContext, TurnPolicyDecision, evaluate_bot_turn_policy};
+use crate::bot_turns::{BotTurnTracker, TurnSeverity, ResolvedMessageContext, TurnPolicyDecision, evaluate_bot_turn_policy};
 use crate::config::{AllowBots, AllowUsers, SttConfig};
 use crate::format;
 use crate::media;
@@ -293,7 +293,6 @@ impl EventHandler for Handler {
             is_self,
             allowed_here,
             is_human_text,
-            max_bot_turns: self.max_bot_turns,
         };
 
         // --- Phase 2+3: Record turns & evaluate policy (#531) ---

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,6 +1,6 @@
 use crate::acp::ContentBlock;
 use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, MessageRef, SenderContext};
-use crate::bot_turns::{BotTurnTracker, TurnAction, TurnSeverity};
+use crate::bot_turns::{BotTurnTracker, TurnAction, TurnSeverity, ResolvedMessageContext, TurnPolicyDecision, evaluate_bot_turn_policy};
 use crate::config::{AllowBots, AllowUsers, SttConfig};
 use crate::media;
 use anyhow::{anyhow, Result};
@@ -659,44 +659,56 @@ pub async fn run_slack_adapter(
                                                     }
                                                 }
 
-                                                // --- Bot turn tracking ---
+                                                // --- Bot turn tracking (resolve/record/evaluate/execute #531) ---
                                                 // Runs before self-check so ALL bot messages (including own)
                                                 // count toward the per-thread limit. Matches Discord #483.
-                                                // Keyed on thread_ts when in a thread, else channel:ts (the
-                                                // same key shape used for per-thread queueing below).
-                                                // Non-thread messages get a unique key per message, so the
-                                                // counter never accumulates — intentional, because bot-to-bot
-                                                // loops only happen inside threads.
                                                 let turn_key = if let Some(thread_ts) = event["thread_ts"].as_str() {
                                                     thread_ts.to_string()
                                                 } else {
                                                     format!("{}:{}", channel_id, event["ts"].as_str().unwrap_or(""))
                                                 };
+
+                                                // Phase 1: Resolve context
+                                                let turn_ctx = ResolvedMessageContext {
+                                                    thread_key: turn_key,
+                                                    is_bot,
+                                                    is_self: is_own_bot_msg,
+                                                    allowed_here: allow_all_channels
+                                                        || allowed_channels.contains(channel_id),
+                                                    is_human_text: !is_bot && is_plain_user_message(subtype, msg_text),
+                                                    max_bot_turns,
+                                                };
+
+                                                // Phase 2+3: Record & evaluate
                                                 {
                                                     let mut tracker = bot_turns.lock().await;
-                                                    if is_bot {
-                                                        match tracker.classify_bot_message(&turn_key) {
-                                                            TurnAction::Continue => {}
-                                                            TurnAction::SilentStop => continue,
-                                                            TurnAction::WarnAndStop { severity, turns, user_message } => {
-                                                                match severity {
-                                                                    TurnSeverity::Hard => warn!(channel_id, turns, "hard bot turn limit reached"),
-                                                                    TurnSeverity::Soft => info!(channel_id, turns, max = max_bot_turns, "soft bot turn limit reached"),
-                                                                }
-                                                                if !is_own_bot_msg {
-                                                                    let warn_channel = ChannelRef {
-                                                                        platform: "slack".into(),
-                                                                        channel_id: channel_id.to_string(),
-                                                                        thread_id: event["thread_ts"].as_str().map(|s| s.to_string()),
-                                                                        parent_id: None,
-                                                                    };
-                                                                    let _ = adapter.send_message(&warn_channel, &user_message).await;
-                                                                }
-                                                                continue;
+                                                    match evaluate_bot_turn_policy(&mut tracker, &turn_ctx) {
+                                                        TurnPolicyDecision::Continue
+                                                        | TurnPolicyDecision::BotContinue
+                                                        | TurnPolicyDecision::HumanReset => {}
+                                                        TurnPolicyDecision::SilentStop => continue,
+                                                        TurnPolicyDecision::WarnAndStop { severity, turns, user_message } => {
+                                                            // Phase 4: Execute
+                                                            match severity {
+                                                                TurnSeverity::Hard => warn!(channel_id, turns, "hard bot turn limit reached"),
+                                                                TurnSeverity::Soft => info!(channel_id, turns, max = max_bot_turns, "soft bot turn limit reached"),
                                                             }
+                                                            let warn_channel = ChannelRef {
+                                                                platform: "slack".into(),
+                                                                channel_id: channel_id.to_string(),
+                                                                thread_id: event["thread_ts"].as_str().map(|s| s.to_string()),
+                                                                parent_id: None,
+                                                            };
+                                                            let _ = adapter.send_message(&warn_channel, &user_message).await;
+                                                            continue;
                                                         }
-                                                    } else if is_plain_user_message(subtype, msg_text) {
-                                                        tracker.on_human_message(&turn_key);
+                                                        TurnPolicyDecision::WarnAndStopSuppressed { severity, turns } => {
+                                                            match severity {
+                                                                TurnSeverity::Hard => warn!(channel_id, turns, "hard bot turn limit reached (warning suppressed)"),
+                                                                TurnSeverity::Soft => info!(channel_id, turns, max = max_bot_turns, "soft bot turn limit reached (warning suppressed)"),
+                                                            }
+                                                            continue;
+                                                        }
                                                     }
                                                 }
 

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,6 +1,6 @@
 use crate::acp::ContentBlock;
 use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, MessageRef, SenderContext};
-use crate::bot_turns::{BotTurnTracker, TurnAction, TurnSeverity, ResolvedMessageContext, TurnPolicyDecision, evaluate_bot_turn_policy};
+use crate::bot_turns::{BotTurnTracker, TurnSeverity, ResolvedMessageContext, TurnPolicyDecision, evaluate_bot_turn_policy};
 use crate::config::{AllowBots, AllowUsers, SttConfig};
 use crate::media;
 use anyhow::{anyhow, Result};
@@ -676,7 +676,6 @@ pub async fn run_slack_adapter(
                                                     allowed_here: allow_all_channels
                                                         || allowed_channels.contains(channel_id),
                                                     is_human_text: !is_bot && is_plain_user_message(subtype, msg_text),
-                                                    max_bot_turns,
                                                 };
 
                                                 // Phase 2+3: Record & evaluate


### PR DESCRIPTION
Fixes #531

## Summary

Extract bot-turn throttling from `message()` into a structured 4-phase pipeline, shared across Discord and Slack adapters.

## Architecture

```
message() arrives
  → Phase 1: Resolve    — build ResolvedMessageContext (once, shared)
  → Phase 2: Record     — BotTurnTracker.classify_bot_message()
  → Phase 3: Evaluate   — evaluate_bot_turn_policy() → TurnPolicyDecision
  → Phase 4: Execute    — adapter acts on decision (send warning, log, return)
```

## Changes

### `bot_turns.rs` (+209 lines)
- `ResolvedMessageContext` — platform-agnostic context struct
- `TurnPolicyDecision` — decision enum (`Continue`, `BotContinue`, `SilentStop`, `WarnAndStop`, `WarnAndStopSuppressed`, `HumanReset`)
- `evaluate_bot_turn_policy()` — pure decision function, no side effects
- 7 new tests for the policy function

### `discord.rs` (refactored)
- Builds `ResolvedMessageContext` with full parent_id thread allowlist semantics
- Replaces inline `classify_bot_message` + `if/else` with `evaluate_bot_turn_policy()` match
- `to_channel()` for parent_id check runs for bot messages only (same perf as #528)

### `slack.rs` (refactored)
- Builds `ResolvedMessageContext` with simple channel allowlist check
- Same pipeline pattern as Discord
- **Bonus**: Slack now also gates warnings behind `allowed_channels` (was missing in #528 which only fixed Discord)

## Behavior Equivalence

- ✅ #483 invariant preserved: all bot messages counted before self-check
- ✅ #528 fix included: warnings respect channel permissions
- ✅ Human message reset unchanged
- ✅ SilentStop / return behavior unchanged
- ✅ No new side effects in evaluate layer

## What this enables

- #530 (dedup) can be solved in the evaluate layer without touching business logic
- Future adapters (Line, Telegram) get throttling for free by building `ResolvedMessageContext`
- Each phase is independently testable