### PR TITLE
fix(chart): use hasKey for boolean enabled to avoid Go template default trap

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -112,7 +112,7 @@ data:
     session_ttl_hours = {{ ($cfg.pool).sessionTtlHours | default 24 }}
 
     [reactions]
-    enabled = {{ ($cfg.reactions).enabled | default true }}
+    enabled = {{ if hasKey ($cfg.reactions) "enabled" }}{{ ($cfg.reactions).enabled }}{{ else }}true{{ end }}
     remove_after_reply = {{ ($cfg.reactions).removeAfterReply | default false }}
     {{- if ($cfg.reactions).toolDisplay }}
     {{- if not (has ($cfg.reactions).toolDisplay (list "full" "compact" "none")) }}
@@ -170,7 +170,7 @@ data:
     {{- range ($cfg.cronjobs) }}
 
     [[cron.jobs]]
-    enabled = {{ .enabled | default true }}
+    enabled = {{ if hasKey . "enabled" }}{{ .enabled }}{{ else }}true{{ end }}
     schedule = {{ .schedule | toJson }}
     channel = {{ .channel | toJson }}
     message = {{ .message | toJson }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -113,7 +113,7 @@ data:
 
     [reactions]
     enabled = {{ if hasKey ($cfg.reactions) "enabled" }}{{ ($cfg.reactions).enabled }}{{ else }}true{{ end }}
-    remove_after_reply = {{ ($cfg.reactions).removeAfterReply | default false }}
+    remove_after_reply = {{ if hasKey ($cfg.reactions) "removeAfterReply" }}{{ ($cfg.reactions).removeAfterReply }}{{ else }}false{{ end }}
     {{- if ($cfg.reactions).toolDisplay }}
     {{- if not (has ($cfg.reactions).toolDisplay (list "full" "compact" "none")) }}
     {{- fail (printf "agents.%s.reactions.toolDisplay must be one of: full, compact, none — got: %s" $name ($cfg.reactions).toolDisplay) }}
@@ -163,7 +163,7 @@ data:
     {{- if or ($cfg.cronjobs) (($cfg.cron).usercronEnabled) (($cfg.cron).usercronPath) }}
 
     [cron]
-    usercron_enabled = {{ (($cfg.cron).usercronEnabled) | default false }}
+    usercron_enabled = {{ if hasKey ($cfg.cron) "usercronEnabled" }}{{ (($cfg.cron).usercronEnabled) }}{{ else }}false{{ end }}
     {{- if (($cfg.cron).usercronPath) }}
     usercron_path = {{ ($cfg.cron).usercronPath | toJson }}
     {{- end }}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -206,7 +206,7 @@ agents:
     #     - schedule: "0 9 * * 1-5"
     #       channel: "123456789"
     #       message: "summarize yesterday's merged PRs"
-    #       enabled: true          # set to false to disable this job without removing it
+    #       enabled: true          # false = skip scheduling (job config is still validated at startup)
     #       platform: "discord"
     #       senderName: "DailyOps"
     #       timezone: "Asia/Taipei"


### PR DESCRIPTION
## What problem does this solve?

PR #638 introduced `enabled` fields for cronjobs and the existing `reactions.enabled` already had the same pattern:

```yaml
enabled = {{ .enabled | default true }}
```

In Go templates, `default` treats `false` as a zero value, so `{{ false | default true }}` returns `true`. This means users **cannot disable** cronjobs or reactions by setting `enabled: false` — the value is silently overridden to `true`.

Discovered during four-monk review of PR #638 by 覺渡法師 (Gemini).

## Changes

| File | What |
|------|------|
| `charts/openab/templates/configmap.yaml` | Replace `{{ .enabled \| default true }}` with `{{ if hasKey . "enabled" }}{{ .enabled }}{{ else }}true{{ end }}` for both `reactions.enabled` and `cron.jobs[].enabled` |
| `charts/openab/values.yaml` | Clarify `enabled` comment: `false = skip scheduling (job config is still validated at startup)` |

## Testing

```bash
# cronjob enabled=false → renders false ✅
helm template test charts/openab \
  --set agents.kiro.cronjobs[0].schedule="0 9 * * 1-5" \
  --set-string agents.kiro.cronjobs[0].channel=123456789 \
  --set agents.kiro.cronjobs[0].message=hello \
  --set agents.kiro.cronjobs[0].enabled=false

# cronjob enabled not set → renders true ✅
helm template test charts/openab \
  --set agents.kiro.cronjobs[0].schedule="0 9 * * 1-5" \
  --set-string agents.kiro.cronjobs[0].channel=123456789 \
  --set agents.kiro.cronjobs[0].message=hello

# reactions enabled=false → renders false ✅
helm template test charts/openab \
  --set agents.kiro.reactions.enabled=false
```

## Related

- Follow-up to PR #638
- Note: `validate_cronjobs()` in `src/cron.rs` still validates disabled jobs at startup. This is a separate runtime concern — suggest opening a follow-up issue if the team wants `enabled: false` to also skip validation.