### PR TITLE
feat: add browser-mcp bridge for agent-browser

### DIFF
--- a/contrib/browser-mcp/README.md
+++ b/contrib/browser-mcp/README.md
@@ -1,0 +1,107 @@
+# Browser MCP — agent-browser bridge for OpenAB
+
+Give your OpenAB agents real browser automation via [agent-browser](https://github.com/vercel-labs/agent-browser), without bloating every container with Chrome.
+
+## Architecture
+
+```
+Container (openab-*)              Host / Sidecar
+┌───────────────────┐            ┌─────────────────────┐
+│ browser-mcp-      │── HTTP ──▶ │ browser-bridge.js    │
+│ stdio.py          │            │   └─▶ agent-browser  │
+│ (MCP stdio proxy) │            │       CLI + Chrome   │
+└───────────────────┘            └─────────────────────┘
+```
+
+- **browser-bridge.js** — Lightweight Node.js HTTP server that wraps `agent-browser` CLI commands.
+- **browser-mcp-stdio.py** — Thin MCP stdio proxy (runs inside the container) that forwards tool calls to the bridge over HTTP.
+
+Containers stay slim. Chrome lives in one place.
+
+## Prerequisites
+
+Install `agent-browser` on the host (or a dedicated sidecar):
+
+```bash
+brew install agent-browser        # macOS
+# or
+npm install -g agent-browser      # any platform
+agent-browser install              # download Chrome
+```
+
+## Quick Start
+
+### 1. Start the bridge on the host
+
+```bash
+./start-browser-bridge.sh
+# or manually:
+node browser-bridge.js             # listens on :3002
+```
+
+### 2. Add to your agent's MCP config
+
+In `~/.kiro/settings/mcp.json` (or the agent JSON's `mcpServers`):
+
+```json
+{
+  "mcpServers": {
+    "browser": {
+      "command": "python3",
+      "args": ["/path/to/browser-mcp-stdio.py"],
+      "env": {
+        "BROWSER_BRIDGE_URL": "http://host.docker.internal:3002/message"
+      }
+    }
+  }
+}
+```
+
+### 3. Add `@browser` to the agent's tools list
+
+```json
+{
+  "tools": ["read", "write", "shell", "web_search", "web_fetch", "@browser"]
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `browse_url` | Open a URL, wait for load, return accessibility snapshot |
+| `browse_snapshot` | Get current page snapshot (optionally scoped by CSS selector) |
+| `browse_click` | Click an element by `@ref` from the snapshot |
+| `browse_type` | Clear and fill a text field by `@ref` |
+| `browse_scroll` | Scroll the page (up/down/left/right) |
+| `browse_screenshot` | Take a screenshot |
+| `browse_get_text` | Get text content of an element |
+| `browse_close` | Close the browser session |
+
+## Recommended Agent Prompt Addition
+
+Add this to your agent's system prompt so it automatically falls back to `@browser` when `web_fetch` fails:
+
+```
+## Browser Automation (@browser MCP)
+When web_fetch fails (JS-rendered pages, Cloudflare blocks, empty content),
+use @browser tools instead:
+- browse_url(url) → opens page, returns accessibility snapshot with @refs
+- browse_click(ref) → click element
+- browse_type(ref, text) → fill text field
+- browse_scroll(direction, pixels) → scroll page
+- browse_close() → close when done
+Order: web_fetch → fails → @browser/browse_url → interact → browse_close
+```
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `BROWSER_BRIDGE_PORT` | `3002` | Port for the HTTP bridge |
+| `AGENT_BROWSER_PATH` | `/opt/homebrew/bin/agent-browser` | Path to agent-browser binary |
+| `BROWSER_BRIDGE_URL` | `http://127.0.0.1:3002/message` | Bridge URL (for the stdio proxy) |
+
+## K8s Deployment
+
+Run the bridge as a sidecar or a shared service. The bridge is stateless — one instance can serve multiple agents. Use a `ClusterIP` Service and point `BROWSER_BRIDGE_URL` at it.

--- a/contrib/browser-mcp/browser-bridge.js
+++ b/contrib/browser-mcp/browser-bridge.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * browser-bridge — HTTP bridge for agent-browser CLI.
+ * Agents in containers call this via host.docker.internal:3002/message
+ * using the same JSON-RPC pattern as flights-mcp.
+ */
+const http = require("http");
+const { execFile } = require("child_process");
+const { promisify } = require("util");
+const exec = promisify(execFile);
+
+const PORT = process.env.BROWSER_BRIDGE_PORT || 3002;
+const AB = process.env.AGENT_BROWSER_PATH || "/opt/homebrew/bin/agent-browser";
+const TIMEOUT = 60_000;
+
+async function runAB(args) {
+  const { stdout } = await exec(AB, args, { timeout: TIMEOUT, maxBuffer: 10 * 1024 * 1024 });
+  return stdout;
+}
+
+const HANDLERS = {
+  async browse_url({ url }) {
+    await runAB(["open", url]);
+    await runAB(["wait", "--load", "networkidle"]);
+    const snap = await runAB(["snapshot", "-i", "-c"]);
+    return snap;
+  },
+  async browse_snapshot({ selector }) {
+    const args = ["snapshot", "-i", "-c"];
+    if (selector) args.push("-s", selector);
+    return await runAB(args);
+  },
+  async browse_click({ ref }) {
+    await runAB(["click", ref]);
+    await runAB(["wait", "500"]);
+    return await runAB(["snapshot", "-i", "-c"]);
+  },
+  async browse_type({ ref, text }) {
+    await runAB(["fill", ref, text]);
+    return `Filled ${ref} with text`;
+  },
+  async browse_screenshot({}) {
+    const path = `/tmp/ab-screenshot-${Date.now()}.png`;
+    await runAB(["screenshot", path]);
+    return `Screenshot saved to ${path}`;
+  },
+  async browse_get_text({ ref }) {
+    return await runAB(["get", "text", ref]);
+  },
+  async browse_scroll({ direction, pixels }) {
+    await runAB(["scroll", direction || "down", String(pixels || 500)]);
+    return await runAB(["snapshot", "-i", "-c"]);
+  },
+  async browse_close({}) {
+    await runAB(["close"]);
+    return "Browser closed";
+  },
+};
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200);
+    return res.end("ok");
+  }
+  if (req.method !== "POST" || req.url !== "/message") {
+    res.writeHead(404);
+    return res.end("not found");
+  }
+  let body = "";
+  for await (const chunk of req) body += chunk;
+  try {
+    const rpc = JSON.parse(body);
+    const { name, arguments: args } = rpc.params || {};
+    const handler = HANDLERS[name];
+    if (!handler) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(JSON.stringify({ jsonrpc: "2.0", id: rpc.id, error: { code: -32601, message: `Unknown tool: ${name}` } }));
+    }
+    const result = await handler(args || {});
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ jsonrpc: "2.0", id: rpc.id, result: { content: [{ type: "text", text: String(result) }] } }));
+  } catch (e) {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ jsonrpc: "2.0", id: 1, error: { code: -32000, message: e.message } }));
+  }
+});
+
+server.listen(PORT, "0.0.0.0", () => console.log(`browser-bridge listening on :${PORT}`));

