### PR TITLE
feat(shutdown): handle SIGTERM for k8s graceful shutdown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,33 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
+/// Wait for SIGINT (ctrl_c) or, on unix, SIGTERM. SIGTERM is what Kubernetes
+/// sends during pod termination, so handling it lets us run the full cleanup
+/// path (shard manager, ACP pool drain) instead of getting SIGKILL'd after the
+/// grace period.
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(error = %e, "failed to install SIGTERM handler, falling back to ctrl_c only");
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = term.recv() => { info!("SIGTERM received"); }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "openab")]
 #[command(about = "Multi-platform ACP agent broker (Discord, Slack)", long_about = None)]
@@ -233,7 +260,7 @@ async fn main() -> anyhow::Result<()> {
         // Graceful Discord shutdown on ctrl_c
         let shard_manager = client.shard_manager.clone();
         tokio::spawn(async move {
-            tokio::signal::ctrl_c().await.ok();
+            shutdown_signal().await;
             info!("shutdown signal received");
             shard_manager.shutdown_all().await;
         });
@@ -241,9 +268,9 @@ async fn main() -> anyhow::Result<()> {
         info!("discord bot running");
         client.start().await?;
     } else {
-        // No Discord — just wait for ctrl_c
+        // No Discord — wait for SIGINT or SIGTERM
         info!("running without discord, press ctrl+c to stop");
-        tokio::signal::ctrl_c().await.ok();
+        shutdown_signal().await;
         info!("shutdown signal received");
     }
 


### PR DESCRIPTION
## Summary

- Add a `shutdown_signal()` helper in `src/main.rs` that waits for SIGINT **or** SIGTERM on unix and falls back to ctrl_c on Windows.
- Replace both `tokio::signal::ctrl_c().await.ok()` call sites with the helper so Kubernetes-style SIGTERM triggers the full cleanup path (Discord shard manager → Slack/gateway shutdown channel → ACP pool drain → child process group SIGTERM/SIGKILL escalation).

Fixes #593.

Discord discussion: https://discord.com/channels/1491295327620169908/1491365157010542652/1498213613410848789

## Why

`tokio::signal::ctrl_c()` only catches SIGINT. Kubernetes sends **SIGTERM** to PID 1 during pod termination, so the previous code skipped graceful cleanup and got SIGKILL'd after `terminationGracePeriodSeconds`.

## Relationship to #449

#449 added `tini` as PID 1 in the Dockerfiles, which ensures SIGTERM is **delivered** to openab (and reaps agent-grandchild zombies). This PR is the complementary second half: making openab **handle** the SIGTERM that tini forwards. Without this change, SIGTERM still hit the default disposition (terminate without running cleanup) even with tini in place.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --bin openab` (124 passed)
- [ ] Manual: `kill -TERM <pid>` against a running openab process and confirm "shutdown signal received" → "openab shut down" in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)