### PR TITLE
feat(helm): render [gateway] config section in ConfigMap + upgrade guide

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -114,6 +114,18 @@ data:
     model = {{ ($cfg.stt).model | default "whisper-large-v3-turbo" | toJson }}
     base_url = {{ ($cfg.stt).baseUrl | default "https://api.groq.com/openai/v1" | toJson }}
     {{- end }}
+    {{- if ($cfg.gateway).url }}
+
+    [gateway]
+    url = {{ ($cfg.gateway).url | toJson }}
+    platform = {{ ($cfg.gateway).platform | default "telegram" | toJson }}
+    {{- if ($cfg.gateway).token }}
+    token = "${GATEWAY_WS_TOKEN}"
+    {{- end }}
+    {{- if ($cfg.gateway).botUsername }}
+    bot_username = {{ ($cfg.gateway).botUsername | toJson }}
+    {{- end }}
+    {{- end }}
   {{- if $cfg.agentsMd }}
   AGENTS.md: |
     {{- $cfg.agentsMd | nindent 4 }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -114,7 +114,10 @@ data:
     model = {{ ($cfg.stt).model | default "whisper-large-v3-turbo" | toJson }}
     base_url = {{ ($cfg.stt).baseUrl | default "https://api.groq.com/openai/v1" | toJson }}
     {{- end }}
-    {{- if ($cfg.gateway).url }}
+    {{- if ($cfg.gateway).enabled }}
+    {{- if not ($cfg.gateway).url }}
+    {{ fail (printf "agents.%s.gateway.url is required when gateway.enabled=true" $name) }}
+    {{- end }}
 
     [gateway]
     url = {{ ($cfg.gateway).url | toJson }}

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -70,6 +70,13 @@ spec:
                   name: {{ include "openab.agentFullname" $d }}
                   key: stt-api-key
             {{- end }}
+            {{- if and ($cfg.gateway).enabled ($cfg.gateway).token }}
+            - name: GATEWAY_WS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $d }}
+                  key: gateway-ws-token
+            {{- end }}
             - name: HOME
               value: {{ $cfg.workingDir | default "/home/agent" }}
             {{- range $k, $v := $cfg.env }}

--- a/charts/openab/templates/secret.yaml
+++ b/charts/openab/templates/secret.yaml
@@ -3,7 +3,8 @@
 {{- $hasDiscord := and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken }}
 {{- $hasSlack := and ($cfg.slack).enabled (or ($cfg.slack).botToken ($cfg.slack).appToken) }}
 {{- $hasStt := and ($cfg.stt).enabled ($cfg.stt).apiKey }}
-{{- if or $hasDiscord $hasSlack $hasStt }}
+{{- $hasGateway := and ($cfg.gateway).enabled ($cfg.gateway).token }}
+{{- if or $hasDiscord $hasSlack $hasStt $hasGateway }}
 {{- $d := dict "ctx" $ "agent" $name "cfg" $cfg }}
 ---
 apiVersion: v1
@@ -27,6 +28,9 @@ data:
   {{- end }}
   {{- if $hasStt }}
   stt-api-key: {{ $cfg.stt.apiKey | b64enc | quote }}
