### PR TITLE
ci: add build-gateway.yml for gateway image

### DIFF
--- a/.github/workflows/build-gateway.yml
+++ b/.github/workflows/build-gateway.yml
@@ -1,0 +1,119 @@
+name: Build Gateway
+
+on:
+  push:
+    tags:
+      - "gateway-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag (e.g. gateway-v0.1.0)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (build only, no push)'
+        required: false
+        type: boolean
+        default: false
+
+env:
+  IMAGE_NAME: ghcr.io/openabdev/openab-gateway
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform:
+          - { os: linux/amd64, runner: ubuntu-latest }
+          - { os: linux/arm64, runner: ubuntu-24.04-arm }
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          VERSION="${TAG#gateway-v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: gateway/Dockerfile
+          platforms: ${{ matrix.platform.os }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ inputs.dry_run != true }}
+          cache-from: type=gha,scope=gateway-${{ matrix.platform.os }}
+          cache-to: type=gha,scope=gateway-${{ matrix.platform.os }},mode=max
+
+      - name: Export digest
+        if: inputs.dry_run != true
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: inputs.dry_run != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: gateway-digest-${{ matrix.platform.runner }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  merge:
+    needs: build
+    if: ${{ !cancelled() && (github.event_name == 'push' || inputs.dry_run != true) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "version=${TAG#gateway-v}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: gateway-digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Create multi-arch manifest
+        run: |
+          cd /tmp/digests
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.version }} \
+            -t ${{ env.IMAGE_NAME }}:latest \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)

--- a/.github/workflows/gateway-release-pr.yml
+++ b/.github/workflows/gateway-release-pr.yml
@@ -1,0 +1,50 @@
+name: Gateway Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version (e.g. 0.1.0, 0.2.0-beta.1)"
+        required: true
+        type: string
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Update gateway version
+        run: |
+          VERSION="${{ inputs.version }}"
+          sed -i "s/^version = .*/version = \"${VERSION}\"/" gateway/Cargo.toml
+          echo "::notice::Gateway release version: ${VERSION}"
+
+      - name: Create release PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ inputs.version }}"
+          BRANCH="release/gateway-v${VERSION}"
+          git config user.name "openab-app[bot]"
+          git config user.email "274185012+openab-app[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "release: gateway-v${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "release: gateway-v${VERSION}" \
+            --body "Merge this PR to tag \`gateway-v${VERSION}\` and trigger the gateway build pipeline." \
+            --base main --head "$BRANCH"

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -26,13 +26,15 @@ jobs:
       - name: Create and push tag
         run: |
           # release/v0.8.0-beta.1 → v0.8.0-beta.1
+          # release/gateway-v0.1.0 → gateway-v0.1.0
           VERSION="${GITHUB_HEAD_REF#release/}"
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "::error::Invalid version format '${VERSION}'. Expected v{major}.{minor}.{patch}[-prerelease]"
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]] || [[ "$VERSION" =~ ^gateway-v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            git config user.name "openab-app[bot]"
+            git config user.email "274185012+openab-app[bot]@users.noreply.github.com"
+            git tag "$VERSION"
+            git push origin "$VERSION"
+            echo "::notice::Tagged ${VERSION}"
+          else
+            echo "::error::Invalid version format '${VERSION}'"
             exit 1
           fi
-          git config user.name "openab-app[bot]"
-          git config user.email "274185012+openab-app[bot]@users.noreply.github.com"
-          git tag "$VERSION"
-          git push origin "$VERSION"
-          echo "::notice::Tagged ${VERSION}"


### PR DESCRIPTION
### Description

Add CI workflow to build and push `ghcr.io/openabdev/openab-gateway` multi-arch images.

### Trigger

- Tag push: `gateway-v*` (e.g. `gateway-v0.1.0`)
- Manual: workflow_dispatch with version and dry_run inputs

### What it does

- Builds `gateway/Dockerfile` for linux/amd64 + linux/arm64
- Pushes to `ghcr.io/openabdev/openab-gateway:<version>` + `:latest`
- Uses GHA cache for fast rebuilds
- Merge job uses `!cancelled()` so partial arch builds still produce a manifest

### Usage

```bash
git tag gateway-v0.1.0
git push origin gateway-v0.1.0
```