### PR TITLE
feat: config-driven cronjob scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +188,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +284,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "089df96cf6a25253b4b6b6744d86f91150a3d4df546f31a95def47976b8cba97"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "phf 0.11.3",
+ "winnow",
 ]
 
 [[package]]
@@ -642,6 +692,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,7 +1060,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "chrono",
+ "chrono-tz",
  "clap",
+ "cron",
  "futures-util",
  "image",
  "libc",
@@ -1036,6 +1113,66 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1639,6 +1776,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -2371,10 +2514,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 unicode-width = "0.2"
 pulldown-cmark = { version = "0.13", default-features = false }
 tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
+cron = "0.16.0"
+chrono = "0.4.44"
+chrono-tz = "0.10.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -129,6 +129,19 @@ data:
     bot_username = {{ ($cfg.gateway).botUsername | toJson }}
     {{- end }}
     {{- end }}
+    {{- range ($cfg.cronjobs) }}
+
+    [[cronjobs]]
+    schedule = {{ .schedule | toJson }}
+    channel = {{ .channel | toJson }}
+    message = {{ .message | toJson }}
+    platform = {{ .platform | default "discord" | toJson }}
+    sender_name = {{ .senderName | default "openab-cron" | toJson }}
+    timezone = {{ .timezone | default "UTC" | toJson }}
+    {{- if .threadId }}
+    thread_id = {{ .threadId | toJson }}
+    {{- end }}
+    {{- end }}
   {{- if $cfg.agentsMd }}
   AGENTS.md: |
     {{- $cfg.agentsMd | nindent 4 }}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -175,6 +175,18 @@ agents:
       platform: "telegram"  # default platform when gateway is enabled
       token: ""         # optional shared secret (injected via GATEWAY_WS_TOKEN env var)
       botUsername: ""   # optional, for @mention gating
+    # Scheduled messages — config-driven cron (ADR: basic-cronjob)
+    # Each entry sends a message to the agent at the specified schedule.
+    # Example:
+    #   cronjobs:
+    #     - schedule: "0 9 * * 1-5"
+    #       channel: "123456789"
+    #       message: "summarize yesterday's merged PRs"
+    #       platform: "discord"
+    #       senderName: "DailyOps"
+    #       timezone: "Asia/Taipei"
+    #       threadId: ""
+    cronjobs: []
     persistence:
       enabled: true
       storageClass: ""

--- a/config.toml.example
+++ b/config.toml.example
@@ -104,3 +104,21 @@ stall_soft_ms = 10000
 stall_hard_ms = 30000
 done_hold_ms = 1500
 error_hold_ms = 2500
+
+# --- Scheduled messages (config-driven cron) ---
+# Each entry sends a message to the agent at the specified schedule.
+# The agent processes it and replies to the target channel.
+
+# [[cronjobs]]
+# schedule = "0 9 * * 1-5"                    # weekdays at 9:00 AM
+# channel = "123456789"                        # target channel/thread ID
+# message = "summarize yesterday's merged PRs" # prompt for the agent
+# platform = "discord"                         # "discord" or "slack"
+# sender_name = "DailyOps"                     # attribution (default: "openab-cron")
+# timezone = "Asia/Taipei"                     # IANA timezone (default: "UTC")
+# thread_id = ""                               # optional: post to existing thread
+
+# [[cronjobs]]
+# schedule = "0 0 * * 0"
+# channel = "123456789"
+# message = "generate weekly status report"

--- a/config.toml.example
+++ b/config.toml.example
@@ -110,12 +110,13 @@ error_hold_ms = 2500
 # The agent processes it and replies to the target channel.
 
 # [[cronjobs]]
+# enabled = true                               # optional, default: true
 # schedule = "0 9 * * 1-5"                    # weekdays at 9:00 AM
 # channel = "123456789"                        # target channel/thread ID
 # message = "summarize yesterday's merged PRs" # prompt for the agent
 # platform = "discord"                         # "discord" or "slack"
 # sender_name = "DailyOps"                     # attribution (default: "openab-cron")
-# timezone = "Asia/Taipei"                     # IANA timezone (default: "UTC")
+# timezone = "America/New_York"                     # IANA timezone (default: "UTC")
 # thread_id = ""                               # optional: post to existing thread
 
 # [[cronjobs]]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -277,7 +277,10 @@ Key mapping (`values.yaml` → `config.toml`):
 | `agents.<name>.cronjobs[].schedule` | `[[cronjobs]] schedule` |
 | `agents.<name>.cronjobs[].channel` | `[[cronjobs]] channel` |
 | `agents.<name>.cronjobs[].message` | `[[cronjobs]] message` |
+| `agents.<name>.cronjobs[].platform` | `[[cronjobs]] platform` |
+| `agents.<name>.cronjobs[].senderName` | `[[cronjobs]] sender_name` |
 | `agents.<name>.cronjobs[].timezone` | `[[cronjobs]] timezone` |
+| `agents.<name>.cronjobs[].threadId` | `[[cronjobs]] thread_id` |
 
 > ⚠️ Use `--set-string` (not `--set`) for Discord/Slack IDs to avoid float64 precision loss:
 > ```bash

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -185,6 +185,58 @@ Speech-to-text transcription for voice messages. Uses an OpenAI-compatible `/aud
 
 ---
 
