### PR TITLE
fix(chart): align cronjob config with openab binary + add usercron support

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -129,9 +129,17 @@ data:
     bot_username = {{ ($cfg.gateway).botUsername | toJson }}
     {{- end }}
     {{- end }}
+    {{- if or ($cfg.cronjobs) ($cfg.cron) }}
+
+    [cron]
+    usercron_enabled = {{ (($cfg.cron).usercronEnabled) | default false }}
+    {{- if (($cfg.cron).usercronPath) }}
+    usercron_path = {{ ($cfg.cron).usercronPath | toJson }}
+    {{- end }}
     {{- range ($cfg.cronjobs) }}
 
-    [[cronjobs]]
+    [[cron.jobs]]
+    enabled = {{ .enabled | default true }}
     schedule = {{ .schedule | toJson }}
     channel = {{ .channel | toJson }}
     message = {{ .message | toJson }}
@@ -140,6 +148,7 @@ data:
     timezone = {{ .timezone | default "UTC" | toJson }}
     {{- if .threadId }}
     thread_id = {{ .threadId | toJson }}
+    {{- end }}
     {{- end }}
     {{- end }}
   {{- if $cfg.agentsMd }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -129,7 +129,7 @@ data:
     bot_username = {{ ($cfg.gateway).botUsername | toJson }}
     {{- end }}
     {{- end }}
-    {{- if or ($cfg.cronjobs) ($cfg.cron) }}
+    {{- if or ($cfg.cronjobs) (($cfg.cron).usercronEnabled) (($cfg.cron).usercronPath) }}
 
     [cron]
     usercron_enabled = {{ (($cfg.cron).usercronEnabled) | default false }}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -186,6 +186,9 @@ agents:
     #       senderName: "DailyOps"
     #       timezone: "Asia/Taipei"
     #       threadId: ""
+    cron:
+      usercronEnabled: false
+      usercronPath: ""
     cronjobs: []
     persistence:
       enabled: true

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -182,6 +182,7 @@ agents:
     #     - schedule: "0 9 * * 1-5"
     #       channel: "123456789"
     #       message: "summarize yesterday's merged PRs"
+    #       enabled: true          # set to false to disable this job without removing it
     #       platform: "discord"
     #       senderName: "DailyOps"
     #       timezone: "Asia/Taipei"


### PR DESCRIPTION
## What problem does this solve?

PR #629 consolidated all cron config under `[cron]` and renamed `[[cronjobs]]` → `[[cron.jobs]]`, but the Helm chart template was not updated to match:

- Chart produces: `[[cronjobs]]` (top-level key)
- openab expects: `[[cron.jobs]]` (under `[cron]` per `Config.cron: CronConfig` in `src/config.rs`)

Result: all Helm-deployed cronjob configs are silently ignored.

Additionally, `usercron_enabled` and `usercron_path` are supported in `config.rs` but had no corresponding chart fields.

## Changes

| File | What |
|------|------|
| `charts/openab/templates/configmap.yaml` | `[[cronjobs]]` → `[[cron.jobs]]`; add `[cron]` section with `usercron_enabled`, `usercron_path`; add `enabled` field per job; wrap in conditional |
| `charts/openab/values.yaml` | Add `cron.usercronEnabled` (default: `false`) and `cron.usercronPath` (default: `""`) |

## Testing

### helm template verification

```bash
# Default — [cron] + usercron_enabled = false
helm template test charts/openab

# With cronjob — produces [cron] + [[cron.jobs]]
helm template test charts/openab \
  --set 'agents.kiro.cronjobs[0].schedule=0 9 * * 1-5' \
  --set-string 'agents.kiro.cronjobs[0].channel=123456789' \
  --set 'agents.kiro.cronjobs[0].message=hello'

# With usercron — renders usercron_path
helm template test charts/openab \
  --set 'agents.kiro.cron.usercronEnabled=true' \
  --set 'agents.kiro.cron.usercronPath=/data/usercron.toml'
```

### OrbStack K8s live test

- ✅ System cron (`[[cron.jobs]]`) — fires every minute, Discord receives message
- ✅ Usercron (cronjob.toml hot-reload) — file detected, registered, and fired without restart

Discord Discussion: https://discord.com/channels/1491295327620169908/1499264765141454940