### PR TITLE
feat(chart): expose maxBotTurns for Slack/Discord

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -54,6 +54,10 @@ data:
     {{- if hasKey $cfg.discord "allowDm" }}
     allow_dm = {{ $cfg.discord.allowDm }}
     {{- end }}
+    {{- /* maxBotTurns: soft cap on consecutive bot turns per thread (human msg resets the counter) */ -}}
+    {{- if hasKey ($cfg.discord | default dict) "maxBotTurns" }}
+    max_bot_turns = {{ ($cfg.discord).maxBotTurns | int }}
+    {{- end }}
     {{- end }}
 
     {{- if and ($cfg.slack).enabled }}
@@ -88,6 +92,10 @@ data:
     {{- fail (printf "agents.%s.slack.allowUserMessages must be one of: involved, mentions, multibot-mentions (use hyphen form, not underscore) — got: %s" $name ($cfg.slack).allowUserMessages) }}
     {{- end }}
     allow_user_messages = {{ ($cfg.slack).allowUserMessages | toJson }}  {{- /* involved (default): respond in bot's threads without @mention | mentions: always require @mention | multibot-mentions: require @mention only when another bot has posted in the thread */ -}}
+    {{- end }}
+    {{- /* maxBotTurns: soft cap on consecutive bot turns per thread (human msg resets the counter) */ -}}
+    {{- if hasKey ($cfg.slack | default dict) "maxBotTurns" }}
+    max_bot_turns = {{ ($cfg.slack).maxBotTurns | int }}
     {{- end }}
     {{- end }}
 

--- a/charts/openab/tests/configmap_test.yaml
+++ b/charts/openab/tests/configmap_test.yaml
@@ -119,3 +119,26 @@ tests:
       - matchRegex:
           path: data["config.toml"]
           pattern: 'allow_dm = false'
+
+  - it: renders discord max_bot_turns when set
+    set:
+      agents.kiro.discord.maxBotTurns: 50
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'max_bot_turns = 50'
+
+  - it: does not render discord max_bot_turns when unset
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'max_bot_turns'
+
+  - it: renders slack max_bot_turns when set
+    set:
+      agents.kiro.slack.enabled: true
+      agents.kiro.slack.maxBotTurns: 30
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'max_bot_turns = 30'

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -145,6 +145,12 @@ agents:
       allowBotMessages: "off"
       # trustedBotIds: []  # empty = any bot (mode permitting); set to restrict
       trustedBotIds: []
+      # maxBotTurns: soft cap on consecutive bot turns per thread before
+      # the bot stops auto-replying. A human message resets the counter.
+      # Default 20 (Rust-side `default_max_bot_turns()`). Raise for long
+      # multi-agent collaborations; lower to throttle runaway loops more
+      # aggressively. Hard cap remains 100 regardless (compiled-in).
+      # maxBotTurns: 20
     slack:
       enabled: false
       botToken: ""       # Bot User OAuth Token (xoxb-...)
@@ -163,6 +169,12 @@ agents:
       #                      only when another bot has also posted in the thread
       #                      (recommended for multi-bot deployments)
       allowUserMessages: "involved"
+      # maxBotTurns: soft cap on consecutive bot turns per thread before
+      # the bot stops auto-replying. A human message resets the counter.
+      # Default 20 (Rust-side `default_max_bot_turns()`). Raise for long
+      # multi-agent collaborations; lower to throttle runaway loops more
+      # aggressively. Hard cap remains 100 regardless (compiled-in).
+      # maxBotTurns: 20
     workingDir: /home/agent
     env: {}
     envFrom: []

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -207,6 +207,28 @@ trusted_bot_ids = ["1111111111", "2222222222"]
 max_bot_turns = 10
 ```
 
+### Helm chart
+
+Same keys are settable from chart values under `agents.<name>.discord` and
+`agents.<name>.slack` using camelCase (Helm convention):
+
+```yaml
+agents:
+  claude:
+    discord:
+      allowBotMessages: "mentions"
+      trustedBotIds: ["1111111111", "2222222222"]
+      maxBotTurns: 50
+    slack:
+      allowBotMessages: "mentions"
+      trustedBotIds: ["U1111111111", "U2222222222"]
+      maxBotTurns: 50
+```
+
+When `maxBotTurns` is omitted from values, the Rust default of 20
+applies. The hard cap of 100 is compiled-in
+(`HARD_BOT_TURN_LIMIT` in `src/bot_turns.rs`) and is not chart-tunable.
+
 ---
 
 ## Quick Reference


### PR DESCRIPTION
Closes #609. Supersedes #610.

Discord Discussion: https://discord.com/channels/1491295327620169908/1491365157010542652/1498547660540608602

## Summary

Takes over @dogzzdogzz's work from #610 — rebased onto latest main, resolved conflict with the new `allowDm` block, and fixed ordering nit (`maxBotTurns` now comes after `allowDm` in the Discord section).

## What changed

- **`charts/openab/templates/configmap.yaml`** — gated `max_bot_turns` blocks for Discord and Slack, using `hasKey` guard pattern. Discord block placed after `allowDm` (behavior knobs grouping).
- **`charts/openab/values.yaml`** — commented `maxBotTurns` placeholder under both Discord and Slack defaults, with doc-comment noting default 20 and hard cap 100.
- **`docs/messaging.md`** — Helm chart example section showing `values.yaml` equivalent of the `config.toml` keys.
- **`charts/openab/tests/configmap_test.yaml`** — 3 new test cases: Discord render, Slack render, unset does not render.

## What did not change

- No Rust code change. Same `src/config.rs` field, same `src/bot_turns.rs` semantics.
- Default-rendered `config.toml` is byte-for-byte identical when `maxBotTurns` is unset.

## Changes vs #610

- Rebased onto latest main (includes `allowDm` block)
- `maxBotTurns` block placed **after** `allowDm` (was before in #610 due to conflict)
- Added chart unit tests (擺渡法師 feedback)
- Squashed feat into single commit + test commit

## Credit

Original implementation by @dogzzdogzz. Taken over with nit fixes by 超渡法師.