### PR TITLE
docs: add config-reference.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ cargo run
 
 ## Configuration Reference
 
+> 📖 Full reference with all options, defaults, and Helm mapping: [docs/config-reference.md](docs/config-reference.md)
+
 ```toml
 [discord]
 bot_token = "${DISCORD_BOT_TOKEN}"   # supports env var expansion

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -166,6 +166,54 @@ Speech-to-text transcription for voice messages. Uses an OpenAI-compatible `/aud
 
 ---
 
+## Customizing via Helm
+
+When deploying with the Helm chart (`charts/openab`), the `config.toml` is generated from `values.yaml`. Each agent is defined under the `agents` map:
+
+```yaml
+agents:
+  kiro:
+    command: kiro-cli
+    args: ["acp", "--trust-all-tools"]
+    discord:
+      enabled: true
+      allowedChannels: ["1234567890"]
+      allowBotMessages: "mentions"
+      trustedBotIds: ["9876543210"]
+    pool:
+      maxSessions: 10
+      sessionTtlHours: 24
+    reactions:
+      enabled: true
+    stt:
+      enabled: true
+      apiKey: "your-groq-key"
+```
+
+Key mapping (`values.yaml` → `config.toml`):
+
+| Helm value | Config key |
+|---|---|
+| `agents.<name>.discord.allowedChannels` | `[discord] allowed_channels` |
+| `agents.<name>.discord.allowBotMessages` | `[discord] allow_bot_messages` |
+| `agents.<name>.discord.trustedBotIds` | `[discord] trusted_bot_ids` |
+| `agents.<name>.discord.allowUserMessages` | `[discord] allow_user_messages` |
+| `agents.<name>.slack.*` | `[slack] *` (same pattern) |
+| `agents.<name>.pool.maxSessions` | `[pool] max_sessions` |
+| `agents.<name>.pool.sessionTtlHours` | `[pool] session_ttl_hours` |
+| `agents.<name>.reactions.enabled` | `[reactions] enabled` |
+| `agents.<name>.stt.apiKey` | `[stt] api_key` |
+
+> ⚠️ Use `--set-string` (not `--set`) for Discord/Slack IDs to avoid float64 precision loss:
+> ```bash
+> helm upgrade --install mybot charts/openab \
+>   --set-string agents.kiro.discord.allowedChannels[0]="1234567890"
+> ```
+
+See `charts/openab/values.yaml` for the full list of Helm values including `persistence`, `image`, `resources`, and multi-agent examples.
+
+---
+
 ## Environment variable interpolation
 
 Any value can reference environment variables with `${VAR_NAME}`:

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -20,7 +20,7 @@ Discord adapter. Requires a Discord bot token.
 | `allow_bot_messages` | string | `"off"` | `"off"` — ignore all bot messages. `"mentions"` — only process bot messages that @mention this bot. `"all"` — process all bot messages (capped by `max_bot_turns`). |
 | `trusted_bot_ids` | string[] | `[]` | When non-empty, only these bot IDs pass the bot gate. Empty = any bot (mode permitting). Ignored when `allow_bot_messages = "off"`. |
 | `allow_user_messages` | string | `"involved"` | `"involved"` — reply in threads bot has participated in without @mention; channel messages require @mention; DMs always process. `"mentions"` — always require @mention. `"multibot-mentions"` — like `"involved"`, but require @mention once another bot has posted in the thread. |
-| `max_bot_turns` | u32 | `20` | Max consecutive bot turns per thread before throttling. Human message resets the counter. |
+| `max_bot_turns` | u32 | `20` | Max consecutive bot turns per thread before throttling. Human message resets the counter. Note: when `allow_bot_messages = "all"`, a separate hardcoded cap of 10 (`MAX_CONSECUTIVE_BOT_TURNS`) stops bot replies regardless of this value. |
 
 ---
 