--- a/contrib/browser-mcp/browser-mcp-stdio.py
+++ b/contrib/browser-mcp/browser-mcp-stdio.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Thin stdio MCP server that proxies browser tools to the browser-bridge on host."""
+import json
+import os
+import sys
+import urllib.request
+
+BRIDGE_URL = os.environ.get("BROWSER_BRIDGE_URL", "http://127.0.0.1:3002/message")
+
+TOOLS = [
+    {
+        "name": "browse_url",
+        "description": "Open a URL in a real browser and return the accessibility snapshot (interactive elements with refs). Use this when web_fetch fails on JS-heavy pages.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "URL to open"},
+            },
+            "required": ["url"],
+        },
+    },
+    {
+        "name": "browse_snapshot",
+        "description": "Get the current page's accessibility snapshot (interactive elements with @refs). Optionally scope to a CSS selector.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "selector": {"type": "string", "description": "Optional CSS selector to scope the snapshot"},
+            },
+        },
+    },
+    {
+        "name": "browse_click",
+        "description": "Click an element by its @ref from the snapshot, then return updated snapshot.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "ref": {"type": "string", "description": "Element ref from snapshot, e.g. @e5"},
+            },
+            "required": ["ref"],
+        },
+    },
+    {
+        "name": "browse_type",
+        "description": "Clear and fill a text field by its @ref.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "ref": {"type": "string", "description": "Element ref, e.g. @e3"},
+                "text": {"type": "string", "description": "Text to type"},
+            },
+            "required": ["ref", "text"],
+        },
+    },
+    {
+        "name": "browse_screenshot",
+        "description": "Take a screenshot of the current page.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "browse_get_text",
+        "description": "Get the text content of an element by its @ref.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "ref": {"type": "string", "description": "Element ref, e.g. @e1"},
+            },
+            "required": ["ref"],
+        },
+    },
+    {
+        "name": "browse_scroll",
+        "description": "Scroll the page in a direction, then return updated snapshot.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "direction": {"type": "string", "description": "up, down, left, or right", "default": "down"},
+                "pixels": {"type": "integer", "description": "Pixels to scroll (default 500)", "default": 500},
+            },
+        },
+    },
+    {
+        "name": "browse_close",
+        "description": "Close the browser session.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+KNOWN_TOOLS = {t["name"] for t in TOOLS}
+
+
+def send(id, result=None, error=None):
+    msg = {"jsonrpc": "2.0", "id": id}
+    if error:
+        msg["error"] = error
+    else:
+        msg["result"] = result
+    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.flush()
+
+
+def proxy_to_bridge(tool_name, args):
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool_name, "arguments": args},
+    }).encode()
+    req = urllib.request.Request(BRIDGE_URL, data=payload, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=90) as resp:
+        return json.loads(resp.read())
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = msg.get("method", "")
+        mid = msg.get("id")
+
+        if method == "initialize":
+            send(mid, {"protocolVersion": "2024-11-05", "capabilities": {"tools": {"listChanged": False}}, "serverInfo": {"name": "browser-mcp", "version": "1.0.0"}})
+        elif method == "notifications/initialized":
+            pass
+        elif method == "tools/list":
+            send(mid, {"tools": TOOLS})
+        elif method == "tools/call":
+            params = msg.get("params", {})
+            name = params.get("name")
+            args = params.get("arguments", {})
+            if name not in KNOWN_TOOLS:
+                send(mid, error={"code": -32601, "message": f"Unknown tool: {name}"})
+                continue
+            try:
+                resp = proxy_to_bridge(name, args)
+                if "error" in resp:
+                    send(mid, {"content": [{"type": "text", "text": f"Bridge error: {resp['error'].get('message', 'unknown')}"}], "isError": True})
+                else:
+                    send(mid, resp.get("result", {"content": [{"type": "text", "text": "No result"}]}))
+            except Exception as e:
+                send(mid, {"content": [{"type": "text", "text": f"Browser bridge unreachable: {e}"}], "isError": True})
+        elif mid is not None:
+            send(mid, error={"code": -32601, "message": f"Unknown method: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/browser-mcp/start-browser-bridge.sh
+++ b/contrib/browser-mcp/start-browser-bridge.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Start browser-bridge for agent-browser MCP
+# Usage: ./start-browser-bridge.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BRIDGE="$SCRIPT_DIR/browser-bridge.js"
+LOG="$SCRIPT_DIR/browser-bridge.log"
+NODE="/opt/homebrew/bin/node"
+PORT=3002
+
+# Check if already running
+if lsof -i :$PORT -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "browser-bridge already running on :$PORT"
+  exit 0
+fi
+
+nohup "$NODE" "$BRIDGE" >> "$LOG" 2>&1 &
+echo "browser-bridge started (PID $!, port $PORT)"

--- a/docs/browser-mcp.md
+++ b/docs/browser-mcp.md
@@ -1,0 +1,28 @@
+# Browser Automation via agent-browser
+
+OpenAB agents can use [agent-browser](https://github.com/vercel-labs/agent-browser) for real browser automation — useful when `web_fetch` fails on JavaScript-heavy or Cloudflare-protected pages.
+
+## How It Works
+
+A lightweight HTTP bridge runs on the host (or as a sidecar), wrapping the `agent-browser` CLI. Containers connect via a thin MCP stdio proxy — no Chrome needed inside containers.
+
+See [`contrib/browser-mcp/`](../contrib/browser-mcp/) for the bridge, proxy, and setup instructions.
+
+## Quick Setup
+
+1. Install `agent-browser` on the host: `brew install agent-browser`
+2. Start the bridge: `node contrib/browser-mcp/browser-bridge.js`
+3. Add `browser` to your agent's MCP config pointing at the bridge
+4. Add `@browser` to the agent's tools list
+5. Optionally add the fallback prompt so agents auto-switch from `web_fetch` to `@browser`
+
+## Tools
+
+- `browse_url(url)` — Open URL, return accessibility snapshot
+- `browse_click(ref)` — Click element by @ref
+- `browse_type(ref, text)` — Fill text field
+- `browse_scroll(direction, pixels)` — Scroll page
+- `browse_snapshot(selector?)` — Re-read current page
+- `browse_get_text(ref)` — Get element text
+- `browse_screenshot()` — Take screenshot
+- `browse_close()` — Close browser session


### PR DESCRIPTION
## Summary
Adds a lightweight HTTP bridge + MCP stdio proxy that gives OpenAB agents real browser automation via [agent-browser](https://github.com/vercel-labs/agent-browser) CLI, without bundling Chrome into every container.

## Architecture
```
Container (openab-*)              Host / Sidecar
┌───────────────────┐            ┌─────────────────────┐
│ browser-mcp-      │── HTTP ──▶ │ browser-bridge.js    │
│ stdio.py          │            │   └─▶ agent-browser  │
│ (MCP stdio proxy) │            │       CLI + Chrome   │
└───────────────────┘            └─────────────────────┘
```

## Files
- `contrib/browser-mcp/browser-bridge.js` — Node.js HTTP bridge wrapping agent-browser CLI
- `contrib/browser-mcp/browser-mcp-stdio.py` — MCP stdio proxy for containers
- `contrib/browser-mcp/start-browser-bridge.sh` — Startup script
- `contrib/browser-mcp/README.md` — Full setup guide
- `docs/browser-mcp.md` — Documentation

## Why
- `web_fetch` fails on JS-rendered and Cloudflare-protected pages
- Bundling Chrome in every container adds ~500MB per image
- This bridge pattern (same as flights-mcp) keeps containers slim

## Tested
- Host bridge on macOS (agent-browser 0.24.1 via Homebrew)
- End-to-end from Docker container → host bridge → agent-browser → real page
- Verified: browse_url, browse_click, browse_close all working