### PR TITLE
fix(gateway): constantize Telegram API URL + reject empty LINE source IDs

### DIFF
--- a/gateway/src/adapters/line.rs
+++ b/gateway/src/adapters/line.rs
@@ -129,7 +129,10 @@ pub async fn webhook(
                     }
                 }
             }
-            None => continue,
+            None => {
+                warn!("LINE event missing source, skipping");
+                continue;
+            }
         };
         let user_id = source
             .and_then(|s| s.user_id.as_deref())

--- a/gateway/src/adapters/line.rs
+++ b/gateway/src/adapters/line.rs
@@ -103,12 +103,32 @@ pub async fn webhook(
         let source = event.source.as_ref();
         let (channel_id, channel_type) = match source {
             Some(s) if s.source_type == "group" => {
-                (s.group_id.clone().unwrap_or_default(), "group".to_string())
+                match s.group_id.as_deref() {
+                    Some(id) if !id.is_empty() => (id.to_string(), "group".to_string()),
+                    _ => {
+                        warn!("LINE group event missing groupId, skipping");
+                        continue;
+                    }
+                }
             }
             Some(s) if s.source_type == "room" => {
-                (s.room_id.clone().unwrap_or_default(), "room".to_string())
+                match s.room_id.as_deref() {
+                    Some(id) if !id.is_empty() => (id.to_string(), "room".to_string()),
+                    _ => {
+                        warn!("LINE room event missing roomId, skipping");
+                        continue;
+                    }
+                }
             }
-            Some(s) => (s.user_id.clone().unwrap_or_default(), "user".to_string()),
+            Some(s) => {
+                match s.user_id.as_deref() {
+                    Some(id) if !id.is_empty() => (id.to_string(), "user".to_string()),
+                    _ => {
+                        warn!("LINE user event missing userId, skipping");
+                        continue;
+                    }
+                }
+            }
             None => continue,
         };
         let user_id = source

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -7,6 +7,10 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
+/// Base URL for Telegram Bot API. Extracted as constant for consistency
+/// with LINE's `LINE_API_BASE` and to enable future mock testing.
+pub const TELEGRAM_API_BASE: &str = "https://api.telegram.org";
+
 // --- Telegram types ---
 
 #[derive(Debug, Deserialize)]
@@ -140,7 +144,7 @@ pub async fn handle_reply(
     if reply.command.as_deref() == Some("create_topic") {
         let req_id = reply.request_id.clone().unwrap_or_default();
         info!(chat_id = %reply.channel.id, "creating forum topic");
-        let url = format!("https://api.telegram.org/bot{bot_token}/createForumTopic");
+        let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/createForumTopic");
         let resp = client
             .post(&url)
             .json(&serde_json::json!({"chat_id": reply.channel.id, "name": reply.content.text}))
@@ -222,7 +226,7 @@ pub async fn handle_reply(
                 })
                 .unwrap_or_default()
         };
-        let url = format!("https://api.telegram.org/bot{bot_token}/setMessageReaction");
+        let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/setMessageReaction");
         let _ = client
             .post(&url)
             .json(&serde_json::json!({
@@ -242,7 +246,7 @@ pub async fn handle_reply(
         thread_id = ?reply.channel.thread_id,
         "gateway → telegram"
     );
-    let url = format!("https://api.telegram.org/bot{bot_token}/sendMessage");
+    let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage");
     let _ = client
         .post(&url)
         .json(&serde_json::json!({


### PR DESCRIPTION
Discord Discussion URL: https://discord.com/channels/1488041051187974246/1497258664090931280

### Description

Two hardening fixes from the deferred review items (#676).

### Changes

**#10 — Telegram API URL constant**

Extract `TELEGRAM_API_BASE` constant, replacing 3 hardcoded `https://api.telegram.org` URLs. Matches LINE's `LINE_API_BASE` pattern. Enables future mock testing for Telegram adapter.

| Before | After |
|---|---|
| `format!("https://api.telegram.org/bot{bot_token}/sendMessage")` | `format!("{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage")` |

**#11 — LINE empty source ID rejection**

Replace `unwrap_or_default()` with explicit empty-check + reject for LINE source IDs (`groupId`, `roomId`, `userId`).

Per [LINE API contract](https://developers.line.biz/en/docs/messaging-api/receiving-messages/), these IDs are guaranteed present for their respective source types:
- `source.type == "group"` → `groupId` always present
- `source.type == "room"` → `roomId` always present
- `source.type == "user"` → `userId` always present

Empty ID = anomalous payload → reject with warning log (fail-closed).

| Before | After |
|---|---|
| `s.group_id.clone().unwrap_or_default()` (empty string enters session pool) | `match s.group_id { Some(id) if !id.is_empty() => ..., _ => { warn!(...); continue; } }` |

### Risk Assessment

- **Telegram**: Zero risk — pure string extraction, URL values unchanged
- **LINE**: Low risk — LINE API guarantees IDs are present. Only rejects anomalous payloads that would cause worse problems downstream (all broken events sharing one session)

### Tests

Existing 6 LINE dispatch tests unaffected (test reply/push routing, not source parsing).

Partial fix for #676