+## `[[cronjobs]]`
+
+Scheduled messages — config-driven cron. Each entry sends a message to the agent at the specified schedule, as if a user typed it. The agent processes the message and replies to the target channel.
+
+```toml
+[[cronjobs]]
+schedule = "0 9 * * 1-5"                    # cron expression (5-field POSIX)
+channel = "123456789"                        # target channel/thread ID
+message = "summarize yesterday's merged PRs" # message sent to agent
+platform = "discord"                         # optional, default: "discord"
+sender_name = "DailyOps"                     # optional, default: "openab-cron"
+timezone = "Asia/Taipei"                     # optional, default: "UTC"
+thread_id = ""                               # optional, post to existing thread
+
+[[cronjobs]]
+schedule = "0 0 * * 0"
+channel = "123456789"
+message = "generate weekly status report"
+platform = "discord"
+timezone = "UTC"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `schedule` | string | *required* | Cron expression (minute, hour, day-of-month, month, day-of-week). |
+| `channel` | string | *required* | Target Discord channel/thread ID or Slack channel ID. |
+| `message` | string | *required* | Message sent to the agent as a prompt. |
+| `platform` | string | `"discord"` | Target platform (`"discord"` or `"slack"`). |
+| `sender_name` | string | `"openab-cron"` | Sender attribution shown in the prompt context. |
+| `timezone` | string | `"UTC"` | IANA timezone for schedule evaluation (e.g. `"Asia/Taipei"`, `"Europe/Berlin"`). |
+| `thread_id` | string | `""` | Optional thread ID to post into an existing thread. |
+
+**Cron expression format:**
+
+```
+┌───────────── minute (0-59)
+│ ┌───────────── hour (0-23)
+│ │ ┌───────────── day of month (1-31)
+│ │ │ ┌───────────── month (1-12)
+│ │ │ │ ┌───────────── day of week (0-7, 0 and 7 = Sunday)
+│ │ │ │ │
+* * * * *
+```
+
+**Behaviors:**
+- Scheduler evaluates expressions once per minute
+- If a previous execution is still running, the next tick is skipped (no overlap)
+- Failed executions are logged but do not block other jobs or chat traffic
+- Stateless — no persistence needed, re-evaluated from config on restart
+
+---
+
 ## Customizing via Helm
 
 When deploying with the Helm chart (`charts/openab`), the `config.toml` is generated from `values.yaml`. Each agent is defined under the `agents` map:
@@ -222,6 +274,10 @@ Key mapping (`values.yaml` → `config.toml`):
 | `agents.<name>.pool.sessionTtlHours` | `[pool] session_ttl_hours` |
 | `agents.<name>.reactions.enabled` | `[reactions] enabled` |
 | `agents.<name>.stt.apiKey` | `[stt] api_key` |
+| `agents.<name>.cronjobs[].schedule` | `[[cronjobs]] schedule` |
+| `agents.<name>.cronjobs[].channel` | `[[cronjobs]] channel` |
+| `agents.<name>.cronjobs[].message` | `[[cronjobs]] message` |
+| `agents.<name>.cronjobs[].timezone` | `[[cronjobs]] timezone` |
 
 > ⚠️ Use `--set-string` (not `--set`) for Discord/Slack IDs to avoid float64 precision loss:
 > ```bash

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -191,12 +191,13 @@ Scheduled messages — config-driven cron. Each entry sends a message to the age
 
 ```toml
 [[cronjobs]]
+enabled = true                               # optional, default: true
 schedule = "0 9 * * 1-5"                    # cron expression (5-field POSIX)
 channel = "123456789"                        # target channel/thread ID
 message = "summarize yesterday's merged PRs" # message sent to agent
 platform = "discord"                         # optional, default: "discord"
 sender_name = "DailyOps"                     # optional, default: "openab-cron"
-timezone = "Asia/Taipei"                     # optional, default: "UTC"
+timezone = "America/New_York"                     # optional, default: "UTC"
 thread_id = ""                               # optional, post to existing thread
 
 [[cronjobs]]
@@ -209,12 +210,13 @@ timezone = "UTC"
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| `enabled` | bool | `true` | Set `false` to disable without removing the entry. |
 | `schedule` | string | *required* | Cron expression (minute, hour, day-of-month, month, day-of-week). |
 | `channel` | string | *required* | Target Discord channel/thread ID or Slack channel ID. |
 | `message` | string | *required* | Message sent to the agent as a prompt. |
 | `platform` | string | `"discord"` | Target platform (`"discord"` or `"slack"`). |
 | `sender_name` | string | `"openab-cron"` | Sender attribution shown in the prompt context. |
-| `timezone` | string | `"UTC"` | IANA timezone for schedule evaluation (e.g. `"Asia/Taipei"`, `"Europe/Berlin"`). |
+| `timezone` | string | `"UTC"` | IANA timezone for schedule evaluation (e.g. `"America/New_York"`, `"Europe/Berlin"`). |
 | `thread_id` | string | `""` | Optional thread ID to post into an existing thread. |
 
 **Cron expression format:**
@@ -274,6 +276,7 @@ Key mapping (`values.yaml` → `config.toml`):
 | `agents.<name>.pool.sessionTtlHours` | `[pool] session_ttl_hours` |
 | `agents.<name>.reactions.enabled` | `[reactions] enabled` |
 | `agents.<name>.stt.apiKey` | `[stt] api_key` |
+| `agents.<name>.cronjobs[].enabled` | `[[cronjobs]] enabled` |
 | `agents.<name>.cronjobs[].schedule` | `[[cronjobs]] schedule` |
 | `agents.<name>.cronjobs[].channel` | `[[cronjobs]] channel` |
 | `agents.<name>.cronjobs[].message` | `[[cronjobs]] message` |

--- a/docs/cronjob.md
+++ b/docs/cronjob.md
@@ -1,0 +1,181 @@
+# Scheduled Messages (Config-Driven Cron)
+
+Send recurring prompts to your agent on a schedule — daily summaries, weekly reports, periodic scans — without external infrastructure.
+
+## How It Works
+
+1. Define `[[cronjobs]]` entries in `config.toml`
+2. OpenAB's internal scheduler evaluates cron expressions once per minute
+3. When a schedule matches, the message is sent to the agent as if a user typed it
+4. The agent processes the message and replies to the target channel
+
+No external scheduler (K8s CronJob, GitHub Actions) is needed for simple use cases.
+
+## Quick Start
+
+Add to your `config.toml`:
+
+```toml
+[[cronjobs]]
+schedule = "0 9 * * 1-5"
+channel = "123456789012345678"
+message = "summarize yesterday's merged PRs"
+```
+
+This sends `summarize yesterday's merged PRs` to the agent every weekday at 09:00 UTC in the specified Discord channel.
+
+## Configuration
+
+Each `[[cronjobs]]` entry supports these fields:
+
+```toml
+[[cronjobs]]
+schedule = "0 9 * * 1-5"                    # required: cron expression
+channel = "123456789012345678"               # required: target channel ID
+message = "summarize yesterday's merged PRs" # required: prompt for the agent
+platform = "discord"                         # optional, default: "discord"
+sender_name = "DailyOps"                     # optional, default: "openab-cron"
+timezone = "Asia/Taipei"                     # optional, default: "UTC"
+thread_id = ""                               # optional: post to existing thread
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `schedule` | ✅ | — | 5-field POSIX cron expression |
+| `channel` | ✅ | — | Discord channel/thread ID or Slack channel ID |
+| `message` | ✅ | — | Message sent to the agent as a prompt |
+| `platform` | | `"discord"` | `"discord"` or `"slack"` |
+| `sender_name` | | `"openab-cron"` | Attribution shown in prompt context |
+| `timezone` | | `"UTC"` | IANA timezone (e.g. `"Asia/Taipei"`, `"Europe/Berlin"`) |
+| `thread_id` | | — | Post into an existing thread instead of the channel |
+
+## Cron Expression Format
+
+Standard 5-field POSIX cron, same as Linux crontab, K8s CronJob, and GitHub Actions:
+
+```
+┌───────────── minute (0-59)
+│ ┌───────────── hour (0-23)
+│ │ ┌───────────── day of month (1-31)
+│ │ │ ┌───────────── month (1-12)
+│ │ │ │ ┌───────────── day of week (0-7, 0 and 7 = Sunday)
+│ │ │ │ │
+* * * * *
+```
+
+### Examples
+
+| Expression | Meaning |
+|---|---|
+| `0 9 * * 1-5` | Weekdays at 09:00 |
+| `0 0 * * 0` | Sundays at midnight |
+| `*/30 * * * *` | Every 30 minutes |
+| `0 18 * * 1-5` | Weekdays at 18:00 |
+| `0 9 1 * *` | First day of every month at 09:00 |
+
+## Timezone Support
+
+By default, schedules are evaluated in UTC. Set `timezone` to any IANA timezone:
+
+```toml
+[[cronjobs]]
+schedule = "0 9 * * 1-5"
+channel = "123456789012345678"
+message = "good morning team, here's today's agenda"
+timezone = "Asia/Taipei"
+```
+
+This fires at 09:00 Taipei time (01:00 UTC).
+
+## Multiple Jobs
+
+Define as many `[[cronjobs]]` entries as you need:
+
+```toml
+[[cronjobs]]
+schedule = "0 9 * * 1-5"
+channel = "123456789012345678"
+message = "summarize yesterday's merged PRs"
+sender_name = "DailyOps"
+timezone = "Asia/Taipei"
+
+[[cronjobs]]
+schedule = "0 0 * * 0"
+channel = "123456789012345678"
+message = "generate weekly status report"
+sender_name = "WeeklyReport"
+
+[[cronjobs]]
+schedule = "0 18 * * 1-5"
+channel = "C0123456789"
+message = "check for any critical alerts in the last 8 hours"
+platform = "slack"
+sender_name = "OpsBot"
+```
+
+## Helm Deployment
+
+When using the Helm chart, define cronjobs under each agent in `values.yaml`:
+
+```yaml
+agents:
+  kiro:
+    cronjobs:
+      - schedule: "0 9 * * 1-5"
+        channel: "123456789012345678"
+        message: "summarize yesterday's merged PRs"
+        platform: "discord"
+        senderName: "DailyOps"
+        timezone: "Asia/Taipei"
+      - schedule: "0 0 * * 0"
+        channel: "123456789012345678"
+        message: "generate weekly status report"
+```
+
+> ⚠️ Use `--set-string` for channel IDs to avoid float64 precision loss:
+> ```bash
+> helm upgrade mybot charts/openab \
+>   --set-string agents.kiro.cronjobs[0].channel="123456789012345678"
+> ```
+
+## Behaviors
+
+- **Minute-aligned**: The scheduler aligns to minute boundaries (`:00`), so `0 9 * * *` fires at exactly 09:00:00, not at whatever second the process started.
+- **Overlap protection**: If a previous execution of the same job is still running, the next tick is skipped.
+- **Isolation**: Cron failures are logged but never block interactive chat traffic.
+- **Stateless**: No persistence needed. Schedules are re-evaluated from config on restart.
+- **Graceful shutdown**: In-flight cron tasks are waited on (up to 30 seconds) during shutdown.
+
+## Sender Identity
+
+When a cron job fires, the agent sees a sender context like:
+
+```
+🕐 [DailyOps]: summarize yesterday's merged PRs
+```
+
+Use `sender_name` to distinguish different scheduled tasks in logs and thread titles. The agent can use this to tailor its response (e.g. "DailyOps asked for a summary" vs "WeeklyReport asked for a report").
+
+## When to Use External Schedulers Instead
+
+Config-driven cron covers the 80% use case: "send this message at this time." For advanced needs, use external schedulers:
+
+| Need | Recommendation |
+|---|---|
+| Simple recurring prompts | ✅ Config-driven cron (this feature) |
+| Long-running jobs (>5 min) | K8s CronJob |
+| Conditional logic / retries | GitHub Actions or Step Functions |
+| Multi-step workflows / DAGs | GitHub Actions or Step Functions |
+| Per-execution isolation | K8s CronJob (separate Pod per run) |
+
+See [Kubernetes CronJob Reference Architecture](cronjob_k8s_refarch.md) for the external scheduler approach.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Job never fires | Invalid cron expression | Check logs for `invalid cron expression, skipping` |
+| Job fires but no reply | Agent error | Check logs for `cron handle_message error` |
+| Wrong time | Timezone mismatch | Set `timezone` explicitly (default is UTC) |
+| Job skipped | Previous execution still running | Check logs for `skipping cronjob, previous execution still running` |
+| Channel not found | Bot not in channel | Invite the bot to the target channel |

--- a/docs/cronjob.md
+++ b/docs/cronjob.md
@@ -30,23 +30,25 @@ Each `[[cronjobs]]` entry supports these fields:
 
 ```toml
 [[cronjobs]]
