### PR TITLE
feat(gateway): @mention gating + emoji reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,14 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 │   User       │               │    openab    │◄── JSON-RPC ──│  (acp mode)  │
 ├──────────────┤  Socket Mode  │    (Rust)    │               └──────────────┘
 │   Slack      │◄─────────────►│              │
-│   User       │               └──────────────┘
-└──────────────┘
+│   User       │               └──────┬───────┘
+├──────────────┤                      │ WebSocket (outbound)
+│   Telegram   │◄──webhook──┐         │
+│   User       │            ▼         ▼
+└──────────────┘     ┌──────────────────┐
+                     │  Custom Gateway  │
+                     │  (standalone)    │
+                     └──────────────────┘
 ```
 
 ## Demo
@@ -50,6 +56,13 @@ See [docs/discord.md](docs/discord.md) for a detailed step-by-step guide.
 <summary><strong>Slack</strong></summary>
 
 See [docs/slack-bot-howto.md](docs/slack-bot-howto.md) for a detailed step-by-step guide.
+
+</details>
+
+<details>
+<summary><strong>Telegram</strong> (via Custom Gateway)</summary>
+
+See [docs/telegram.md](docs/telegram.md) for the full setup guide. Requires the standalone [Custom Gateway](gateway/) service.
 
 </details>
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -1,0 +1,213 @@
+# Telegram Setup
+
+Connect a Telegram bot to OpenAB via the Custom Gateway.
+
+```
+Telegram ──POST──▶ Gateway (:8080) ◀──WebSocket── OAB Pod
+                                       (OAB connects out)
+```
+
+## Prerequisites
+
+- A running OAB instance (with kiro-cli or any ACP agent authenticated)
+- Docker or a Kubernetes cluster
+- A Telegram bot token (from [@BotFather](https://t.me/BotFather))
+
+## 1. Create a Telegram Bot
+
+1. Open [@BotFather](https://t.me/BotFather) in Telegram
+2. Send `/newbot`, follow the prompts
+3. Copy the bot token (e.g. `123456:ABC-DEF...`)
+4. Optional: send `/setprivacy` → `Disable` so the bot can see all group messages (required for @mention gating in groups)
+
+## 2. Run the Gateway
+
+### Docker
+
+```bash
+docker run -d --name openab-gateway \
+  -e TELEGRAM_BOT_TOKEN="your-bot-token" \
+  -e TELEGRAM_SECRET_TOKEN="your-webhook-secret" \
+  -e GATEWAY_WS_TOKEN="your-ws-auth-token" \
+  -p 8080:8080 \
+  ghcr.io/openabdev/openab-gateway:0.1.0
+```
+
+### Kubernetes
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openab-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openab-gateway
+  template:
+    metadata:
+      labels:
+        app: openab-gateway
+    spec:
+      containers:
+        - name: gateway
+          image: ghcr.io/openabdev/openab-gateway:0.1.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: TELEGRAM_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openab-gateway
+                  key: telegram-bot-token
+            - name: TELEGRAM_SECRET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openab-gateway
+                  key: telegram-secret-token
+            - name: GATEWAY_WS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openab-gateway
+                  key: ws-token
+            - name: GATEWAY_LISTEN
+              value: "0.0.0.0:8080"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openab-gateway
+spec:
+  selector:
+    app: openab-gateway
+  ports:
+    - port: 8080
+      targetPort: 8080
+```
+
+## 3. Configure OAB
+
+Add a `[gateway]` section to your OAB `config.toml`:
+
+```toml
+[gateway]
+url = "ws://openab-gateway:8080/ws"
+platform = "telegram"
+token = "${GATEWAY_WS_TOKEN}"
+bot_username = "your_bot_username"
+
+[agent]
+command = "kiro-cli"
+args = ["acp", "--trust-all-tools"]
+working_dir = "/home/agent"
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `url` | Yes | WebSocket URL of the gateway |
+| `platform` | No | Session key namespace (default: `telegram`) |
+| `token` | No | Shared WS auth token (recommended) |
+| `bot_username` | No | Bot username for @mention gating in groups |
+
+## 4. Set the Telegram Webhook
+
+The gateway needs a public HTTPS URL for Telegram to send updates to.
+
+### Option A: Cloudflare Tunnel (quickest for dev/testing)
+
+```bash
+cloudflared tunnel --url http://localhost:8080
+# Copy the https://xxx.trycloudflare.com URL
+```
+
+### Option B: Reverse proxy (production)
+
+Use nginx, Caddy, or a cloud load balancer with TLS termination pointing to the gateway's `:8080`.
+
+### Register the webhook
+
+```bash
+export BOT_TOKEN="your-bot-token"
+export WEBHOOK_URL="https://your-gateway-host"
+export SECRET="your-webhook-secret"
+
+curl "https://api.telegram.org/bot${BOT_TOKEN}/setWebhook?url=${WEBHOOK_URL}/webhook/telegram&secret_token=${SECRET}"
+```
+
+Verify:
+
+```bash
+curl "https://api.telegram.org/bot${BOT_TOKEN}/getWebhookInfo"
+```
+
+## 5. Bot Permissions for Supergroups
+
+For forum topic creation (thread isolation like Discord):
+
+1. Open the supergroup → Settings → Administrators
+2. Find the bot → Edit
+3. Enable **Manage Topics**
+
+Without this permission, the bot replies in the main chat instead of creating topics.
+
+## Features
+
+### @mention gating
+
+In groups and supergroups, the bot only responds when @mentioned:
+
+```
+@your_bot explain VPC peering    ← triggers agent
+explain VPC peering              ← ignored in groups
+```
+
+DMs and replies within forum topics always trigger the agent (no @mention needed).
+
+### Emoji reactions
+
+The bot shows status reactions on your message as the agent works:
+
+| Stage | Emoji |
+|---|---|
+| Queued | 👀 |
+| Thinking | 🤔 |
+| Tool use | 🔥 (general), 👨‍💻 (coding), ⚡ (web) |
+| Done | 👍 |
+| Error | 😱 |
+
+### Forum topics
+
+In supergroups with topics enabled, each new conversation auto-creates a forum topic (like Discord threads). Follow-up messages in the same topic reuse the same agent session.
+
+### Markdown rendering
+
+Agent replies are rendered with Telegram Markdown: **bold**, `code`, and code blocks work. Headers (`##`) and tables render as plain text (Telegram limitation).
+
+## Environment Variables (Gateway)
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `TELEGRAM_BOT_TOKEN` | Yes | — | Bot API token from @BotFather |
+| `TELEGRAM_SECRET_TOKEN` | No | — | Webhook signature validation |
+| `GATEWAY_WS_TOKEN` | No | — | WebSocket auth token |
+| `GATEWAY_LISTEN` | No | `0.0.0.0:8080` | Listen address |
+| `TELEGRAM_WEBHOOK_PATH` | No | `/webhook/telegram` | Webhook endpoint path |
+
+## Troubleshooting
+
+**Bot doesn't respond in groups:**
+- Check bot privacy mode: `/setprivacy` → `Disable` in @BotFather
+- Verify `bot_username` in OAB config matches the bot's actual username
+- Check the bot is @mentioned in the message
+
+**"not enough rights to create a topic":**
+- Give the bot **Manage Topics** permission in supergroup admin settings
+
+**Webhook returns 502/530:**
+- Check the Cloudflare Tunnel or reverse proxy is running
+- Verify `curl http://localhost:8080/health` returns `ok`
+
+**Agent spawns but immediately closes:**
+- Run `kubectl exec -it deployment/openab-telegram -- kiro-cli login --use-device-flow`
+- Ensure auth is persisted on a PVC, not an emptyDir

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -265,6 +265,9 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
     // Receive OAB replies → Telegram
     let bot_token = state.bot_token.clone();
     let event_tx_for_recv = state.event_tx.clone();
