### PR TITLE
fix(discord): conditional streaming parity with Slack

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1338,4 +1338,32 @@ mod tests {
             assert_eq!(result, c.expect, "FAILED: {}", c.name);
         }
     }
+
+    // --- use_streaming parity tests (regression for #533) ---
+    // Discord must mirror Slack: streaming only when allow_bot_messages=Off.
+    // When bots can post (Mentions/All), send-once avoids placeholder interference
+    // in bot-to-bot threads. See Slack fix in 4eed3fc and discord regression in 27b9e58.
+
+    /// Pure helper that mirrors DiscordAdapter::use_streaming() logic.
+    fn discord_should_stream(mode: AllowBots) -> bool {
+        mode == AllowBots::Off
+    }
+
+    /// Default (Off): streaming enabled for smooth human UX.
+    #[test]
+    fn discord_streams_when_bots_off() {
+        assert!(discord_should_stream(AllowBots::Off));
+    }
+
+    /// Mentions: send-once to avoid placeholder interference in bot-to-bot threads.
+    #[test]
+    fn discord_no_stream_when_bots_mentions() {
+        assert!(!discord_should_stream(AllowBots::Mentions));
+    }
+
+    /// All: send-once.
+    #[test]
+    fn discord_no_stream_when_bots_all() {
+        assert!(!discord_should_stream(AllowBots::All));
+    }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1352,26 +1352,21 @@ mod tests {
     // When bots can post (Mentions/All), send-once avoids placeholder interference
     // in bot-to-bot threads. See Slack fix in 4eed3fc and discord regression in 27b9e58.
 
-    /// Pure helper that mirrors DiscordAdapter::use_streaming() logic.
-    fn discord_should_stream(mode: AllowBots) -> bool {
-        mode == AllowBots::Off
-    }
-
     /// Default (Off): streaming enabled for smooth human UX.
     #[test]
     fn discord_streams_when_bots_off() {
-        assert!(discord_should_stream(AllowBots::Off));
+        assert!(super::discord_should_stream(AllowBots::Off));
     }
 
     /// Mentions: send-once to avoid placeholder interference in bot-to-bot threads.
     #[test]
     fn discord_no_stream_when_bots_mentions() {
-        assert!(!discord_should_stream(AllowBots::Mentions));
+        assert!(!super::discord_should_stream(AllowBots::Mentions));
     }
 
     /// All: send-once.
     #[test]
     fn discord_no_stream_when_bots_all() {
-        assert!(!discord_should_stream(AllowBots::All));
+        assert!(!super::discord_should_stream(AllowBots::All));
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -71,7 +71,7 @@ impl ChatAdapter for DiscordAdapter {
     }
 
     fn use_streaming(&self) -> bool {
-        self.allow_bot_messages == AllowBots::Off
+        discord_should_stream(self.allow_bot_messages)
     }
 
     async fn create_thread(
@@ -898,6 +898,14 @@ fn resolve_mentions(content: &str, bot_id: UserId) -> String {
     // 3. Fallback: replace role mentions only (user mentions are preserved)
     let out = ROLE_MENTION_RE.replace_all(&out, "@(role)").to_string();
     out.trim().to_string()
+}
+
+/// Whether the Discord adapter should use streaming edit.
+/// Streaming is disabled when bots can post (Mentions/All) to avoid
+/// placeholder message interference in bot-to-bot threads.
+/// Mirrors the Slack adapter logic from commit 4eed3fc.
+fn discord_should_stream(allow_bot_messages: AllowBots) -> bool {
+    allow_bot_messages == AllowBots::Off
 }
 
 /// Pure thread detection: determines whether a channel is a Discord thread

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -29,11 +29,12 @@ const PARTICIPATION_CACHE_MAX: usize = 1000;
 
 pub struct DiscordAdapter {
     http: Arc<Http>,
+    allow_bot_messages: AllowBots,
 }
 
 impl DiscordAdapter {
-    pub fn new(http: Arc<Http>) -> Self {
-        Self { http }
+    pub fn new(http: Arc<Http>, allow_bot_messages: AllowBots) -> Self {
+        Self { http, allow_bot_messages }
     }
 }
 
@@ -70,7 +71,7 @@ impl ChatAdapter for DiscordAdapter {
     }
 
     fn use_streaming(&self) -> bool {
-        true
+        self.allow_bot_messages == AllowBots::Off
     }
 
     async fn create_thread(
@@ -321,7 +322,7 @@ impl EventHandler for Handler {
         }
 
         let adapter = self.adapter.get_or_init(|| {
-            Arc::new(DiscordAdapter::new(ctx.http.clone()))
+            Arc::new(DiscordAdapter::new(ctx.http.clone(), self.allow_bot_messages))
         }).clone();
 
         let channel_id = msg.channel_id.get();


### PR DESCRIPTION
## Problem

When `allow_bot_messages=mentions|all`, Discord still uses streaming edit (placeholder + live updates). This causes placeholder message interference in bot-to-bot threads — the same issue Slack fixed in #420.

## Root Cause

`27b9e58` restored `use_streaming() → true` unconditionally when fixing #502, but did not port the conditional logic that was added to Slack in `4eed3fc`.

## Fix

Mirror the Slack adapter logic in `DiscordAdapter`:

```rust
fn use_streaming(&self) -> bool {
    self.allow_bot_messages == AllowBots::Off
}
```

- `allow_bot_messages=off` (default): streaming edit — better UX for human conversations
- `allow_bot_messages=mentions|all`: send-once — avoids placeholder interference in multibot threads

## Changes

- Add `allow_bot_messages: AllowBots` field to `DiscordAdapter`
- Pass it from `Handler` at adapter init time
- Change `use_streaming()` from hardcoded `true` to conditional