### PR TITLE
fix: add thread_metadata check to WarnAndStop path

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -302,7 +302,7 @@ impl EventHandler for Handler {
                             if let Ok(serenity::model::channel::Channel::Guild(gc)) =
                                 msg.channel_id.to_channel(&ctx.http).await
                             {
-                                if gc.parent_id.is_some_and(|pid| {
+                                if gc.thread_metadata.is_some() && gc.parent_id.is_some_and(|pid| {
                                     self.allowed_channels.contains(&pid.get())
                                 }) {
                                     allowed_here = true;

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -292,19 +292,25 @@ impl EventHandler for Handler {
                         // Must match the full thread allowlist semantics: a thread is allowed
                         // if its own channel_id OR its parent_id is in allowed_channels.
                         let ch = msg.channel_id.get();
-                        let mut allowed_here = self.allow_all_channels
-                            || self.allowed_channels.contains(&ch);
+                        let in_allowed_channel = self.allowed_channels.contains(&ch);
+                        let mut allowed_here = self.allow_all_channels || in_allowed_channel;
                         if !allowed_here {
-                            // Thread channel_id won't be in allowed_channels directly —
-                            // check parent_id via to_channel(). Only called on the
-                            // WarnAndStop path (once per soft/hard limit hit), not on
-                            // every bot message.
+                            // Reuse detect_thread() for thread allowlist semantics.
+                            // Only called on the WarnAndStop path (once per soft/hard
+                            // limit hit), not on every bot message.
                             if let Ok(serenity::model::channel::Channel::Guild(gc)) =
                                 msg.channel_id.to_channel(&ctx.http).await
                             {
-                                if gc.thread_metadata.is_some() && gc.parent_id.is_some_and(|pid| {
-                                    self.allowed_channels.contains(&pid.get())
-                                }) {
+                                let (in_thread, _) = detect_thread(
+                                    gc.thread_metadata.is_some(),
+                                    gc.parent_id.map(|id| id.get()),
+                                    gc.owner_id.map(|id| id.get()),
+                                    bot_id.get(),
+                                    &self.allowed_channels,
+                                    self.allow_all_channels,
+                                    in_allowed_channel,
+                                );
+                                if in_thread {
                                     allowed_here = true;
                                 }
                             }
@@ -1424,6 +1430,19 @@ mod tests {
             );
             assert_eq!(result, c.expect, "FAILED: {}", c.name);
         }
+    }
+
+    // --- WarnAndStop regression test (#633) ---
+    // The WarnAndStop path now delegates to detect_thread(). This test pins
+    // the exact scenario from #633: a category child channel whose category
+    // ID is in another bot's allowed_channels must NOT be treated as allowed.
+    #[test]
+    fn detect_thread_rejects_category_child_in_warn_and_stop() {
+        let category_id: u64 = 200;
+        let allowed = HashSet::from([category_id]);
+        // Category child: has parent_id (the category) but NO thread_metadata.
+        let (in_thread, _) = detect_thread(false, Some(category_id), None, 1000, &allowed, false, false);
+        assert!(!in_thread, "category child must not match allowed_channels via parent_id");
     }
 
     // --- Per-thread streaming tests (#534) ---


### PR DESCRIPTION
## Bug

When running multiple agents (e.g. Kiro in channel A, Gemini in channel B), if channel A sits under a Discord category whose ID happens to match one of Gemini's `allowed_channels`, Gemini incorrectly believes it has permission to post in channel A.

This is especially easy to trigger with cronjobs — cronjob messages are bot messages that don't reset the turn counter. Once the counter hits `soft_limit`, Gemini's WarnAndStop fires and posts a "turn limit reached" warning in channel A, where it should never appear.

## Root Cause

The `WarnAndStop` path in `discord.rs` (~L305) checks `parent_id` to determine if the bot is allowed to post, but doesn't first verify `thread_metadata` to distinguish threads from category children. In Discord's API, both threads and category child channels have `parent_id` set — threads point to their parent channel, category children point to their category. Without the `thread_metadata` check, a category child's `parent_id` (the category ID) gets matched against `allowed_channels`, causing a false positive.

This is the same class of bug that `detect_thread()` fixed in PRs #506/#518/#519, but the fix was never applied to the WarnAndStop code path.

## Fix

Add `gc.thread_metadata.is_some()` guard before the `parent_id` lookup, so `parent_id` is only used for the allowlist check when the channel is actually a thread:

```rust
// Before
if gc.parent_id.is_some_and(|pid| {

// After
if gc.thread_metadata.is_some() && gc.parent_id.is_some_and(|pid| {
```

## Testing

- `cargo check` ✅
- `cargo test` — 175 passed, 0 failed ✅

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1498994945384648766

Closes #633