### PR TITLE
fix(slack): gate WarnAndStop warning by allowed_channels (#557)

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -680,7 +680,9 @@ pub async fn run_slack_adapter(
                                                                     TurnSeverity::Hard => warn!(channel_id, turns, "hard bot turn limit reached"),
                                                                     TurnSeverity::Soft => info!(channel_id, turns, max = max_bot_turns, "soft bot turn limit reached"),
                                                                 }
-                                                                if !is_own_bot_msg {
+                                                                let channel_allowed = allow_all_channels
+                                                                    || allowed_channels.contains(channel_id);
+                                                                if !is_own_bot_msg && channel_allowed {
                                                                     let warn_channel = ChannelRef {
                                                                         platform: "slack".into(),
                                                                         channel_id: channel_id.to_string(),

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+test file

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-test file


### PR DESCRIPTION
## Summary

Fixes `TurnAction::WarnAndStop` sending the bot turn limit warning to channels outside `allowed_channels`.

Bot turn tracking intentionally runs before channel gating (line 649–651) so all bot messages are counted. However the warning *send* was not gated — the bot posted into channels it was never configured to participate in. The Discord adapter already handles this correctly (`discord.rs:279–303`).

**Fix:** check `allow_all_channels || allowed_channels.contains(channel_id)` before calling `adapter.send_message`, mirroring the Discord implementation.

Fixes openabdev/openab#557

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1496961096182006023/1497313281000603819

## Test plan

E2E verified on fork branch `bugfix/557-warn-stop-allowed-channels` with two live bot instances against Slack API:

- [x] **Test A** — bot-2 sent 21 messages in `#oncall-support-skill` (not in bot-1's `allowed_channels`) → bot-1 posted **no warning** (fix confirmed)
- [x] **Test B** — bot-2 sent 21 messages in `#all-chuangwangfu` (in bot-1's `allowed_channels`) → bot-1 **still posted the warning** after turn 20 (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)