### PR TITLE
fix(helm): add missing gateway permission fields in ConfigMap

### DIFF
--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -24,22 +24,22 @@ Agents deployed:
     Required scopes: app_mentions:read, chat:write, channels:history, groups:history, channels:read, groups:read, reactions:write, files:read
 {{- end }}
 
-{{- if eq $cfg.command "kiro-cli" }}
+{{- if eq (toString $cfg.command) "kiro-cli" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- kiro-cli login --use-device-flow
-{{- else if eq $cfg.command "codex-acp" }}
+{{- else if eq (toString $cfg.command) "codex-acp" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- codex login --device-auth
-{{- else if eq $cfg.command "claude-agent-acp" }}
+{{- else if eq (toString $cfg.command) "claude-agent-acp" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- claude setup-token
-{{- else if eq $cfg.command "gemini" }}
+{{- else if eq (toString $cfg.command) "gemini" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- gemini
-{{- else if eq $cfg.command "opencode" }}
+{{- else if eq (toString $cfg.command) "opencode" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- opencode auth login
-{{- else if eq $cfg.command "cursor-agent" }}
+{{- else if eq (toString $cfg.command) "cursor-agent" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- cursor-agent login
 {{- end }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -128,6 +128,23 @@ data:
     {{- if ($cfg.gateway).botUsername }}
     bot_username = {{ ($cfg.gateway).botUsername | toJson }}
     {{- end }}
+    allow_all_channels = {{ if and (hasKey ($cfg.gateway) "allowAllChannels") (ne ($cfg.gateway).allowAllChannels nil) }}{{ ($cfg.gateway).allowAllChannels }}{{ else if ($cfg.gateway).allowedChannels }}false{{ else }}true{{ end }}
+    {{- range ($cfg.gateway).allowedChannels }}
+    {{- if regexMatch "e\+|E\+" (toString .) }}
+    {{- fail (printf "gateway.allowedChannels contains a mangled ID: %s — use --set-string instead of --set for channel IDs" (toString .)) }}
+    {{- end }}
+    {{- end }}
+    allowed_channels = {{ ($cfg.gateway).allowedChannels | default list | toJson }}
+    allow_all_users = {{ if and (hasKey ($cfg.gateway) "allowAllUsers") (ne ($cfg.gateway).allowAllUsers nil) }}{{ ($cfg.gateway).allowAllUsers }}{{ else if ($cfg.gateway).allowedUsers }}false{{ else }}true{{ end }}
+    {{- range ($cfg.gateway).allowedUsers }}
+    {{- if regexMatch "e\+|E\+" (toString .) }}
+    {{- fail (printf "gateway.allowedUsers contains a mangled ID: %s — use --set-string instead of --set for user IDs" (toString .)) }}
+    {{- end }}
+    {{- end }}
+    allowed_users = {{ ($cfg.gateway).allowedUsers | default list | toJson }}
+    {{- if ($cfg.gateway).botUsername }}
+    bot_username = {{ ($cfg.gateway).botUsername | toJson }}
+    {{- end }}
     {{- end }}
     {{- if or ($cfg.cronjobs) (($cfg.cron).usercronEnabled) (($cfg.cron).usercronPath) }}
 

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -130,14 +130,14 @@ data:
     {{- end }}
     allow_all_channels = {{ if and (hasKey ($cfg.gateway) "allowAllChannels") (ne ($cfg.gateway).allowAllChannels nil) }}{{ ($cfg.gateway).allowAllChannels }}{{ else if ($cfg.gateway).allowedChannels }}false{{ else }}true{{ end }}
     {{- range ($cfg.gateway).allowedChannels }}
-    {{- if regexMatch "e\+|E\+" (toString .) }}
+    {{- if regexMatch "[eE]\\+" (toString .) }}
     {{- fail (printf "gateway.allowedChannels contains a mangled ID: %s — use --set-string instead of --set for channel IDs" (toString .)) }}
     {{- end }}
     {{- end }}
     allowed_channels = {{ ($cfg.gateway).allowedChannels | default list | toJson }}
     allow_all_users = {{ if and (hasKey ($cfg.gateway) "allowAllUsers") (ne ($cfg.gateway).allowAllUsers nil) }}{{ ($cfg.gateway).allowAllUsers }}{{ else if ($cfg.gateway).allowedUsers }}false{{ else }}true{{ end }}
     {{- range ($cfg.gateway).allowedUsers }}
-    {{- if regexMatch "e\+|E\+" (toString .) }}
+    {{- if regexMatch "[eE]\\+" (toString .) }}
     {{- fail (printf "gateway.allowedUsers contains a mangled ID: %s — use --set-string instead of --set for user IDs" (toString .)) }}
     {{- end }}
     {{- end }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -142,9 +142,6 @@ data:
     {{- end }}
     {{- end }}
     allowed_users = {{ ($cfg.gateway).allowedUsers | default list | toJson }}
-    {{- if ($cfg.gateway).botUsername }}
-    bot_username = {{ ($cfg.gateway).botUsername | toJson }}
-    {{- end }}
     {{- end }}
     {{- if or ($cfg.cronjobs) (($cfg.cron).usercronEnabled) (($cfg.cron).usercronPath) }}
 


### PR DESCRIPTION
## What problem does it solve?
This PR fixes a bug where gateway permissions (`allowedUsers`, `allowAllUsers`, etc.)
were missing from the Helm Chart template.
It also improves robustness in NOTES.txt.\n\n

## How does it solve it?
1. Added missing fields to `configmap.yaml`.
2. Added ID validation.
3. Updated `NOTES.txt` to handle list-type commands safely.