### PR TITLE
feat(discord): global slash commands + /reset for DM sessions

### DIFF
--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,0 +1,76 @@
+# Slash Commands
+
+OpenAB registers Discord slash commands for session control. These work in both guild threads and DMs.
+
+## Commands
+
+| Command | Description | Requires active session? |
+|---------|-------------|--------------------------|
+| `/models` | Select the AI model via dropdown menu | Yes |
+| `/agents` | Select the agent mode via dropdown menu | Yes |
+| `/cancel` | Cancel the current in-flight operation | Yes |
+| `/reset` | Reset the conversation session (clear history, start fresh) | Yes |
+
+All responses are **ephemeral** — only the user who invoked the command sees the reply.
+
+## Platform Support
+
+| Platform | Supported | Notes |
+|----------|-----------|-------|
+| Discord (guild threads) | ✅ | Commands registered per-guild for instant availability |
+| Discord (DMs) | ✅ | Commands registered globally; may take up to 1 hour to appear after first deploy |
+| Slack | ❌ | Slack blocks third-party slash commands in threads; see [slack-bot-howto.md](slack-bot-howto.md#slash-commands-are-not-supported-on-slack) |
+
+## How They Work
+
+### `/models` and `/agents`
+
+These read `configOptions` from the ACP `initialize` / `session/new` response and present them as a Discord Select Menu.
+
+When the user picks an option, OpenAB sends `session/set_config_option` to the ACP backend.
+
+**Agent support varies:**
+
+| Agent | `/models` | `/agents` |
+|-------|-----------|-----------|
+| kiro-cli | ✅ Returns available models via `models` fallback | ✅ Returns modes (`kiro_default`, `kiro_planner`) via `modes` fallback |
+| claude-code | ❌ No `configOptions` emitted | ❌ |
+| codex | ❌ | ❌ |
+| gemini | ❌ | ❌ |
+| cursor-agent | ❌ (tracking: #493) | ❌ |
+| copilot | ❌ (tracking: #496) | ❌ |
+
+If the agent doesn't expose options, the user sees: `⚠️ No model options available. Start a conversation first by @mentioning the bot.`
+
+> **Note:** Discord Select Menus are limited to 25 items. If the agent returns more, only the first 25 are shown with a count of how many were truncated.
+
+### `/cancel`
+
+Sends a `session/cancel` JSON-RPC notification to the ACP backend. This aborts in-flight LLM requests and tool calls immediately — no need to wait for the current response to finish.
+
+### `/reset`
+
+Destroys the current ACP session (kills the process) and clears all session state. The next message in the thread or DM will automatically create a fresh session via the session pool.
+
+This is equivalent to the `sessions close` + `sessions new` pattern used by [OpenClaw ACPX](https://github.com/openclaw/acpx).
+
+**What gets cleared:**
+- Conversation history
+- ACP process and connection
+- Suspended session state (no resume after reset)
+
+**What is preserved:**
+- Bot identity and system prompt (re-applied on next session creation)
+- Config settings in `config.toml`
+
+## Passing CLI Commands via @mention
+
+In addition to slash commands, you can pass built-in CLI commands directly after an @mention:
+
+```
+@MyBot /compact
+@MyBot /clear
+@MyBot /model claude-sonnet-4
+```
+
+These are forwarded as-is to the ACP session as a prompt. Any command the underlying CLI supports in its interactive mode works here. This is the recommended workaround for agents that don't expose `configOptions`.

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -50,7 +50,7 @@ Sends a `session/cancel` JSON-RPC notification to the ACP backend. This aborts i
 
 ### `/reset`
 
-Destroys the current ACP session (kills the process) and clears all session state. The next message in the thread or DM will automatically create a fresh session via the session pool.
+Cancels any in-flight operation, then removes the session from the pool. The ACP process terminates once the last reference is released. The next message in the thread or DM will automatically create a fresh session.
 
 This is equivalent to the `sessions close` + `sessions new` pattern used by [OpenClaw ACPX](https://github.com/openclaw/acpx).
 

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -292,6 +292,22 @@ impl SessionPool {
         Ok(())
     }
 
+    /// Reset a session: remove the active connection and clear suspended state.
+    /// The next message will trigger a fresh `get_or_create` with a new ACP session.
+    pub async fn reset_session(&self, thread_id: &str) -> Result<()> {
+        let mut state = self.state.write().await;
+        let had_active = state.active.remove(thread_id).is_some();
+        state.cancel_handles.remove(thread_id);
+        state.suspended.remove(thread_id);
+        state.creating.remove(thread_id);
+        if had_active {
+            info!(thread_id, "session reset");
+            Ok(())
+        } else {
+            Err(anyhow!("no session for thread {thread_id}"))
+        }
+    }
+
     pub async fn cleanup_idle(&self, ttl_secs: u64) {
         let cutoff = Instant::now() - std::time::Duration::from_secs(ttl_secs);
 

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -292,9 +292,31 @@ impl SessionPool {
         Ok(())
     }
 
-    /// Reset a session: remove the active connection and clear suspended state.
-    /// The next message will trigger a fresh `get_or_create` with a new ACP session.
+    /// Reset a session: cancel any in-flight operation, remove the active connection,
+    /// and clear all suspended state. The ACP process will be killed once the last
+    /// Arc reference is dropped (after streaming finishes). The next message will
+    /// trigger a fresh `get_or_create` with a new ACP session.
     pub async fn reset_session(&self, thread_id: &str) -> Result<()> {
+        // Send session/cancel via the lock-free stdin handle first.
+        // This stops in-flight streaming even while with_connection() holds the
+        // connection mutex, so the old process finishes promptly.
+        if let Some((stdin, session_id)) = {
+            let state = self.state.read().await;
+            state.cancel_handles.get(thread_id).cloned()
+        } {
+            let data = serde_json::to_string(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "session/cancel",
+                "params": {"sessionId": session_id}
+            }))?;
+            tracing::info!(session_id, "reset: sending session/cancel");
+            use tokio::io::AsyncWriteExt;
+            let mut w = stdin.lock().await;
+            let _ = w.write_all(data.as_bytes()).await;
+            let _ = w.write_all(b"\n").await;
+            let _ = w.flush().await;
+        }
+
         let mut state = self.state.write().await;
         let had_active = state.active.remove(thread_id).is_some();
         state.cancel_handles.remove(thread_id);

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use std::sync::LazyLock;
 use serenity::builder::{CreateActionRow, CreateCommand, CreateInteractionResponse, CreateInteractionResponseMessage, CreateSelectMenu, CreateSelectMenuKind, CreateSelectMenuOption, CreateThread, EditMessage};
 use serenity::http::Http;
-use serenity::model::application::{ComponentInteractionDataKind, Interaction};
+use serenity::model::application::{Command, ComponentInteractionDataKind, Interaction};
 use serenity::model::channel::{AutoArchiveDuration, Message, MessageType, ReactionType};
 use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, MessageId, UserId};
@@ -638,26 +638,35 @@ impl EventHandler for Handler {
     async fn ready(&self, ctx: Context, ready: Ready) {
         info!(user = %ready.user.name, "discord bot connected");
 
-        // Register /model slash command to all guilds the bot is in
+        // Build the shared command list once.
+        let commands = vec![
+            CreateCommand::new("models")
+                .description("Select the AI model for this session"),
+            CreateCommand::new("agents")
+                .description("Select the agent mode for this session"),
+            CreateCommand::new("cancel")
+                .description("Cancel the current operation"),
+            CreateCommand::new("reset")
+                .description("Reset the conversation session"),
+        ];
+
+        // Register global commands (works in DMs + all guilds after propagation).
+        if let Err(e) = Command::set_global_commands(&ctx.http, commands.clone()).await {
+            tracing::warn!(error = %e, "failed to register global slash commands");
+        } else {
+            info!("registered global slash commands");
+        }
+
+        // Also register per-guild for instant availability (global can take up to 1h).
         for guild in &ready.guilds {
             let guild_id = guild.id;
             if let Err(e) = guild_id
-                .set_commands(
-                    &ctx.http,
-                    vec![
-                        CreateCommand::new("models")
-                            .description("Select the AI model for this session"),
-                        CreateCommand::new("agents")
-                            .description("Select the agent mode for this session"),
-                        CreateCommand::new("cancel")
-                            .description("Cancel the current operation"),
-                    ],
-                )
+                .set_commands(&ctx.http, commands.clone())
                 .await
             {
-                tracing::warn!(%guild_id, error = %e, "failed to register slash commands");
+                tracing::warn!(%guild_id, error = %e, "failed to register guild slash commands");
             } else {
-                info!(%guild_id, "registered slash commands");
+                info!(%guild_id, "registered guild slash commands");
             }
         }
     }
@@ -673,6 +682,9 @@ impl EventHandler for Handler {
             Interaction::Command(cmd) if cmd.data.name == "cancel" => {
                 self.handle_cancel_command(&ctx, &cmd).await;
             }
+            Interaction::Command(cmd) if cmd.data.name == "reset" => {
+                self.handle_reset_command(&ctx, &cmd).await;
+            }
             Interaction::Component(comp) if comp.data.custom_id.starts_with("acp_config_") => {
                 self.handle_config_select(&ctx, &comp).await;
             }
@@ -686,11 +698,13 @@ impl EventHandler for Handler {
 
 impl Handler {
     /// Build a Discord select menu from ACP configOptions with the given category.
+    /// Discord limits Select Menus to 25 options; excess options are truncated.
     fn build_config_select(options: &[ConfigOption], category: &str) -> Option<CreateSelectMenu> {
         let opt = options.iter().find(|o| o.category.as_deref() == Some(category))?;
         let menu_options: Vec<CreateSelectMenuOption> = opt
             .options
             .iter()
+            .take(25)
             .map(|o| {
                 let mut item = CreateSelectMenuOption::new(&o.name, &o.value);
                 if let Some(desc) = &o.description {
@@ -707,15 +721,22 @@ impl Handler {
             return None;
         }
 
+        let truncated = opt.options.len() > 25;
+        let placeholder = format!(
+            "Current: {}{}",
+            opt.options.iter()
+                .find(|o| o.value == opt.current_value)
+                .map(|o| o.name.as_str())
+                .unwrap_or(&opt.current_value),
+            if truncated { format!(" ({} more not shown)", opt.options.len() - 25) } else { String::new() },
+        );
+
         Some(
             CreateSelectMenu::new(
                 format!("acp_config_{}", opt.id),
                 CreateSelectMenuKind::String { options: menu_options },
             )
-            .placeholder(format!("Current: {}", opt.options.iter()
-                .find(|o| o.value == opt.current_value)
-                .map(|o| o.name.as_str())
-                .unwrap_or(&opt.current_value)))
+            .placeholder(placeholder)
         )
     }
 
@@ -767,6 +788,27 @@ impl Handler {
         );
         if let Err(e) = cmd.create_response(&ctx.http, response).await {
             tracing::error!(error = %e, "failed to respond to /cancel command");
+        }
+    }
+
+    async fn handle_reset_command(
+        &self,
+        ctx: &Context,
+        cmd: &serenity::model::application::CommandInteraction,
+    ) {
+        let thread_key = format!("discord:{}", cmd.channel_id.get());
+        let result = self.router.pool().reset_session(&thread_key).await;
+
+        let msg = match result {
+            Ok(()) => "🔄 Session reset. Start a new conversation!".to_string(),
+            Err(e) => format!("⚠️ {e}"),
+        };
+
+        let response = CreateInteractionResponse::Message(
+            CreateInteractionResponseMessage::new().content(msg).ephemeral(true),
+        );
+        if let Err(e) = cmd.create_response(&ctx.http, response).await {
+            tracing::error!(error = %e, "failed to respond to /reset command");
         }
     }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -699,12 +699,20 @@ impl EventHandler for Handler {
 impl Handler {
     /// Build a Discord select menu from ACP configOptions with the given category.
     /// Discord limits Select Menus to 25 options; excess options are truncated.
+    /// The currently selected option is always included (placed first if needed).
     fn build_config_select(options: &[ConfigOption], category: &str) -> Option<CreateSelectMenu> {
         let opt = options.iter().find(|o| o.category.as_deref() == Some(category))?;
-        let menu_options: Vec<CreateSelectMenuOption> = opt
-            .options
-            .iter()
+
+        // Ensure current selection is in the first 25 by placing it first,
+        // then filling remaining slots with the rest in original order.
+        let sorted: Vec<_> = opt.options.iter()
+            .filter(|o| o.value == opt.current_value)
+            .chain(opt.options.iter().filter(|o| o.value != opt.current_value))
             .take(25)
+            .collect();
+
+        let menu_options: Vec<CreateSelectMenuOption> = sorted
+            .iter()
             .map(|o| {
                 let mut item = CreateSelectMenuOption::new(&o.name, &o.value);
                 if let Some(desc) = &o.description {
@@ -801,7 +809,7 @@ impl Handler {
 
         let msg = match result {
             Ok(()) => "🔄 Session reset. Start a new conversation!".to_string(),
-            Err(e) => format!("⚠️ {e}"),
+            Err(_) => "⚠️ No active session to reset. Start a conversation first by @mentioning the bot.".to_string(),
         };
 
         let response = CreateInteractionResponse::Message(


### PR DESCRIPTION
## Summary

Register `/models`, `/agents`, `/cancel`, `/reset` as **global** slash commands so they work in Discord DMs. Also fix the >25 models crash in Select Menu.

Discord Discussion URL: https://discord.com/channels/1490282656913559673/1499552285942878289

Closes #663
Fixes #631
Ref #489

## Changes

**`src/discord.rs`**
- Add `Command::set_global_commands()` in `ready()` for DM support
- Keep per-guild registration for instant availability (global commands take up to 1h to propagate)
- Add `/reset` to the command list
- Add `handle_reset_command()` — calls `pool.reset_session()`, replies with ephemeral confirmation
- Fix #631: `build_config_select()` now `.take(25)` to respect Discord Select Menu limit, shows truncation count in placeholder

**`src/acp/pool.rs`**
- Add `reset_session()` — removes active connection (Drop kills process group), clears cancel handles, suspended state, and creation gate. Next message triggers fresh `get_or_create`.

## Design Decisions

- **Global + guild dual registration** — global for DM support; guild for instant availability in servers
- **`reset_session` drops the connection** — follows the ACPX `sessions close` pattern (prior art from openclaw/acpx). The ACP process is killed via process group Drop, and the next user message creates a fresh session via `get_or_create`
- **No process leak** — `reset_session` clears all state maps (active, cancel_handles, suspended, creating) so nothing is orphaned
- **>25 models fix** — truncate to 25 with placeholder showing overflow count, rather than failing silently or crashing

## Prior Art

- OpenClaw ACPX harness: `sessions close` + `sessions new` triggered by `/new` hook interception
- OpenClaw gateway: user-facing `/new`/`/reset` separated from admin `sessions.reset` RPC (v2026.3.11)

## Testing

- `cargo build` ✅
- `cargo test` — 194 tests pass, 0 failures
- No new unit tests added (slash command handlers require Discord API mocking; pool `reset_session` is a thin state-clearing method)
