### PR TITLE
fix: bump CLI versions — gemini 0.40.0, copilot 1.0.39 (others held)

### DIFF
--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
-ARG COPILOT_VERSION=1.0.36
+ARG COPILOT_VERSION=1.0.39
 RUN npm install -g @github/copilot@${COPILOT_VERSION} --retry 3
 
 # Install gh CLI (for auth and token management)

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
-ARG GEMINI_CLI_VERSION=0.39.1
+ARG GEMINI_CLI_VERSION=0.40.0
 RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} --retry 3
 
 # Install gh CLI


### PR DESCRIPTION
## Summary

Bump safe-to-upgrade CLI versions in Dockerfiles. **5 of 7 CLIs intentionally held** due to active regressions affecting Linux/container/headless workloads.

Discord Discussion URL: N/A

## Changes

| Dockerfile | CLI | Old | New | Notes |
|---|---|---|---|---|
| `Dockerfile.gemini` | `@google/gemini-cli` | 0.39.1 | **0.40.0** | Zero regression/bug-labelled issues; minor headless nits only |
| `Dockerfile.copilot` | `@github/copilot` | 1.0.36 | **1.0.39** | No public issue tracker; 3 patch versions, low risk |

## NOT updated (intentionally)

| Dockerfile | CLI | Pinned | Latest | Why |
|---|---|---|---|---|
| `Dockerfile` | kiro-cli | 2.1.1 | 2.2.0 | Changelog not published yet (404). Cannot assess risk. Hold until release notes are public. |
| `Dockerfile.codex` | `@openai/codex` | 0.125.0 | 0.125.0 | Already current — no bump needed |
| `Dockerfile.claude` | `@anthropic-ai/claude-code` | 2.1.116 | 2.1.123 | 🔴 **BLOCKER**: [#54632](https://github.com/anthropics/claude-code/issues/54632) — v2.1.123 crashes on startup on Linux x86-64 (`Module not found`, Bun bundling issue). Also [#54083](https://github.com/anthropics/claude-code/issues/54083) — Bedrock auth broken since 2.1.119. **2.1.116 remains the safe ceiling.** |
| `Dockerfile.cursor` | Cursor Agent CLI | 2026.04.17-787b533 | 2026.04.29-c83a488 | 🔴 Released today (Apr 29) with zero community validation. Unresolved CPU 100% regression from 04.13 build. Headless sandbox init bug still open. |
| `Dockerfile.opencode` | `opencode-ai` | 1.14.25 | 1.14.29 | 🔴 [#24977](https://github.com/anomalyco/opencode/issues/24977) — Bedrock auth regression in 1.14.29 (ignores AWS credential chain). [#24846](https://github.com/anomalyco/opencode/issues/24846) — ACP `newSession`/`authenticate` methods broken. Both directly affect openab. |
| `Dockerfile.codex` | `codex-acp` | 0.11.1 | — | No new release needed |
| `Dockerfile.claude` | `claude-agent-acp` | 0.29.2 | — | Still current |

## Per-CLI Risk Assessment

### claude-code — 🔴 HOLD at 2.1.116

- **#54632** (regression, platform:linux): v2.1.123 crashes on startup on Linux x86-64 baseline. `Module not found` error from Bun v1.3.14 bundling. **Hard blocker — CLI is completely unusable.**
- **#54083** (regression, platform:linux, api:bedrock): Bedrock auth fails with 403 + infinite retry since v2.1.119.
- **#54018**: Async subagent loops silently dropped (affects orchestration reliability).
- **#53948**: Plugin install no longer copies symlinked skills since v2.1.117.
- **Safe ceiling: 2.1.116** (current pin). Do not upgrade until #54632 is fixed.

### opencode-ai — 🔴 HOLD at 1.14.25

- **#24977** (regression): Bedrock provider requires API key in 1.14.29, ignoring AWS credential chain (SSO/IAM roles). **Blocker if using Bedrock.**
- **#24846** (acp): ACP `newSession` and `authenticate` methods return errors in 1.14.29. **Directly affects openab headless mode.**
- **#24927**: JSON error injected into SSE stream on Ubuntu.
- **#24985**: MCP client fails to init servers missing optional methods.
- 1.14.28 might be safer (Bedrock still works), but ACP issues may persist. **Stay on 1.14.25.**

### cursor — 🔴 HOLD at 2026.04.17-787b533

- CPU 100% / agent hang regression reported against 04.13 build, no confirmed fix.
- Headless sandbox init bug ignores `sandbox.json` on Linux (confirmed by Cursor staff, unresolved).
- 2026.04.29 released today — zero community validation in Docker/Linux.
- If 04.17 is stable, no reason to risk upgrading.

### kiro-cli — 🟡 HOLD at 2.1.1

- 2.2.0 is on the stable manifest but changelog returns 404. Cannot assess breaking changes.
- No known Linux/headless regressions on 2.1.1.
- Revisit once release notes are published.

### gemini-cli — 🟢 SAFE to bump to 0.40.0

- Zero issues with `regression` or `bug` labels.
- Minor nits: #26193 (ripgrep fallback message in non-interactive), #26168 (subagent discovery prompt).
- Neither is a blocker for headless Docker workloads.

### copilot — 🟢 SAFE to bump to 1.0.39

- No public issue tracker. 3 patch versions since 1.0.36.
- Low risk based on patch-only increment.

### codex — ✅ Already current at 0.125.0

- No version-specific regressions reported.
- Notable existing issues: #16451 (Linux sandbox denies /dev/null), #19309 (exec mode exits early). Neither is new.

## How to verify

```bash
# npm packages
npm view @google/gemini-cli version   # expect 0.40.0
npm view @github/copilot version      # expect 1.0.39

# Held versions (confirm still pinned)
curl -fsSL https://prod.download.cli.kiro.dev/stable/latest/manifest.json | grep version  # 2.2.0 available but held
npm view @anthropic-ai/claude-code version  # 2.1.123 available but held
npm view opencode-ai version                # 1.14.29 available but held
```

Ref: #573