### PR TITLE
docs(upgrade): add cleanup phase for stale backups

### DIFF
--- a/docs/ai-install-upgrade.md
+++ b/docs/ai-install-upgrade.md
@@ -143,7 +143,7 @@ rollback openab per the upgrade SOP — the upgrade to v0.7.7 failed
   │    is still reachable and update values.yaml if  │
   │    the URL has rotated                           │
   │                                                  │
-  │  ALL PASS ──► ✅ DONE                             │
+  │  ALL PASS ──► proceed to 6. CLEANUP            │
   │  ANY FAIL ──► proceed to 5. ROLLBACK             │
   └─────────────────────────────────────────────────┘
 ```

--- a/docs/ai-install-upgrade.md
+++ b/docs/ai-install-upgrade.md
@@ -216,6 +216,7 @@ rollback openab per the upgrade SOP — the upgrade to v0.7.7 failed
 **Then ask the user:**
 - Which old backups to delete (if any)
 - Whether to keep the most recent N backups as a policy going forward
+- Recommend keeping at least the latest stable backup as a safety net
 
 **Do NOT** delete anything without explicit user confirmation.
 

--- a/docs/ai-install-upgrade.md
+++ b/docs/ai-install-upgrade.md
@@ -41,13 +41,15 @@ rollback openab per the upgrade SOP — the upgrade to v0.7.7 failed
                              │             pass      fail
                              │               │         │
                              ▼               ▼         ▼
-                        ┌─────────┐    ┌─────────┐ ┌──────────┐
-                        │  ABORT  │    │  DONE ✅ │ │5. ROLLBACK│
-                        │         │    └─────────┘ │          │
-                        └─────────┘                │ uninstall│
-                                                   │ reinstall│
-                                                   │ restore  │
-                                                   └──────────┘
+                        ┌─────────┐    ┌──────────┐ ┌──────────┐
+                        │  ABORT  │    │6. CLEANUP│ │5. ROLLBACK│
+                        │         │    │  (ask    │ │          │
+                        └─────────┘    │  user)   │ │ uninstall│
+                                       └────┬─────┘ │ reinstall│
+                                            ▼       │ restore  │
+                                       ┌─────────┐  └──────────┘
+                                       │  DONE ✅ │
+                                       └─────────┘
 ```
 
 **Invariant:** At every point, the system is either running the current version, running the target version, or being restored to the current version. No data is lost.
@@ -181,6 +183,41 @@ rollback openab per the upgrade SOP — the upgrade to v0.7.7 failed
   │ ✅ Rollback complete
   └──────────────────────────────────────────────
 ```
+
+---
+
+## 6. Cleanup (post-upgrade)
+
+**Goal:** After a successful upgrade, evaluate old backups and let the user decide what to keep.
+
+> **[AI Instruction]** This phase is advisory. List what you find and ask the user — do NOT auto-delete anything.
+
+```
+  Local Disk
+  ┌──────────────────────────────────────────────┐
+  │  ~/openab-backups/                           │
+  │  ├── 0.7.5_20260401/  (1.2 GB)              │
+  │  ├── 0.7.6_20260415/  (1.4 GB)              │
+  │  └── 0.7.7_20260501/  (1.5 GB)  ◄── current │
+  └──────────────────────────────────────────────┘
+
+  Step ①  List all backup directories with size and date
+  Step ②  Show total disk usage
+  Step ③  Ask the user which backups to remove (if any)
+```
+
+**What to report:**
+
+| Item | Command |
+|------|---------|
+| Backup dirs | `du -sh ~/openab-backups/*/` |
+| Total size | `du -sh ~/openab-backups/` |
+
+**Then ask the user:**
+- Which old backups to delete (if any)
+- Whether to keep the most recent N backups as a policy going forward
+
+**Do NOT** delete anything without explicit user confirmation.
 
 ---
 


### PR DESCRIPTION
## Summary

Add a **Section 6: Cleanup (post-upgrade)** to `docs/ai-install-upgrade.md`.

After a successful upgrade, the AI agent now lists existing backup directories with sizes and asks the user which old backups to remove. No auto-deletion — purely advisory.

## Changes

- Updated the flow diagram to show Cleanup phase between Smoke Test pass and DONE
- Added Section 6 with:
  - Backup directory listing (`du -sh`)
  - Total disk usage report
  - Interactive prompt asking user which backups to keep/remove

## Context

Raised by Allen in maintainers channel — backup directories accumulate over upgrades and can grow large (14 GB+). Rather than prescribing a fixed retention policy (keep N), this lets the AI prompt the user to evaluate and decide.

cc @pahud