### PR TITLE
fix: bump CLI versions — copilot 1.0.37, opencode 1.14.28

### DIFF
--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
-ARG COPILOT_VERSION=1.0.36
+ARG COPILOT_VERSION=1.0.37
 RUN npm install -g @github/copilot@${COPILOT_VERSION} --retry 3
 
 # Install gh CLI (for auth and token management)

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -26,7 +26,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install opencode
-ARG OPENCODE_VERSION=1.14.25
+ARG OPENCODE_VERSION=1.14.28
 RUN npm install -g opencode-ai@${OPENCODE_VERSION} --retry 3
 
 # Install gh CLI (matches Dockerfile.claude / Dockerfile.gemini / Dockerfile.codex)


### PR DESCRIPTION
## Summary

Bump pinned CLI versions in Dockerfiles after investigating latest releases and upstream bug trackers.

Discord Discussion URL: N/A

## Changes

| Dockerfile | CLI | Old | New | Notes |
|---|---|---|---|---|
| `Dockerfile.copilot` | `@github/copilot` | 1.0.36 | **1.0.37** | No public issue tracker; 1 patch version, low risk |
| `Dockerfile.opencode` | `opencode-ai` | 1.14.25 | **1.14.28** | SIGTERM hang exists in both old and new; 3 patch fixes included |

## NOT updated (intentionally)

| Dockerfile | CLI | Pinned | Latest | Why |
|---|---|---|---|---|
| `Dockerfile` | kiro-cli | 2.1.1 | 2.1.1 | Already latest |
| `Dockerfile.codex` | `@openai/codex` | 0.125.0 | 0.125.0 | Already latest |
| `Dockerfile.claude` | `@anthropic-ai/claude-code` | 2.1.116 | 2.1.119 | HOLD — Linux sandbox crash, Bedrock auth broken, teammate tmux crash on 2.1.117+ |
| `Dockerfile.gemini` | `@google/gemini-cli` | 0.39.1 | 0.39.1 | Already latest |
| `Dockerfile.cursor` | Cursor Agent CLI | 2026.04.17-787b533 | 2026.04.17-787b533 | Already latest |
| `Dockerfile.codex` | `codex-acp` | 0.11.1 | — | No new release needed |
| `Dockerfile.claude` | `claude-agent-acp` | 0.29.2 | — | Still current |

## claude-code risk assessment (HOLD at 2.1.116)

2.1.117-2.1.119 have multiple regressions that directly affect Linux/Docker/headless:

- **#53615 / #53683**: --continue crashes on Linux with sandbox required but unavailable (2.1.120). Even without sandbox config, sandbox.failIfUnavailable defaults to true.
- **#54083**: Bedrock auth token header broken again (2.1.119). 403 errors on previously working setups.
- **#53152**: Teammate agent crashes in tmux (2.1.117+, confirmed working on 2.1.116).
- **#53031**: Silent model rerouting to opus-4-7 1M context even when explicitly requesting 200k (2.1.119).

**Zero** regressions on 2.1.114-2.1.116. 2.1.116 remains the safe ceiling.

## opencode-ai risk assessment

Known issues on 1.14.28 (also present on 1.14.25):
- **#24658**: SIGTERM hangs — process does not clean up MCP servers, LSP clients, PTYs. Critical for Docker lifecycle. This is a core issue present in both old and new versions.
- **#24683**: Context auto-compression never triggers. Long-standing, all versions.
- **#24604**: Write tool SchemaError in plan mode (1.14.28 specific, works in build mode).

Upgrading does not make SIGTERM worse. 1.14.28 includes 3 patch fixes. Recommend running ACP smoke test after merge.

## codex note (no bump, but known issues)

Current pinned 0.125.0 has open regressions affecting Linux/exec mode:
- **#19309**: codex exec exits silently with code 0 without doing work
- **#16685**: MCP tool calls always cancelled in exec mode
- **#16451**: Linux sandbox denies /dev/null and /dev/zero (workaround: use_legacy_landlock=true)

No new codex version available. These are pre-existing issues.

## gemini-cli note (no bump, but known ACP issues)

Current pinned 0.39.1 has open bugs in ACP/headless mode:
- **#26021**: MCP servers not connected in non-interactive mode
- **#25345**: ACP stdout polluted by debug logs, corrupting NDJSON protocol
- **#23507**: run_shell_command fails silently in ACP mode

These are long-standing issues, not new regressions. No new version available.

## How to verify

```bash
npm view @github/copilot version        # expect 1.0.37
npm view opencode-ai version            # expect 1.14.28
```

Ref: #573
