### PR TITLE
fix(cron): create thread from trigger message before handle_message

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -1,5 +1,6 @@
 use crate::adapter::{AdapterRouter, ChatAdapter, ChannelRef, SenderContext};
 use crate::config::CronJobConfig;
+use crate::format;
 use chrono::{Timelike, Utc};
 use chrono_tz::Tz;
 use cron::Schedule;
@@ -257,13 +258,28 @@ async fn fire_cronjob(
         }
     };
 
+    // Create a thread from the trigger message (matches normal Discord flow)
+    let thread_name = format::shorten_thread_name(&job.message);
+    let reply_channel = if job.thread_id.is_some() {
+        // Already targeting an existing thread, no need to create one
+        thread_channel.clone()
+    } else {
+        match adapter.create_thread(&thread_channel, &trigger_msg, &thread_name).await {
+            Ok(ch) => ch,
+            Err(e) => {
+                error!(channel = %job.channel, error = %e, "failed to create cron thread");
+                return;
+            }
+        }
+    };
+
     // Trigger agent processing
     if let Err(e) = router
-        .handle_message(&adapter, &thread_channel, &sender_json, &job.message, vec![], &trigger_msg, false)
+        .handle_message(&adapter, &reply_channel, &sender_json, &job.message, vec![], &trigger_msg, false)
         .await
     {
         error!("cron handle_message error: {e}");
-        let _ = adapter.send_message(&thread_channel, &format!("⚠️ cronjob error: {e}")).await;
+        let _ = adapter.send_message(&reply_channel, &format!("⚠️ cronjob error: {e}")).await;
     }
 }
 

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -231,24 +231,6 @@ async fn fire_cronjob(
         parent_id: None,
     };
 
-    let sender = SenderContext {
-        schema: "openab.sender.v1".into(),
-        sender_id: "openab-cron".into(),
-        sender_name: job.sender_name.clone(),
-        display_name: job.sender_name.clone(),
-        channel: job.platform.clone(),
-        channel_id: job.channel.clone(),
-        thread_id: job.thread_id.clone(),
-        is_bot: true,
-    };
-    let sender_json = match serde_json::to_string(&sender) {
-        Ok(j) => j,
-        Err(e) => {
-            warn!(error = %e, "failed to serialize cron sender context, skipping");
-            return;
-        }
-    };
-
     // Send visible message first so users see what triggered
     let trigger_msg = match adapter.send_message(&thread_channel, &format!("🕐 [{}]: {}", job.sender_name, job.message)).await {
         Ok(msg) => msg,
@@ -258,18 +240,38 @@ async fn fire_cronjob(
         }
     };
 
-    // Create a thread from the trigger message (matches normal Discord flow)
-    let thread_name = format::shorten_thread_name(&job.message);
+    // Mirrors get_or_create_thread() in discord.rs
     let reply_channel = if job.thread_id.is_some() {
         // Already targeting an existing thread, no need to create one
         thread_channel.clone()
     } else {
+        let thread_name = format::shorten_thread_name(&job.message);
         match adapter.create_thread(&thread_channel, &trigger_msg, &thread_name).await {
             Ok(ch) => ch,
             Err(e) => {
                 error!(channel = %job.channel, error = %e, "failed to create cron thread");
+                let _ = adapter.send_message(&thread_channel, &format!("⚠️ cronjob: failed to create thread: {e}")).await;
                 return;
             }
+        }
+    };
+
+    // Build sender context after reply_channel is known so thread_id is accurate
+    let sender = SenderContext {
+        schema: "openab.sender.v1".into(),
+        sender_id: "openab-cron".into(),
+        sender_name: job.sender_name.clone(),
+        display_name: job.sender_name.clone(),
+        channel: job.platform.clone(),
+        channel_id: reply_channel.parent_id.as_deref().unwrap_or(&reply_channel.channel_id).to_string(),
+        thread_id: reply_channel.thread_id.clone().or(Some(reply_channel.channel_id.clone())),
+        is_bot: true,
+    };
+    let sender_json = match serde_json::to_string(&sender) {
+        Ok(j) => j,
+        Err(e) => {
+            warn!(error = %e, "failed to serialize cron sender context, skipping");
+            return;
         }
     };
 


### PR DESCRIPTION
## Summary

Fixes #612 — cronjob replies were going directly to the channel instead of creating a thread.

## Changes

`fire_cronjob()` in `cron.rs` now calls `adapter.create_thread()` using the trigger message as the anchor before calling `handle_message()`. This matches the normal Discord flow where `get_or_create_thread()` is called before processing.

When `thread_id` is already specified in the cronjob config (targeting an existing thread), thread creation is skipped.

## What was tested

- Built and deployed `fix-cron-thread` image to zhangfei on black (k3s)
- Configured `[[cronjobs]]` with `schedule = "* * * * *"` for rapid testing
- Verified thread creation from the trigger message in Discord
- Verified agent reply goes into the thread, not the channel