### PR TITLE
fix: bump CLI versions — kiro 2.2.0, cursor 2026.04.29, opencode 1.14.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install kiro-cli (auto-detect arch, copy binary directly)
-ARG KIRO_CLI_VERSION=2.1.1
+ARG KIRO_CLI_VERSION=2.2.0
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-aarch64-linux.zip"; \
     else URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-x86_64-linux.zip"; fi && \

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # URL scheme scraped from Cursor's official downloads page — no apt/yum package exists.
 # If Cursor changes this pattern, the build fails with curl 404. Monitor
 # https://cursor.com/cli or https://docs.cursor.com/cli for version/URL updates.
-ARG CURSOR_VERSION=2026.04.17-787b533
+ARG CURSOR_VERSION=2026.04.29-c83a488
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
     curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -26,7 +26,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install opencode
-ARG OPENCODE_VERSION=1.14.25
+ARG OPENCODE_VERSION=1.14.28
 RUN npm install -g opencode-ai@${OPENCODE_VERSION} --retry 3
 
 # Install gh CLI (matches Dockerfile.claude / Dockerfile.gemini / Dockerfile.codex)


### PR DESCRIPTION
## Summary

Bump pinned CLI versions in Dockerfiles after investigating latest releases and upstream bug trackers.

Discord Discussion URL: N/A

## Changes

| Dockerfile | CLI | Old | New | Notes |
|---|---|---|---|---|
| `Dockerfile` | kiro-cli | 2.1.1 | **2.2.0** | Adaptive thinking, subagent tool dispatch fix (see changelog below) |
| `Dockerfile.cursor` | Cursor Agent CLI | 2026.04.17-787b533 | **2026.04.29-c83a488** | 12-day update; no public issue tracker, download verified |
| `Dockerfile.opencode` | `opencode-ai` | 1.14.25 | **1.14.28** | ⚠️ Safe ceiling — 1.14.29 has Bedrock auth regression (#24977) and GPT 5.3 breakage (#24899) |

## kiro-cli 2.2.0 changelog (2026-04-27)

Source: `kiro-cli changelog` output

- **Added:** Support adaptive thinking: Preserve model reasoning across multi-turn conversations for improved response quality
- **Fixed:** Fix subagent tool dispatch silently failing when MCP server events invalidate cached tool specs during execution

## NOT updated (intentionally)

| Dockerfile | CLI | Pinned | Latest | Why |
|---|---|---|---|---|
| `Dockerfile.codex` | `@openai/codex` | 0.125.0 | 0.125.0 | Already latest |
| `Dockerfile.codex` | `codex-acp` | 0.11.1 | — | No new release needed |
| `Dockerfile.claude` | `@anthropic-ai/claude-code` | 2.1.116 | 2.1.123 | ⛔ **HOLD** — see risk assessment below |
| `Dockerfile.claude` | `claude-agent-acp` | 0.29.2 | — | Still current |
| `Dockerfile.gemini` | `@google/gemini-cli` | 0.40.0 | 0.40.0 | Already latest |
| `Dockerfile.copilot` | `@github/copilot` | 1.0.39 | 1.0.39 | Already latest |

## claude-code risk assessment ⛔ HOLD at 2.1.116

Open regressions tagged `platform:linux` on versions **2.1.117–2.1.123**:

| Issue | Version | Impact | Affects openab? |
|---|---|---|---|
| [#54632](https://github.com/anthropics/claude-code/issues/54632) | 2.1.123 | Startup crash `Module not found` (Linux x86-64 standalone binary, Bun ELF) | ⚠️ Standalone binary only — openab uses npm install, **may** be safe, but untested |
| [#54841](https://github.com/anthropics/claude-code/issues/54841) | 2.1.123 | Claude 4.7 model performance/reliability regression on Linux | ℹ️ Model-side, not CLI-specific |
| [#54083](https://github.com/anthropics/claude-code/issues/54083) | 2.1.119+ | AWS Bedrock auth token header failing (Linux, `needs-info`) | ⛔ **Directly affects openab** — we use Bedrock |
| [#52822](https://github.com/anthropics/claude-code/issues/52822) | 2.1.119 | PreToolUse hook `allow` does not suppress native permission prompt (Linux) | ⚠️ May affect ACP permission flow |
| [#52309](https://github.com/anthropics/claude-code/issues/52309) | 2.1.116 | tmux resize causes duplicated/corrupted output (Linux) | ℹ️ Already on current version, TUI-only |

**Verdict:** 2.1.116 remains the safe ceiling. The Bedrock auth regression (#54083) starting at 2.1.119 is a blocker for openab. Wait for Anthropic to fix before bumping.

## opencode-ai risk assessment — bump to 1.14.28

| Issue | Version | Impact | Affects openab? |
|---|---|---|---|
| [#24977](https://github.com/anomalyco/opencode/issues/24977) | 1.14.29 | Bedrock provider requires API key (regression from 1.14.28) | ⛔ Would break Bedrock — **skip 1.14.29** |
| [#24899](https://github.com/anomalyco/opencode/issues/24899) | 1.14.29 | GPT 5.3 Codex tool calls stall | ⛔ Tool calls broken — **skip 1.14.29** |
| [#24985](https://github.com/anomalyco/opencode/issues/24985) | all | MCP client fails on servers without optional `prompts/list` | ℹ️ Not a regression, pre-existing |

1.14.30 is latest but both #24977 and #24899 are still open with no confirmed fix. **1.14.28 is the safe ceiling.**

## codex risk assessment — no update needed

All 20 open bugs are tagged `app` (desktop), `windows-os`, or `macOS`. Zero CLI-specific regressions. Already on latest (0.125.0).

## gemini-cli — no update needed

Zero open bugs with `bug` label. Already on latest (0.40.0).

## How to verify

```bash
# kiro-cli
curl -fsSL https://prod.download.cli.kiro.dev/stable/latest/manifest.json | grep version

# npm packages
npm view @openai/codex version          # 0.125.0
npm view @anthropic-ai/claude-code version  # 2.1.123 (we stay at 2.1.116)
npm view @google/gemini-cli version     # 0.40.0
npm view @github/copilot version        # 1.0.39
npm view opencode-ai version            # 1.14.30 (we pin 1.14.28)

# cursor
curl -fsSL https://cursor.com/install | grep "2026\."
```

Ref: #573