+  {{- end }}
+  {{- if $hasGateway }}
+  gateway-ws-token: {{ $cfg.gateway.token | b64enc | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openab/tests/gateway_test.yaml
+++ b/charts/openab/tests/gateway_test.yaml
@@ -1,0 +1,89 @@
+suite: gateway config rendering
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: does not render [gateway] when gateway not configured
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: '\[gateway\]'
+
+  - it: does not render [gateway] when enabled is false
+    set:
+      agents.kiro.gateway.enabled: false
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: '\[gateway\]'
+
+  - it: renders [gateway] when enabled is true with url
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[gateway\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'url = "ws://openab-gateway:8080/ws"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'platform = "telegram"'
+
+  - it: fails when enabled is true but url is empty
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "gateway.url is required when gateway.enabled=true"
+
+  - it: renders token placeholder when token is set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.token: "my-secret"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'token = "\$\{GATEWAY_WS_TOKEN\}"'
+
+  - it: omits token line when token is empty
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'GATEWAY_WS_TOKEN'
+
+  - it: renders bot_username when set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.botUsername: "my_bot"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'bot_username = "my_bot"'
+
+  - it: omits bot_username when not set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'bot_username'
+
+  - it: renders custom platform
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.platform: "line"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'platform = "line"'

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -170,7 +170,8 @@ agents:
       model: "whisper-large-v3-turbo"
       baseUrl: "https://api.groq.com/openai/v1"
     gateway:
-      url: ""           # e.g. ws://openab-gateway:8080/ws — leave empty to disable
+      enabled: false    # set to true + provide url to enable
+      url: ""           # e.g. ws://openab-gateway:8080/ws
       platform: "telegram"  # default platform when gateway is enabled
       token: ""         # optional shared secret (injected via GATEWAY_WS_TOKEN env var)
       botUsername: ""   # optional, for @mention gating

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -169,6 +169,11 @@ agents:
       apiKey: ""
       model: "whisper-large-v3-turbo"
       baseUrl: "https://api.groq.com/openai/v1"
+    gateway:
+      url: ""           # e.g. ws://openab-gateway:8080/ws — leave empty to disable
+      platform: "telegram"  # default platform when gateway is enabled
+      token: ""         # optional shared secret (injected via GATEWAY_WS_TOKEN env var)
+      botUsername: ""   # optional, for @mention gating
     persistence:
       enabled: true
       storageClass: ""

--- a/docs/ai-install-upgrade.md
+++ b/docs/ai-install-upgrade.md
@@ -100,6 +100,8 @@ rollback openab per the upgrade SOP — the upgrade to v0.7.7 failed
 
 > **Pod label selector:** `app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/component=kiro`
 
+> **Gateway config migration (one-time, if applicable):** If you previously enabled a custom gateway by manually patching the ConfigMap (e.g. adding `[gateway]` to `config.toml` by hand), that block is not captured by `helm get values`. Before upgrading, copy the gateway settings into your `values.yaml` under `agents.<name>.gateway` so they are preserved on every subsequent `helm upgrade`. See chart `values.yaml` for the field reference (`url`, `platform`, `token`, `botUsername`). After migrating, do not manually edit the ConfigMap again — manage gateway config through `values.yaml` only.
+
 ---
 
 ## 3. Upgrade
@@ -134,6 +136,10 @@ rollback openab per the upgrade SOP — the upgrade to v0.7.7 failed
   │  ✓ no panic/fatal in logs                        │
   │  ✓ "bot connected" in logs                       │
   │  ✓ helm chart version matches TARGET             │
+  │  ✓ (if gateway enabled) no gateway disconnect    │
+  │    errors in logs; verify Cloudflare tunnel URL  │
+  │    is still reachable and update values.yaml if  │
+  │    the URL has rotated                           │
   │                                                  │
   │  ALL PASS ──► ✅ DONE                             │
   │  ANY FAIL ──► proceed to 5. ROLLBACK             │

--- a/docs/ai-install-upgrade.md
+++ b/docs/ai-install-upgrade.md
@@ -100,7 +100,7 @@ rollback openab per the upgrade SOP — the upgrade to v0.7.7 failed
 
 > **Pod label selector:** `app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/component=kiro`
 
-> **Gateway config migration (one-time, if applicable):** If you previously enabled a custom gateway by manually patching the ConfigMap (e.g. adding `[gateway]` to `config.toml` by hand), that block is not captured by `helm get values`. Before upgrading, copy the gateway settings into your `values.yaml` under `agents.<name>.gateway` so they are preserved on every subsequent `helm upgrade`. See chart `values.yaml` for the field reference (`url`, `platform`, `token`, `botUsername`). After migrating, do not manually edit the ConfigMap again — manage gateway config through `values.yaml` only.
+> **Gateway config migration (one-time, if applicable):** If you previously enabled a custom gateway by manually patching the ConfigMap (e.g. adding `[gateway]` to `config.toml` by hand), that block is not captured by `helm get values`. Before upgrading, copy the gateway settings into your `values.yaml` under `agents.<name>.gateway` and set `enabled: true` so they are preserved on every subsequent `helm upgrade`. See chart `values.yaml` for the field reference (`enabled`, `url`, `platform`, `token`, `botUsername`). After migrating, do not manually edit the ConfigMap again — manage gateway config through `values.yaml` only.
 
 ---
 


### PR DESCRIPTION
## Summary
* Adds conditional `[gateway]` rendering to `charts/openab/templates/configmap.yaml`, guarded by `gateway.enabled` — when `enabled` is false (default), the section is not rendered and existing users are unaffected
* Adds `gateway` defaults block to `charts/openab/values.yaml` (`enabled`, `url`, `platform`, `token`, `botUsername`) following the same guard pattern as `[stt]`
* Validates that `gateway.url` is required when `gateway.enabled=true` — fails at `helm template` time if missing
* Updates `docs/ai-install-upgrade.md` with a one-time migration note for users who previously hand-patched the ConfigMap, and a post-upgrade gateway connectivity check (including Cloudflare tunnel URL rotation) in the Smoke Test step
* Adds helm unittest suite (`gateway_test.yaml`) with 9 test cases

Closes #566

## Problem

The `[gateway]` config section was not rendered by the Helm chart. Users running a custom gateway (e.g. Telegram) had to manually patch the ConfigMap after every `helm upgrade`, since the upgrade regenerates `config.toml` from the template and silently drops the `[gateway]` block — breaking the WebSocket connection without any obvious error.

## Changes

### `charts/openab/templates/configmap.yaml`

```yaml
{{- if ($cfg.gateway).enabled }}
{{- if not ($cfg.gateway).url }}
{{ fail (printf "agents.%s.gateway.url is required when gateway.enabled=true" $name) }}
{{- end }}

[gateway]
url = {{ ($cfg.gateway).url | toJson }}
platform = {{ ($cfg.gateway).platform | default "telegram" | toJson }}
{{- if ($cfg.gateway).token }}
token = "${GATEWAY_WS_TOKEN}"
{{- end }}
{{- if ($cfg.gateway).botUsername }}
bot_username = {{ ($cfg.gateway).botUsername | toJson }}
{{- end }}
{{- end }}
```

### `charts/openab/values.yaml`

```yaml
gateway:
  enabled: false    # set to true + provide url to enable
  url: ""           # e.g. ws://openab-gateway:8080/ws
  platform: "telegram"  # default platform when gateway is enabled
  token: ""         # optional shared secret (injected via GATEWAY_WS_TOKEN env var)
  botUsername: ""   # optional, for @mention gating
```

### `docs/ai-install-upgrade.md`
* **Backup step**: one-time migration note — users who previously hand-patched `[gateway]` into the ConfigMap must copy settings to `values.yaml` and set `enabled: true` before upgrading
* **Smoke Test step**: conditional check for gateway disconnect errors and Cloudflare tunnel URL rotation

### `charts/openab/tests/gateway_test.yaml`
9 test cases covering:
* Default (no gateway configured) → no `[gateway]` section
* `enabled: false` with url set → no `[gateway]` section
* `enabled: true` with url → renders `[gateway]` with url + platform
* `enabled: true` without url → `fail` at template time
* Token set → renders `${GATEWAY_WS_TOKEN}` placeholder
* Token empty → omits token line
* botUsername set → renders `bot_username`
* botUsername empty → omits `bot_username`
* Custom platform → renders custom value

## Pre-Review

| Check | Result |
|---|---|
| Guard pattern matches `[stt]` (`enabled` flag + required field validation) | ✅ |
| Nil-safe accessor pattern (`($cfg.gateway).enabled`) | ✅ Consistent with `[stt]` / `[slack]` |
| Zero-impact default (`enabled: false` → no section rendered) | ✅ |
| Token injected as env var ref, not plaintext | ✅ |
| Template indentation within `config.toml: \|` multiline string | ✅ |
| `values.yaml` field placement and defaults | ✅ |
| Doc migration note placement (pre-upgrade, Backup step) | ✅ |
| Doc smoke test check is conditional | ✅ |
| Helm unittest coverage (9 cases, all pass) | ✅ |

## Test Plan
* `helm unittest` — 28 tests pass (3 suites: adapter-enablement, configmap, gateway)
* `helm template` with `gateway.enabled: false` → no `[gateway]` section in output
* `helm template` with `gateway.enabled: true` + url set → `[gateway]` section rendered correctly
* `helm template` with `gateway.enabled: true` + url empty → template fails with clear error
* `helm template` with `gateway.token` empty → `token` line omitted
* `helm template` with `gateway.token` set → `token = "${GATEWAY_WS_TOKEN}"` rendered
* Existing deployments without gateway: `helm upgrade` produces identical `config.toml`

Discussion: https://discord.com/channels/1491295327620169908/1497587810796961894