### PR TITLE
feat: custom gateway adapter + Telegram PoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ config.toml
 .env
 .kiro/
 CLAUDE.md
+gateway/target/

--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,53 +12,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
+name = "android_system_properties"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "libc",
 ]
 
 [[package]]
@@ -72,26 +25,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "atomic-waker"
@@ -104,6 +37,61 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite 0.29.0",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -133,22 +121,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -179,56 +155,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "clap"
-version = "4.6.0"
+name = "chrono"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "clap_builder",
- "clap_derive",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
-name = "clap_builder"
-version = "4.6.0"
+name = "core-foundation-sys"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -237,15 +181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -259,34 +194,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
- "serde",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
- "serde_core",
-]
 
 [[package]]
 name = "digest"
@@ -326,35 +237,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "foldhash"
@@ -372,27 +258,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -400,12 +271,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -436,13 +301,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -496,22 +358,6 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
-
-[[package]]
-name = "gif"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -574,6 +420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +438,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -602,11 +455,11 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.38",
+ "rustls 0.23.39",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -630,6 +483,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -742,34 +619,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "color_quant",
- "gif",
- "image-webp",
- "moxcms",
- "num-traits",
- "png",
- "zune-core",
- "zune-jpeg",
-]
-
-[[package]]
-name = "image-webp"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
-dependencies = [
- "byteorder-lite",
- "quick-error",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,12 +645,6 @@ dependencies = [
  "memchr",
  "serde",
 ]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -835,15 +678,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "litemap"
@@ -882,6 +719,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,26 +735,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "mio"
@@ -925,16 +748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,12 +755,6 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -965,36 +772,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openab"
-version = "0.8.1"
+name = "openab-gateway"
+version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
- "base64",
- "clap",
+ "axum",
+ "chrono",
  "futures-util",
- "image",
- "libc",
- "rand 0.8.5",
- "regex",
  "reqwest",
- "rpassword",
  "serde",
  "serde_json",
- "serenity",
- "tempfile",
  "tokio",
- "tokio-tungstenite",
- "toml",
+ "tokio-tungstenite 0.21.0",
  "tracing",
  "tracing-subscriber",
- "unicode-width",
  "uuid",
 ]
 
@@ -1034,19 +825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,12 +832,6 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1090,18 +862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,7 +873,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls 0.23.39",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -1133,7 +893,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls 0.23.39",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -1179,9 +939,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1246,18 +1006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,9 +1030,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1293,11 +1039,10 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.38",
+ "rustls 0.23.39",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1305,16 +1050,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1332,44 +1075,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rpassword"
-version = "7.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327b72899159dfae8060c51a1f6aebe955245bcd9cc4997eed0f623caea022e4"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "rustls"
@@ -1387,14 +1096,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -1422,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1448,16 +1157,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "secrecy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "serde",
- "zeroize",
-]
 
 [[package]]
 name = "semver"
@@ -1485,15 +1184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cow"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7bbbec7196bfde255ab54b65e34087c0849629280028238e67ee25d6a4b7da"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,12 +1208,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
+name = "serde_path_to_error"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
+ "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1536,37 +1228,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serenity"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bde37f42765dfdc34e2a039e0c84afbf79a3101c1941763b0beb816c2f17541"
-dependencies = [
- "arrayvec",
- "async-trait",
- "base64",
- "bitflags",
- "bytes",
- "dashmap",
- "flate2",
- "futures",
- "mime_guess",
- "parking_lot",
- "percent-encoding",
- "reqwest",
- "rustc-hash",
- "secrecy",
- "serde",
- "serde_cow",
- "serde_json",
- "time",
- "tokio",
- "tokio-tungstenite",
- "tracing",
- "typemap_rev",
- "url",
 ]
 
 [[package]]
@@ -1606,12 +1267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,12 +1293,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1680,19 +1329,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1745,37 +1381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,9 +1407,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -1845,7 +1450,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.38",
+ "rustls 0.23.39",
  "tokio",
 ]
 
@@ -1861,63 +1466,21 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
- "tungstenite",
+ "tungstenite 0.21.0",
  "webpki-roots 0.26.11",
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.18"
+name = "tokio-tungstenite"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
+ "futures-util",
+ "log",
  "tokio",
+ "tungstenite 0.29.0",
 ]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1932,6 +1495,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2009,16 +1573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,15 +1582,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -2057,7 +1608,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls 0.22.4",
  "rustls-pki-types",
  "sha1",
