### PR TITLE
feat: add Discord DM support

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -14,6 +14,8 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 # allow_user_messages = "involved"  # "involved" (default) | "mentions"
                                      # "involved" = reply in threads bot owns or has participated in
                                      # "mentions" = always require @mention
+# allow_dm = false                     # true = respond to Discord DMs; false (default) = ignore DMs
+                                       # allowed_users still applies in DMs
 
 # [slack]
 # bot_token = "${SLACK_BOT_TOKEN}"     # Bot User OAuth Token (xoxb-...)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -39,6 +39,7 @@ Discord adapter. Requires a Discord bot token.
 | `allow_bot_messages` | string | `"off"` | `"off"` — ignore all bot messages. `"mentions"` — only process bot messages that @mention this bot. `"all"` — process all bot messages (capped by `max_bot_turns`). |
 | `trusted_bot_ids` | string[] | `[]` | When non-empty, only these bot IDs pass the bot gate. Empty = any bot (mode permitting). Ignored when `allow_bot_messages = "off"`. |
 | `allow_user_messages` | string | `"involved"` | `"involved"` — reply in threads bot has participated in without @mention; channel messages require @mention; DMs always process. `"mentions"` — always require @mention. `"multibot-mentions"` — like `"involved"`, but require @mention once another bot has posted in the thread. |
+| `allow_dm` | bool | `false` | `true` = respond to Discord DMs; `false` = ignore DMs. `allowed_users` still applies in DMs. Each DM user consumes one session slot. |
 | `max_bot_turns` | u32 | `20` | Max consecutive bot turns per thread before throttling. Human message resets the counter. Note: when `allow_bot_messages = "all"`, a separate hardcoded cap of 10 (`MAX_CONSECUTIVE_BOT_TURNS`) stops bot replies regardless of this value. |
 
 ---

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -1,11 +1,48 @@
 # Messaging Model
 
-This document explains the four messaging patterns in OpenAB, each building on the previous one:
+This document explains the five messaging patterns in OpenAB, each building on the previous one:
 
+0. **Human → Bot in DM** — Private 1:1 conversations (opt-in).
 1. **Human → Bot in Channel** — How a conversation starts via @mention.
 2. **Human → Bot in Thread** — How follow-up messages work without @mention.
 3. **Human → Multiple Bots in Thread** — How multi-bot threads behave and how to control them.
 4. **Bot → Bot in Thread** — How bots can talk to each other and how to prevent loops.
+
+---
+
+## 0. Human → Bot in DM
+
+Users can interact with the bot privately via direct message. DMs are **opt-in** — disabled by default to prevent unexpected resource usage.
+
+When `allow_dm = true`, a DM is treated as an **implicit @mention** (mirrors Slack behavior). No thread is created — the bot replies directly in the DM channel.
+
+```
+User DMs BotA: help me with X
+  → BotA replies in DM (no thread, no @mention needed)
+```
+
+### Key behaviors
+
+- **`allowed_users` still enforced** — DMs are not a backdoor past user allowlists.
+- **Bot turn tracking applies** — `max_bot_turns` prevents loops in DM conversations.
+- **Session pool shared** — Each DM user consumes one session slot (`discord:{dm_channel_id}`). Existing TTL cleanup and eviction apply.
+- **Discord only** — Slack natively supports DMs without extra config. This setting applies to the Discord adapter only.
+
+### Relevant config
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `allow_dm` | bool | `false` | `true` = respond to Discord DMs; `false` = ignore DMs. |
+| `allowed_users` | string[] | `[]` | User IDs allowed to interact. Still enforced in DMs. |
+
+### Example config.toml
+
+```toml
+[discord]
+bot_token = "${DISCORD_BOT_TOKEN}"
+allow_dm = true                      # opt-in to DM support
+allowed_users = ["9876543210"]       # restrict who can DM the bot
+```
 
 ---
 
