### PR TITLE
helm: expose allow_dm in discord config

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -51,6 +51,9 @@ data:
     {{- end }}
     allow_user_messages = {{ $cfg.discord.allowUserMessages | toJson }}  {{- /* involved (default): respond in bot's threads without @mention | mentions: always require @mention | multibot-mentions: require @mention only when another bot has posted in the thread */ -}}
     {{- end }}
+    {{- if hasKey $cfg.discord "allowDm" }}
+    allow_dm = {{ $cfg.discord.allowDm }}
+    {{- end }}
     {{- end }}
 
     {{- if and ($cfg.slack).enabled }}

--- a/charts/openab/tests/configmap_test.yaml
+++ b/charts/openab/tests/configmap_test.yaml
@@ -97,3 +97,25 @@ tests:
       - matchRegex:
           path: data["config.toml"]
           pattern: 'allow_user_messages = "multibot-mentions"'
+
+  - it: renders allow_dm = false by default
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'allow_dm = false'
+
+  - it: renders allow_dm = true when set
+    set:
+      agents.kiro.discord.allowDm: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'allow_dm = true'
+
+  - it: renders allow_dm = false when explicitly set
+    set:
+      agents.kiro.discord.allowDm: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'allow_dm = false'

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -135,6 +135,8 @@ agents:
         - "YOUR_CHANNEL_ID"
       # ⚠️ Use --set-string for user IDs to avoid float64 precision loss
       allowedUsers: []  # only checked when allowAllUsers=false
+      # allowDm: true | false (default) — whether the bot responds to direct messages
+      allowDm: false
       # allowBotMessages: "off" (default) | "mentions" | "all"
       # recommended for multi-agent collaboration
       allowBotMessages: "off"


### PR DESCRIPTION
## Summary

Expose the `allow_dm` config field in the Helm chart so users can control whether the bot responds to direct messages.

Closes #661

## Changes

- **`values.yaml`**: Add `allowDm: false` to the `discord` section
- **`configmap.yaml`**: Render `allow_dm` in the `[discord]` block when `allowDm` is set
- **`tests/configmap_test.yaml`**: 3 unit tests (default false, explicit true, explicit false)

## Tested

- `helm template` renders `allow_dm = false` correctly
- All 3 helm unit tests pass