### PR TITLE
fix(cron): skip validation for disabled cronjobs

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -41,6 +41,7 @@ const VALID_PLATFORMS: &[&str] = &["discord", "slack"];
 /// Validate all cronjob configs (fail-fast on bad cron expressions or timezones).
 pub fn validate_cronjobs(cronjobs: &[CronJobConfig], configured_platforms: &[&str]) -> anyhow::Result<()> {
     for (i, job) in cronjobs.iter().enumerate() {
+        if !job.enabled { continue; }
         parse_cron_expr(&job.schedule).map_err(|e| {
             anyhow::anyhow!("cronjobs[{i}]: invalid cron expression {:?}: {e}", job.schedule)
         })?;
@@ -609,6 +610,26 @@ platform = "slack"
         }];
         let err = validate_cronjobs(&jobs, &["discord"]).unwrap_err();
         assert!(err.to_string().contains("not configured"));
+    }
+
+    #[test]
+    fn validate_cronjobs_disabled_with_invalid_cron_passes() {
+        let jobs = vec![CronJobConfig {
+            enabled: false, schedule: "bad".into(), channel: "123".into(),
+            message: "hi".into(), platform: "discord".into(), sender_name: "test".into(),
+            thread_id: None, timezone: "UTC".into(),
+        }];
+        assert!(validate_cronjobs(&jobs, &["discord"]).is_ok());
+    }
+
+    #[test]
+    fn validate_cronjobs_enabled_with_invalid_cron_still_fails() {
+        let jobs = vec![CronJobConfig {
+            enabled: true, schedule: "bad".into(), channel: "123".into(),
+            message: "hi".into(), platform: "discord".into(), sender_name: "test".into(),
+            thread_id: None, timezone: "UTC".into(),
+        }];
+        assert!(validate_cronjobs(&jobs, &["discord"]).is_err());
     }
 
     // --- file_mtime tests ---


### PR DESCRIPTION
## What problem does this solve?

`validate_cronjobs()` validates **all** cronjob configs at startup, including those with `enabled: false`. This means a disabled job with an invalid cron expression or timezone causes openab to fail at startup, even though the job would never be scheduled.

This contradicts the user expectation that `enabled: false` means "this job does not affect the system."

The runtime scheduler (`parse_job_list()`) already correctly skips disabled jobs — only the startup preflight validation was inconsistent.

Discovered by 擺渡法師 (Codex) during four-monk review of PR #638.

## Changes

| File | What |
|------|------|
| `src/cron.rs` | Add `if !job.enabled { continue; }` to `validate_cronjobs()` |
| `src/cron.rs` | Add 2 tests: disabled job with invalid cron passes, enabled job with invalid cron still fails |

## Testing

```
running 7 tests
test cron::tests::validate_cronjobs_enabled_with_invalid_cron_still_fails ... ok
test cron::tests::validate_cronjobs_invalid_timezone_fails ... ok
test cron::tests::validate_cronjobs_disabled_with_invalid_cron_passes ... ok
test cron::tests::validate_cronjobs_unknown_platform_fails ... ok
test cron::tests::validate_cronjobs_valid_passes ... ok
test cron::tests::validate_cronjobs_unconfigured_platform_fails ... ok
test cron::tests::validate_cronjobs_invalid_cron_fails ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 170 filtered out
```

## Related

- Follow-up to PR #638 and PR #639
- Aligns startup validation with runtime scheduling semantics