### PR TITLE
fix(slack): use thread_ts key for multibot_threads cache lookup in handle_message

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1117,7 +1117,8 @@ async fn handle_message(
     let adapter_dyn: Arc<dyn ChatAdapter> = adapter.clone();
     let other_bot_present = {
         let cache = adapter.multibot_threads.lock().await;
-        cache.contains_key(&thread_channel.channel_id)
+        thread_channel.thread_id.as_deref()
+            .is_some_and(|ts| cache.get(ts).is_some_and(|inst| inst.elapsed() < adapter.session_ttl))
     };
     if let Err(e) = router
         .handle_message(&adapter_dyn, &thread_channel, &sender_json, &prompt, extra_blocks, &trigger_msg, other_bot_present)

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+test file

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-test file


### PR DESCRIPTION
## Summary

Fixes the wrong cache key used in `handle_message` when computing `other_bot_present`, which caused streaming to never be disabled in multi-bot threads.

- `multibot_threads` cache is written with `thread_ts` as key (`note_other_bot_in_thread`, line 91)
- `bot_participated_in_thread` (line 228) reads it correctly with `thread_ts`
- `handle_message` (line 1120) was reading with `channel_id` — a key that never exists — so `other_bot_present` was permanently `false` and `use_streaming()` always returned `true`

**Fix:** use `thread_channel.thread_id` with the same TTL-aware pattern as line 228.

Fixes openabdev/openab#556

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1496961096182006023/1497313281000603819

## Test plan

E2E verified on fork branch `bugfix/556-multibot-cache-key` with two live bot instances against Slack API:

- [x] bot-1 replies in a fresh thread → `edited: true` (streaming ON — correct, only bot-1 in thread)
- [x] bot-2 posts in same thread → `note_other_bot_in_thread` populates cache with `thread_ts`
- [x] bot-1 replies again in same thread → **no `edited` field** (streaming OFF — fix confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)