@@ -2067,34 +1618,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "typemap_rev"
-version = "0.3.0"
+name = "tungstenite"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -2118,7 +1667,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -2134,16 +1682,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2179,11 +1721,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2192,7 +1734,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2273,19 +1815,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2323,23 +1852,52 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
-name = "weezl"
-version = "0.1.12"
+name = "windows-core"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"
@@ -2348,19 +1906,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-sys"
-version = "0.52.0"
+name = "windows-result"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2513,15 +2080,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,6 +2087,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -2723,18 +2287,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
-dependencies = [
- "zune-core",
-]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "openab-gateway"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+axum = { version = "0.8", features = ["ws"] }
+tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
+futures-util = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+anyhow = "1"
+uuid = { version = "1", features = ["v4"] }
+chrono = { version = "0.4", features = ["serde"] }

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,14 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY gateway/Cargo.toml gateway/Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY gateway/src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /build/target/release/openab-gateway /usr/local/bin/openab-gateway
+EXPOSE 8080
+ENTRYPOINT ["openab-gateway"]

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -21,6 +21,8 @@ The gateway normalizes all inbound events to a unified schema (`openab.gateway.e
 
 For architecture details, see [ADR: Custom Gateway](../docs/adr/custom-gateway.md).
 
+> **Design note:** The gateway is intentionally NOT included in the OAB container image. It is a separate service with its own build, deployment, and scaling lifecycle. This follows the ADR principle that OAB remains outbound-only and platform-agnostic — all inbound webhook handling and platform credentials live in the gateway.
+
 ---
 
 ## Quick Start

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,21 +1,44 @@
 # OpenAB Custom Gateway
 
-Standalone gateway service that bridges webhook-based platforms (Telegram, LINE, GitHub, etc.) to OAB via WebSocket.
+A standalone service that bridges webhook-based platforms and custom event sources to OAB via WebSocket. OAB connects outbound to the gateway — no inbound ports or TLS required on OAB.
 
-See [ADR: Custom Gateway](../docs/adr/custom-gateway.md) for architecture details.
+```
+                External (HTTPS)                    Internal (cluster)
+                ────────────────                    ──────────────────
+
+Telegram  ──POST──▶ ┌─────────────────────┐
+LINE      ──POST──▶ │                     │
+GitHub    ──POST──▶ │   Custom Gateway    │ ◀──WebSocket── OAB Pod
+CI/CD     ──POST──▶ │     :8080           │    (OAB connects out)
+curl/cron ──POST──▶ │                     │
+                     └─────────────────────┘
+
+Discord  ◀──WebSocket── OAB Pod  (unchanged, direct)
+Slack    ◀──WebSocket── OAB Pod  (unchanged, direct)
+```
+
+The gateway normalizes all inbound events to a unified schema (`openab.gateway.event.v1`), forwards them to OAB over WebSocket, and routes OAB replies back to the originating platform API.
+
+For architecture details, see [ADR: Custom Gateway](../docs/adr/custom-gateway.md).
+
+---
 
 ## Quick Start
 
 ```bash
-# Build
 cargo build --release
-
-# Run (Telegram)
 export TELEGRAM_BOT_TOKEN="your-bot-token"
 ./target/release/openab-gateway
 ```
 
-## Environment Variables
+### OAB Config
+
+```toml
+[gateway]
+url = "ws://gateway:8080/ws"
+```
+
+### Environment Variables
 
 | Variable | Default | Description |
 |---|---|---|
@@ -23,7 +46,7 @@ export TELEGRAM_BOT_TOKEN="your-bot-token"
 | `GATEWAY_LISTEN` | `0.0.0.0:8080` | Listen address |
 | `TELEGRAM_WEBHOOK_PATH` | `/webhook/telegram` | Webhook endpoint path |
 
-## Endpoints
+### Endpoints
 
 | Path | Description |
 |---|---|
@@ -31,17 +54,78 @@ export TELEGRAM_BOT_TOKEN="your-bot-token"
 | `GET /ws` | WebSocket server (OAB connects here) |
 | `GET /health` | Health check |
 
-## OAB Config
+---
 
-```toml
-[gateway]
-url = "ws://gateway:8080/ws"
-```
+## Platform Setup
 
-## Setting Up the Telegram Webhook
+### Telegram
+
+1. Create a bot via [@BotFather](https://t.me/BotFather) and get the token.
+
+2. Start the gateway:
+   ```bash
+   export TELEGRAM_BOT_TOKEN="your-token"
+   ./target/release/openab-gateway
+   ```
+
+3. Expose the gateway over HTTPS (Telegram requires it). Easiest option — Cloudflare Tunnel:
+   ```bash
+   cloudflared tunnel --url http://localhost:8080
+   ```
+
+4. Set the webhook:
+   ```bash
+   curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook?url=https://your-host/webhook/telegram"
+   ```
+
+5. For supergroup forum topics (thread isolation like Discord), give the bot **Manage Topics** permission in the group settings.
+
+### LINE (TBD)
+
+LINE adapter is planned. It will follow the same pattern:
+- Webhook at `/webhook/line`
+- Signature validation via `X-Line-Signature` header
+- Reply via LINE Push Message API
+
+See [ADR: LINE Adapter](../docs/adr/line-adapter.md) for the design.
+
+### Other Platforms (TBD)
+
+GitHub webhooks, CI/CD events, monitoring alerts — any HTTP event source can be added as a gateway adapter. See the ADR for the adapter interface.
+
+---
+
+## Custom Event Source
+
+Any HTTP client can drive an OAB agent session by posting to the webhook endpoint. This turns OAB into an event-driven agent platform — no chat app required.
+
+### Example: trigger an agent from a cron job
 
 ```bash
-curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook?url=https://your-gateway-host/webhook/telegram"
+curl -X POST http://gateway:8080/webhook/telegram \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": {
+      "message_id": 1,
+      "chat": {"id": 12345, "type": "private"},
+      "from": {"id": 99, "first_name": "CronJob", "username": "scheduler", "is_bot": false},
+      "text": "run daily security scan on staging"
+    }
+  }'
 ```
 
-> **Note:** Telegram requires HTTPS. Use a reverse proxy, Cloudflare Tunnel, or similar for TLS termination.
+### Example: generic event (future `/webhook/custom` endpoint)
+
+Once a generic webhook adapter is added, any JSON payload can trigger an agent:
+
+```bash
+curl -X POST http://gateway:8080/webhook/custom \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "ops-alerts",
+    "sender": "cloudwatch",
+    "text": "CPU > 90% on prod-api-3 for 5 minutes, investigate and suggest fix"
+  }'
+```
+
+The agent response is delivered back through the gateway to whatever reply mechanism the adapter defines — Telegram message, GitHub comment, Slack DM, PagerDuty note, or simply logged.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,0 +1,47 @@
+# OpenAB Custom Gateway
+
+Standalone gateway service that bridges webhook-based platforms (Telegram, LINE, GitHub, etc.) to OAB via WebSocket.
+
+See [ADR: Custom Gateway](../docs/adr/custom-gateway.md) for architecture details.
+
+## Quick Start
+
+```bash
+# Build
+cargo build --release
+
+# Run (Telegram)
+export TELEGRAM_BOT_TOKEN="your-bot-token"
+./target/release/openab-gateway
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `TELEGRAM_BOT_TOKEN` | (required) | Telegram Bot API token |
+| `GATEWAY_LISTEN` | `0.0.0.0:8080` | Listen address |
+| `TELEGRAM_WEBHOOK_PATH` | `/webhook/telegram` | Webhook endpoint path |
+
+## Endpoints
+
+| Path | Description |
+|---|---|
+| `POST /webhook/telegram` | Telegram webhook receiver |
+| `GET /ws` | WebSocket server (OAB connects here) |
+| `GET /health` | Health check |
+
+## OAB Config
+
+```toml
+[gateway]
+url = "ws://gateway:8080/ws"
+```
+
+## Setting Up the Telegram Webhook
+
+```bash
+curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook?url=https://your-gateway-host/webhook/telegram"
+```
+
+> **Note:** Telegram requires HTTPS. Use a reverse proxy, Cloudflare Tunnel, or similar for TLS termination.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -3,15 +3,15 @@
 A standalone service that bridges webhook-based platforms and custom event sources to OAB via WebSocket. OAB connects outbound to the gateway — no inbound ports or TLS required on OAB.
 
 ```
-                External (HTTPS)                    Internal (cluster)
-                ────────────────                    ──────────────────
+                 External (HTTPS)                    Internal (cluster)
+                 ────────────────                    ──────────────────
 
-Telegram  ──POST──▶ ┌─────────────────────┐
-LINE      ──POST──▶ │                     │
-GitHub    ──POST──▶ │   Custom Gateway    │ ◀──WebSocket── OAB Pod
-CI/CD     ──POST──▶ │     :8080           │    (OAB connects out)
-curl/cron ──POST──▶ │                     │
-                     └─────────────────────┘
+Telegram  ──POST──▶┌─────────────────────┐
+LINE      ──POST──▶│                     │
+GitHub    ──POST──▶│   Custom Gateway    │◀──WebSocket── OAB Pod
+CI/CD     ──POST──▶│     :8080           │   (OAB connects out)
+curl/cron ──POST──▶│                     │
+                    └─────────────────────┘
 
 Discord  ◀──WebSocket── OAB Pod  (unchanged, direct)
 Slack    ◀──WebSocket── OAB Pod  (unchanged, direct)

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -132,8 +132,6 @@ struct AppState {
     ws_token: Option<String>,
     /// Broadcast channel: gateway → OAB (events)
     event_tx: broadcast::Sender<String>,
-    /// Collected reply senders from connected OAB clients
-    reply_handlers: Mutex<Vec<tokio::sync::mpsc::Sender<GatewayReply>>>,
 }
 
 // --- Telegram webhook handler ---
@@ -247,7 +245,6 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
 
     // Channel for replies from this OAB client
     let (reply_tx, mut reply_rx) = tokio::sync::mpsc::channel::<GatewayReply>(64);
-    state.reply_handlers.lock().await.push(reply_tx);
 
     info!("OAB client connected via WebSocket");
 
@@ -397,7 +394,6 @@ async fn main() -> Result<()> {
         secret_token,
         ws_token,
         event_tx,
-        reply_handlers: Mutex::new(Vec::new()),
     });
 
     let app = Router::new()

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -1,0 +1,358 @@
+use anyhow::Result;
+use axum::{
+    Json, Router,
+    extract::State,
+    routing::{get, post},
+};
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::{broadcast, Mutex};
+use tracing::{error, info, warn};
+
+// --- Event schema (ADR openab.gateway.event.v1) ---
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GatewayEvent {
+    pub schema: String,
+    pub event_id: String,
+    pub timestamp: String,
+    pub platform: String,
+    pub event_type: String,
+    pub channel: ChannelInfo,
+    pub sender: SenderInfo,
+    pub content: Content,
+    pub message_id: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ChannelInfo {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub channel_type: String,
+    pub thread_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SenderInfo {
+    pub id: String,
+    pub name: String,
+    pub display_name: String,
+    pub is_bot: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Content {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    pub text: String,
+}
+
+// --- Reply schema (ADR openab.gateway.reply.v1) ---
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GatewayReply {
+    pub schema: String,
+    pub reply_to: String,
+    pub platform: String,
+    pub channel: ReplyChannel,
+    pub content: Content,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub request_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReplyChannel {
+    pub id: String,
+    pub thread_id: Option<String>,
+}
+
+/// Response from gateway back to OAB for commands (e.g. create_topic)
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GatewayResponse {
+    pub schema: String,
+    pub request_id: String,
+    pub success: bool,
+    pub thread_id: Option<String>,
+    pub error: Option<String>,
+}
+
+// --- Telegram types (minimal) ---
+
+#[derive(Debug, Deserialize)]
+struct TelegramUpdate {
+    message: Option<TelegramMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramMessage {
+    message_id: i64,
+    message_thread_id: Option<i64>,
+    chat: TelegramChat,
+    from: Option<TelegramUser>,
+    text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramChat {
+    id: i64,
+    #[serde(rename = "type")]
+    chat_type: String,
+    is_forum: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramUser {
+    id: i64,
+    first_name: String,
+    last_name: Option<String>,
+    username: Option<String>,
+    is_bot: bool,
+}
+
+// --- App state ---
+
+struct AppState {
+    bot_token: String,
+    /// Broadcast channel: gateway → OAB (events)
+    event_tx: broadcast::Sender<String>,
+    /// Collected reply senders from connected OAB clients
+    reply_handlers: Mutex<Vec<tokio::sync::mpsc::Sender<GatewayReply>>>,
+}
+
+// --- Telegram webhook handler ---
+
+async fn telegram_webhook(
+    State(state): State<Arc<AppState>>,
+    Json(update): Json<TelegramUpdate>,
+) -> &'static str {
+    let Some(msg) = update.message else {
+        return "ok";
+    };
+    let Some(text) = msg.text.as_deref() else {
+        return "ok";
+    };
+    // Skip empty messages
+    if text.trim().is_empty() {
+        return "ok";
+    }
+
+    let from = msg.from.as_ref();
+    let sender_name = from
+        .and_then(|u| u.username.as_deref())
+        .unwrap_or("unknown");
+    let display_name = from
+        .map(|u| {
+            let mut n = u.first_name.clone();
+            if let Some(last) = &u.last_name {
+                n.push(' ');
+                n.push_str(last);
+            }
+            n
+        })
+        .unwrap_or_else(|| "Unknown".into());
+
+    let event = GatewayEvent {
+        schema: "openab.gateway.event.v1".into(),
+        event_id: format!("evt_{}", uuid::Uuid::new_v4()),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        platform: "telegram".into(),
+        event_type: "message".into(),
+        channel: ChannelInfo {
+            id: msg.chat.id.to_string(),
+            channel_type: msg.chat.chat_type.clone(),
+            thread_id: msg.message_thread_id.map(|id| id.to_string()),
+        },
+        sender: SenderInfo {
+            id: from.map(|u| u.id.to_string()).unwrap_or_default(),
+            name: sender_name.into(),
+            display_name,
+            is_bot: from.map(|u| u.is_bot).unwrap_or(false),
+        },
+        content: Content {
+            content_type: "text".into(),
+            text: text.into(),
+        },
+        message_id: msg.message_id.to_string(),
+    };
+
+    let json = serde_json::to_string(&event).unwrap();
+    info!(chat_id = %msg.chat.id, sender = %sender_name, "telegram → gateway");
+    let _ = state.event_tx.send(json);
+    "ok"
+}
+
+// --- WebSocket handler (OAB connects here) ---
+
+async fn ws_handler(
+    State(state): State<Arc<AppState>>,
+    ws: axum::extract::WebSocketUpgrade,
+) -> axum::response::Response {
+    ws.on_upgrade(move |socket| handle_oab_connection(state, socket))
+}
+
+async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::WebSocket) {
+    use axum::extract::ws::Message;
+
+    let (mut ws_tx, mut ws_rx) = socket.split();
+    let mut event_rx = state.event_tx.subscribe();
+
+    // Channel for replies from this OAB client
+    let (reply_tx, mut reply_rx) = tokio::sync::mpsc::channel::<GatewayReply>(64);
+    state.reply_handlers.lock().await.push(reply_tx);
+
+    info!("OAB client connected via WebSocket");
+
+    // Forward gateway events → OAB
+    let send_task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                Ok(event_json) = event_rx.recv() => {
+                    if ws_tx.send(Message::Text(event_json.into())).await.is_err() {
+                        break;
+                    }
+                }
+                // No reply forwarding needed on this path — replies go to Telegram directly
+            }
+        }
+    });
+
+    // Receive OAB replies → Telegram
+    let bot_token = state.bot_token.clone();
+    let event_tx_for_recv = state.event_tx.clone();
+    let recv_task = tokio::spawn(async move {
+        let client = reqwest::Client::new();
+        while let Some(Ok(msg)) = ws_rx.next().await {
+            if let Message::Text(text) = msg {
+                match serde_json::from_str::<GatewayReply>(&text) {
+                    Ok(reply) => {
+                        // Handle create_topic command
+                        if reply.command.as_deref() == Some("create_topic") {
+                            let req_id = reply.request_id.clone().unwrap_or_default();
+                            info!(chat_id = %reply.channel.id, "creating forum topic");
+                            let url = format!(
+                                "https://api.telegram.org/bot{}/createForumTopic",
+                                bot_token
+                            );
+                            let resp = client
+                                .post(&url)
+                                .json(&serde_json::json!({
+                                    "chat_id": reply.channel.id,
+                                    "name": reply.content.text,
+                                }))
+                                .send()
+                                .await;
+                            let gw_resp = match resp {
+                                Ok(r) => {
+                                    let body: serde_json::Value = r.json().await.unwrap_or_default();
+                                    if body["ok"].as_bool() == Some(true) {
+                                        let tid = body["result"]["message_thread_id"].as_i64()
+                                            .map(|id| id.to_string());
+                                        info!(thread_id = ?tid, "forum topic created");
+                                        GatewayResponse {
+                                            schema: "openab.gateway.response.v1".into(),
+                                            request_id: req_id,
+                                            success: true,
+                                            thread_id: tid,
+                                            error: None,
+                                        }
+                                    } else {
+                                        let err = body["description"].as_str()
+                                            .unwrap_or("unknown error").to_string();
+                                        warn!(err = %err, "createForumTopic failed");
+                                        GatewayResponse {
+                                            schema: "openab.gateway.response.v1".into(),
+                                            request_id: req_id,
+                                            success: false,
+                                            thread_id: None,
+                                            error: Some(err),
+                                        }
+                                    }
+                                }
+                                Err(e) => GatewayResponse {
+                                    schema: "openab.gateway.response.v1".into(),
+                                    request_id: req_id,
+                                    success: false,
+                                    thread_id: None,
+                                    error: Some(e.to_string()),
+                                },
+                            };
+                            // Send response back — need to use event_tx broadcast
+                            let json = serde_json::to_string(&gw_resp).unwrap();
+                            let _ = event_tx_for_recv.send(json);
+                            continue;
+                        }
+
+                        // Normal send_message
+                        info!(chat_id = %reply.channel.id, thread_id = ?reply.channel.thread_id, "gateway → telegram");
+                        let url = format!(
+                            "https://api.telegram.org/bot{}/sendMessage",
+                            bot_token
+                        );
+                        let _ = client
+                            .post(&url)
+                            .json(&serde_json::json!({
+                                "chat_id": reply.channel.id,
+                                "text": reply.content.text,
+                                "message_thread_id": reply.channel.thread_id,
+                            }))
+                            .send()
+                            .await
+                            .map_err(|e| error!("telegram send error: {e}"));
+                    }
+                    Err(e) => warn!("invalid reply from OAB: {e}"),
+                }
+            }
+        }
+    });
+
+    tokio::select! {
+        _ = send_task => {},
+        _ = recv_task => {},
+    }
+    info!("OAB client disconnected");
+}
+
+// --- Health check ---
+
+async fn health() -> &'static str {
+    "ok"
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let bot_token = std::env::var("TELEGRAM_BOT_TOKEN")
+        .expect("TELEGRAM_BOT_TOKEN must be set");
+    let listen_addr = std::env::var("GATEWAY_LISTEN")
+        .unwrap_or_else(|_| "0.0.0.0:8080".into());
+    let webhook_path = std::env::var("TELEGRAM_WEBHOOK_PATH")
+        .unwrap_or_else(|_| "/webhook/telegram".into());
+
+    let (event_tx, _) = broadcast::channel::<String>(256);
+
+    let state = Arc::new(AppState {
+        bot_token,
+        event_tx,
+        reply_handlers: Mutex::new(Vec::new()),
+    });
+
+    let app = Router::new()
+        .route(&webhook_path, post(telegram_webhook))
+        .route("/ws", get(ws_handler))
+        .route("/health", get(health))
+        .with_state(state);
+
+    info!(addr = %listen_addr, webhook = %webhook_path, "gateway starting");
+    let listener = tokio::net::TcpListener::bind(&listen_addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use axum::{
     extract::State,
+    response::IntoResponse,
     routing::{get, post},
     Json, Router,
 };
@@ -128,6 +129,7 @@ struct TelegramUser {
 struct AppState {
     bot_token: String,
     secret_token: Option<String>,
+    ws_token: Option<String>,
     /// Broadcast channel: gateway → OAB (events)
     event_tx: broadcast::Sender<String>,
     /// Collected reply senders from connected OAB clients
@@ -223,8 +225,17 @@ async fn telegram_webhook(
 
 async fn ws_handler(
     State(state): State<Arc<AppState>>,
+    query: axum::extract::Query<std::collections::HashMap<String, String>>,
     ws: axum::extract::WebSocketUpgrade,
 ) -> axum::response::Response {
+    // Validate WS token if configured
+    if let Some(ref expected) = state.ws_token {
+        let provided = query.get("token").map(|s| s.as_str());
+        if provided != Some(expected.as_str()) {
+            warn!("WebSocket rejected: invalid or missing token");
+            return axum::http::StatusCode::UNAUTHORIZED.into_response();
+        }
+    }
     ws.on_upgrade(move |socket| handle_oab_connection(state, socket))
 }
 
@@ -367,6 +378,7 @@ async fn main() -> Result<()> {
 
     let bot_token = std::env::var("TELEGRAM_BOT_TOKEN").expect("TELEGRAM_BOT_TOKEN must be set");
     let secret_token = std::env::var("TELEGRAM_SECRET_TOKEN").ok();
+    let ws_token = std::env::var("GATEWAY_WS_TOKEN").ok();
     let listen_addr = std::env::var("GATEWAY_LISTEN").unwrap_or_else(|_| "0.0.0.0:8080".into());
     let webhook_path =
         std::env::var("TELEGRAM_WEBHOOK_PATH").unwrap_or_else(|_| "/webhook/telegram".into());
@@ -374,12 +386,16 @@ async fn main() -> Result<()> {
     if secret_token.is_none() {
         warn!("TELEGRAM_SECRET_TOKEN not set — webhook requests are NOT validated (insecure)");
     }
+    if ws_token.is_none() {
+        warn!("GATEWAY_WS_TOKEN not set — WebSocket connections are NOT authenticated (insecure)");
+    }
 
     let (event_tx, _) = broadcast::channel::<String>(256);
 
     let state = Arc::new(AppState {
         bot_token,
         secret_token,
+        ws_token,
         event_tx,
         reply_handlers: Mutex::new(Vec::new()),
     });

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -22,6 +22,7 @@ pub struct GatewayEvent {
     pub channel: ChannelInfo,
     pub sender: SenderInfo,
     pub content: Content,
+    pub mentions: Vec<String>,
     pub message_id: String,
 }
 
@@ -93,6 +94,16 @@ struct TelegramMessage {
     chat: TelegramChat,
     from: Option<TelegramUser>,
     text: Option<String>,
+    #[serde(default)]
+    entities: Vec<TelegramEntity>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramEntity {
+    #[serde(rename = "type")]
+    entity_type: String,
+    offset: usize,
+    length: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -116,6 +127,7 @@ struct TelegramUser {
 
 struct AppState {
     bot_token: String,
+    secret_token: Option<String>,
     /// Broadcast channel: gateway → OAB (events)
     event_tx: broadcast::Sender<String>,
     /// Collected reply senders from connected OAB clients
@@ -126,17 +138,28 @@ struct AppState {
 
 async fn telegram_webhook(
     State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
     Json(update): Json<TelegramUpdate>,
-) -> &'static str {
+) -> axum::http::StatusCode {
+    // Validate secret_token if configured
+    if let Some(ref expected) = state.secret_token {
+        let provided = headers
+            .get("x-telegram-bot-api-secret-token")
+            .and_then(|v| v.to_str().ok());
+        if provided != Some(expected.as_str()) {
+            warn!("webhook rejected: invalid or missing secret_token");
+            return axum::http::StatusCode::UNAUTHORIZED;
+        }
+    }
     let Some(msg) = update.message else {
-        return "ok";
+        return axum::http::StatusCode::OK;
     };
     let Some(text) = msg.text.as_deref() else {
-        return "ok";
+        return axum::http::StatusCode::OK;
     };
     // Skip empty messages
     if text.trim().is_empty() {
-        return "ok";
+        return axum::http::StatusCode::OK;
     }
 
     let from = msg.from.as_ref();
@@ -153,6 +176,17 @@ async fn telegram_webhook(
             n
         })
         .unwrap_or_else(|| "Unknown".into());
+
+    // Extract @mentions from entities
+    let mentions: Vec<String> = msg
+        .entities
+        .iter()
+        .filter(|e| e.entity_type == "mention")
+        .filter_map(|e| {
+            text.get(e.offset..e.offset + e.length)
+                .map(|s| s.trim_start_matches('@').to_string())
+        })
+        .collect();
 
     let event = GatewayEvent {
         schema: "openab.gateway.event.v1".into(),
@@ -175,13 +209,14 @@ async fn telegram_webhook(
             content_type: "text".into(),
             text: text.into(),
         },
+        mentions,
         message_id: msg.message_id.to_string(),
     };
 
     let json = serde_json::to_string(&event).unwrap();
     info!(chat_id = %msg.chat.id, sender = %sender_name, "telegram → gateway");
     let _ = state.event_tx.send(json);
-    "ok"
+    axum::http::StatusCode::OK
 }
 
 // --- WebSocket handler (OAB connects here) ---
@@ -332,15 +367,21 @@ async fn main() -> Result<()> {
 
     let bot_token = std::env::var("TELEGRAM_BOT_TOKEN")
         .expect("TELEGRAM_BOT_TOKEN must be set");
+    let secret_token = std::env::var("TELEGRAM_SECRET_TOKEN").ok();
     let listen_addr = std::env::var("GATEWAY_LISTEN")
         .unwrap_or_else(|_| "0.0.0.0:8080".into());
     let webhook_path = std::env::var("TELEGRAM_WEBHOOK_PATH")
         .unwrap_or_else(|_| "/webhook/telegram".into());
 
+    if secret_token.is_none() {
+        warn!("TELEGRAM_SECRET_TOKEN not set — webhook requests are NOT validated (insecure)");
+    }
+
     let (event_tx, _) = broadcast::channel::<String>(256);
 
     let state = Arc::new(AppState {
         bot_token,
+        secret_token,
         event_tx,
         reply_handlers: Mutex::new(Vec::new()),
     });

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use axum::{
-    Json, Router,
     extract::State,
     routing::{get, post},
+    Json, Router,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -281,9 +281,11 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                                 .await;
                             let gw_resp = match resp {
                                 Ok(r) => {
-                                    let body: serde_json::Value = r.json().await.unwrap_or_default();
+                                    let body: serde_json::Value =
+                                        r.json().await.unwrap_or_default();
                                     if body["ok"].as_bool() == Some(true) {
-                                        let tid = body["result"]["message_thread_id"].as_i64()
+                                        let tid = body["result"]["message_thread_id"]
+                                            .as_i64()
                                             .map(|id| id.to_string());
                                         info!(thread_id = ?tid, "forum topic created");
                                         GatewayResponse {
@@ -294,8 +296,10 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                                             error: None,
                                         }
                                     } else {
-                                        let err = body["description"].as_str()
-                                            .unwrap_or("unknown error").to_string();
+                                        let err = body["description"]
+                                            .as_str()
+                                            .unwrap_or("unknown error")
+                                            .to_string();
                                         warn!(err = %err, "createForumTopic failed");
                                         GatewayResponse {
                                             schema: "openab.gateway.response.v1".into(),
@@ -322,10 +326,7 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
 
                         // Normal send_message
                         info!(chat_id = %reply.channel.id, thread_id = ?reply.channel.thread_id, "gateway → telegram");
-                        let url = format!(
-                            "https://api.telegram.org/bot{}/sendMessage",
-                            bot_token
-                        );
+                        let url = format!("https://api.telegram.org/bot{}/sendMessage", bot_token);
                         let _ = client
                             .post(&url)
                             .json(&serde_json::json!({
@@ -360,18 +361,15 @@ async fn health() -> &'static str {
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .init();
 
-    let bot_token = std::env::var("TELEGRAM_BOT_TOKEN")
-        .expect("TELEGRAM_BOT_TOKEN must be set");
+    let bot_token = std::env::var("TELEGRAM_BOT_TOKEN").expect("TELEGRAM_BOT_TOKEN must be set");
     let secret_token = std::env::var("TELEGRAM_SECRET_TOKEN").ok();
-    let listen_addr = std::env::var("GATEWAY_LISTEN")
-        .unwrap_or_else(|_| "0.0.0.0:8080".into());
-    let webhook_path = std::env::var("TELEGRAM_WEBHOOK_PATH")
-        .unwrap_or_else(|_| "/webhook/telegram".into());
+    let listen_addr = std::env::var("GATEWAY_LISTEN").unwrap_or_else(|_| "0.0.0.0:8080".into());
+    let webhook_path =
+        std::env::var("TELEGRAM_WEBHOOK_PATH").unwrap_or_else(|_| "/webhook/telegram".into());
 
     if secret_token.is_none() {
         warn!("TELEGRAM_SECRET_TOKEN not set — webhook requests are NOT validated (insecure)");

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ impl<'de> Deserialize<'de> for AllowBots {
 pub struct Config {
     pub discord: Option<DiscordConfig>,
     pub slack: Option<SlackConfig>,
+    pub gateway: Option<GatewayConfig>,
     pub agent: AgentConfig,
     #[serde(default)]
     pub pool: PoolConfig,
@@ -157,6 +158,12 @@ pub struct SlackConfig {
     /// Human message resets the counter. Default: 20.
     #[serde(default = "default_max_bot_turns")]
     pub max_bot_turns: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GatewayConfig {
+    /// WebSocket URL of the custom gateway (e.g. ws://gateway:8080/ws)
+    pub url: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,6 +164,15 @@ pub struct SlackConfig {
 pub struct GatewayConfig {
     /// WebSocket URL of the custom gateway (e.g. ws://gateway:8080/ws)
     pub url: String,
+    /// Platform name for session key namespacing (e.g. "telegram", "line")
+    #[serde(default = "default_gateway_platform")]
+    pub platform: String,
+    /// Shared token for WebSocket authentication (optional but recommended)
+    pub token: Option<String>,
+}
+
+fn default_gateway_platform() -> String {
+    "telegram".into()
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -17,6 +17,8 @@ struct GatewayEvent {
     schema: String,
     #[allow(dead_code)]
     event_id: String,
+    #[allow(dead_code)]
+    timestamp: String,
     platform: String,
     channel: GwChannel,
     sender: GwSender,
@@ -276,6 +278,7 @@ pub async fn run_gateway_adapter(
         let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
         let adapter: Arc<dyn ChatAdapter> =
             Arc::new(GatewayAdapter::new(ws_tx, pending.clone(), platform));
+        let mut tasks: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
 
         loop {
             tokio::select! {
@@ -314,7 +317,7 @@ pub async fn run_gateway_adapter(
                                     };
 
                                     let sender_ctx = SenderContext {
-                                        schema: "sender.v1".into(),
+                                        schema: "openab.sender.v1".into(),
                                         sender_id: event.sender.id.clone(),
                                         sender_name: event.sender.name.clone(),
                                         display_name: event.sender.display_name.clone(),
@@ -335,7 +338,7 @@ pub async fn run_gateway_adapter(
                                     let router = router.clone();
                                     let prompt = event.content.text.clone();
 
-                                    tokio::spawn(async move {
+                                    tasks.spawn(async move {
                                         // If supergroup with no thread_id, create a forum topic
                                         let thread_channel = if event.channel.channel_type == "supergroup"
                                             && channel.thread_id.is_none()
@@ -384,12 +387,16 @@ pub async fn run_gateway_adapter(
                 }
                 _ = shutdown_rx.changed() => {
                     if *shutdown_rx.borrow() {
-                        info!("gateway adapter shutting down");
+                        info!("gateway adapter shutting down, waiting for {} in-flight tasks", tasks.len());
+                        while tasks.join_next().await.is_some() {}
                         return Ok(());
                     }
                 }
             }
         } // inner loop — break here means reconnect
+
+        // Drain in-flight tasks before reconnecting
+        while tasks.join_next().await.is_some() {}
 
         warn!(backoff = backoff_secs, "reconnecting to gateway");
         tokio::select! {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1,4 +1,4 @@
-use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, MessageRef, SenderContext};
+use crate::adapter::{AdapterRouter, ChannelRef, ChatAdapter, MessageRef, SenderContext};
 use anyhow::Result;
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
@@ -91,17 +91,23 @@ struct GatewayResponse {
 type PendingRequests = Arc<Mutex<HashMap<String, tokio::sync::oneshot::Sender<GatewayResponse>>>>;
 
 pub struct GatewayAdapter {
-    ws_tx: Mutex<futures_util::stream::SplitSink<
-        tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
-        Message,
-    >>,
+    ws_tx: Mutex<
+        futures_util::stream::SplitSink<
+            tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+            >,
+            Message,
+        >,
+    >,
     pending: PendingRequests,
 }
 
 impl GatewayAdapter {
     fn new(
         ws_tx: futures_util::stream::SplitSink<
-            tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+            tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+            >,
             Message,
         >,
         pending: PendingRequests,
@@ -178,18 +184,20 @@ impl ChatAdapter for GatewayAdapter {
             request_id: Some(req_id.clone()),
         };
         let json = serde_json::to_string(&reply)?;
-        self.ws_tx.lock().await.send(Message::Text(json.into())).await?;
+        self.ws_tx
+            .lock()
+            .await
+            .send(Message::Text(json.into()))
+            .await?;
 
         // Wait for response (5s timeout)
         match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
-            Ok(Ok(resp)) if resp.success => {
-                Ok(ChannelRef {
-                    platform: channel.platform.clone(),
-                    channel_id: channel.channel_id.clone(),
-                    thread_id: resp.thread_id,
-                    parent_id: None,
-                })
-            }
+            Ok(Ok(resp)) if resp.success => Ok(ChannelRef {
+                platform: channel.platform.clone(),
+                channel_id: channel.channel_id.clone(),
+                thread_id: resp.thread_id,
+                parent_id: None,
+            }),
             Ok(Ok(resp)) => {
                 warn!(err = ?resp.error, "create_topic failed, falling back to same channel");
                 Ok(channel.clone())
@@ -257,117 +265,117 @@ pub async fn run_gateway_adapter(
 
         loop {
             tokio::select! {
-                msg = ws_rx.next() => {
-                    match msg {
-                        Some(Ok(Message::Text(text))) => {
-                            let text_str: &str = &text;
+                    msg = ws_rx.next() => {
+                        match msg {
+                            Some(Ok(Message::Text(text))) => {
+                                let text_str: &str = &text;
 
-                            // Check if it's a response to a pending command
-                            if let Ok(resp) = serde_json::from_str::<GatewayResponse>(text_str) {
-                            if resp.schema == "openab.gateway.response.v1" {
-                                if let Some(tx) = pending.lock().await.remove(&resp.request_id) {
-                                    let _ = tx.send(resp);
+                                // Check if it's a response to a pending command
+                                if let Ok(resp) = serde_json::from_str::<GatewayResponse>(text_str) {
+                                if resp.schema == "openab.gateway.response.v1" {
+                                    if let Some(tx) = pending.lock().await.remove(&resp.request_id) {
+                                        let _ = tx.send(resp);
+                                    }
+                                    continue;
                                 }
-                                continue;
                             }
-                        }
 
-                        match serde_json::from_str::<GatewayEvent>(text_str) {
-                            Ok(event) => {
-                                if event.sender.is_bot {
-                                    continue; // skip bot messages
-                                }
-                                info!(
-                                    platform = %event.platform,
-                                    sender = %event.sender.name,
-                                    channel = %event.channel.id,
-                                    "gateway event received"
-                                );
+                            match serde_json::from_str::<GatewayEvent>(text_str) {
+                                Ok(event) => {
+                                    if event.sender.is_bot {
+                                        continue; // skip bot messages
+                                    }
+                                    info!(
+                                        platform = %event.platform,
+                                        sender = %event.sender.name,
+                                        channel = %event.channel.id,
+                                        "gateway event received"
+                                    );
 
-                                let channel = ChannelRef {
-                                    platform: event.platform.clone(),
-                                    channel_id: event.channel.id.clone(),
-                                    thread_id: event.channel.thread_id.clone(),
-                                    parent_id: None,
-                                };
-
-                                let sender_ctx = SenderContext {
-                                    schema: "sender.v1".into(),
-                                    sender_id: event.sender.id.clone(),
-                                    sender_name: event.sender.name.clone(),
-                                    display_name: event.sender.display_name.clone(),
-                                    channel: event.channel.channel_type.clone(),
-                                    channel_id: event.channel.id.clone(),
-                                    thread_id: event.channel.thread_id.clone(),
-                                    is_bot: event.sender.is_bot,
-                                };
-                                let sender_json = serde_json::to_string(&sender_ctx)
-                                    .unwrap_or_default();
-
-                                let trigger_msg = MessageRef {
-                                    channel: channel.clone(),
-                                    message_id: event.message_id.clone(),
-                                };
-
-                                let adapter = adapter.clone();
-                                let router = router.clone();
-                                let prompt = event.content.text.clone();
-
-                                tokio::spawn(async move {
-                                    // If supergroup with no thread_id, create a forum topic
-                                    let thread_channel = if event.channel.channel_type == "supergroup"
-                                        && channel.thread_id.is_none()
-                                    {
-                                        let title = crate::format::shorten_thread_name(&prompt);
-                                        match adapter.create_thread(&channel, &trigger_msg, &title).await {
-                                            Ok(tc) => tc,
-                                            Err(e) => {
-                                                warn!("create_thread failed, using channel: {e}");
-                                                channel.clone()
-                                            }
-                                        }
-                                    } else {
-                                        channel.clone()
+                                    let channel = ChannelRef {
+                                        platform: event.platform.clone(),
+                                        channel_id: event.channel.id.clone(),
+                                        thread_id: event.channel.thread_id.clone(),
+                                        parent_id: None,
                                     };
 
-                                    if let Err(e) = router
-                                        .handle_message(
-                                            &adapter,
-                                            &thread_channel,
-                                            &sender_json,
-                                            &prompt,
-                                            vec![],
-                                            &trigger_msg,
-                                            false,
-                                        )
-                                        .await
-                                    {
-                                        error!("gateway message handling error: {e}");
-                                    }
-                                });
+                                    let sender_ctx = SenderContext {
+                                        schema: "sender.v1".into(),
+                                        sender_id: event.sender.id.clone(),
+                                        sender_name: event.sender.name.clone(),
+                                        display_name: event.sender.display_name.clone(),
+                                        channel: event.channel.channel_type.clone(),
+                                        channel_id: event.channel.id.clone(),
+                                        thread_id: event.channel.thread_id.clone(),
+                                        is_bot: event.sender.is_bot,
+                                    };
+                                    let sender_json = serde_json::to_string(&sender_ctx)
+                                        .unwrap_or_default();
+
+                                    let trigger_msg = MessageRef {
+                                        channel: channel.clone(),
+                                        message_id: event.message_id.clone(),
+                                    };
+
+                                    let adapter = adapter.clone();
+                                    let router = router.clone();
+                                    let prompt = event.content.text.clone();
+
+                                    tokio::spawn(async move {
+                                        // If supergroup with no thread_id, create a forum topic
+                                        let thread_channel = if event.channel.channel_type == "supergroup"
+                                            && channel.thread_id.is_none()
+                                        {
+                                            let title = crate::format::shorten_thread_name(&prompt);
+                                            match adapter.create_thread(&channel, &trigger_msg, &title).await {
+                                                Ok(tc) => tc,
+                                                Err(e) => {
+                                                    warn!("create_thread failed, using channel: {e}");
+                                                    channel.clone()
+                                                }
+                                            }
+                                        } else {
+                                            channel.clone()
+                                        };
+
+                                        if let Err(e) = router
+                                            .handle_message(
+                                                &adapter,
+                                                &thread_channel,
+                                                &sender_json,
+                                                &prompt,
+                                                vec![],
+                                                &trigger_msg,
+                                                false,
+                                            )
+                                            .await
+                                        {
+                                            error!("gateway message handling error: {e}");
+                                        }
+                                    });
+                                }
+                                Err(e) => warn!("invalid gateway event: {e}"),
                             }
-                            Err(e) => warn!("invalid gateway event: {e}"),
                         }
+                        Some(Ok(Message::Close(_))) | None => {
+                            warn!("gateway WebSocket closed, will reconnect");
+                            break;
+                        }
+                        Some(Err(e)) => {
+                            error!("gateway WebSocket error: {e}, will reconnect");
+                            break;
+                        }
+                        _ => {}
                     }
-                    Some(Ok(Message::Close(_))) | None => {
-                        warn!("gateway WebSocket closed, will reconnect");
-                        break;
+                }
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        info!("gateway adapter shutting down");
+                        return Ok(());
                     }
-                    Some(Err(e)) => {
-                        error!("gateway WebSocket error: {e}, will reconnect");
-                        break;
-                    }
-                    _ => {}
                 }
             }
-            _ = shutdown_rx.changed() => {
-                if *shutdown_rx.borrow() {
-                    info!("gateway adapter shutting down");
-                    return Ok(());
-                }
-            }
-        }
-    } // inner loop — break here means reconnect
+        } // inner loop — break here means reconnect
 
         warn!(backoff = backoff_secs, "reconnecting to gateway");
         tokio::select! {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1,0 +1,346 @@
+use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, MessageRef, SenderContext};
+use anyhow::Result;
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio_tungstenite::tungstenite::Message;
+use tracing::{error, info, warn};
+
+// --- Gateway event/reply schemas (mirrors gateway service) ---
+
+#[derive(Clone, Debug, Deserialize)]
+struct GatewayEvent {
+    #[allow(dead_code)]
+    schema: String,
+    event_id: String,
+    platform: String,
+    channel: GwChannel,
+    sender: GwSender,
+    content: GwContent,
+    message_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GwChannel {
+    id: String,
+    #[serde(rename = "type")]
+    channel_type: String,
+    thread_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GwSender {
+    id: String,
+    name: String,
+    display_name: String,
+    is_bot: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GwContent {
+    #[allow(dead_code)]
+    #[serde(rename = "type")]
+    content_type: String,
+    text: String,
+}
+
+#[derive(Serialize)]
+struct GatewayReply {
+    schema: String,
+    reply_to: String,
+    platform: String,
+    channel: ReplyChannel,
+    content: ReplyContent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ReplyChannel {
+    id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thread_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ReplyContent {
+    #[serde(rename = "type")]
+    content_type: String,
+    text: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GatewayResponse {
+    #[allow(dead_code)]
+    schema: String,
+    request_id: String,
+    success: bool,
+    thread_id: Option<String>,
+    error: Option<String>,
+}
+
+// --- GatewayAdapter: ChatAdapter over WebSocket ---
+
+type PendingRequests = Arc<Mutex<HashMap<String, tokio::sync::oneshot::Sender<GatewayResponse>>>>;
+
+pub struct GatewayAdapter {
+    ws_tx: Mutex<futures_util::stream::SplitSink<
+        tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+        Message,
+    >>,
+    pending: PendingRequests,
+}
+
+impl GatewayAdapter {
+    fn new(
+        ws_tx: futures_util::stream::SplitSink<
+            tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+            Message,
+        >,
+        pending: PendingRequests,
+    ) -> Self {
+        Self {
+            ws_tx: Mutex::new(ws_tx),
+            pending,
+        }
+    }
+}
+
+#[async_trait]
+impl ChatAdapter for GatewayAdapter {
+    fn platform(&self) -> &'static str {
+        "gateway"
+    }
+
+    fn message_limit(&self) -> usize {
+        4096 // Telegram limit
+    }
+
+    async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
+        let reply = GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: String::new(),
+            platform: channel.platform.clone(),
+            channel: ReplyChannel {
+                id: channel.channel_id.clone(),
+                thread_id: channel.thread_id.clone(),
+            },
+            content: ReplyContent {
+                content_type: "text".into(),
+                text: content.into(),
+            },
+            command: None,
+            request_id: None,
+        };
+        let json = serde_json::to_string(&reply)?;
+        self.ws_tx
+            .lock()
+            .await
+            .send(Message::Text(json.into()))
+            .await?;
+        Ok(MessageRef {
+            channel: channel.clone(),
+            message_id: "gw_sent".into(),
+        })
+    }
+
+    async fn create_thread(
+        &self,
+        channel: &ChannelRef,
+        _trigger_msg: &MessageRef,
+        title: &str,
+    ) -> Result<ChannelRef> {
+        // Send create_topic command to gateway
+        let req_id = format!("req_{}", uuid::Uuid::new_v4());
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.pending.lock().await.insert(req_id.clone(), tx);
+
+        let reply = GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: String::new(),
+            platform: channel.platform.clone(),
+            channel: ReplyChannel {
+                id: channel.channel_id.clone(),
+                thread_id: None,
+            },
+            content: ReplyContent {
+                content_type: "text".into(),
+                text: title.into(),
+            },
+            command: Some("create_topic".into()),
+            request_id: Some(req_id.clone()),
+        };
+        let json = serde_json::to_string(&reply)?;
+        self.ws_tx.lock().await.send(Message::Text(json.into())).await?;
+
+        // Wait for response (5s timeout)
+        match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
+            Ok(Ok(resp)) if resp.success => {
+                Ok(ChannelRef {
+                    platform: channel.platform.clone(),
+                    channel_id: channel.channel_id.clone(),
+                    thread_id: resp.thread_id,
+                    parent_id: None,
+                })
+            }
+            Ok(Ok(resp)) => {
+                warn!(err = ?resp.error, "create_topic failed, falling back to same channel");
+                Ok(channel.clone())
+            }
+            _ => {
+                warn!("create_topic timeout, falling back to same channel");
+                self.pending.lock().await.remove(&req_id);
+                Ok(channel.clone())
+            }
+        }
+    }
+
+    async fn add_reaction(&self, _msg: &MessageRef, _emoji: &str) -> Result<()> {
+        Ok(()) // no-op for PoC
+    }
+
+    async fn remove_reaction(&self, _msg: &MessageRef, _emoji: &str) -> Result<()> {
+        Ok(()) // no-op for PoC
+    }
+
+    fn use_streaming(&self, _other_bot_present: bool) -> bool {
+        false // send-once for Telegram
+    }
+}
+
+// --- Run the gateway adapter (connects to gateway WS, routes events to AdapterRouter) ---
+
+pub async fn run_gateway_adapter(
+    gateway_url: String,
+    router: Arc<AdapterRouter>,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) -> Result<()> {
+    info!(url = %gateway_url, "connecting to custom gateway");
+
+    let (ws_stream, _) = tokio_tungstenite::connect_async(&gateway_url).await?;
+    info!("connected to gateway");
+
+    let (ws_tx, mut ws_rx) = ws_stream.split();
+    let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
+    let adapter: Arc<dyn ChatAdapter> = Arc::new(GatewayAdapter::new(ws_tx, pending.clone()));
+
+    loop {
+        tokio::select! {
+            msg = ws_rx.next() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        let text_str: &str = &text;
+
+                        // Check if it's a response to a pending command
+                        if let Ok(resp) = serde_json::from_str::<GatewayResponse>(text_str) {
+                            if resp.schema == "openab.gateway.response.v1" {
+                                if let Some(tx) = pending.lock().await.remove(&resp.request_id) {
+                                    let _ = tx.send(resp);
+                                }
+                                continue;
+                            }
+                        }
+
+                        match serde_json::from_str::<GatewayEvent>(text_str) {
+                            Ok(event) => {
+                                if event.sender.is_bot {
+                                    continue; // skip bot messages
+                                }
+                                info!(
+                                    platform = %event.platform,
+                                    sender = %event.sender.name,
+                                    channel = %event.channel.id,
+                                    "gateway event received"
+                                );
+
+                                let channel = ChannelRef {
+                                    platform: event.platform.clone(),
+                                    channel_id: event.channel.id.clone(),
+                                    thread_id: event.channel.thread_id.clone(),
+                                    parent_id: None,
+                                };
+
+                                let sender_ctx = SenderContext {
+                                    schema: "sender.v1".into(),
+                                    sender_id: event.sender.id.clone(),
+                                    sender_name: event.sender.name.clone(),
+                                    display_name: event.sender.display_name.clone(),
+                                    channel: event.channel.channel_type.clone(),
+                                    channel_id: event.channel.id.clone(),
+                                    thread_id: event.channel.thread_id.clone(),
+                                    is_bot: event.sender.is_bot,
+                                };
+                                let sender_json = serde_json::to_string(&sender_ctx)
+                                    .unwrap_or_default();
+
+                                let trigger_msg = MessageRef {
+                                    channel: channel.clone(),
+                                    message_id: event.message_id.clone(),
+                                };
+
+                                let adapter = adapter.clone();
+                                let router = router.clone();
+                                let prompt = event.content.text.clone();
+
+                                tokio::spawn(async move {
+                                    // If supergroup with no thread_id, create a forum topic
+                                    let thread_channel = if event.channel.channel_type == "supergroup"
+                                        && channel.thread_id.is_none()
+                                    {
+                                        let title = crate::format::shorten_thread_name(&prompt);
+                                        match adapter.create_thread(&channel, &trigger_msg, &title).await {
+                                            Ok(tc) => tc,
+                                            Err(e) => {
+                                                warn!("create_thread failed, using channel: {e}");
+                                                channel.clone()
+                                            }
+                                        }
+                                    } else {
+                                        channel.clone()
+                                    };
+
+                                    if let Err(e) = router
+                                        .handle_message(
+                                            &adapter,
+                                            &thread_channel,
+                                            &sender_json,
+                                            &prompt,
+                                            vec![],
+                                            &trigger_msg,
+                                            false,
+                                        )
+                                        .await
+                                    {
+                                        error!("gateway message handling error: {e}");
+                                    }
+                                });
+                            }
+                            Err(e) => warn!("invalid gateway event: {e}"),
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => {
+                        warn!("gateway WebSocket closed");
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        error!("gateway WebSocket error: {e}");
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() {
+                    info!("gateway adapter shutting down");
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -20,6 +20,8 @@ struct GatewayEvent {
     channel: GwChannel,
     sender: GwSender,
     content: GwContent,
+    #[serde(default)]
+    mentions: Vec<String>,
     message_id: String,
 }
 
@@ -220,24 +222,48 @@ pub async fn run_gateway_adapter(
     router: Arc<AdapterRouter>,
     mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
 ) -> Result<()> {
-    info!(url = %gateway_url, "connecting to custom gateway");
-
-    let (ws_stream, _) = tokio_tungstenite::connect_async(&gateway_url).await?;
-    info!("connected to gateway");
-
-    let (ws_tx, mut ws_rx) = ws_stream.split();
-    let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
-    let adapter: Arc<dyn ChatAdapter> = Arc::new(GatewayAdapter::new(ws_tx, pending.clone()));
+    let mut backoff_secs = 1u64;
+    const MAX_BACKOFF: u64 = 30;
 
     loop {
-        tokio::select! {
-            msg = ws_rx.next() => {
-                match msg {
-                    Some(Ok(Message::Text(text))) => {
-                        let text_str: &str = &text;
+        // Check shutdown before connecting
+        if *shutdown_rx.borrow() {
+            info!("gateway adapter shutting down");
+            return Ok(());
+        }
 
-                        // Check if it's a response to a pending command
-                        if let Ok(resp) = serde_json::from_str::<GatewayResponse>(text_str) {
+        info!(url = %gateway_url, "connecting to custom gateway");
+
+        let ws_stream = match tokio_tungstenite::connect_async(&gateway_url).await {
+            Ok((stream, _)) => {
+                backoff_secs = 1; // reset on success
+                info!("connected to gateway");
+                stream
+            }
+            Err(e) => {
+                error!(err = %e, backoff = backoff_secs, "gateway connection failed, retrying");
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
+                    _ = shutdown_rx.changed() => { return Ok(()); }
+                }
+                backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF);
+                continue;
+            }
+        };
+
+        let (ws_tx, mut ws_rx) = ws_stream.split();
+        let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
+        let adapter: Arc<dyn ChatAdapter> = Arc::new(GatewayAdapter::new(ws_tx, pending.clone()));
+
+        loop {
+            tokio::select! {
+                msg = ws_rx.next() => {
+                    match msg {
+                        Some(Ok(Message::Text(text))) => {
+                            let text_str: &str = &text;
+
+                            // Check if it's a response to a pending command
+                            if let Ok(resp) = serde_json::from_str::<GatewayResponse>(text_str) {
                             if resp.schema == "openab.gateway.response.v1" {
                                 if let Some(tx) = pending.lock().await.remove(&resp.request_id) {
                                     let _ = tx.send(resp);
@@ -324,11 +350,11 @@ pub async fn run_gateway_adapter(
                         }
                     }
                     Some(Ok(Message::Close(_))) | None => {
-                        warn!("gateway WebSocket closed");
+                        warn!("gateway WebSocket closed, will reconnect");
                         break;
                     }
                     Some(Err(e)) => {
-                        error!("gateway WebSocket error: {e}");
+                        error!("gateway WebSocket error: {e}, will reconnect");
                         break;
                     }
                     _ => {}
@@ -337,10 +363,17 @@ pub async fn run_gateway_adapter(
             _ = shutdown_rx.changed() => {
                 if *shutdown_rx.borrow() {
                     info!("gateway adapter shutting down");
-                    break;
+                    return Ok(());
                 }
             }
         }
-    }
-    Ok(())
+    } // inner loop — break here means reconnect
+
+        warn!(backoff = backoff_secs, "reconnecting to gateway");
+        tokio::select! {
+            _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
+            _ = shutdown_rx.changed() => { return Ok(()); }
+        }
+        backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF);
+    } // outer reconnect loop
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -15,12 +15,14 @@ use tracing::{error, info, warn};
 struct GatewayEvent {
     #[allow(dead_code)]
     schema: String,
+    #[allow(dead_code)]
     event_id: String,
     platform: String,
     channel: GwChannel,
     sender: GwSender,
     content: GwContent,
     #[serde(default)]
+    #[allow(dead_code)]
     mentions: Vec<String>,
     message_id: String,
 }
@@ -100,6 +102,7 @@ pub struct GatewayAdapter {
         >,
     >,
     pending: PendingRequests,
+    platform_name: &'static str,
 }
 
 impl GatewayAdapter {
@@ -111,10 +114,12 @@ impl GatewayAdapter {
             Message,
         >,
         pending: PendingRequests,
+        platform_name: &'static str,
     ) -> Self {
         Self {
             ws_tx: Mutex::new(ws_tx),
             pending,
+            platform_name,
         }
     }
 }
@@ -122,7 +127,7 @@ impl GatewayAdapter {
 #[async_trait]
 impl ChatAdapter for GatewayAdapter {
     fn platform(&self) -> &'static str {
-        "gateway"
+        self.platform_name
     }
 
     fn message_limit(&self) -> usize {
@@ -146,11 +151,7 @@ impl ChatAdapter for GatewayAdapter {
             request_id: None,
         };
         let json = serde_json::to_string(&reply)?;
-        self.ws_tx
-            .lock()
-            .await
-            .send(Message::Text(json.into()))
-            .await?;
+        self.ws_tx.lock().await.send(Message::Text(json)).await?;
         Ok(MessageRef {
             channel: channel.clone(),
             message_id: "gw_sent".into(),
@@ -184,11 +185,7 @@ impl ChatAdapter for GatewayAdapter {
             request_id: Some(req_id.clone()),
         };
         let json = serde_json::to_string(&reply)?;
-        self.ws_tx
-            .lock()
-            .await
-            .send(Message::Text(json.into()))
-            .await?;
+        self.ws_tx.lock().await.send(Message::Text(json)).await?;
 
         // Wait for response (5s timeout)
         match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
@@ -227,9 +224,25 @@ impl ChatAdapter for GatewayAdapter {
 
 pub async fn run_gateway_adapter(
     gateway_url: String,
+    platform_name: String,
+    ws_token: Option<String>,
     router: Arc<AdapterRouter>,
     mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
 ) -> Result<()> {
+    // Leak the platform name for 'static lifetime — one allocation per adapter lifetime
+    let platform: &'static str = Box::leak(platform_name.into_boxed_str());
+
+    // Append auth token as query param if configured
+    let connect_url = match &ws_token {
+        Some(token) => {
+            let sep = if gateway_url.contains('?') { "&" } else { "?" };
+            format!("{gateway_url}{sep}token={token}")
+        }
+        None => {
+            warn!("gateway.token not set — WebSocket connection is NOT authenticated");
+            gateway_url.clone()
+        }
+    };
     let mut backoff_secs = 1u64;
     const MAX_BACKOFF: u64 = 30;
 
@@ -242,7 +255,7 @@ pub async fn run_gateway_adapter(
 
         info!(url = %gateway_url, "connecting to custom gateway");
 
-        let ws_stream = match tokio_tungstenite::connect_async(&gateway_url).await {
+        let ws_stream = match tokio_tungstenite::connect_async(&connect_url).await {
             Ok((stream, _)) => {
                 backoff_secs = 1; // reset on success
                 info!("connected to gateway");
@@ -261,7 +274,8 @@ pub async fn run_gateway_adapter(
 
         let (ws_tx, mut ws_rx) = ws_stream.split();
         let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
-        let adapter: Arc<dyn ChatAdapter> = Arc::new(GatewayAdapter::new(ws_tx, pending.clone()));
+        let adapter: Arc<dyn ChatAdapter> =
+            Arc::new(GatewayAdapter::new(ws_tx, pending.clone(), platform));
 
         loop {
             tokio::select! {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod reactions;
 mod setup;
 mod slack;
 mod stt;
+mod gateway;
 
 use adapter::AdapterRouter;
 use clap::Parser;
@@ -83,8 +84,8 @@ async fn main() -> anyhow::Result<()> {
         "config loaded"
     );
 
-    if cfg.discord.is_none() && cfg.slack.is_none() {
-        anyhow::bail!("no adapter configured — add [discord] and/or [slack] to config.toml");
+    if cfg.discord.is_none() && cfg.slack.is_none() && cfg.gateway.is_none() {
+        anyhow::bail!("no adapter configured — add [discord], [slack], and/or [gateway] to config.toml");
     }
 
     let pool = Arc::new(acp::SessionPool::new(cfg.agent, cfg.pool.max_sessions));
@@ -140,6 +141,7 @@ async fn main() -> anyhow::Result<()> {
         let stt = cfg.stt.clone();
         let session_ttl = std::time::Duration::from_secs(ttl_secs);
         let max_bot_turns = slack_cfg.max_bot_turns;
+        let slack_shutdown_rx = shutdown_rx.clone();
         Some(tokio::spawn(async move {
             if let Err(e) = slack::run_slack_adapter(
                 slack_cfg.bot_token,
@@ -155,11 +157,25 @@ async fn main() -> anyhow::Result<()> {
                 session_ttl,
                 stt,
                 router,
-                shutdown_rx,
+                slack_shutdown_rx,
             )
             .await
             {
                 error!("slack adapter error: {e}");
+            }
+        }))
+    } else {
+        None
+    };
+
+    // Spawn Gateway adapter (background task)
+    let gateway_handle = if let Some(gw_cfg) = cfg.gateway {
+        let router = router.clone();
+        let shutdown_rx = shutdown_rx.clone();
+        info!(url = %gw_cfg.url, "starting gateway adapter");
+        Some(tokio::spawn(async move {
+            if let Err(e) = gateway::run_gateway_adapter(gw_cfg.url, router, shutdown_rx).await {
+                error!("gateway adapter error: {e}");
             }
         }))
     } else {
@@ -236,6 +252,9 @@ async fn main() -> anyhow::Result<()> {
     // Signal Slack adapter to shut down gracefully
     let _ = shutdown_tx.send(true);
     if let Some(handle) = slack_handle {
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+    }
+    if let Some(handle) = gateway_handle {
         let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
     }
     let shutdown_pool = pool;

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ async fn main() -> anyhow::Result<()> {
         let shutdown_rx = shutdown_rx.clone();
         info!(url = %gw_cfg.url, "starting gateway adapter");
         Some(tokio::spawn(async move {
-            if let Err(e) = gateway::run_gateway_adapter(gw_cfg.url, router, shutdown_rx).await {
+            if let Err(e) = gateway::run_gateway_adapter(gw_cfg.url, gw_cfg.platform, gw_cfg.token, router, shutdown_rx).await {
                 error!("gateway adapter error: {e}");
             }
         }))


### PR DESCRIPTION
### Description

Implements the v2 custom gateway architecture from [ADR: Custom Gateway](docs/adr/custom-gateway.md). OAB connects outbound to a standalone gateway service via WebSocket — no inbound ports, no TLS on OAB.

### Architecture

```
Telegram ──POST──▶ Gateway (:8080)
                      ▲ WebSocket (OAB initiates outbound)
                   OAB Pod (gateway.rs adapter)
                      ▼
                   AdapterRouter → SessionPool → kiro-cli