@@ -175,6 +212,10 @@ max_bot_turns = 10
 ## Quick Reference
 
 ```
+Layer 0 — Human → Bot (DM)
+  Config: allow_dm, allowed_users
+  DM to bot                     →  Bot replies directly (no thread, no @mention)
+
 Layer 1 — Human → Bot (Channel)
   Config: allowed_channels, allowed_users, reactions
   @BotA in channel              →  OAB creates thread, BotA responds

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,10 @@ pub struct DiscordConfig {
     /// Human message resets the counter. Default: 20.
     #[serde(default = "default_max_bot_turns")]
     pub max_bot_turns: u32,
+    /// Allow the bot to respond to Discord direct messages (DMs).
+    /// Default: false (opt-in). `allowed_users` still applies in DMs.
+    #[serde(default)]
+    pub allow_dm: bool,
 }
 
 fn default_max_bot_turns() -> u32 { 20 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1023,6 +1023,16 @@ fn should_process_dm(allow_dm: bool) -> bool {
     allow_dm
 }
 
+/// Pure decision function: should thread creation be skipped?
+/// Returns `true` when the message should reuse the current channel
+/// directly (existing thread or DM), `false` when a new thread should
+/// be created. Pins the invariant that DMs never call
+/// `get_or_create_thread()` — Discord DM channels cannot create threads.
+#[cfg(test)]
+fn should_skip_thread_creation(in_thread: bool, is_dm: bool) -> bool {
+    in_thread || is_dm
+}
+
 /// Pure decision function: should this message be processed or ignored?
 /// Returns `true` if the message should be processed (bot responds).
 /// Extracted from the EventHandler::message gating logic for testability.
@@ -1592,5 +1602,30 @@ mod tests {
             false,  // involved
             false,  // other_bot_present
         ));
+    }
+
+    // --- Thread creation skip tests (regression for #656 DM bug) ---
+    // Pins the invariant: DMs must never call get_or_create_thread().
+    // Discord DM channels do not support thread creation.
+
+    /// GIVEN: is_dm = true, not in a thread
+    /// THEN:  skip thread creation (use DM channel directly)
+    #[test]
+    fn dm_skips_thread_creation() {
+        assert!(should_skip_thread_creation(false, true));
+    }
+
+    /// GIVEN: already in a thread, not a DM
+    /// THEN:  skip thread creation (reuse existing thread)
+    #[test]
+    fn existing_thread_skips_thread_creation() {
+        assert!(should_skip_thread_creation(true, false));
+    }
+
+    /// GIVEN: not in a thread, not a DM (normal channel message)
+    /// THEN:  do NOT skip — create a new thread
+    #[test]
+    fn normal_channel_creates_thread() {
+        assert!(!should_skip_thread_creation(false, false));
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -154,6 +154,8 @@ pub struct Handler {
     pub max_bot_turns: u32,
     /// Per-thread bot turn tracker. Both counters reset on human msg.
     pub bot_turns: tokio::sync::Mutex<BotTurnTracker>,
+    /// Allow the bot to respond to Discord DMs.
+    pub allow_dm: bool,
 }
 
 impl Handler {
@@ -397,7 +399,7 @@ impl EventHandler for Handler {
         // Thread detection: single to_channel() call for both allowed and
         // non-allowed channels. Uses thread_metadata (not parent_id) to
         // identify threads — see detect_thread() doc comments for rationale.
-        let (in_thread, bot_owns_thread, thread_parent_id) = match msg.channel_id.to_channel(&ctx.http).await {
+        let (in_thread, bot_owns_thread, thread_parent_id, is_dm) = match msg.channel_id.to_channel(&ctx.http).await {
             Ok(serenity::model::channel::Channel::Guild(gc)) => {
                 let parent = gc.parent_id.map(|id| id.get().to_string());
                 let result = detect_thread(
@@ -418,19 +420,29 @@ impl EventHandler for Handler {
                     bot_owns = ?result.1,
                     "thread check"
                 );
-                (result.0, result.1.unwrap_or(false), if result.0 { parent } else { None })
+                (result.0, result.1.unwrap_or(false), if result.0 { parent } else { None }, false)
+            }
+            Ok(serenity::model::channel::Channel::Private(_)) => {
+                tracing::debug!(channel_id = %msg.channel_id, "DM channel");
+                (false, false, None, true)
             }
             Ok(other) => {
                 tracing::debug!(channel_id = %msg.channel_id, kind = ?other, "not a guild thread");
-                (false, false, None)
+                (false, false, None, false)
             }
             Err(e) => {
                 tracing::debug!(channel_id = %msg.channel_id, error = %e, "to_channel failed");
-                (false, false, None)
+                (false, false, None, false)
             }
         };
 
-        if !in_allowed_channel && !in_thread {
+        // DM gating: allow_dm must be true, otherwise reject
+        if is_dm && !self.allow_dm {
+            tracing::debug!(channel_id = %msg.channel_id, "DM rejected (allow_dm=false)");
+            return;
+        }
+
+        if !is_dm && !in_allowed_channel && !in_thread {
             return;
         }
 
@@ -440,7 +452,8 @@ impl EventHandler for Handler {
         //   (Option A) OR has previously posted in it (Option B).
         // MultibotMentions: same as Involved, but if other bots are also
         //   in the thread, require @mention to avoid all bots responding.
-        if !is_mentioned {
+        // DMs are treated as implicit @mention (mirrors Slack behavior).
+        if !is_mentioned && !is_dm {
             match self.allow_user_messages {
                 AllowUsers::Mentions => return,
                 AllowUsers::Involved => {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -596,7 +596,8 @@ impl EventHandler for Handler {
             "processing"
         );
 
-        let thread_channel = if in_thread {
+        let thread_channel = if in_thread || is_dm {
+            // DMs use the DM channel directly (no threads in DMs).
             ChannelRef {
                 platform: "discord".into(),
                 channel_id: msg.channel_id.get().to_string(),
@@ -1009,6 +1010,17 @@ fn detect_thread(
 /// Bot authors skip this check — they are gated by `allow_bot_messages` + `trusted_bot_ids`.
 fn is_denied_user(is_bot: bool, allow_all_users: bool, allowed_users: &HashSet<u64>, user_id: u64) -> bool {
     !is_bot && !allow_all_users && !allowed_users.contains(&user_id)
+}
+
+/// Pure decision function: should a DM be processed?
+/// Returns `true` if the DM should be processed (bot responds).
+/// Mirrors the DM gating logic in EventHandler::message:
+/// - `allow_dm` must be true
+/// - `allowed_users` still applies (checked separately via `is_denied_user`)
+/// - DMs bypass `allowed_channels` and `@mention` requirements
+#[cfg(test)]
+fn should_process_dm(allow_dm: bool) -> bool {
+    allow_dm
 }
 
 /// Pure decision function: should this message be processed or ignored?
@@ -1522,5 +1534,63 @@ mod tests {
     fn denied_user_bot_skips_allowlist() {
         let allowed = HashSet::from([100]);
         assert!(!is_denied_user(true, false, &allowed, 999));
+    }
+
+    // --- DM gating tests (#656) ---
+    // DMs are gated by `allow_dm` config. When allowed, DMs bypass
+    // `allowed_channels` and treat the message as implicit @mention.
+
+    /// GIVEN: allow_dm = false
+    /// WHEN:  user sends a DM
+    /// THEN:  DM is rejected
+    #[test]
+    fn dm_rejected_when_allow_dm_false() {
+        assert!(!should_process_dm(false));
+    }
+
+    /// GIVEN: allow_dm = true
+    /// WHEN:  user sends a DM
+    /// THEN:  DM is accepted
+    #[test]
+    fn dm_accepted_when_allow_dm_true() {
+        assert!(should_process_dm(true));
+    }
+
+    /// GIVEN: allow_dm = true, user NOT in allowed_users
+    /// WHEN:  user sends a DM
+    /// THEN:  user is denied (allowed_users still enforced in DMs)
+    #[test]
+    fn dm_denied_user_still_enforced() {
+        let allowed = HashSet::from([100]);
+        // DM passes allow_dm gate, but user gate still applies
+        assert!(should_process_dm(true));
+        assert!(is_denied_user(false, false, &allowed, 999));
+    }
+
+    /// GIVEN: allow_dm = true, user in allowed_users
+    /// WHEN:  user sends a DM
+    /// THEN:  user is allowed
+    #[test]
+    fn dm_allowed_user_passes() {
+        let allowed = HashSet::from([100]);
+        assert!(should_process_dm(true));
+        assert!(!is_denied_user(false, false, &allowed, 100));
+    }
+
+    /// DMs are treated as implicit @mention — should_process_user_message
+    /// is never called for DMs (the `!is_dm` guard skips it).
+    /// This test verifies the Involved mode would reject a non-thread,
+    /// non-mentioned message — confirming DMs MUST bypass this check.
+    #[test]
+    fn dm_must_bypass_user_message_gating() {
+        // Without the `!is_dm` bypass, a DM would be rejected by Involved mode
+        // because is_mentioned=false and in_thread=false.
+        assert!(!should_process_user_message(
+            AllowUsers::Involved,
+            false,  // is_mentioned (DMs don't have @mention)
+            false,  // in_thread (DMs are not threads)
+            false,  // involved
+            false,  // other_bot_present
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,6 +294,7 @@ async fn main() -> anyhow::Result<()> {
             trusted_bots = trusted_bot_ids.len(),
             allow_bot_messages = ?discord_cfg.allow_bot_messages,
             allow_user_messages = ?discord_cfg.allow_user_messages,
+            allow_dm = discord_cfg.allow_dm,
             "starting discord adapter"
         );
 
@@ -313,11 +314,13 @@ async fn main() -> anyhow::Result<()> {
             session_ttl: std::time::Duration::from_secs(ttl_secs),
             max_bot_turns: discord_cfg.max_bot_turns,
             bot_turns: tokio::sync::Mutex::new(bot_turns::BotTurnTracker::new(discord_cfg.max_bot_turns)),
+            allow_dm: discord_cfg.allow_dm,
         };
 
         let intents = GatewayIntents::GUILD_MESSAGES
             | GatewayIntents::MESSAGE_CONTENT
-            | GatewayIntents::GUILDS;
+            | GatewayIntents::GUILDS
+            | GatewayIntents::DIRECT_MESSAGES;
 
         let mut client = Client::builder(&discord_cfg.bot_token, intents)
             .event_handler(handler)


### PR DESCRIPTION
## Summary

Add Discord direct message (DM) support, gated behind a new `allow_dm` config option (default: `false`).

Discord Discussion URL: https://discord.com/channels/1490282656913559673/1499505696679399608

Closes #656

## Changes

**`src/config.rs`**
- Add `allow_dm: bool` field to `DiscordConfig` (default `false`)

**`src/discord.rs`**
- Add `allow_dm: bool` field to `Handler` struct
- Detect `Channel::Private` in the `to_channel()` match → set `is_dm = true`
- DM gating: reject DMs when `allow_dm = false`
- Bypass `allowed_channels` check for DMs (DMs have no guild channel)
- Treat DMs as implicit `@mention` (mirrors Slack behavior)
- Fix: DMs skip thread creation (DM channels cannot create threads)
- Add `should_process_dm()` pure function + 5 unit tests for DM gating

**`src/main.rs`**
- Pass `allow_dm` from config to Handler
- Add `DIRECT_MESSAGES` gateway intent
- Log `allow_dm` at startup

**`config.toml.example`**
- Document the new `allow_dm` option

## Design Decisions

- **Default `false`** — opt-in for safety; prevents unexpected resource usage from random DMs
- **`allowed_users` still enforced** — DMs are not a backdoor past user allowlists
- **Bot turn tracking applies** — prevents infinite loops in DM conversations
- **Mirrors Slack pattern** — Slack treats DMs as implicit mention; this does the same
- **DMs skip thread creation** — Discord DM channels do not support threads; messages reply directly in the DM channel

## Known Limitations (follow-up)

DM sessions share the same `max_sessions` pool as guild channel sessions. Each DM user consumes one session slot (key: `discord:{dm_channel_id}`). Existing eviction and TTL cleanup apply, but under heavy DM load, DM sessions compete with guild sessions for pool capacity.

Future considerations:
- `max_dm_sessions` — dedicated cap for DM sessions
- Shorter TTL for DM sessions
- DM sessions evicted first when pool is full

## Testing

- Added `should_process_dm()` pure function with 5 unit tests covering: allow/reject, user allowlist enforcement in DMs, and implicit @mention bypass verification
- Added `should_skip_thread_creation()` with 3 regression tests pinning the DM thread-skip invariant
- No Rust toolchain in this environment; requesting peer review for compilation verification