+    // Track per-message reaction state (Telegram replaces all reactions atomically)
+    let reaction_state: Arc<Mutex<std::collections::HashMap<String, Vec<String>>>> =
+        Arc::new(Mutex::new(std::collections::HashMap::new()));
     let recv_task = tokio::spawn(async move {
         let client = reqwest::Client::new();
         while let Some(Ok(msg)) = ws_rx.next().await {
@@ -333,15 +336,42 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                         }
 
                         // Handle add_reaction / remove_reaction
+                        // Telegram setMessageReaction replaces ALL reactions, so we track state
                         if reply.command.as_deref() == Some("add_reaction")
                             || reply.command.as_deref() == Some("remove_reaction")
                         {
+                            let msg_key = format!("{}:{}", reply.channel.id, reply.reply_to);
                             let emoji = &reply.content.text;
+                            // Map unsupported emojis to Telegram-compatible ones
+                            let tg_emoji = match emoji.as_str() {
+                                "👨\u{200d}💻" => "⚡",
+                                "🆗" => "👍",
+                                other => other,
+                            };
                             let is_add = reply.command.as_deref() == Some("add_reaction");
-                            let reactions = if is_add {
-                                serde_json::json!([{"type": "emoji", "emoji": emoji}])
-                            } else {
-                                serde_json::json!([])
+                            {
+                                let mut reactions = reaction_state.lock().await;
+                                let set = reactions.entry(msg_key.clone()).or_insert_with(Vec::new);
+                                if is_add {
+                                    if !set.contains(&tg_emoji.to_string()) {
+                                        set.push(tg_emoji.to_string());
+                                    }
+                                } else {
+                                    set.retain(|e| e != tg_emoji);
+                                }
+                            }
+                            let current: Vec<serde_json::Value> = {
+                                let reactions = reaction_state.lock().await;
+                                reactions
+                                    .get(&msg_key)
+                                    .map(|v| {
+                                        v.iter()
+                                            .map(|e| {
+                                                serde_json::json!({"type": "emoji", "emoji": e})
+                                            })
+                                            .collect()
+                                    })
+                                    .unwrap_or_default()
                             };
                             let url = format!(
                                 "https://api.telegram.org/bot{}/setMessageReaction",
@@ -352,7 +382,7 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                                 .json(&serde_json::json!({
                                     "chat_id": reply.channel.id,
                                     "message_id": reply.reply_to,
-                                    "reaction": reactions,
+                                    "reaction": current,
                                 }))
                                 .send()
                                 .await

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -332,6 +332,34 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                             continue;
                         }
 
+                        // Handle add_reaction / remove_reaction
+                        if reply.command.as_deref() == Some("add_reaction")
+                            || reply.command.as_deref() == Some("remove_reaction")
+                        {
+                            let emoji = &reply.content.text;
+                            let is_add = reply.command.as_deref() == Some("add_reaction");
+                            let reactions = if is_add {
+                                serde_json::json!([{"type": "emoji", "emoji": emoji}])
+                            } else {
+                                serde_json::json!([])
+                            };
+                            let url = format!(
+                                "https://api.telegram.org/bot{}/setMessageReaction",
+                                bot_token
+                            );
+                            let _ = client
+                                .post(&url)
+                                .json(&serde_json::json!({
+                                    "chat_id": reply.channel.id,
+                                    "message_id": reply.reply_to,
+                                    "reaction": reactions,
+                                }))
+                                .send()
+                                .await
+                                .map_err(|e| error!("telegram reaction error: {e}"));
+                            continue;
+                        }
+
                         // Normal send_message
                         info!(chat_id = %reply.channel.id, thread_id = ?reply.channel.thread_id, "gateway → telegram");
                         let url = format!("https://api.telegram.org/bot{}/sendMessage", bot_token);

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -344,7 +344,6 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                             let emoji = &reply.content.text;
                             // Map unsupported emojis to Telegram-compatible ones
                             let tg_emoji = match emoji.as_str() {
-                                "👨\u{200d}💻" => "⚡",
                                 "🆗" => "👍",
                                 other => other,
                             };

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -398,6 +398,7 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                                 "chat_id": reply.channel.id,
                                 "text": reply.content.text,
                                 "message_thread_id": reply.channel.thread_id,
+                                "parse_mode": "Markdown",
                             }))
                             .send()
                             .await

--- a/src/config.rs
+++ b/src/config.rs
@@ -169,6 +169,8 @@ pub struct GatewayConfig {
     pub platform: String,
     /// Shared token for WebSocket authentication (optional but recommended)
     pub token: Option<String>,
+    /// Bot username for @mention gating in groups (e.g. "my_bot")
+    pub bot_username: Option<String>,
 }
 
 fn default_gateway_platform() -> String {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -209,12 +209,46 @@ impl ChatAdapter for GatewayAdapter {
         }
     }
 
-    async fn add_reaction(&self, _msg: &MessageRef, _emoji: &str) -> Result<()> {
-        Ok(()) // no-op for PoC
+    async fn add_reaction(&self, msg: &MessageRef, emoji: &str) -> Result<()> {
+        let reply = GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: msg.message_id.clone(),
+            platform: msg.channel.platform.clone(),
+            channel: ReplyChannel {
+                id: msg.channel.channel_id.clone(),
+                thread_id: msg.channel.thread_id.clone(),
+            },
+            content: ReplyContent {
+                content_type: "text".into(),
+                text: emoji.into(),
+            },
+            command: Some("add_reaction".into()),
+            request_id: None,
+        };
+        let json = serde_json::to_string(&reply)?;
+        self.ws_tx.lock().await.send(Message::Text(json)).await?;
+        Ok(())
     }
 
-    async fn remove_reaction(&self, _msg: &MessageRef, _emoji: &str) -> Result<()> {
-        Ok(()) // no-op for PoC
+    async fn remove_reaction(&self, msg: &MessageRef, emoji: &str) -> Result<()> {
+        let reply = GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: msg.message_id.clone(),
+            platform: msg.channel.platform.clone(),
+            channel: ReplyChannel {
+                id: msg.channel.channel_id.clone(),
+                thread_id: msg.channel.thread_id.clone(),
+            },
+            content: ReplyContent {
+                content_type: "text".into(),
+                text: emoji.into(),
+            },
+            command: Some("remove_reaction".into()),
+            request_id: None,
+        };
+        let json = serde_json::to_string(&reply)?;
+        self.ws_tx.lock().await.send(Message::Text(json)).await?;
+        Ok(())
     }
 
     fn use_streaming(&self, _other_bot_present: bool) -> bool {
@@ -228,6 +262,7 @@ pub async fn run_gateway_adapter(
     gateway_url: String,
     platform_name: String,
     ws_token: Option<String>,
+    bot_username: Option<String>,
     router: Arc<AdapterRouter>,
     mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
 ) -> Result<()> {
@@ -302,6 +337,21 @@ pub async fn run_gateway_adapter(
                                     if event.sender.is_bot {
                                         continue; // skip bot messages
                                     }
+
+                                    // @mention gating: in groups, only respond if bot is mentioned
+                                    // DMs (private) and thread replies always pass through
+                                    let is_group = event.channel.channel_type == "group"
+                                        || event.channel.channel_type == "supergroup";
+                                    let in_thread = event.channel.thread_id.is_some();
+                                    if is_group && !in_thread {
+                                        if let Some(ref bot_name) = bot_username {
+                                            let mentioned = event.mentions.iter().any(|m| m == bot_name);
+                                            if !mentioned {
+                                                continue; // skip non-mentioned group messages
+                                            }
+                                        }
+                                    }
+
                                     info!(
                                         platform = %event.platform,
                                         sender = %event.sender.name,

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ async fn main() -> anyhow::Result<()> {
         let shutdown_rx = shutdown_rx.clone();
         info!(url = %gw_cfg.url, "starting gateway adapter");
         Some(tokio::spawn(async move {
-            if let Err(e) = gateway::run_gateway_adapter(gw_cfg.url, gw_cfg.platform, gw_cfg.token, router, shutdown_rx).await {
+            if let Err(e) = gateway::run_gateway_adapter(gw_cfg.url, gw_cfg.platform, gw_cfg.token, gw_cfg.bot_username, router, shutdown_rx).await {
                 error!("gateway adapter error: {e}");
             }
         }))


### PR DESCRIPTION
### Description

Two features for the gateway adapter + full Telegram setup docs.

**@mention gating** — in groups/supergroups, only respond when the bot is @mentioned. DMs and thread replies always pass through. Matches Discord/Slack behavior.

**Emoji reactions** — `add_reaction`/`remove_reaction` via Telegram `setMessageReaction` API with stateful per-message tracking (Telegram replaces all reactions atomically, unlike Discord). Enables the existing StatusReactionController emoji rotation (👀→🤔→🔥→👍).

**Markdown rendering** — agent replies rendered with Telegram Markdown (bold, code, code blocks).

**Docs** — `docs/telegram.md` full setup guide + README updated with architecture diagram and Quick Start link.

### Config

```toml
[gateway]
url = "ws://gateway:8080/ws"
platform = "telegram"
token = "${GATEWAY_WS_TOKEN}"
bot_username = "the_gemini_saga_bot"
```

### Changes

- `src/gateway.rs` — mention filter, reaction commands over WS
- `src/config.rs` — `bot_username` field
- `gateway/src/main.rs` — reaction handler with state tracking, emoji mapping, Markdown parse_mode
- `docs/telegram.md` — full setup guide (bot creation, gateway deploy, OAB config, webhook, permissions, troubleshooting)
- `README.md` — architecture diagram + Quick Start updated

### Follow-up (not in this PR)

- [ ] Separate Helm chart for gateway (`openab/openab-gateway`)
- [ ] Fallback to plain text when Markdown parsing fails
- [ ] Strip unsupported Markdown syntax (headers, tables) for cleaner Telegram rendering