### PR TITLE
docs(markdown) Adding arguments of agents.gemini.discord.enabled=true and specify Gemini model.

### DIFF
--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -26,7 +26,7 @@ helm install openab openab/openab \
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
 > 
->  (Optional)`agents.gemini.args='{--acp}'` could be modified as `{--model,gemini-3-pro-preview,--acp}` if specific model is required. Otherwise, the defalut value will be 'Auto (Gemini 3)'.
+> (Optional) `agents.gemini.args='{--acp}'` could be modified as `{--model,gemini-3-pro-preview,--acp}` if specific model is required. Otherwise, the default value will be 'Auto (Gemini 3)'.
 
 ## Manual config.toml
 

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -26,7 +26,7 @@ helm install openab openab/openab \
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
 > 
-> `agents.gemini.args='{--acp}'` could be `{--model,gemini-3-pro-preview,--acp}` if specific model is required. Otherwise, it will be 'Auto (Gemini 3)'. 
+>  (Optional)`agents.gemini.args='{--acp}'` could be modified as `{--model,gemini-3-pro-preview,--acp}` if specific model is required. Otherwise, the defalut value will be 'Auto (Gemini 3)'.
 
 ## Manual config.toml
 

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -15,6 +15,7 @@ The image installs `@google/gemini-cli` globally via npm.
 ```bash
 helm install openab openab/openab \
   --set agents.kiro.enabled=false \
+  --set agents.gemini.discord.enabled=true \
   --set agents.gemini.discord.botToken="$DISCORD_BOT_TOKEN" \
   --set-string 'agents.gemini.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agents.gemini.image=ghcr.io/openabdev/openab-gemini:latest \
@@ -24,6 +25,8 @@ helm install openab openab/openab \
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
+> 
+> `agents.gemini.args='{--acp}'` could be `{--model,gemini-3-pro-preview,--acp}` if specific model is required. Otherwise, it will be 'Auto (Gemini 3)'. 
 
 ## Manual config.toml
 


### PR DESCRIPTION
Adding arguments of agents.gemini.discord.enabled=true and specify Gemini model.
Per https://discord.com/channels/1491295327620169908/1491365158868619404/1498273257214840862