+enabled = true                               # optional, default: true
 schedule = "0 9 * * 1-5"                    # required: cron expression
 channel = "123456789012345678"               # required: target channel ID
 message = "summarize yesterday's merged PRs" # required: prompt for the agent
 platform = "discord"                         # optional, default: "discord"
 sender_name = "DailyOps"                     # optional, default: "openab-cron"
-timezone = "Asia/Taipei"                     # optional, default: "UTC"
+timezone = "America/New_York"                     # optional, default: "UTC"
 thread_id = ""                               # optional: post to existing thread
 ```
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
+| `enabled` | | `true` | Set `false` to disable without removing the entry |
 | `schedule` | ✅ | — | 5-field POSIX cron expression |
 | `channel` | ✅ | — | Discord channel/thread ID or Slack channel ID |
 | `message` | ✅ | — | Message sent to the agent as a prompt |
 | `platform` | | `"discord"` | `"discord"` or `"slack"` |
 | `sender_name` | | `"openab-cron"` | Attribution shown in prompt context |
-| `timezone` | | `"UTC"` | IANA timezone (e.g. `"Asia/Taipei"`, `"Europe/Berlin"`) |
+| `timezone` | | `"UTC"` | IANA timezone (e.g. `"America/New_York"`, `"Europe/Berlin"`) |
 | `thread_id` | | — | Post into an existing thread instead of the channel |
 
 ## Cron Expression Format
@@ -82,10 +84,10 @@ By default, schedules are evaluated in UTC. Set `timezone` to any IANA timezone:
 schedule = "0 9 * * 1-5"
 channel = "123456789012345678"
 message = "good morning team, here's today's agenda"
-timezone = "Asia/Taipei"
+timezone = "America/New_York"
 ```
 
-This fires at 09:00 Taipei time (01:00 UTC).
+This fires at 09:00 New York time (13:00 or 14:00 UTC depending on DST).
 
 ## Multiple Jobs
 
@@ -97,7 +99,7 @@ schedule = "0 9 * * 1-5"
 channel = "123456789012345678"
 message = "summarize yesterday's merged PRs"
 sender_name = "DailyOps"
-timezone = "Asia/Taipei"
+timezone = "America/New_York"
 
 [[cronjobs]]
 schedule = "0 0 * * 0"
@@ -126,7 +128,7 @@ agents:
         message: "summarize yesterday's merged PRs"
         platform: "discord"
         senderName: "DailyOps"