@@ -111,7 +111,7 @@ Session pool settings for managing concurrent agent sessions.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `max_sessions` | usize | `10` | Maximum number of concurrent agent sessions. |
+| `max_sessions` | usize | `10` | Maximum number of concurrent agent sessions. When full, the oldest idle session is suspended (recoverable); if all sessions are busy, new requests are rejected. |
 | `session_ttl_hours` | u64 | `4` | Session time-to-live in hours. Idle sessions are reclaimed after this period. The example config uses `24`. |
 
 ---

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,0 +1,177 @@
+# Configuration Reference
+
+OpenAB is configured via a TOML file (default: `config.toml`). Environment variables can be interpolated using `${VAR_NAME}` syntax.
+
+At least one adapter section (`[discord]` or `[slack]`) is required.
+
+---
+
+## `[discord]`
+
+Discord adapter. Requires a Discord bot token.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `bot_token` | string | *required* | Discord bot token. Use `${DISCORD_BOT_TOKEN}` for env var. |
+| `allow_all_channels` | bool \| omit | auto-detect | `true` = all channels; `false` = only `allowed_channels`. Omitted = inferred from list (non-empty → false, empty → true). |
+| `allowed_channels` | string[] | `[]` | Channel IDs to allow. Only checked when `allow_all_channels` resolves to false. |
+| `allow_all_users` | bool \| omit | auto-detect | `true` = any user; `false` = only `allowed_users`. Omitted = inferred from list. |
+| `allowed_users` | string[] | `[]` | User IDs to allow. Only checked when `allow_all_users` resolves to false. |
+| `allow_bot_messages` | string | `"off"` | `"off"` — ignore all bot messages. `"mentions"` — only process bot messages that @mention this bot. `"all"` — process all bot messages (capped by `max_bot_turns`). |
+| `trusted_bot_ids` | string[] | `[]` | When non-empty, only these bot IDs pass the bot gate. Empty = any bot (mode permitting). Ignored when `allow_bot_messages = "off"`. |
+| `allow_user_messages` | string | `"involved"` | `"involved"` — reply in threads bot has participated in without @mention; channel messages require @mention; DMs always process. `"mentions"` — always require @mention. `"multibot-mentions"` — like `"involved"`, but require @mention once another bot has posted in the thread. |
+| `max_bot_turns` | u32 | `20` | Max consecutive bot turns per thread before throttling. Human message resets the counter. |
+
+---
+
+## `[slack]`
+
+Slack adapter using Socket Mode. Requires both a Bot User OAuth Token and an App-Level Token.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `bot_token` | string | *required* | Bot User OAuth Token (`xoxb-...`). |
+| `app_token` | string | *required* | App-Level Token (`xapp-...`) for Socket Mode. |
+| `allow_all_channels` | bool \| omit | auto-detect | Same behavior as Discord. |
+| `allowed_channels` | string[] | `[]` | Slack channel IDs (e.g. `C0123456789`). |
+| `allow_all_users` | bool \| omit | auto-detect | Same behavior as Discord. |
+| `allowed_users` | string[] | `[]` | Slack user IDs (e.g. `U0123456789`). |
+| `allow_bot_messages` | string | `"off"` | Same as Discord. |
+| `trusted_bot_ids` | string[] | `[]` | Slack Bot User IDs (`U...`). Find via: click bot profile → Copy member ID. |
+| `allow_user_messages` | string | `"involved"` | Same as Discord. |
+| `max_bot_turns` | u32 | `20` | Same as Discord. |
+
+---
+
+## `[agent]`
+
+The AI agent subprocess that OpenAB spawns to handle messages via ACP.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `command` | string | *required* | Agent binary (e.g. `kiro-cli`, `claude`, `codex`, `gemini`, `copilot`, `opencode`, `cursor-agent`). |
+| `args` | string[] | `[]` | CLI arguments passed to the agent. |
+| `working_dir` | string | `"/tmp"` | Working directory for the agent process. |
+| `env` | map | `{}` | Extra environment variables (e.g. `{ ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}" }`). |
+
+### Agent examples
+
+```toml
+# Kiro CLI
+[agent]
+command = "kiro-cli"
+args = ["acp", "--trust-all-tools"]
+working_dir = "/home/agent"
+
+# Claude Code
+[agent]
+command = "claude"
+args = ["--acp"]
+working_dir = "/home/agent"
+env = { ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}" }
+
+# Codex
+[agent]
+command = "codex"
+args = ["--acp"]
+working_dir = "/home/agent"
+env = { OPENAI_API_KEY = "${OPENAI_API_KEY}" }
+
+# Gemini CLI
+[agent]
+command = "gemini"
+args = ["--acp"]
+working_dir = "/home/agent"
+env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
+
+# GitHub Copilot
+[agent]
+command = "copilot"
+args = ["--acp", "--stdio"]
+working_dir = "/home/agent"
+
+# opencode
+[agent]
+command = "opencode"
+args = ["acp"]
+working_dir = "/home/node"
+
+# Cursor Agent
+[agent]
+command = "cursor-agent"
+args = ["acp", "--model", "auto", "--workspace", "/home/agent"]
+working_dir = "/home/agent"
+```
+
+---
+
+## `[pool]`
+
+Session pool settings for managing concurrent agent sessions.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `max_sessions` | usize | `10` | Maximum number of concurrent agent sessions. |
+| `session_ttl_hours` | u64 | `4` | Session time-to-live in hours. Idle sessions are reclaimed after this period. |
+
+---
+
+## `[reactions]`
+
+Emoji reaction feedback on messages to show agent processing status.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | Enable/disable reaction feedback. |
+| `remove_after_reply` | bool | `false` | Remove the status reaction after the agent replies. |
+
+### `[reactions.emojis]`
+
+Customize the emoji for each processing stage.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `queued` | 👀 | Message received, queued for processing. |
+| `thinking` | 🤔 | Agent is thinking / generating. |
+| `tool` | 🔥 | Agent is calling a tool. |
+| `coding` | 👨‍💻 | Agent is writing code. |
+| `web` | ⚡ | Agent is doing web operations. |
+| `done` | 🆗 | Agent finished successfully. |
+| `error` | 😱 | Agent encountered an error. |
+
+### `[reactions.timing]`
+
+Fine-tune reaction timing behavior (milliseconds).
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `debounce_ms` | `700` | Debounce interval before updating the reaction emoji. |
+| `stall_soft_ms` | `10000` | Soft stall threshold — warn if no progress. |
+| `stall_hard_ms` | `30000` | Hard stall threshold — consider the agent stuck. |
+| `done_hold_ms` | `1500` | How long to show the done emoji before removing (if `remove_after_reply`). |
+| `error_hold_ms` | `2500` | How long to show the error emoji before removing. |
+
+---
+
+## `[stt]`
+
+Speech-to-text transcription for voice messages. Uses an OpenAI-compatible `/audio/transcriptions` endpoint.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `false` | Enable voice message transcription. |
+| `api_key` | string | `""` | API key for the STT service. |
+| `model` | string | `"whisper-large-v3-turbo"` | Model name to use for transcription. |
+| `base_url` | string | `"https://api.groq.com/openai/v1"` | Base URL of the STT API. |
+
+---
+
+## Environment variable interpolation
+
+Any value can reference environment variables with `${VAR_NAME}`:
+
+```toml
+bot_token = "${DISCORD_BOT_TOKEN}"
+```
+
+Undefined variables resolve to an empty string.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -112,7 +112,7 @@ Session pool settings for managing concurrent agent sessions.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `max_sessions` | usize | `10` | Maximum number of concurrent agent sessions. |
-| `session_ttl_hours` | u64 | `4` | Session time-to-live in hours. Idle sessions are reclaimed after this period. |
+| `session_ttl_hours` | u64 | `4` | Session time-to-live in hours. Idle sessions are reclaimed after this period. The example config uses `24`. |
 
 ---
 
