### PR TITLE
fix(chart): apply hasKey to remaining boolean defaults for consistency

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -113,7 +113,7 @@ data:
 
     [reactions]
     enabled = {{ ($cfg.reactions).enabled | default true }}
-    remove_after_reply = {{ ($cfg.reactions).removeAfterReply | default false }}
+    remove_after_reply = {{ if hasKey ($cfg.reactions) "removeAfterReply" }}{{ ($cfg.reactions).removeAfterReply }}{{ else }}false{{ end }}
     {{- if ($cfg.reactions).toolDisplay }}
     {{- if not (has ($cfg.reactions).toolDisplay (list "full" "compact" "none")) }}
     {{- fail (printf "agents.%s.reactions.toolDisplay must be one of: full, compact, none — got: %s" $name ($cfg.reactions).toolDisplay) }}
@@ -163,7 +163,7 @@ data:
     {{- if or ($cfg.cronjobs) (($cfg.cron).usercronEnabled) (($cfg.cron).usercronPath) }}
 
     [cron]
-    usercron_enabled = {{ (($cfg.cron).usercronEnabled) | default false }}
+    usercron_enabled = {{ if hasKey ($cfg.cron) "usercronEnabled" }}{{ (($cfg.cron).usercronEnabled) }}{{ else }}false{{ end }}
     {{- if (($cfg.cron).usercronPath) }}
     usercron_path = {{ ($cfg.cron).usercronPath | toJson }}
     {{- end }}


### PR DESCRIPTION
## What problem does this solve?

PR #639 fixed the `| default true` trap for `enabled` fields, but two `| default false` fields were left unchanged:

- `remove_after_reply = {{ ($cfg.reactions).removeAfterReply | default false }}`
- `usercron_enabled = {{ (($cfg.cron).usercronEnabled) | default false }}`

While `{{ false | default false }}` happens to produce the correct result today, it creates a **latent trap** — if anyone changes the default to `true` in the future, the same false-is-zero-value bug would resurface silently.

Flagged during triage review of PR #639.

## Changes

| File | What |
|------|------|
| `charts/openab/templates/configmap.yaml` | Replace `| default false` with `hasKey` pattern for `removeAfterReply` and `usercronEnabled` |

## Testing

```bash
# removeAfterReply=true → renders true ✅
helm template test charts/openab --set agents.kiro.reactions.removeAfterReply=true | grep remove_after_reply

# removeAfterReply=false → renders false ✅
helm template test charts/openab --set agents.kiro.reactions.removeAfterReply=false | grep remove_after_reply

# removeAfterReply not set → renders false (default) ✅
helm template test charts/openab | grep remove_after_reply

# usercronEnabled=true → renders true ✅
helm template test charts/openab --set agents.kiro.cron.usercronEnabled=true | grep usercron_enabled

# usercronEnabled=false → renders false ✅
helm template test charts/openab --set agents.kiro.cron.usercronEnabled=false --set agents.kiro.cron.usercronPath=/tmp/cron | grep usercron_enabled

# usercronEnabled not set → renders false (default) ✅
helm template test charts/openab --set agents.kiro.cron.usercronPath=/tmp/cron | grep usercron_enabled
```

## Related

- Follow-up to PR #639
- Consistency fix — no behavioral change for current users