### PR TITLE
fix: bump CLI versions — kiro 2.1.1, codex 0.125.0, claude 2.1.116, gemini 0.39.1, copilot 1.0.36, cursor 2026.04.17, opencode 1.14.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install kiro-cli (auto-detect arch, copy binary directly)
-ARG KIRO_CLI_VERSION=2.0.0
+ARG KIRO_CLI_VERSION=2.1.1
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-aarch64-linux.zip"; \
     else URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-x86_64-linux.zip"; fi && \

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # Without CLAUDE_CODE_EXECUTABLE the adapter uses its own bundled SDK cli.js,
 # ignoring the globally installed claude-code binary (see #418).
 ARG CLAUDE_AGENT_ACP_VERSION=0.29.2
-ARG CLAUDE_CODE_VERSION=2.1.114
+ARG CLAUDE_CODE_VERSION=2.1.116
 RUN npm install -g @agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION} @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} --retry 3
 ENV CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude
 

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 
 # Pre-install codex-acp and codex CLI globally
 ARG CODEX_ACP_VERSION=0.11.1
-ARG CODEX_VERSION=0.121.0
+ARG CODEX_VERSION=0.125.0
 RUN npm install -g @zed-industries/codex-acp@${CODEX_ACP_VERSION} @openai/codex@${CODEX_VERSION} --retry 3
 
 # Install gh CLI

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
-ARG COPILOT_VERSION=1.0.30
+ARG COPILOT_VERSION=1.0.36
 RUN npm install -g @github/copilot@${COPILOT_VERSION} --retry 3
 
 # Install gh CLI (for auth and token management)

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # URL scheme scraped from Cursor's official downloads page — no apt/yum package exists.
 # If Cursor changes this pattern, the build fails with curl 404. Monitor
 # https://cursor.com/cli or https://docs.cursor.com/cli for version/URL updates.
-ARG CURSOR_VERSION=2026.04.15-dccdccd
+ARG CURSOR_VERSION=2026.04.17-787b533
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
     curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
-ARG GEMINI_CLI_VERSION=0.38.1
+ARG GEMINI_CLI_VERSION=0.39.1
 RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} --retry 3
 
 # Install gh CLI

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -26,7 +26,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install opencode
-ARG OPENCODE_VERSION=1.4.6
+ARG OPENCODE_VERSION=1.14.25
 RUN npm install -g opencode-ai@${OPENCODE_VERSION} --retry 3
 
 # Install gh CLI (matches Dockerfile.claude / Dockerfile.gemini / Dockerfile.codex)


### PR DESCRIPTION
## Summary

Bump all pinned CLI versions in Dockerfiles after investigating latest releases and upstream bug trackers.

Discord Discussion URL: N/A

## Changes

| Dockerfile | CLI | Old | New | Notes |
|---|---|---|---|---|
| `Dockerfile` | kiro-cli | 2.0.0 | **2.1.1** | Shell streaming, Tool Search, Skills as slash commands, RHEL support, device flow auth |
| `Dockerfile.codex` | `@openai/codex` | 0.121.0 | **0.125.0** | Unix socket transport, permission profiles; open bugs are app/Windows only |
| `Dockerfile.claude` | `@anthropic-ai/claude-code` | 2.1.114 | **2.1.116** | ⚠️ Safe ceiling — 2.1.118+ has resume crash, sandbox regressions (all macOS/Windows) |
| `Dockerfile.gemini` | `@google/gemini-cli` | 0.38.1 | **0.39.1** | Context compression, memory/leak fixes; **zero** open bugs with `bug` label |
| `Dockerfile.copilot` | `@github/copilot` | 1.0.30 | **1.0.36** | No public issue tracker; 6 patch versions, low risk |
| `Dockerfile.cursor` | Cursor Agent CLI | 2026.04.15-dccdccd | **2026.04.17-787b533** | From official install script + Homebrew |
| `Dockerfile.opencode` | `opencode-ai` | 1.4.6 | **1.14.25** | ⚠️ Large version jump (8+ minors); open bugs are all Windows/web/TUI — headless safe |

## NOT updated (intentionally)

| Dockerfile | Dependency | Pinned | Why |
|---|---|---|---|
| `Dockerfile.codex` | `codex-acp` | 0.11.1 | No new release needed |
| `Dockerfile.claude` | `claude-agent-acp` | 0.29.2 | Bumped in #474, still current |

## claude-code risk assessment

All open regressions are on **2.1.118-2.1.120** and tagged `platform:macos` or `platform:windows`:
- `#53086` `#53145` `#53214`: `--resume` crash "g9H is not a function" (2.1.120, macOS)
- `#53085`: sandbox required but unavailable (2.1.120, macOS)
- `#53152`: Teammate agent crash in tmux (2.1.120, WSL)
- `#53294`: Hangs on non-Metal GPU (2.1.118+, macOS)

**Zero** regressions on 2.1.114–2.1.116. **Zero** regressions tagged `platform:linux`. 2.1.116 is the safe ceiling.

## opencode-ai note

Large version jump from 1.4.6 → 1.14.25. The 1.0+ rewrite introduced opentui (new TUI layer), but openab runs opencode in ACP headless mode — TUI changes don't affect us. All open bugs are Windows/web/TUI. Recommend running full ACP smoke test after merge.

## How to verify

```bash
# kiro-cli
curl -fsSL https://prod.download.cli.kiro.dev/stable/latest/manifest.json | jq -r '.version'

# npm packages
npm view @openai/codex version
npm view @anthropic-ai/claude-code version
npm view @google/gemini-cli version
npm view @github/copilot version
npm view opencode-ai version

# cursor
curl -fsSL https://cursor.com/install | grep '2026\.'
```

Ref: #326, #412, #474