```

### OAB Changes (generic, platform-agnostic)

- `src/gateway.rs` — `GatewayAdapter` implementing `ChatAdapter` over WebSocket
- `src/config.rs` — `[gateway]` config with `url`, `platform`, `token` fields (+12 lines)
- `src/main.rs` — spawn gateway adapter alongside Slack/Discord (+22 lines)

### Gateway Service (Telegram-specific, standalone)

- `gateway/` — axum HTTP + WebSocket server with own Dockerfile
- Telegram webhook → normalize to `openab.gateway.event.v1`
- OAB replies → Telegram `sendMessage` API
- `create_topic` command → Telegram `createForumTopic` for forum thread isolation
- `secret_token` validation on webhook, shared token auth on WebSocket

### Config

```toml
[gateway]
url = "ws://gateway:8080/ws"
platform = "telegram"          # session key namespace (default: telegram)
token = "${GATEWAY_WS_TOKEN}"  # shared WS auth token (recommended)
```

### Testing

- E2E verified locally: Telegram DM → Gateway → OAB → kiro-cli → reply → Telegram
- Supergroup forum topic creation tested (requires bot Manage Topics permission)
- Cloudflare Tunnel used for HTTPS webhook endpoint

### Follow-up (not in this PR)

- [ ] CI/CD: add `build-gateway.yml` workflow to build and push `ghcr.io/openabdev/openab-gateway` image
- [ ] Helm: gateway subchart or standalone chart
- [ ] LINE adapter
- [ ] Generic `/webhook/custom` endpoint
- [ ] @mention gating using the `mentions` field in group chats