### PR TITLE
feat(discord,slack): per-thread streaming based on multibot detection

### DIFF
--- a/docs/discord.md
+++ b/docs/discord.md
@@ -168,6 +168,23 @@ Each thread gets its own agent session. Sessions are cleaned up after `session_t
 
 ---
 
+## Streaming
+
+OpenAB uses **edit-streaming** on Discord — the bot sends a placeholder message and updates it every 1.5 seconds as tokens arrive, giving a live typing effect.
+
+Streaming is decided **per-thread**, not globally:
+
+| Thread state | Streaming |
+|---|---|
+| Single bot + human | ✅ ON — live edit updates |
+| 2+ bots in thread | ❌ OFF — send-once to avoid edit interference |
+
+When a second bot posts in a thread, streaming automatically switches off for that thread. This prevents multiple bots from editing placeholder messages simultaneously, which causes visual glitches on Discord.
+
+No configuration needed — this is automatic based on multibot detection.
+
+---
+
 ## Multi-Bot Setup
 
 Multiple bots can share the same Discord channel. Each bot only responds to its own @mentions.

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -111,6 +111,7 @@ impl AdapterRouter {
     /// Handle an incoming user message. The adapter is responsible for
     /// filtering, resolving the thread, and building the SenderContext.
     /// This method handles sender context injection, session management, and streaming.
+    #[allow(clippy::too_many_arguments)]
     pub async fn handle_message(
         &self,
         adapter: &Arc<dyn ChatAdapter>,

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -81,9 +81,9 @@ pub trait ChatAdapter: Send + Sync + 'static {
     }
 
     /// Whether this adapter should use streaming edit (true) or send-once (false).
-    /// Required: each adapter must explicitly declare its streaming capability
-    /// to prevent silent regression if the trait default changes.
-    fn use_streaming(&self) -> bool;
+    /// `other_bot_present` indicates if another bot has posted in the current thread.
+    /// Streaming should be disabled in multi-bot threads to avoid edit interference.
+    fn use_streaming(&self, other_bot_present: bool) -> bool;
 }
 
 // --- AdapterRouter ---
@@ -119,6 +119,7 @@ impl AdapterRouter {
         prompt: &str,
         extra_blocks: Vec<ContentBlock>,
         trigger_msg: &MessageRef,
+        other_bot_present: bool,
     ) -> Result<()> {
         tracing::debug!(platform = adapter.platform(), "processing message");
 
@@ -179,6 +180,7 @@ impl AdapterRouter {
                 content_blocks,
                 thread_channel,
                 reactions.clone(),
+                other_bot_present,
             )
             .await;
 
@@ -216,11 +218,12 @@ impl AdapterRouter {
         content_blocks: Vec<ContentBlock>,
         thread_channel: &ChannelRef,
         reactions: Arc<StatusReactionController>,
+        other_bot_present: bool,
     ) -> Result<()> {
         let adapter = adapter.clone();
         let thread_channel = thread_channel.clone();
         let message_limit = adapter.message_limit();
-        let streaming = adapter.use_streaming();
+        let streaming = adapter.use_streaming(other_bot_present);
 
         self.pool
             .with_connection(thread_key, |conn| {
@@ -504,11 +507,11 @@ mod tests {
             async fn add_reaction(&self, _: &MessageRef, _: &str) -> Result<()> { Ok(()) }
             async fn remove_reaction(&self, _: &MessageRef, _: &str) -> Result<()> { Ok(()) }
             // use_streaming() MUST be declared — removing this line should fail compilation
-            fn use_streaming(&self) -> bool { false }
+            fn use_streaming(&self, _other_bot_present: bool) -> bool { false }
         }
 
         let adapter = TestAdapter;
         // Verify the method is callable and returns the declared value
-        assert!(!adapter.use_streaming());
+        assert!(!adapter.use_streaming(false));
     }
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -83,6 +83,10 @@ pub trait ChatAdapter: Send + Sync + 'static {
     /// Whether this adapter should use streaming edit (true) or send-once (false).
     /// `other_bot_present` indicates if another bot has posted in the current thread.
     /// Streaming should be disabled in multi-bot threads to avoid edit interference.
+    /// NOTE: Slight race window exists — the multibot cache is checked before
+    /// handle_message, so a bot arriving between the check and the response will
+    /// not be detected until the next message. This is acceptable: the first
+    /// response may stream, but subsequent ones will correctly use send-once.
     fn use_streaming(&self, other_bot_present: bool) -> bool;
 }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -29,12 +29,11 @@ const PARTICIPATION_CACHE_MAX: usize = 1000;
 
 pub struct DiscordAdapter {
     http: Arc<Http>,
-    allow_bot_messages: AllowBots,
 }
 
 impl DiscordAdapter {
-    pub fn new(http: Arc<Http>, allow_bot_messages: AllowBots) -> Self {
-        Self { http, allow_bot_messages }
+    pub fn new(http: Arc<Http>) -> Self {
+        Self { http }
     }
 }
 
@@ -70,8 +69,8 @@ impl ChatAdapter for DiscordAdapter {
         Ok(())
     }
 
-    fn use_streaming(&self) -> bool {
-        discord_should_stream(self.allow_bot_messages)
+    fn use_streaming(&self, other_bot_present: bool) -> bool {
+        !other_bot_present
     }
 
     async fn create_thread(
@@ -322,7 +321,7 @@ impl EventHandler for Handler {
         }
 
         let adapter = self.adapter.get_or_init(|| {
-            Arc::new(DiscordAdapter::new(ctx.http.clone(), self.allow_bot_messages))
+            Arc::new(DiscordAdapter::new(ctx.http.clone()))
         }).clone();
 
         let channel_id = msg.channel_id.get();
@@ -591,11 +590,17 @@ impl EventHandler for Handler {
 
         let trigger_msg = discord_msg_ref(&msg);
 
+        // Per-thread streaming: check if another bot is present in this thread
+        let other_bot_present = {
+            let cache = self.multibot_threads.lock().await;
+            cache.contains_key(&msg.channel_id.to_string())
+        };
+
         let router = self.router.clone();
         tokio::spawn(async move {
             let sender_json = serde_json::to_string(&sender).unwrap();
             if let Err(e) = router
-                .handle_message(&adapter, &thread_channel, &sender_json, &prompt, extra_blocks, &trigger_msg)
+                .handle_message(&adapter, &thread_channel, &sender_json, &prompt, extra_blocks, &trigger_msg, other_bot_present)
                 .await
             {
                 error!("handle_message error: {e}");
@@ -901,13 +906,6 @@ fn resolve_mentions(content: &str, bot_id: UserId) -> String {
 }
 
 /// Whether the Discord adapter should use streaming edit.
-/// Streaming is disabled when bots can post (Mentions/All) to avoid
-/// placeholder message interference in bot-to-bot threads.
-/// Mirrors the Slack adapter logic from commit 4eed3fc.
-fn discord_should_stream(allow_bot_messages: AllowBots) -> bool {
-    allow_bot_messages == AllowBots::Off
-}
-
 /// Pure thread detection: determines whether a channel is a Discord thread
 /// in an allowed parent, and whether the bot owns it.
 ///
@@ -1349,24 +1347,19 @@ mod tests {
 
     // --- use_streaming parity tests (regression for #533) ---
     // Discord must mirror Slack: streaming only when allow_bot_messages=Off.
-    // When bots can post (Mentions/All), send-once avoids placeholder interference
-    // in bot-to-bot threads. See Slack fix in 4eed3fc and discord regression in 27b9e58.
+    // Per-thread streaming: ON by default, OFF when another bot is present (#534).
 
-    /// Default (Off): streaming enabled for smooth human UX.
+    /// Single bot thread: streaming enabled.
     #[test]
-    fn discord_streams_when_bots_off() {
-        assert!(super::discord_should_stream(AllowBots::Off));
+    fn discord_streams_when_no_other_bot() {
+        let adapter = super::DiscordAdapter::new(Arc::new(super::Http::new("")));
+        assert!(adapter.use_streaming(false));
     }
 
-    /// Mentions: send-once to avoid placeholder interference in bot-to-bot threads.
+    /// Multi-bot thread: send-once to avoid edit interference.
     #[test]
-    fn discord_no_stream_when_bots_mentions() {
-        assert!(!super::discord_should_stream(AllowBots::Mentions));
-    }
-
-    /// All: send-once.
-    #[test]
-    fn discord_no_stream_when_bots_all() {
-        assert!(!super::discord_should_stream(AllowBots::All));
+    fn discord_no_stream_when_other_bot_present() {
+        let adapter = super::DiscordAdapter::new(Arc::new(super::Http::new("")));
+        assert!(!adapter.use_streaming(true));
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1345,9 +1345,8 @@ mod tests {
         }
     }
 
-    // --- use_streaming parity tests (regression for #533) ---
-    // Discord must mirror Slack: streaming only when allow_bot_messages=Off.
-    // Per-thread streaming: ON by default, OFF when another bot is present (#534).
+    // --- Per-thread streaming tests (#534) ---
+    // Streaming ON by default, OFF when another bot is detected in the thread.
 
     /// Single bot thread: streaming enabled.
     #[test]

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -67,7 +67,8 @@ pub struct SlackAdapter {
     multibot_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
     /// TTL for participation cache entries (matches session_ttl_hours from config).
     session_ttl: std::time::Duration,
-    /// Controls streaming behavior: Off → streaming edit, Mentions/All → send-once.
+    /// Retained for API compatibility; streaming is now per-thread (#534).
+    #[allow(dead_code)]
     allow_bot_messages: AllowBots,
 }
 
@@ -419,8 +420,8 @@ impl ChatAdapter for SlackAdapter {
         Ok(())
     }
 
-    fn use_streaming(&self) -> bool {
-        self.allow_bot_messages == AllowBots::Off
+    fn use_streaming(&self, other_bot_present: bool) -> bool {
+        !other_bot_present
     }
 }
 
@@ -1118,8 +1119,12 @@ async fn handle_message(
     };
 
     let adapter_dyn: Arc<dyn ChatAdapter> = adapter.clone();
+    let other_bot_present = {
+        let cache = adapter.multibot_threads.lock().await;
+        cache.contains_key(&thread_channel.channel_id)
+    };
     if let Err(e) = router
-        .handle_message(&adapter_dyn, &thread_channel, &sender_json, &prompt, extra_blocks, &trigger_msg)
+        .handle_message(&adapter_dyn, &thread_channel, &sender_json, &prompt, extra_blocks, &trigger_msg, other_bot_present)
         .await
     {
         error!("Slack handle_message error: {e}");
@@ -1347,20 +1352,13 @@ mod tests {
         assert_eq!(strip_mime_params("  text/plain  "), "text/plain");
     }
 
-    /// Regression test: Slack streaming depends on allow_bot_messages config.
-    /// Off → stream (better human UX), Mentions/All → send-once (avoids bot-to-bot interference).
-    /// See PR #420 for design rationale.
+    /// Per-thread streaming: ON by default, OFF when another bot is present (#534).
     #[test]
-    fn streaming_enabled_only_when_bots_off() {
+    fn streaming_per_thread() {
         let ttl = std::time::Duration::from_secs(300);
+        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions);
 
-        let off = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Off);
-        assert!(off.use_streaming(), "should stream when allow_bot_messages=Off");
-
-        let mentions = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions);
-        assert!(!mentions.use_streaming(), "should NOT stream when allow_bot_messages=Mentions");
-
-        let all = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::All);
-        assert!(!all.use_streaming(), "should NOT stream when allow_bot_messages=All");
+        assert!(adapter.use_streaming(false), "should stream when no other bot");
+        assert!(!adapter.use_streaming(true), "should NOT stream when other bot present");
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -67,13 +67,10 @@ pub struct SlackAdapter {
     multibot_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
     /// TTL for participation cache entries (matches session_ttl_hours from config).
     session_ttl: std::time::Duration,
-    /// Retained for API compatibility; streaming is now per-thread (#534).
-    #[allow(dead_code)]
-    allow_bot_messages: AllowBots,
 }
 
 impl SlackAdapter {
-    pub fn new(bot_token: String, session_ttl: std::time::Duration, allow_bot_messages: AllowBots) -> Self {
+    pub fn new(bot_token: String, session_ttl: std::time::Duration, _allow_bot_messages: AllowBots) -> Self {
         Self {
             client: reqwest::Client::new(),
             bot_token,
@@ -83,7 +80,6 @@ impl SlackAdapter {
             participated_threads: tokio::sync::Mutex::new(HashMap::new()),
             multibot_threads: tokio::sync::Mutex::new(HashMap::new()),
             session_ttl,
-            allow_bot_messages,
         }
     }
 


### PR DESCRIPTION
### Description

Streaming is now ON by default and only disabled when another bot is detected in the thread. Replaces the global `allow_bot_messages`-based decision from #533.

### Changes

- `use_streaming(other_bot_present: bool)` replaces `use_streaming()`
- Discord/Slack check `multibot_threads` cache before `handle_message`
- Removed `discord_should_stream()` and `allow_bot_messages` from `DiscordAdapter`

### Decision Logic

```rust
fn use_streaming(&self, other_bot_present: bool) -> bool {
    !other_bot_present
}
```

No dependency on `allow_bot_messages` config.

### Validation

- `cargo check` — no warnings ✅
- `cargo test` — 107/107 passed ✅

Closes #534