### PR TITLE
docs(readme): fix expired Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE**, and other webhook-based platforms are supported via the standalone [Custom Gateway](gateway/).
 
-🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://discord.gg/YNksK9M6)** 🎉
+🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://discord.gg/DmbhfDZjQS)** 🎉
 
 ```
 ┌──────────────┐  Gateway WS   ┌──────────────┐  ACP stdio    ┌──────────────┐


### PR DESCRIPTION
## Context
The Discord invite link in README.md has expired. Closes #651

## Summary
Replace the expired Discord invite link (`YNksK9M6`) with a permanent one (`DmbhfDZjQS`).

## Changes
- Updated Discord invite URL in README.md line 9

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365150664560881