### PR TITLE
fix(docker): update CMD to use -c flag for config path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["tini", "--"]
-CMD ["openab", "run", "/etc/openab/config.toml"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]


### PR DESCRIPTION
### Description

PR #87 changed config loading from positional arg (`openab run /path`) to named flag (`openab run -c /path`), but the Dockerfile `CMD` was not updated. This breaks all container deployments on `0.8.1-beta.4`.

### Steps to Reproduce

1. `docker run ghcr.io/openabdev/openab:0.8.1-beta.4`
2. Container crashes with: `error: unexpected argument '/etc/openab/config.toml' found`

### Expected Behavior

Container starts normally using the mounted config file.

**Fix:** `CMD ["openab", "run", "/etc/openab/config.toml"]` → `CMD ["openab", "run", "-c", "/etc/openab/config.toml"]`