### PR TITLE
fix(reactions): restore tool_display default to full

### DIFF
--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -48,7 +48,7 @@ agents:
     #   reactions:
     #     enabled: true
     #     removeAfterReply: false
-    #     # toolDisplay: "compact" (default) | "full" | "none"
+    #     # toolDisplay: "full" (default) | "compact" | "none"
     #   persistence:
     #     enabled: true
     #     storageClass: ""
@@ -81,7 +81,7 @@ agents:
     #   reactions:
     #     enabled: true
     #     removeAfterReply: false
-    #     # toolDisplay: "compact" (default) | "full" | "none"
+    #     # toolDisplay: "full" (default) | "compact" | "none"
     #   persistence:
     #     enabled: true
     #     storageClass: ""
@@ -111,7 +111,7 @@ agents:
     #   reactions:
     #     enabled: true
     #     removeAfterReply: false
-    #     # toolDisplay: "compact" (default) | "full" | "none"
+    #     # toolDisplay: "full" (default) | "compact" | "none"
     #   persistence:
     #     enabled: true
     #     storageClass: ""
@@ -167,7 +167,7 @@ agents:
     reactions:
       enabled: true
       removeAfterReply: false
-      # toolDisplay: "compact" (default) | "full" | "none"
+      # toolDisplay: "full" (default) | "compact" | "none"
       # compact: show count summary (e.g. ✅ 3 · 🔧 1 tool(s))
       # full: show complete tool titles (for debugging)
       # none: hide tool lines entirely

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -160,7 +160,7 @@ Emoji reaction feedback on messages to show agent processing status.
 |-----|------|---------|-------------|
 | `enabled` | bool | `true` | Enable/disable reaction feedback. |
 | `remove_after_reply` | bool | `false` | Remove the status reaction after the agent replies. |
-| `tool_display` | string | `"compact"` | How tool calls are rendered: `"full"` (complete title), `"compact"` (count summary, e.g. `✅ 3 · 🔧 1 tool(s)`), or `"none"` (hidden). |
+| `tool_display` | string | `"full"` | How tool calls are rendered: `"full"` (complete title), `"compact"` (count summary, e.g. `✅ 3 · 🔧 1 tool(s)`), or `"none"` (hidden). |
 
 ### `[reactions.emojis]`
 

--- a/docs/tool-display.md
+++ b/docs/tool-display.md
@@ -6,7 +6,7 @@ Control how tool calls are rendered in chat messages during agent responses.
 
 ```toml
 [reactions]
-tool_display = "compact"   # full | compact | none
+tool_display = "full"   # full | compact | none
 ```
 
 ### Helm
@@ -15,24 +15,12 @@ tool_display = "compact"   # full | compact | none
 agents:
   kiro:
     reactions:
-      toolDisplay: "compact"   # full | compact | none
+      toolDisplay: "full"   # full | compact | none
 ```
 
 ## Modes
 
-### `compact` (default)
-
-Shows a single-line count summary. No tool names, commands, or arguments are displayed.
-
-```
-✅ 3 · 🔧 1 tool(s)
-
-Agent response text here...
-```
-
-Best for: everyday use, public channels, mobile.
-
-### `full`
+### `full` (default)
 
 Shows each tool call with its complete title. When more than 3 tools finish, they collapse into a count summary automatically.
 
@@ -45,6 +33,18 @@ Agent response text here...
 ```
 
 Best for: debugging, understanding what the agent is doing step by step.
+
+### `compact`
+
+Shows a single-line count summary. No tool names, commands, or arguments are displayed.
+
+```
+✅ 3 · 🔧 1 tool(s)
+
+Agent response text here...
+```
+
+Best for: everyday use, public channels, mobile.
 
 ### `none`
 
@@ -66,6 +66,6 @@ Best for: clean output when you only care about the final answer.
 
 ## Notes
 
-- **Default changed**: `compact` is the new default. Previously, tool calls were always shown in full. If you want the old behavior, set `tool_display = "full"`.
+- **Default**: `full` shows complete tool titles. Use `tool_display = "compact"` for a cleaner count-only summary, or `"none"` to hide tools entirely.
 - **Reaction emojis are independent**: The emoji reactions on messages (👀→🤔→🔧→🆗) work regardless of `tool_display` setting.
 - **Streaming behavior**: In `compact` mode, the count updates in real-time as tools start and finish. In `full` mode, individual tool lines appear and update during streaming.

--- a/src/config.rs
+++ b/src/config.rs
@@ -253,13 +253,13 @@ fn default_cron_timezone() -> String { "UTC".into() }
 
 /// Controls how tool calls are rendered in chat messages.
 ///
-/// - `full`: show complete tool title including arguments (original behavior)
-/// - `compact`: show only a count summary, e.g. `✅ 3 · 🔧 1 tool(s)` (default)
+/// - `full`: show complete tool title including arguments (default, original behavior)
+/// - `compact`: show only a count summary, e.g. `✅ 3 · 🔧 1 tool(s)`
 /// - `none`: hide tool lines entirely, only show final response
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ToolDisplay {
-    Full,
     #[default]
+    Full,
     Compact,
     None,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -571,6 +571,11 @@ command = "echo"
     }
 
     #[test]
+    fn tool_display_default_is_full() {
+        assert_eq!(ToolDisplay::default(), ToolDisplay::Full);
+    }
+
+    #[test]
     fn parse_gateway_config_explicit_allow_all_overrides_list() {
         let toml = r#"
 [gateway]


### PR DESCRIPTION
## Summary

Restore `tool_display` default from `compact` back to `full` to fix a breaking change introduced in #658.

Discord Discussion URL: https://discord.com/channels/1486155598964719616/1499505047845736458

## Problem

PR #658 changed the default `tool_display` from `full` (original behavior) to `compact`. This is a **breaking change** — existing deployments that never explicitly set `tool_display` would silently get different behavior after upgrading.

## Fix

- Move `#[default]` from `Compact` to `Full` in the `ToolDisplay` enum (`src/config.rs`)
- Update doc comments and Helm `values.yaml` comments to reflect `full` as the default

Users who want `compact` mode can opt in explicitly:
```toml
[reactions]
tool_display = "compact"
```

## Changes
- `src/config.rs`: Move `#[default]` attribute to `Full` variant, update doc comments
- `charts/openab/values.yaml`: Update 4 comment lines to show `full` as default

Ref: #658