@@ -160,9 +160,9 @@ Speech-to-text transcription for voice messages. Uses an OpenAI-compatible `/aud
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | bool | `false` | Enable voice message transcription. |
-| `api_key` | string | `""` | API key for the STT service. |
+| `api_key` | string | `""` | API key for the STT service. When empty and `base_url` contains `groq.com`, the `GROQ_API_KEY` environment variable is used automatically. For local servers, use `api_key = "not-needed"`. |
 | `model` | string | `"whisper-large-v3-turbo"` | Model name to use for transcription. |
-| `base_url` | string | `"https://api.groq.com/openai/v1"` | Base URL of the STT API. |
+| `base_url` | string | `"https://api.groq.com/openai/v1"` | Base URL of the STT API. Any OpenAI-compatible `/audio/transcriptions` endpoint works. |
 
 ---
 

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -61,6 +61,8 @@ Complete guide to setting up, configuring, and running OpenAB with Discord.
 
 ## Configuration Reference
 
+> 📖 Full config options with defaults: [docs/config-reference.md](config-reference.md#discord)
+
 ```toml
 [discord]
 bot_token = "${DISCORD_BOT_TOKEN}"

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -54,6 +54,8 @@ See individual agent docs for authentication steps:
 
 ## Bot-to-Bot Communication
 
+> 📖 Full config options: [docs/config-reference.md](config-reference.md)
+
 By default, each agent ignores messages from other bots. To enable multi-agent collaboration in the same channel (e.g. a code review bot handing off to a deploy bot), configure `allow_bot_messages` in each agent's `config.toml`:
 
 ```toml

--- a/docs/slack-bot-howto.md
+++ b/docs/slack-bot-howto.md
@@ -57,6 +57,8 @@ Socket Mode uses a persistent WebSocket connection — no public URL or ingress 
 
 ## 6. Configure openab
 
+> 📖 Full config options with defaults: [docs/config-reference.md](config-reference.md#slack)
+
 Add the `[slack]` section to your `config.toml`:
 
 ```toml

--- a/docs/stt.md
+++ b/docs/stt.md
@@ -4,6 +4,8 @@ openab can automatically transcribe Discord voice message attachments and forwar
 
 ## Quick Start
 
+> 📖 Full STT config options: [docs/config-reference.md](config-reference.md#stt)
+
 Add an `[stt]` section to your `config.toml`:
 
 ```toml


### PR DESCRIPTION
## Summary

Add `docs/config-reference.md` — a comprehensive TOML configuration reference for OpenAB.

## What's covered

- **`[discord]`** — all 9 fields including multi-bot collaboration settings (`allow_bot_messages`, `trusted_bot_ids`, `allow_user_messages`)
- **`[slack]`** — all 10 fields including Socket Mode tokens
- **`[agent]`** — 4 fields + examples for all 7 supported backends (Kiro CLI, Claude, Codex, Gemini, Copilot, opencode, Cursor)
- **`[pool]`** — session pool management
- **`[reactions]`** — emoji customization + timing tuning
- **`[stt]`** — speech-to-text (Groq Whisper)
- **Environment variable interpolation** — `${VAR_NAME}` syntax

All default values are sourced directly from `src/config.rs`.