### PR TITLE
fix(docker): update CMD in all agent Dockerfiles to use -c flag

### DIFF
--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -35,4 +35,4 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["tini", "--"]
-CMD ["openab", "run", "/etc/openab/config.toml"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -32,4 +32,4 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["tini", "--"]
-CMD ["openab", "run", "/etc/openab/config.toml"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -31,4 +31,4 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["tini", "--"]
-CMD ["openab", "run", "/etc/openab/config.toml"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -43,4 +43,4 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["tini", "--"]
-CMD ["openab", "run", "/etc/openab/config.toml"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -31,5 +31,5 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["tini", "--"]
-CMD ["openab", "run", "/etc/openab/config.toml"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -46,4 +46,4 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENTRYPOINT ["tini", "--"]
-CMD ["openab", "run", "/etc/openab/config.toml"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]


### PR DESCRIPTION
### Description

Follow-up to #544. PR #87 changed config loading from positional arg to `-c` flag, but only the default `Dockerfile` was fixed. The 6 agent-specific Dockerfiles still use the old positional arg, breaking all agent-specific container images on `0.8.1-beta.4`.

### Affected Files

- `Dockerfile.claude`
- `Dockerfile.codex`
- `Dockerfile.copilot`
- `Dockerfile.cursor`
- `Dockerfile.gemini`
- `Dockerfile.opencode`

### Steps to Reproduce

```bash
docker run ghcr.io/openabdev/openab-copilot:0.8.1-beta.4
# error: unexpected argument '/etc/openab/config.toml' found
```

### Expected Behavior

Container starts normally.