-        timezone: "Asia/Taipei"
+        timezone: "America/New_York"
       - schedule: "0 0 * * 0"
         channel: "123456789012345678"
         message: "generate weekly status report"

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,7 +45,6 @@ pub struct Config {
     #[serde(default)]
     pub stt: SttConfig,
     #[serde(default)]
-    #[serde(default)]
     pub markdown: MarkdownConfig,
     #[serde(default)]
     pub cronjobs: Vec<CronJobConfig>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,7 +45,10 @@ pub struct Config {
     #[serde(default)]
     pub stt: SttConfig,
     #[serde(default)]
+    #[serde(default)]
     pub markdown: MarkdownConfig,
+    #[serde(default)]
+    pub cronjobs: Vec<CronJobConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -198,6 +201,31 @@ pub struct PoolConfig {
     #[serde(default = "default_ttl_hours")]
     pub session_ttl_hours: u64,
 }
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CronJobConfig {
+    /// Cron expression (5-field POSIX format)
+    pub schedule: String,
+    /// Target channel ID
+    pub channel: String,
+    /// Message to send to the agent
+    pub message: String,
+    /// Target platform (default: "discord")
+    #[serde(default = "default_cron_platform")]
+    pub platform: String,
+    /// Sender name for attribution (default: "openab-cron")
+    #[serde(default = "default_cron_sender")]
+    pub sender_name: String,
+    /// Optional thread ID (post to existing thread)
+    pub thread_id: Option<String>,
+    /// Timezone (default: "UTC")
+    #[serde(default = "default_cron_timezone")]
+    pub timezone: String,
+}
+
+fn default_cron_platform() -> String { "discord".into() }
+fn default_cron_sender() -> String { "openab-cron".into() }
+fn default_cron_timezone() -> String { "UTC".into() }
 
 #[derive(Debug, Deserialize)]
 pub struct ReactionsConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,6 +203,9 @@ pub struct PoolConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct CronJobConfig {
+    /// Whether this cronjob is active (default: true)
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     /// Cron expression (5-field POSIX format)
     pub schedule: String,
     /// Target channel ID

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -1,6 +1,6 @@
 use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, SenderContext};
 use crate::config::CronJobConfig;
-use chrono::Utc;
+use chrono::{Timelike, Utc};
 use chrono_tz::Tz;
 use cron::Schedule;
 use std::collections::{HashMap, HashSet};
@@ -16,14 +16,23 @@ pub fn parse_cron_expr(expr: &str) -> Result<Schedule, cron::error::Error> {
     Schedule::from_str(&six_field)
 }
 
-/// Check whether a cron schedule should fire given the current time and a tick interval.
-/// Returns true if the next upcoming event is within `tick_secs` seconds from now.
-pub fn should_fire(schedule: &Schedule, tz: Tz, tick_secs: i64) -> bool {
-    let now_tz = Utc::now().with_timezone(&tz);
+/// Check whether a cron schedule should fire right now.
+/// Truncates the current time to the minute boundary and checks if the
+/// schedule has an event at exactly that minute.
+pub fn should_fire(schedule: &Schedule, tz: Tz) -> bool {
+    let now = Utc::now().with_timezone(&tz);
+    // Truncate to start of current minute
+    let minute_start = now
+        .with_second(0).unwrap()
+        .with_nanosecond(0).unwrap();
+    // Query upcoming events from 1 second before the minute boundary.
+    // `upcoming()` returns events strictly > the query time, so querying
+    // from (minute_start - 1s) will include minute_start itself.
+    let query_from = minute_start - chrono::Duration::seconds(1);
     schedule
-        .upcoming(tz)
+        .after(&query_from)
         .next()
-        .map(|next| (next - now_tz).num_seconds() <= tick_secs)
+        .map(|next| next == minute_start)
         .unwrap_or(false)
 }
 
@@ -120,7 +129,7 @@ pub async fn run_scheduler(
         tokio::select! {
             _ = ticker.tick() => {
                 for (idx, (schedule, tz, job)) in jobs.iter().enumerate() {
-                    if !should_fire(schedule, *tz, 60) {
+                    if !should_fire(schedule, *tz) {
                         continue;
                     }
                     // Skip if previous execution still running
@@ -251,6 +260,7 @@ async fn fire_cronjob(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{Datelike, Timelike};
 
     #[test]
     fn parse_valid_cron_expression() {
@@ -301,23 +311,20 @@ mod tests {
 
     #[test]
     fn should_fire_every_minute_returns_true() {
-        // "* * * * *" fires every minute, so next event is always within 60s
+        // "* * * * *" fires every minute — current minute always matches
         let schedule = parse_cron_expr("* * * * *").unwrap();
-        assert!(should_fire(&schedule, chrono_tz::UTC, 60));
-    }
-
-    #[test]
-    fn should_fire_with_zero_tick_window_returns_false() {
-        // "* * * * *" next event is up to 60s away; 0-second window should not fire
-        let schedule = parse_cron_expr("* * * * *").unwrap();
-        assert!(!should_fire(&schedule, chrono_tz::UTC, 0));
+        assert!(should_fire(&schedule, chrono_tz::UTC));
     }
 
     #[test]
     fn should_fire_returns_false_for_distant_schedule() {
-        // Schedule for Jan 1 at 00:00 — unless we happen to be on Jan 1, this is months away
+        // Schedule for Jan 1 at 00:00 — unless we happen to be on Jan 1, this won't match
         let schedule = parse_cron_expr("0 0 1 1 *").unwrap();
-        assert!(!should_fire(&schedule, chrono_tz::UTC, 60));
+        // Only passes if today is NOT Jan 1 at 00:xx UTC
+        let now = chrono::Utc::now();
+        if now.month() != 1 || now.day() != 1 || now.hour() != 0 {
+            assert!(!should_fire(&schedule, chrono_tz::UTC));
+        }
     }
 
     #[test]
@@ -325,7 +332,7 @@ mod tests {
         let schedule = parse_cron_expr("* * * * *").unwrap();
         let tz: Tz = "Asia/Taipei".parse().unwrap();
         // Every-minute schedule should fire regardless of timezone
-        assert!(should_fire(&schedule, tz, 60));
+        assert!(should_fire(&schedule, tz));
     }
 
     #[test]

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -27,6 +27,9 @@ pub fn should_fire(schedule: &Schedule, tz: Tz, tick_secs: i64) -> bool {
         .unwrap_or(false)
 }
 
+/// Known platforms that have adapter support.
+const VALID_PLATFORMS: &[&str] = &["discord", "slack"];
+
 /// Validate all cronjob configs at startup (fail-fast on bad cron expressions or timezones).
 pub fn validate_cronjobs(cronjobs: &[CronJobConfig]) -> anyhow::Result<()> {
     for (i, job) in cronjobs.iter().enumerate() {
@@ -36,6 +39,9 @@ pub fn validate_cronjobs(cronjobs: &[CronJobConfig]) -> anyhow::Result<()> {
         job.timezone.parse::<Tz>().map_err(|e| {
             anyhow::anyhow!("cronjobs[{i}]: invalid timezone {:?}: {e}", job.timezone)
         })?;
+        if !VALID_PLATFORMS.contains(&job.platform.as_str()) {
+            anyhow::bail!("cronjobs[{i}]: unknown platform {:?} (expected one of: {VALID_PLATFORMS:?})", job.platform);
+        }
     }
     Ok(())
 }
@@ -52,7 +58,8 @@ pub async fn run_scheduler(
         return;
     }
 
-    // Parse and validate all cron expressions upfront
+    // Parse cron expressions into Schedule objects. Already validated at
+    // startup by validate_cronjobs(), so errors here are purely defensive.
     let jobs: Vec<(Schedule, Tz, CronJobConfig)> = cronjobs
         .into_iter()
         .filter_map(|job| {
@@ -170,7 +177,9 @@ impl Drop for InFlightGuard {
     fn drop(&mut self) {
         let idx = self.idx;
         let set = self.set.clone();
-        // spawn a tiny task because Drop is sync and we need an async lock
+        // spawn a tiny task because Drop is sync and we need an async lock.
+        // If the runtime is shutting down this spawn may be ignored, which is
+        // fine — the in-flight set is irrelevant once the scheduler exits.
         tokio::spawn(async move {
             set.lock().await.remove(&idx);
         });

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -40,7 +40,8 @@ pub fn should_fire(schedule: &Schedule, tz: Tz) -> bool {
 const VALID_PLATFORMS: &[&str] = &["discord", "slack"];
 
 /// Validate all cronjob configs at startup (fail-fast on bad cron expressions or timezones).
-pub fn validate_cronjobs(cronjobs: &[CronJobConfig]) -> anyhow::Result<()> {
+/// `configured_platforms` is the set of platforms that have adapters configured (e.g. "discord", "slack").
+pub fn validate_cronjobs(cronjobs: &[CronJobConfig], configured_platforms: &[&str]) -> anyhow::Result<()> {
     for (i, job) in cronjobs.iter().enumerate() {
         parse_cron_expr(&job.schedule).map_err(|e| {
             anyhow::anyhow!("cronjobs[{i}]: invalid cron expression {:?}: {e}", job.schedule)
@@ -50,6 +51,9 @@ pub fn validate_cronjobs(cronjobs: &[CronJobConfig]) -> anyhow::Result<()> {
         })?;
         if !VALID_PLATFORMS.contains(&job.platform.as_str()) {
             anyhow::bail!("cronjobs[{i}]: unknown platform {:?} (expected one of: {VALID_PLATFORMS:?})", job.platform);
+        }
+        if !configured_platforms.contains(&job.platform.as_str()) {
+            anyhow::bail!("cronjobs[{i}]: platform {:?} is not configured — add [{}] to config.toml", job.platform, job.platform);
         }
     }
     Ok(())

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -1,4 +1,4 @@
-use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, MessageRef, SenderContext};
+use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, SenderContext};
 use crate::config::CronJobConfig;
 use chrono::Utc;
 use chrono_tz::Tz;
@@ -8,6 +8,24 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
+
+/// Parse a 5-field POSIX cron expression into a `Schedule`.
+/// The `cron` crate expects a 6-field expression (with seconds), so we prepend "0".
+pub fn parse_cron_expr(expr: &str) -> Result<Schedule, cron::error::Error> {
+    let six_field = format!("0 {}", expr);
+    Schedule::from_str(&six_field)
+}
+
+/// Check whether a cron schedule should fire given the current time and a tick interval.
+/// Returns true if the next upcoming event is within `tick_secs` seconds from now.
+pub fn should_fire(schedule: &Schedule, tz: Tz, tick_secs: i64) -> bool {
+    let now_tz = Utc::now().with_timezone(&tz);
+    schedule
+        .upcoming(tz)
+        .next()
+        .map(|next| (next - now_tz).num_seconds() <= tick_secs)
+        .unwrap_or(false)
+}
 
 /// Run the internal cron scheduler. Evaluates cron expressions once per minute.
 pub async fn run_scheduler(
@@ -22,11 +40,10 @@ pub async fn run_scheduler(
     }
 
     // Parse and validate all cron expressions upfront
-    let jobs: Vec<(Schedule, Tz, &CronJobConfig)> = cronjobs
-        .iter()
+    let jobs: Vec<(Schedule, Tz, CronJobConfig)> = cronjobs
+        .into_iter()
         .filter_map(|job| {
-            let expr = format!("0 {}", job.schedule);
-            let schedule = match Schedule::from_str(&expr) {
+            let schedule = match parse_cron_expr(&job.schedule) {
                 Ok(s) => s,
                 Err(e) => {
                     error!(schedule = %job.schedule, error = %e, "invalid cron expression, skipping");
@@ -62,46 +79,88 @@ pub async fn run_scheduler(
     // Track in-flight jobs to prevent overlapping executions
     let in_flight: Arc<Mutex<HashSet<usize>>> = Arc::new(Mutex::new(HashSet::new()));
 
+    // Use interval instead of sleep to compensate for drift.
+    // Delay (not Burst) so we skip missed ticks instead of rapid-firing.
+    // First, align to the next minute boundary so cron fires at :00, not at
+    // whatever second the process happened to start.
+    let now = Utc::now();
+    let secs_into_minute = now.timestamp() % 60;
+    let align_delay = if secs_into_minute == 0 { 0 } else { 60 - secs_into_minute as u64 };
+    if align_delay > 0 {
+        debug!(align_secs = align_delay, "aligning to next minute boundary");
+        tokio::time::sleep(std::time::Duration::from_secs(align_delay)).await;
+    }
+    let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    // Track spawned tasks so we can wait for them on shutdown
+    let mut tasks: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
+
     loop {
         tokio::select! {
-            _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
-                let now = Utc::now();
+            _ = ticker.tick() => {
                 for (idx, (schedule, tz, job)) in jobs.iter().enumerate() {
-                    let now_tz = now.with_timezone(tz);
-                    if let Some(next) = schedule.upcoming(*tz).next() {
-                        let diff = (next - now_tz).num_seconds();
-                        debug!(schedule = %job.schedule, timezone = %job.timezone, next = %next, diff_secs = diff, "checking");
-                        if diff <= 60 {
-                            // Skip if previous execution still running
-                            {
-                                let running = in_flight.lock().await;
-                                if running.contains(&idx) {
-                                    warn!(schedule = %job.schedule, channel = %job.channel, "skipping cronjob, previous execution still running");
-                                    continue;
-                                }
-                            }
-                            info!(
-                                schedule = %job.schedule,
-                                channel = %job.channel,
-                                platform = %job.platform,
-                                message = %job.message,
-                                sender = %job.sender_name,
-                                "🔔 cronjob fired"
-                            );
-                            let in_flight = in_flight.clone();
-                            in_flight.lock().await.insert(idx);
-                            fire_cronjob(idx, job, &router, &adapters, in_flight).await;
+                    if !should_fire(schedule, *tz, 60) {
+                        continue;
+                    }
+                    // Skip if previous execution still running
+                    {
+                        let running = in_flight.lock().await;
+                        if running.contains(&idx) {
+                            warn!(schedule = %job.schedule, channel = %job.channel, "skipping cronjob, previous execution still running");
+                            continue;
                         }
                     }
+                    info!(
+                        schedule = %job.schedule,
+                        channel = %job.channel,
+                        platform = %job.platform,
+                        message = %job.message,
+                        sender = %job.sender_name,
+                        "🔔 cronjob fired"
+                    );
+                    in_flight.lock().await.insert(idx);
+
+                    // Spawn the entire fire_cronjob so send_message doesn't block the loop
+                    let job = job.clone();
+                    let router = router.clone();
+                    let adapters = adapters.clone();
+                    let in_flight = in_flight.clone();
+                    tasks.spawn(async move {
+                        fire_cronjob(idx, &job, &router, &adapters, in_flight).await;
+                    });
                 }
+                // Reap completed tasks to avoid unbounded growth
+                while tasks.try_join_next().is_some() {}
             }
             _ = shutdown_rx.changed() => {
                 if *shutdown_rx.borrow() {
-                    info!("cron scheduler shutting down");
+                    info!("cron scheduler shutting down, waiting for in-flight tasks");
+                    // Wait for all in-flight tasks with a timeout
+                    let drain = async { while tasks.join_next().await.is_some() {} };
+                    let _ = tokio::time::timeout(std::time::Duration::from_secs(30), drain).await;
                     return;
                 }
             }
         }
+    }
+}
+
+/// RAII guard that removes a job index from the in-flight set on drop.
+/// Ensures cleanup even if the task panics or returns early.
+struct InFlightGuard {
+    idx: usize,
+    set: Arc<Mutex<HashSet<usize>>>,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        let idx = self.idx;
+        let set = self.set.clone();
+        // spawn a tiny task because Drop is sync and we need an async lock
+        tokio::spawn(async move {
+            set.lock().await.remove(&idx);
+        });
     }
 }
 
@@ -112,11 +171,13 @@ async fn fire_cronjob(
     adapters: &HashMap<String, Arc<dyn ChatAdapter>>,
     in_flight: Arc<Mutex<HashSet<usize>>>,
 ) {
+    // Guard ensures idx is removed from in_flight even on panic or early return
+    let _guard = InFlightGuard { idx, set: in_flight };
+
     let adapter = match adapters.get(&job.platform) {
         Some(a) => a.clone(),
         None => {
             error!(platform = %job.platform, "no adapter for platform, skipping cronjob");
-            in_flight.lock().await.remove(&idx);
             return;
         }
     };
@@ -138,30 +199,151 @@ async fn fire_cronjob(
         thread_id: job.thread_id.clone(),
         is_bot: true,
     };
-    let sender_json = serde_json::to_string(&sender).unwrap_or_default();
+    let sender_json = match serde_json::to_string(&sender) {
+        Ok(j) => j,
+        Err(e) => {
+            warn!(error = %e, "failed to serialize cron sender context, skipping");
+            return;
+        }
+    };
 
     // Send visible message first so users see what triggered
     let trigger_msg = match adapter.send_message(&thread_channel, &format!("🕐 [{}]: {}", job.sender_name, job.message)).await {
         Ok(msg) => msg,
         Err(e) => {
             error!(channel = %job.channel, error = %e, "failed to send cron message");
-            in_flight.lock().await.remove(&idx);
             return;
         }
     };
 
     // Trigger agent processing
-    let router = router.clone();
-    let adapter = adapter.clone();
-    let prompt = job.message.clone();
-    let thread_channel = thread_channel.clone();
-    tokio::spawn(async move {
-        if let Err(e) = router
-            .handle_message(&adapter, &thread_channel, &sender_json, &prompt, vec![], &trigger_msg, false)
-            .await
-        {
-            error!("cron handle_message error: {e}");
-        }
-        in_flight.lock().await.remove(&idx);
-    });
+    if let Err(e) = router
+        .handle_message(&adapter, &thread_channel, &sender_json, &job.message, vec![], &trigger_msg, false)
+        .await
+    {
+        error!("cron handle_message error: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_cron_expression() {
+        let schedule = parse_cron_expr("0 9 * * 1-5").unwrap();
+        // Should produce upcoming times
+        let next = schedule.upcoming(chrono_tz::UTC).next();
+        assert!(next.is_some());
+    }
+
+    #[test]
+    fn parse_every_minute_cron() {
+        let schedule = parse_cron_expr("* * * * *").unwrap();
+        let next = schedule.upcoming(chrono_tz::UTC).next();
+        assert!(next.is_some());
+    }
+
+    #[test]
+    fn parse_invalid_cron_expression() {
+        let result = parse_cron_expr("not a cron");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_invalid_cron_too_many_fields() {
+        // 6 fields (user provides seconds) — should fail or behave unexpectedly
+        let result = parse_cron_expr("0 0 9 * * 1-5");
+        // With our "0 " prefix this becomes 7 fields — should error
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn valid_timezone_parses() {
+        let tz: Result<Tz, _> = "Asia/Taipei".parse();
+        assert!(tz.is_ok());
+    }
+
+    #[test]
+    fn invalid_timezone_fails() {
+        let tz: Result<Tz, _> = "Mars/Olympus".parse();
+        assert!(tz.is_err());
+    }
+
+    #[test]
+    fn utc_timezone_parses() {
+        let tz: Result<Tz, _> = "UTC".parse();
+        assert!(tz.is_ok());
+    }
+
+    #[test]
+    fn should_fire_every_minute_returns_true() {
+        // "* * * * *" fires every minute, so next event is always within 60s
+        let schedule = parse_cron_expr("* * * * *").unwrap();
+        assert!(should_fire(&schedule, chrono_tz::UTC, 60));
+    }
+
+    #[test]
+    fn should_fire_with_zero_tick_window_returns_false() {
+        // "* * * * *" next event is up to 60s away; 0-second window should not fire
+        let schedule = parse_cron_expr("* * * * *").unwrap();
+        assert!(!should_fire(&schedule, chrono_tz::UTC, 0));
+    }
+
+    #[test]
+    fn should_fire_returns_false_for_distant_schedule() {
+        // Schedule for Jan 1 at 00:00 — unless we happen to be on Jan 1, this is months away
+        let schedule = parse_cron_expr("0 0 1 1 *").unwrap();
+        assert!(!should_fire(&schedule, chrono_tz::UTC, 60));
+    }
+
+    #[test]
+    fn should_fire_respects_timezone() {
+        let schedule = parse_cron_expr("* * * * *").unwrap();
+        let tz: Tz = "Asia/Taipei".parse().unwrap();
+        // Every-minute schedule should fire regardless of timezone
+        assert!(should_fire(&schedule, tz, 60));
+    }
+
+    #[test]
+    fn cronjob_config_defaults() {
+        let toml_str = r#"
+[[cronjobs]]
+schedule = "0 9 * * 1-5"
+channel = "123"
+message = "hello"
+"#;
+        let cfg: CronJobsWrapper = toml::from_str(toml_str).unwrap();
+        let job = &cfg.cronjobs[0];
+        assert_eq!(job.platform, "discord");
+        assert_eq!(job.sender_name, "openab-cron");
+        assert_eq!(job.timezone, "UTC");
+        assert!(job.thread_id.is_none());
+    }
+
+    #[test]
+    fn cronjob_config_custom_values() {
+        let toml_str = r#"
+[[cronjobs]]
+schedule = "0 18 * * 1-5"
+channel = "456"
+message = "report"
+platform = "slack"
+sender_name = "DailyOps"
+timezone = "Asia/Taipei"
+thread_id = "789"
+"#;
+        let cfg: CronJobsWrapper = toml::from_str(toml_str).unwrap();
+        let job = &cfg.cronjobs[0];
+        assert_eq!(job.platform, "slack");
+        assert_eq!(job.sender_name, "DailyOps");
+        assert_eq!(job.timezone, "Asia/Taipei");
+        assert_eq!(job.thread_id.as_deref(), Some("789"));
+    }
+
+    /// Helper struct for deserializing just the cronjobs array in tests.
+    #[derive(serde::Deserialize)]
+    struct CronJobsWrapper {
+        cronjobs: Vec<CronJobConfig>,
+    }
 }

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -1,0 +1,167 @@
+use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, MessageRef, SenderContext};
+use crate::config::CronJobConfig;
+use chrono::Utc;
+use chrono_tz::Tz;
+use cron::Schedule;
+use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, warn};
+
+/// Run the internal cron scheduler. Evaluates cron expressions once per minute.
+pub async fn run_scheduler(
+    cronjobs: Vec<CronJobConfig>,
+    router: Arc<AdapterRouter>,
+    adapters: HashMap<String, Arc<dyn ChatAdapter>>,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) {
+    if cronjobs.is_empty() {
+        debug!("no cronjobs configured, scheduler not started");
+        return;
+    }
+
+    // Parse and validate all cron expressions upfront
+    let jobs: Vec<(Schedule, Tz, &CronJobConfig)> = cronjobs
+        .iter()
+        .filter_map(|job| {
+            let expr = format!("0 {}", job.schedule);
+            let schedule = match Schedule::from_str(&expr) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!(schedule = %job.schedule, error = %e, "invalid cron expression, skipping");
+                    return None;
+                }
+            };
+            let tz: Tz = match job.timezone.parse() {
+                Ok(t) => t,
+                Err(e) => {
+                    error!(timezone = %job.timezone, error = %e, "invalid timezone, skipping");
+                    return None;
+                }
+            };
+            info!(
+                schedule = %job.schedule,
+                timezone = %job.timezone,
+                channel = %job.channel,
+                platform = %job.platform,
+                message = %job.message,
+                "cronjob registered"
+            );
+            Some((schedule, tz, job))
+        })
+        .collect();
+
+    if jobs.is_empty() {
+        warn!("all cronjob expressions invalid, scheduler not started");
+        return;
+    }
+
+    info!(count = jobs.len(), "cron scheduler started");
+
+    // Track in-flight jobs to prevent overlapping executions
+    let in_flight: Arc<Mutex<HashSet<usize>>> = Arc::new(Mutex::new(HashSet::new()));
+
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                let now = Utc::now();
+                for (idx, (schedule, tz, job)) in jobs.iter().enumerate() {
+                    let now_tz = now.with_timezone(tz);
+                    if let Some(next) = schedule.upcoming(*tz).next() {
+                        let diff = (next - now_tz).num_seconds();
+                        debug!(schedule = %job.schedule, timezone = %job.timezone, next = %next, diff_secs = diff, "checking");
+                        if diff <= 60 {
+                            // Skip if previous execution still running
+                            {
+                                let running = in_flight.lock().await;
+                                if running.contains(&idx) {
+                                    warn!(schedule = %job.schedule, channel = %job.channel, "skipping cronjob, previous execution still running");
+                                    continue;
+                                }
+                            }
+                            info!(
+                                schedule = %job.schedule,
+                                channel = %job.channel,
+                                platform = %job.platform,
+                                message = %job.message,
+                                sender = %job.sender_name,
+                                "🔔 cronjob fired"
+                            );
+                            let in_flight = in_flight.clone();
+                            in_flight.lock().await.insert(idx);
+                            fire_cronjob(idx, job, &router, &adapters, in_flight).await;
+                        }
+                    }
+                }
+            }
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() {
+                    info!("cron scheduler shutting down");
+                    return;
+                }
+            }
+        }
+    }
+}
+
+async fn fire_cronjob(
+    idx: usize,
+    job: &CronJobConfig,
+    router: &Arc<AdapterRouter>,
+    adapters: &HashMap<String, Arc<dyn ChatAdapter>>,
+    in_flight: Arc<Mutex<HashSet<usize>>>,
+) {
+    let adapter = match adapters.get(&job.platform) {
+        Some(a) => a.clone(),
+        None => {
+            error!(platform = %job.platform, "no adapter for platform, skipping cronjob");
+            in_flight.lock().await.remove(&idx);
+            return;
+        }
+    };
+
+    let thread_channel = ChannelRef {
+        platform: job.platform.clone(),
+        channel_id: job.channel.clone(),
+        thread_id: job.thread_id.clone(),
+        parent_id: None,
+    };
+
+    let sender = SenderContext {
+        schema: "openab.sender.v1".into(),
+        sender_id: "openab-cron".into(),
+        sender_name: job.sender_name.clone(),
+        display_name: job.sender_name.clone(),
+        channel: job.platform.clone(),
+        channel_id: job.channel.clone(),
+        thread_id: job.thread_id.clone(),
+        is_bot: true,
+    };
+    let sender_json = serde_json::to_string(&sender).unwrap_or_default();
+
+    // Send visible message first so users see what triggered
+    let trigger_msg = match adapter.send_message(&thread_channel, &format!("🕐 [{}]: {}", job.sender_name, job.message)).await {
+        Ok(msg) => msg,
+        Err(e) => {
+            error!(channel = %job.channel, error = %e, "failed to send cron message");
+            in_flight.lock().await.remove(&idx);
+            return;
+        }
+    };
+
+    // Trigger agent processing
+    let router = router.clone();
+    let adapter = adapter.clone();
+    let prompt = job.message.clone();
+    let thread_channel = thread_channel.clone();
+    tokio::spawn(async move {
+        if let Err(e) = router
+            .handle_message(&adapter, &thread_channel, &sender_json, &prompt, vec![], &trigger_msg, false)
+            .await
+        {
+            error!("cron handle_message error: {e}");
+        }
+        in_flight.lock().await.remove(&idx);
+    });
+}

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -27,6 +27,19 @@ pub fn should_fire(schedule: &Schedule, tz: Tz, tick_secs: i64) -> bool {
         .unwrap_or(false)
 }
 
+/// Validate all cronjob configs at startup (fail-fast on bad cron expressions or timezones).
+pub fn validate_cronjobs(cronjobs: &[CronJobConfig]) -> anyhow::Result<()> {
+    for (i, job) in cronjobs.iter().enumerate() {
+        parse_cron_expr(&job.schedule).map_err(|e| {
+            anyhow::anyhow!("cronjobs[{i}]: invalid cron expression {:?}: {e}", job.schedule)
+        })?;
+        job.timezone.parse::<Tz>().map_err(|e| {
+            anyhow::anyhow!("cronjobs[{i}]: invalid timezone {:?}: {e}", job.timezone)
+        })?;
+    }
+    Ok(())
+}
+
 /// Run the internal cron scheduler. Evaluates cron expressions once per minute.
 pub async fn run_scheduler(
     cronjobs: Vec<CronJobConfig>,
@@ -222,6 +235,7 @@ async fn fire_cronjob(
         .await
     {
         error!("cron handle_message error: {e}");
+        let _ = adapter.send_message(&thread_channel, &format!("⚠️ cronjob error: {e}")).await;
     }
 }
 

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -75,6 +75,12 @@ pub async fn run_scheduler(
     // startup by validate_cronjobs(), so errors here are purely defensive.
     let jobs: Vec<(Schedule, Tz, CronJobConfig)> = cronjobs
         .into_iter()
+        .filter(|job| {
+            if !job.enabled {
+                info!(schedule = %job.schedule, channel = %job.channel, "cronjob disabled, skipping");
+            }
+            job.enabled
+        })
         .filter_map(|job| {
             let schedule = match parse_cron_expr(&job.schedule) {
                 Ok(s) => s,
@@ -349,10 +355,25 @@ message = "hello"
 "#;
         let cfg: CronJobsWrapper = toml::from_str(toml_str).unwrap();
         let job = &cfg.cronjobs[0];
+        assert_eq!(job.enabled, true);
         assert_eq!(job.platform, "discord");
         assert_eq!(job.sender_name, "openab-cron");
         assert_eq!(job.timezone, "UTC");
         assert!(job.thread_id.is_none());
+    }
+
+    #[test]
+    fn cronjob_config_disabled() {
+        let toml_str = r#"
+[[cronjobs]]
+enabled = false
+schedule = "0 9 * * 1-5"
+channel = "123"
+message = "hello"
+"#;
+        let cfg: CronJobsWrapper = toml::from_str(toml_str).unwrap();
+        let job = &cfg.cronjobs[0];
+        assert_eq!(job.enabled, false);
     }
 
     #[test]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -48,7 +48,9 @@ impl ChatAdapter for DiscordAdapter {
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> anyhow::Result<MessageRef> {
-        let ch_id: u64 = channel.channel_id.parse()?;
+        // Discord threads are channels, so prefer thread_id when set
+        let target = channel.thread_id.as_deref().unwrap_or(&channel.channel_id);
+        let ch_id: u64 = target.parse()?;
         let msg = ChannelId::new(ch_id).say(&self.http, content).await?;
         Ok(MessageRef {
             channel: channel.clone(),

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -35,6 +35,12 @@ impl DiscordAdapter {
     pub fn new(http: Arc<Http>) -> Self {
         Self { http }
     }
+
+    /// Resolve the effective Discord channel ID from a ChannelRef.
+    /// Discord threads are channels, so prefer thread_id when set.
+    fn resolve_channel(channel: &ChannelRef) -> &str {
+        channel.thread_id.as_deref().unwrap_or(&channel.channel_id)
+    }
 }
 
 #[async_trait]
@@ -48,9 +54,7 @@ impl ChatAdapter for DiscordAdapter {
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> anyhow::Result<MessageRef> {
-        // Discord threads are channels, so prefer thread_id when set
-        let target = channel.thread_id.as_deref().unwrap_or(&channel.channel_id);
-        let ch_id: u64 = target.parse()?;
+        let ch_id: u64 = Self::resolve_channel(channel).parse()?;
         let msg = ChannelId::new(ch_id).say(&self.http, content).await?;
         Ok(MessageRef {
             channel: channel.clone(),
@@ -59,7 +63,7 @@ impl ChatAdapter for DiscordAdapter {
     }
 
     async fn edit_message(&self, msg: &MessageRef, content: &str) -> anyhow::Result<()> {
-        let ch_id: u64 = msg.channel.channel_id.parse()?;
+        let ch_id: u64 = Self::resolve_channel(&msg.channel).parse()?;
         let msg_id: u64 = msg.message_id.parse()?;
         ChannelId::new(ch_id)
             .edit_message(
@@ -99,7 +103,7 @@ impl ChatAdapter for DiscordAdapter {
     }
 
     async fn add_reaction(&self, msg: &MessageRef, emoji: &str) -> anyhow::Result<()> {
-        let ch_id: u64 = msg.channel.channel_id.parse()?;
+        let ch_id: u64 = Self::resolve_channel(&msg.channel).parse()?;
         let msg_id: u64 = msg.message_id.parse()?;
         self.http
             .create_reaction(
@@ -112,7 +116,7 @@ impl ChatAdapter for DiscordAdapter {
     }
 
     async fn remove_reaction(&self, msg: &MessageRef, emoji: &str) -> anyhow::Result<()> {
-        let ch_id: u64 = msg.channel.channel_id.parse()?;
+        let ch_id: u64 = Self::resolve_channel(&msg.channel).parse()?;
         let msg_id: u64 = msg.message_id.parse()?;
         self.http
             .delete_reaction_me(
@@ -1425,5 +1429,29 @@ mod tests {
     fn discord_no_stream_when_other_bot_present() {
         let adapter = super::DiscordAdapter::new(Arc::new(super::Http::new("")));
         assert!(!adapter.use_streaming(true));
+    }
+
+    // --- resolve_channel tests ---
+
+    #[test]
+    fn resolve_channel_uses_channel_id_when_no_thread() {
+        let ch = ChannelRef {
+            platform: "discord".into(),
+            channel_id: "111".into(),
+            thread_id: None,
+            parent_id: None,
+        };
+        assert_eq!(DiscordAdapter::resolve_channel(&ch), "111");
+    }
+
+    #[test]
+    fn resolve_channel_prefers_thread_id_when_set() {
+        let ch = ChannelRef {
+            platform: "discord".into(),
+            channel_id: "111".into(),
+            thread_id: Some("222".into()),
+            parent_id: None,
+        };
+        assert_eq!(DiscordAdapter::resolve_channel(&ch), "222");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,6 +312,9 @@ async fn main() -> anyhow::Result<()> {
     if let Some(handle) = gateway_handle {
         let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
     }
+    if let Some(handle) = cron_handle {
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+    }
     let shutdown_pool = pool;
     shutdown_pool.shutdown().await;
     info!("openab shut down");

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,10 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Validate cronjob config at startup (fail-fast on bad cron expressions or timezones)
-    cron::validate_cronjobs(&cfg.cronjobs)?;
+    let mut configured_platforms: Vec<&str> = Vec::new();
+    if cfg.discord.is_some() { configured_platforms.push("discord"); }
+    if cfg.slack.is_some() { configured_platforms.push("slack"); }
+    cron::validate_cronjobs(&cfg.cronjobs, &configured_platforms)?;
 
     // Spawn Slack adapter (background task)
     let slack_handle = if let Some(slack_cfg) = cfg.slack {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod acp;
 mod adapter;
 mod bot_turns;
 mod config;
+mod cron;
 mod discord;
 mod error_display;
 mod format;
@@ -150,6 +151,7 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Spawn Slack adapter (background task)
+    let slack_bot_token = cfg.slack.as_ref().map(|s| (s.bot_token.clone(), s.allow_bot_messages));
     let slack_handle = if let Some(slack_cfg) = cfg.slack {
         let allow_all_channels = config::resolve_allow_all(slack_cfg.allow_all_channels, &slack_cfg.allowed_channels);
         let allow_all_users = config::resolve_allow_all(slack_cfg.allow_all_users, &slack_cfg.allowed_users);
@@ -205,6 +207,31 @@ async fn main() -> anyhow::Result<()> {
             if let Err(e) = gateway::run_gateway_adapter(gw_cfg.url, gw_cfg.platform, gw_cfg.token, gw_cfg.bot_username, router, shutdown_rx).await {
                 error!("gateway adapter error: {e}");
             }
+        }))
+    } else {
+        None
+    };
+
+    // Spawn cron scheduler (background task)
+    let cron_handle = if !cfg.cronjobs.is_empty() {
+        let shutdown_rx = shutdown_rx.clone();
+        let cronjobs = cfg.cronjobs.clone();
+        let cron_router = router.clone();
+        let mut cron_adapters: std::collections::HashMap<String, Arc<dyn adapter::ChatAdapter>> =
+            std::collections::HashMap::new();
+        if let Some(ref dc) = cfg.discord {
+            let http = Arc::new(serenity::http::Http::new(&dc.bot_token));
+            cron_adapters.insert("discord".into(), Arc::new(discord::DiscordAdapter::new(http)));
+        }
+        if let Some((ref token, allow_bots)) = slack_bot_token {
+            let session_ttl = std::time::Duration::from_secs(cfg.pool.session_ttl_hours * 3600);
+            cron_adapters.insert("slack".into(), Arc::new(slack::SlackAdapter::new(
+                token.clone(), session_ttl, allow_bots,
+            )));
+        }
+        info!(count = cronjobs.len(), "starting cron scheduler");
+        Some(tokio::spawn(async move {
+            cron::run_scheduler(cronjobs, cron_router, cron_adapters, shutdown_rx).await;
         }))
     } else {
         None

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,7 +320,8 @@ async fn main() -> anyhow::Result<()> {
         let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
     }
     if let Some(handle) = cron_handle {
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+        // cron.rs drains in-flight tasks for up to 30s, so wait slightly longer
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(35), handle).await;
     }
     let shutdown_pool = pool;
     shutdown_pool.shutdown().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,8 +150,20 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
+    // Pre-build shared adapters for cron scheduler (avoids duplicate Http clients / rate-limit buckets)
+    let shared_discord_adapter: Option<Arc<dyn adapter::ChatAdapter>> = cfg.discord.as_ref().map(|dc| {
+        let http = Arc::new(serenity::http::Http::new(&dc.bot_token));
+        Arc::new(discord::DiscordAdapter::new(http)) as Arc<dyn adapter::ChatAdapter>
+    });
+    let session_ttl_dur = std::time::Duration::from_secs(ttl_secs);
+    let shared_slack_adapter: Option<Arc<slack::SlackAdapter>> = cfg.slack.as_ref().map(|s| {
+        Arc::new(slack::SlackAdapter::new(s.bot_token.clone(), session_ttl_dur, s.allow_bot_messages))
+    });
+
+    // Validate cronjob config at startup (fail-fast on bad cron expressions or timezones)
+    cron::validate_cronjobs(&cfg.cronjobs)?;
+
     // Spawn Slack adapter (background task)
-    let slack_bot_token = cfg.slack.as_ref().map(|s| (s.bot_token.clone(), s.allow_bot_messages));
     let slack_handle = if let Some(slack_cfg) = cfg.slack {
         let allow_all_channels = config::resolve_allow_all(slack_cfg.allow_all_channels, &slack_cfg.allowed_channels);
         let allow_all_users = config::resolve_allow_all(slack_cfg.allow_all_users, &slack_cfg.allowed_users);
@@ -169,12 +181,12 @@ async fn main() -> anyhow::Result<()> {
         );
         let router = router.clone();
         let stt = cfg.stt.clone();
-        let session_ttl = std::time::Duration::from_secs(ttl_secs);
         let max_bot_turns = slack_cfg.max_bot_turns;
         let slack_shutdown_rx = shutdown_rx.clone();
+        let adapter = shared_slack_adapter.clone().expect("shared_slack_adapter must exist when slack config is present");
         Some(tokio::spawn(async move {
             if let Err(e) = slack::run_slack_adapter(
-                slack_cfg.bot_token,
+                adapter,
                 slack_cfg.app_token,
                 allow_all_channels,
                 allow_all_users,
@@ -184,7 +196,6 @@ async fn main() -> anyhow::Result<()> {
                 slack_cfg.trusted_bot_ids.into_iter().collect(),
                 slack_cfg.allow_user_messages,
                 max_bot_turns,
-                session_ttl,
                 stt,
                 router,
                 slack_shutdown_rx,
@@ -212,22 +223,18 @@ async fn main() -> anyhow::Result<()> {
         None
     };
 
-    // Spawn cron scheduler (background task)
+    // Spawn cron scheduler (background task) — reuses shared adapters
     let cron_handle = if !cfg.cronjobs.is_empty() {
         let shutdown_rx = shutdown_rx.clone();
         let cronjobs = cfg.cronjobs.clone();
         let cron_router = router.clone();
         let mut cron_adapters: std::collections::HashMap<String, Arc<dyn adapter::ChatAdapter>> =
             std::collections::HashMap::new();
-        if let Some(ref dc) = cfg.discord {
-            let http = Arc::new(serenity::http::Http::new(&dc.bot_token));
-            cron_adapters.insert("discord".into(), Arc::new(discord::DiscordAdapter::new(http)));
+        if let Some(ref a) = shared_discord_adapter {
+            cron_adapters.insert("discord".into(), a.clone());
         }
-        if let Some((ref token, allow_bots)) = slack_bot_token {
-            let session_ttl = std::time::Duration::from_secs(cfg.pool.session_ttl_hours * 3600);
-            cron_adapters.insert("slack".into(), Arc::new(slack::SlackAdapter::new(
-                token.clone(), session_ttl, allow_bots,
-            )));
+        if let Some(ref a) = shared_slack_adapter {
+            cron_adapters.insert("slack".into(), a.clone() as Arc<dyn adapter::ChatAdapter>);
         }
         info!(count = cronjobs.len(), "starting cron scheduler");
         Some(tokio::spawn(async move {

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -83,6 +83,11 @@ impl SlackAdapter {
         }
     }
 
+    /// Returns the bot token for use in API calls outside the adapter.
+    pub fn bot_token(&self) -> &str {
+        &self.bot_token
+    }
+
     /// Eagerly record that another bot has posted in a thread. Called from the
     /// event loop when a bot message arrives, so multibot detection doesn't
     /// depend on fetching thread history. Idempotent.
@@ -474,7 +479,7 @@ const MAX_CONSECUTIVE_BOT_TURNS: usize = 10;
 /// Reconnects automatically on disconnect.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_slack_adapter(
-    bot_token: String,
+    adapter: Arc<SlackAdapter>,
     app_token: String,
     allow_all_channels: bool,
     allow_all_users: bool,
@@ -484,13 +489,12 @@ pub async fn run_slack_adapter(
     trusted_bot_ids: HashSet<String>,
     allow_user_messages: AllowUsers,
     max_bot_turns: u32,
-    session_ttl: std::time::Duration,
     stt_config: SttConfig,
     router: Arc<AdapterRouter>,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> Result<()> {
-    let adapter = Arc::new(SlackAdapter::new(bot_token.clone(), session_ttl, allow_bot_messages));
     let queue = Arc::new(KeyedAsyncQueue::new());
+    let bot_token = adapter.bot_token().to_string();
     let bot_turns = Arc::new(tokio::sync::Mutex::new(BotTurnTracker::new(max_bot_turns)));
 
     loop {


### PR DESCRIPTION
## Summary

Implements the config-driven cronjob scheduler proposed in [ADR: Basic CronJob Support](https://github.com/openabdev/openab/pull/591). Users define `[[cronjobs]]` in `config.toml` to schedule recurring messages to the agent — no external infrastructure needed.

## Design

- Lightweight internal scheduler evaluates cron expressions once per minute
- Fires message into existing session pool as if a user typed it
- Reply posted to target channel via normal platform adapter (Discord / Slack)
- Stateless, restart-safe, fire-and-forget on failure

## Changes

- `src/cron.rs` — New scheduler module: cron parsing, timezone support, overlap protection
- `src/config.rs` — Add `CronJobConfig` struct with schedule, channel, message, platform, timezone, sender_name, thread_id
- `src/main.rs` — Spawn scheduler background task, pass Discord/Slack adapters
- `charts/openab/values.yaml` — Add `cronjobs: []` default
- `charts/openab/templates/configmap.yaml` — Render `[[cronjobs]]` blocks
- `docs/config-reference.md` — Full `[[cronjobs]]` documentation
- `config.toml.example` — Example config

## Config Example

```toml
[[cronjobs]]
schedule = "0 9 * * 1-5"
channel = "123456789"
message = "summarize yesterday's merged PRs"
platform = "discord"
sender_name = "DailyOps"
timezone = "Asia/Taipei"
```

## Testing

- Deployed to OrbStack K8s, verified scheduler fires on schedule
- Verified message appears in Discord thread + AI processes and replies
- Timezone support tested with Asia/Taipei
- Overlap protection: skips if previous execution still running
- All 121 existing tests pass

## Scope (per ADR)

**In scope:** config-driven cron, Discord/Slack, timezone, overlap skip
**Out of scope:** agent self-configuring cron, retries, conditional logic, runtime API

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1498329410816839862