### PR TITLE
feat(chart): expose maxBotTurns for Slack and Discord adapters

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -51,6 +51,10 @@ data:
     {{- end }}
     allow_user_messages = {{ $cfg.discord.allowUserMessages | toJson }}  {{- /* involved (default): respond in bot's threads without @mention | mentions: always require @mention | multibot-mentions: require @mention only when another bot has posted in the thread */ -}}
     {{- end }}
+    {{- /* maxBotTurns: soft cap on consecutive bot turns per thread (human msg resets the counter) */ -}}
+    {{- if hasKey ($cfg.discord | default dict) "maxBotTurns" }}
+    max_bot_turns = {{ ($cfg.discord).maxBotTurns | int }}
+    {{- end }}
     {{- end }}
 
     {{- if and ($cfg.slack).enabled }}
@@ -85,6 +89,10 @@ data:
     {{- fail (printf "agents.%s.slack.allowUserMessages must be one of: involved, mentions, multibot-mentions (use hyphen form, not underscore) — got: %s" $name ($cfg.slack).allowUserMessages) }}
     {{- end }}
     allow_user_messages = {{ ($cfg.slack).allowUserMessages | toJson }}  {{- /* involved (default): respond in bot's threads without @mention | mentions: always require @mention | multibot-mentions: require @mention only when another bot has posted in the thread */ -}}
+    {{- end }}
+    {{- /* maxBotTurns: soft cap on consecutive bot turns per thread (human msg resets the counter) */ -}}
+    {{- if hasKey ($cfg.slack | default dict) "maxBotTurns" }}
+    max_bot_turns = {{ ($cfg.slack).maxBotTurns | int }}
     {{- end }}
     {{- end }}
 

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -137,6 +137,12 @@ agents:
       allowBotMessages: "off"
       # trustedBotIds: []  # empty = any bot (mode permitting); set to restrict
       trustedBotIds: []
+      # maxBotTurns: soft cap on consecutive bot turns per thread before
+      # the bot stops auto-replying. A human message resets the counter.
+      # Default 20 (Rust-side `default_max_bot_turns()`). Raise for long
+      # multi-agent collaborations; lower to throttle runaway loops more
+      # aggressively. Hard cap remains 100 regardless (compiled-in).
+      # maxBotTurns: 20
     slack:
       enabled: false
       botToken: ""       # Bot User OAuth Token (xoxb-...)
@@ -155,6 +161,12 @@ agents:
       #                      only when another bot has also posted in the thread
       #                      (recommended for multi-bot deployments)
       allowUserMessages: "involved"
+      # maxBotTurns: soft cap on consecutive bot turns per thread before
+      # the bot stops auto-replying. A human message resets the counter.
+      # Default 20 (Rust-side `default_max_bot_turns()`). Raise for long
+      # multi-agent collaborations; lower to throttle runaway loops more
+      # aggressively. Hard cap remains 100 regardless (compiled-in).
+      # maxBotTurns: 20
     workingDir: /home/agent
     env: {}
     envFrom: []

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -170,6 +170,28 @@ trusted_bot_ids = ["1111111111", "2222222222"]
 max_bot_turns = 10
 ```
 
+### Helm chart
+
+Same keys are settable from chart values under `agents.<name>.discord` and
+`agents.<name>.slack` using camelCase (Helm convention):
+
+```yaml
+agents:
+  claude:
+    discord:
+      allowBotMessages: "mentions"
+      trustedBotIds: ["1111111111", "2222222222"]
+      maxBotTurns: 50
+    slack:
+      allowBotMessages: "mentions"
+      trustedBotIds: ["U1111111111", "U2222222222"]
+      maxBotTurns: 50
+```
+
+When `maxBotTurns` is omitted from values, the Rust default of 20
+applies. The hard cap of 100 is compiled-in
+(`HARD_BOT_TURN_LIMIT` in `src/bot_turns.rs`) and is not chart-tunable.
+
 ---
 
 ## Quick Reference


### PR DESCRIPTION
Closes #609.

## Summary

Wires the existing Rust `max_bot_turns` config field through the Helm chart so deployers can set the soft cap from chart values instead of being stuck on the hardcoded default of 20.

## What changed

- **`charts/openab/templates/configmap.yaml`** — two short, gated blocks (Discord and Slack) that emit `max_bot_turns = <int>` into `config.toml` when `agents.<name>.discord.maxBotTurns` / `…slack.maxBotTurns` is set. When unset, no line is rendered → Rust's `default_max_bot_turns()` (20) applies, matching previous behaviour exactly.
- **`charts/openab/values.yaml`** — adds a commented `maxBotTurns` placeholder under both `discord:` and `slack:` default blocks, alongside the existing `allowBotMessages` / `trustedBotIds` knobs, with a doc-comment noting the 20 default and the compiled-in hard cap of 100.
- **`docs/messaging.md`** — adds a "Helm chart" example block under the existing config.toml example so deployers see the chart-side equivalent of the same keys.

## What did **not** change

- No Rust code change. Same `src/config.rs` field, same `src/bot_turns.rs` semantics, same `HARD_BOT_TURN_LIMIT = 100` (still compiled-in, intentionally not chart-tunable).
- No new tests. The existing `bot_turns.rs` tests cover soft-limit semantics; this PR only wires an existing value through a new surface.
- Default-rendered `config.toml` is byte-for-byte identical to the previous chart output when `maxBotTurns` is unset.

## Verification

- `helm lint charts/openab` — clean.
- `helm template … --set agents.claude.discord.maxBotTurns=50` → emits `max_bot_turns = 50` in the rendered `config.toml`.
- `helm template …` without that flag → emits no `max_bot_turns` line (default 20 from Rust applies).

## Test plan

- [ ] Reviewer confirms `helm lint` is clean
- [ ] Reviewer confirms `helm template` with and without `maxBotTurns` set produces the expected diff
- [ ] After merge + chart bump + image deploy, fleet-infra-side tenants set `agents.claude.{discord,slack}.maxBotTurns: 50` and verify the rendered ConfigMap on the cluster contains `max_bot_turns = 50`

## Discord Link
Discord Link: https://discord.com/channels/1491295327620169908/1491365157010542652/1498547660540608602

🤖 Generated with [Claude Code](https://claude.com/claude-code)