### PR TITLE
ci: add build-gateway.yml for gateway image

### DIFF
--- a/.github/workflows/build-gateway.yml
+++ b/.github/workflows/build-gateway.yml
@@ -1,0 +1,120 @@
+name: Build Gateway
+
+on:
+  push:
+    tags:
+      - "gateway-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag (e.g. gateway-v0.1.0)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (build only, no push)'
+        required: false
+        type: boolean
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/openabdev/openab-gateway
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform:
+          - { os: linux/amd64, runner: ubuntu-latest }
+          - { os: linux/arm64, runner: ubuntu-24.04-arm }
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          VERSION="${TAG#gateway-v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: gateway/Dockerfile
+          platforms: ${{ matrix.platform.os }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ inputs.dry_run != true }}
+          cache-from: type=gha,scope=gateway-${{ matrix.platform.os }}
+          cache-to: type=gha,scope=gateway-${{ matrix.platform.os }},mode=max
+
+      - name: Export digest
+        if: inputs.dry_run != true
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: inputs.dry_run != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: gateway-digest-${{ matrix.platform.runner }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  merge:
+    needs: build
+    if: inputs.dry_run != true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "version=${TAG#gateway-v}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: gateway-digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Create multi-arch manifest
+        run: |
+          cd /tmp/digests
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.version }} \
+            -t ${{ env.IMAGE_NAME }}:latest \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)


### PR DESCRIPTION
Add CI workflow to build and push `ghcr.io/openabdev/openab-gateway` multi-arch images.

Triggered by `gateway-v*` tags or workflow_dispatch. Multi-arch (amd64 + arm64), digest merge, GHA cache. Separate from main `build.yml` — gateway has its own release lifecycle.

```bash
git tag gateway-v0.1.0
git push origin gateway-v0.1.0
```