### PR TITLE
docs: implement tiered PR contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,8 @@
 
 Closes #
 
+Discord Discussion URL: https://discord.com/channels/...
+
 ## At a Glance
 
 <!-- ASCII diagram showing the high-level flow or where this change fits in the system. Example:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,62 @@
+## What problem does this solve?
+
+<!-- Describe the pain point or requirement in plain language. Link the related issue if one exists. -->
+
+Closes #
+
+## At a Glance
+
+<!-- ASCII diagram showing the high-level flow or where this change fits in the system. Example:
+
+┌──────────────┐     ┌───────┐     ┌───────────┐
+│ Discord User │────►│ openab│────►│ ACP Agent │
+└──────────────┘     └───┬───┘     └───────────┘
+                         │
+                         ▼
+                  ┌──────────────┐
+                  │ your change  │
+                  └──────────────┘
+-->
+
+```
+(your diagram here)
+```
+
+## Prior Art & Industry Research
+
+<!-- 
+Research how at least OpenClaw and Hermes Agent handle this problem.
+Include links to relevant docs, source code, or discussions.
+-->
+
+**OpenClaw:**
+<!-- How does OpenClaw solve this? Link to relevant code/docs. -->
+
+**Hermes Agent:**
+<!-- How does Hermes Agent solve this? Link to relevant code/docs. -->
+
+**Other references (optional):**
+
+## Proposed Solution
+
+<!-- Describe your technical approach, architecture decisions, and key implementation details. -->
+
+## Why this approach?
+
+<!-- 
+Explain why you chose this approach over the alternatives found in your research.
+What are the tradeoffs? What are the known limitations?
+-->
+
+## Alternatives Considered
+
+<!-- List approaches you evaluated but did not choose, and why. -->
+
+## Validation
+
+<!-- How do you prove this works? Show, don't just tell. -->
+
+- [ ] `cargo check` passes
+- [ ] `cargo test` passes (including new tests)
+- [ ] Manual testing — describe the steps you took and what you observed
+- [ ] Screenshots, logs, or terminal output demonstrating the feature working end-to-end

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,21 +4,11 @@
 
 Closes #
 
-Discord Discussion URL: https://discord.com/channels/...
+Discord Discussion URL: <!-- Strongly recommended. Link the Discord thread where this was discussed. -->
 
 ## At a Glance
 
-<!-- ASCII diagram showing the high-level flow or where this change fits in the system. Example:
-
-┌──────────────┐     ┌───────┐     ┌───────────┐
-│ Discord User │────►│ openab│────►│ ACP Agent │
-└──────────────┘     └───┬───┘     └───────────┘
-                         │
-                         ▼
-                  ┌──────────────┐
-                  │ your change  │
-                  └──────────────┘
--->
+<!-- ASCII diagram showing the high-level flow or where this change fits in the system. For docs-only or trivial changes, write "N/A". -->
 
 ```
 (your diagram here)
@@ -26,7 +16,10 @@ Discord Discussion URL: https://discord.com/channels/...
 
 ## Prior Art & Industry Research
 
-<!-- 
+<!--
+Required for architectural, runtime, agent, scheduling, delivery, or persistence changes.
+For docs-only, chore, CI, release, or trivial bug fixes, write "Not applicable — [reason]".
+
 Research how at least OpenClaw and Hermes Agent handle this problem.
 Include links to relevant docs, source code, or discussions.
 -->
@@ -45,7 +38,7 @@ Include links to relevant docs, source code, or discussions.
 
 ## Why this approach?
 
-<!-- 
+<!--
 Explain why you chose this approach over the alternatives found in your research.
 What are the tradeoffs? What are the known limitations?
 -->
@@ -56,9 +49,26 @@ What are the tradeoffs? What are the known limitations?
 
 ## Validation
 
-<!-- How do you prove this works? Show, don't just tell. -->
+<!--
+Show that your change works. Pick the checks relevant to your PR type:
 
+Rust changes:
 - [ ] `cargo check` passes
 - [ ] `cargo test` passes (including new tests)
+- [ ] `cargo clippy` clean
+
+Helm chart changes:
+- [ ] `helm lint charts/openab` passes
+- [ ] `helm template` renders correctly
+
+CI/workflow changes:
+- [ ] Workflow syntax is valid
+- [ ] Tested with act or dry-run where possible
+
+Docs-only changes:
+- [ ] Links are valid
+- [ ] Renders correctly in GitHub preview
+
+All PRs:
 - [ ] Manual testing — describe the steps you took and what you observed
-- [ ] Screenshots, logs, or terminal output demonstrating the feature working end-to-end
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,10 @@ Thanks for your interest in contributing! This guide covers what we expect in pu
 
 Every PR must address the following in its description. The [PR template](/.github/pull_request_template.md) will prompt you for each section.
 
+### 0. Discord Discussion URL
+
+Every PR must include a Discord Discussion URL in the body (e.g. `https://discord.com/channels/...`). PRs without one will be labeled `closing-soon` and auto-closed after 3 days.
+
 ### 1. What problem does this solve?
 
 Describe the pain point or requirement in plain language. Link the related issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,15 @@
 
 Thanks for your interest in contributing! This guide covers what we expect in pull requests.
 
+For the full rationale behind these guidelines, see the [PR Contribution Guidelines ADR](/docs/adr/pr-contribution-guidelines.md).
+
 ## Pull Request Guidelines
 
 Every PR must address the following in its description. The [PR template](/.github/pull_request_template.md) will prompt you for each section.
 
 ### 0. Discord Discussion URL
 
-Every PR must include a Discord Discussion URL in the body (e.g. `https://discord.com/channels/...`). PRs without one will be labeled `closing-soon` and auto-closed after 3 days.
+We strongly recommend including a Discord Discussion URL in the PR body (e.g. `https://discord.com/channels/...`). Discussing your idea in Discord before opening a PR helps align on direction and avoids wasted effort. If no Discord discussion exists, explain the context directly in the PR description.
 
 ### 1. What problem does this solve?
 
@@ -16,7 +18,9 @@ Describe the pain point or requirement in plain language. Link the related issue
 
 ### 2. Prior Art & Industry Research
 
-Before proposing a solution, research how the industry handles the same problem. At minimum, investigate:
+**Required for architectural, runtime, agent, scheduling, delivery, or persistence changes.** For docs-only, chore, CI, release, or trivial bug fixes, write "Not applicable" with a brief reason.
+
+When prior art research is required, investigate at minimum:
 
 - **[OpenClaw](https://github.com/openclaw/openclaw)** — the largest open-source AI agent gateway
 - **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** — Nous Research's self-hosted agent with multi-platform messaging
@@ -35,11 +39,16 @@ Describe your technical approach, then explain why you chose it over the alterna
 
 List approaches you evaluated but did not choose, and explain why they were rejected.
 
-### 5. Test Plan
+### 5. Validation
 
-- `cargo check` and `cargo test` must pass
-- Describe any manual testing performed
-- Add unit tests for new functionality
+Pick the checks relevant to your PR type:
+
+- **Rust changes:** `cargo check`, `cargo test`, `cargo clippy`
+- **Helm chart changes:** `helm lint`, `helm template`
+- **CI/workflow changes:** workflow syntax validation, dry-run where possible
+- **Docs-only changes:** links are valid, renders correctly in GitHub preview
+
+Describe any manual testing performed and add unit tests for new functionality.
 
 ## Why We Require Prior Art Research
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to OpenAB
+
+Thanks for your interest in contributing! This guide covers what we expect in pull requests.
+
+## Pull Request Guidelines
+
+Every PR must address the following in its description. The [PR template](/.github/pull_request_template.md) will prompt you for each section.
+
+### 1. What problem does this solve?
+
+Describe the pain point or requirement in plain language. Link the related issue.
+
+### 2. Prior Art & Industry Research
+
+Before proposing a solution, research how the industry handles the same problem. At minimum, investigate:
+
+- **[OpenClaw](https://github.com/openclaw/openclaw)** — the largest open-source AI agent gateway
+- **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** — Nous Research's self-hosted agent with multi-platform messaging
+
+Include links to relevant source code, documentation, or discussions. If neither project addresses the problem, state that explicitly with evidence.
+
+### 3. Proposed Solution & Why This Approach
+
+Describe your technical approach, then explain why you chose it over the alternatives found in your research. Be explicit about:
+
+- Tradeoffs you accepted
+- Known limitations
+- How this could evolve in the future
+
+### 4. Alternatives Considered
+
+List approaches you evaluated but did not choose, and explain why they were rejected.
+
+### 5. Test Plan
+
+- `cargo check` and `cargo test` must pass
+- Describe any manual testing performed
+- Add unit tests for new functionality
+
+## Why We Require Prior Art Research
+
+OpenAB is a young project. We want every design decision to be informed by what's already working in production elsewhere. This:
+
+- Prevents reinventing the wheel
+- Surfaces better patterns we might not have considered
+- Documents the design space for future contributors
+- Makes reviews faster — reviewers don't have to do the research themselves
+
+## Development Setup
+
+```bash
+cargo build
+cargo test
+cargo check
+```
+
+## Code Style
+
+- Run `cargo fmt` before committing
+- Run `cargo clippy` and address warnings
+- Keep PRs focused — one feature or fix per PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,11 @@ We strongly recommend including a Discord Discussion URL in the PR body (e.g. `h
 
 Describe the pain point or requirement in plain language. Link the related issue.
 
-### 2. Prior Art & Industry Research
+### 2. At a Glance
+
+Provide an ASCII diagram showing the high-level flow or where your change fits in the system. For docs-only or trivial changes, write "N/A".
+
+### 3. Prior Art & Industry Research
 
 **Required for architectural, runtime, agent, scheduling, delivery, or persistence changes.** For docs-only, chore, CI, release, or trivial bug fixes, write "Not applicable" with a brief reason.
 
@@ -27,19 +31,23 @@ When prior art research is required, investigate at minimum:
 
 Include links to relevant source code, documentation, or discussions. If neither project addresses the problem, state that explicitly with evidence.
 
-### 3. Proposed Solution & Why This Approach
+### 4. Proposed Solution
 
-Describe your technical approach, then explain why you chose it over the alternatives found in your research. Be explicit about:
+Describe your technical approach, architecture decisions, and key implementation details.
+
+### 5. Why This Approach
+
+Explain why you chose this approach over the alternatives found in your research. Be explicit about:
 
 - Tradeoffs you accepted
 - Known limitations
 - How this could evolve in the future
 
-### 4. Alternatives Considered
+### 6. Alternatives Considered
 
 List approaches you evaluated but did not choose, and explain why they were rejected.
 
-### 5. Validation
+### 7. Validation
 
 Pick the checks relevant to your PR type:
 

--- a/docs/adr/pr-contribution-guidelines.md
+++ b/docs/adr/pr-contribution-guidelines.md
@@ -21,7 +21,7 @@ This front-loads research cost onto the contributor (who understands the problem
 
 ## 2. Decision
 
-Establish a standard PR template requiring contributors to research prior art (at minimum OpenClaw and Hermes Agent) before proposing solutions, and to document the problem, approach, tradeoffs, and alternatives in every PR description.
+Establish a standard PR template and tiered contribution guidelines. All PRs document the problem, approach, tradeoffs, and alternatives. Architectural and runtime changes additionally require prior art research (at minimum OpenClaw and Hermes Agent). Docs-only, chore, CI, release, and trivial bug fixes use a lighter process.
 
 ### Required PR Sections
 
@@ -29,20 +29,20 @@ Every PR must include these sections in its description:
 
 | # | Section | Purpose |
 |---|---------|---------|
-| 0 | **Discord Discussion URL** | Link to the prior Discord discussion. PRs without one are auto-labeled `closing-soon` and closed after 3 days. |
+| 0 | **Discord Discussion URL** | Strongly recommended. Link to the prior Discord discussion. If none exists, explain context in the PR description. |
 | 1 | **What problem does this solve?** | Pain point or requirement in plain language. Link the related issue. |
-| 2 | **At a Glance** | ASCII diagram showing the high-level flow, architecture, or where the change fits in the system. |
-| 3 | **Prior Art & Industry Research** | How OpenClaw and Hermes Agent handle the same problem. Links to code/docs. |
+| 2 | **At a Glance** | ASCII diagram showing the high-level flow, architecture, or where the change fits in the system. "N/A" for docs-only or trivial changes. |
+| 3 | **Prior Art & Industry Research** | Required for architectural/runtime changes. "Not applicable" with reason for docs/chore/CI/release/trivial fixes. |
 | 4 | **Proposed Solution** | Technical approach, architecture decisions, key implementation details. |
 | 5 | **Why This Approach** | Why this over the alternatives from research. Tradeoffs and limitations. |
 | 6 | **Alternatives Considered** | Approaches evaluated but not chosen, and why. |
-| 7 | **Validation** | How do you prove it works? Unit tests, integration tests, manual testing steps, screenshots, logs. |
+| 7 | **Validation** | Relevant checks for the PR type: Rust, Helm, CI, or docs validation as applicable. |
 
-### Mandatory Prior Art Research
+### Tiered Prior Art Research
 
-Contributors must research at minimum these two projects:
+Prior art research is **required** for PRs that touch architectural, runtime, agent, scheduling, delivery, or persistence concerns. Contributors must research at minimum these two projects:
 
-| Project | Why it's mandatory |
+| Project | Why it's a reference |
 |---|---|
 | [OpenClaw](https://github.com/openclaw/openclaw) | Largest open-source AI agent gateway. Plugin architecture across 7+ messaging platforms. Mature patterns for media, security, session management. |
 | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Nous Research's self-hosted agent. Gateway architecture across 17+ platforms. Strong prior art on messaging, tool integration, and service management. |
@@ -53,6 +53,8 @@ For each project, document:
 - What we can learn from their approach
 
 If neither project addresses the problem, state that explicitly with evidence.
+
+For **docs-only, chore, CI, release, or trivial bug fixes**, write "Not applicable — [reason]" in the prior art section.
 
 ### Research Flow
 
@@ -81,7 +83,7 @@ Contributor researches prior art
 | Phase | Deliverable | Description |
 |-------|-------------|-------------|
 | **1** | `.github/pull_request_template.md` | Auto-populated PR form with all required sections |
-| **2** | `CONTRIBUTING.md` | Contributor guide explaining the guidelines and linking to this ADR |
+| **2** | `CONTRIBUTING.md` | Contributor guide explaining the tiered guidelines and linking to this ADR |
 | **3** | Review process update | Reviewers check for prior art section completeness |
 
 ## 4. Alternatives Considered
@@ -96,7 +98,7 @@ Contributor researches prior art
 - Pros: uniform quality across all PRs
 - Cons: excessive overhead for trivial/docs/small fixes; may discourage contributions
 
-### Option 3: Tiered policy by PR type (recommended follow-up)
+### Option 3: Tiered policy by PR type (adopted)
 
 - Pros: full prior-art analysis for architectural changes, lighter structure for minor PRs
 - Cons: requires defining the boundary between "minor" and "architectural"
@@ -110,8 +112,8 @@ Contributor researches prior art
 ## Consequences
 
 - **Positive:** Higher-quality PRs, faster reviews, architectural consistency, less reinventing the wheel
-- **Negative:** Higher upfront cost for contributors; may slow down first-time contributions
-- **Mitigation:** Clear examples (PR #225), PR template auto-populates sections, consider tiered policy for trivial changes
+- **Negative:** Higher upfront cost for contributors on architectural PRs; may slow down first-time contributions
+- **Mitigation:** Clear examples (PR #225), PR template auto-populates sections, tiered policy keeps docs/chore/CI contributions lightweight
 
 ## References
 

--- a/docs/adr/pr-contribution-guidelines.md
+++ b/docs/adr/pr-contribution-guidelines.md
@@ -1,20 +1,12 @@
-# RFC 002: Pull Request Contribution Guidelines
+# ADR: PR Contribution Guidelines
 
-| Field | Value |
-|-------|-------|
-| **RFC** | 002 |
-| **Title** | Pull Request Contribution Guidelines |
-| **Author** | @chaodu-agent |
-| **Status** | Draft |
-| **Created** | 2026-04-13 |
+- **Status:** Proposed
+- **Date:** 2026-04-13
+- **Author:** @chaodu-agent
 
 ---
 
-## Summary
-
-Establish a standard PR template requiring contributors to research prior art (at minimum OpenClaw and Hermes Agent) before proposing solutions, and to document the problem, approach, tradeoffs, and alternatives in every PR description.
-
-## Motivation
+## 1. Context & Problem Statement
 
 OpenAB is growing and accepting external contributions. Without a clear PR standard, we see PRs that:
 
@@ -23,11 +15,13 @@ OpenAB is growing and accepting external contributions. Without a clear PR stand
 - Don't justify why a particular approach was chosen over alternatives
 - Make review harder because reviewers must do the research themselves
 
-**Good example:** Issue #224 / PR #225 (voice message STT) included a thorough prior art investigation — comparing OpenClaw's `audio-transcription-runner.ts` preflight pipeline with Hermes Agent's `transcription_tools.py` local-first approach, producing a clear comparison table, and explaining why openab chose a simpler OpenAI-compatible endpoint design. This is the standard we want every PR to meet.
+This front-loads research cost onto the contributor (who understands the problem best) rather than distributing it across reviewers.
 
-**What we want to avoid:** PRs that jump straight to implementation without documenting how existing projects solve the same problem — forcing reviewers to do the research themselves during review.
+**Good example:** Issue #224 / PR #225 (voice message STT) included a thorough prior art investigation — comparing OpenClaw's `audio-transcription-runner.ts` preflight pipeline with Hermes Agent's `transcription_tools.py` local-first approach, producing a clear comparison table, and explaining why OpenAB chose a simpler OpenAI-compatible endpoint design.
 
-## Design
+## 2. Decision
+
+Establish a standard PR template requiring contributors to research prior art (at minimum OpenClaw and Hermes Agent) before proposing solutions, and to document the problem, approach, tradeoffs, and alternatives in every PR description.
 
 ### Required PR Sections
 
@@ -62,7 +56,7 @@ If neither project addresses the problem, state that explicitly with evidence.
 
 ### Research Flow
 
-```
+```text
 Contributor researches prior art
         │
         ▼
@@ -82,88 +76,45 @@ Contributor researches prior art
                               └──────────────────────────────────┘
 ```
 
-## Implementation
+## 3. Implementation
 
 | Phase | Deliverable | Description |
 |-------|-------------|-------------|
 | **1** | `.github/pull_request_template.md` | Auto-populated PR form with all required sections |
-| **2** | `CONTRIBUTING.md` | Contributor guide explaining the guidelines and linking to this RFC |
+| **2** | `CONTRIBUTING.md` | Contributor guide explaining the guidelines and linking to this ADR |
 | **3** | Review process update | Reviewers check for prior art section completeness |
 
-### PR Template
+## 4. Alternatives Considered
 
-```markdown
-## What problem does this solve?
+### Option 1: No formal template — rely on reviewer feedback
 
-<!-- Describe the pain point in plain language. Link the related issue. -->
+- Pros: zero contributor friction
+- Cons: inconsistent quality, reviewers repeat the same feedback, research burden falls on reviewers
 
-Closes #
+### Option 2: Strict mandatory template everywhere
 
-Discord Discussion URL: https://discord.com/channels/...
+- Pros: uniform quality across all PRs
+- Cons: excessive overhead for trivial/docs/small fixes; may discourage contributions
 
-## At a Glance
+### Option 3: Tiered policy by PR type (recommended follow-up)
 
-<!-- ASCII diagram showing the high-level flow or where this change fits in the system. Example:
+- Pros: full prior-art analysis for architectural changes, lighter structure for minor PRs
+- Cons: requires defining the boundary between "minor" and "architectural"
 
-┌──────────────┐     ┌───────┐     ┌───────────┐
-│ Discord User │────►│ openab│────►│ ACP Agent │
-└──────────────┘     └───┬───┘     └───────────┘
-                         │
-                         ▼
-                  ┌──────────────┐
-                  │ your change  │
-                  └──────────────┘
--->
-
-```
-(your diagram here)
-```
-
-## Prior Art & Industry Research
-
-<!-- Research how at least OpenClaw and Hermes Agent handle this problem. -->
-
-**OpenClaw:**
-<!-- How does OpenClaw solve this? Link to relevant code/docs. -->
-
-**Hermes Agent:**
-<!-- How does Hermes Agent solve this? Link to relevant code/docs. -->
-
-**Other references (optional):**
-
-## Proposed Solution
-
-<!-- Technical approach, architecture decisions, key implementation details. -->
-
-## Why This Approach
-
-<!-- Why this over the alternatives from your research? Tradeoffs? Limitations? -->
-
-## Alternatives Considered
-
-<!-- Approaches evaluated but not chosen, and why. -->
-
-## Validation
-
-<!-- How do you prove this works? Show, don't just tell. -->
-
-- [ ] `cargo check` passes
-- [ ] `cargo test` passes (including new tests)
-- [ ] Manual testing — describe the steps you took and what you observed
-- [ ] Screenshots, logs, or terminal output demonstrating the feature working end-to-end
-```
-
-## Open Questions
+## 5. Open Questions
 
 1. Should we enforce the prior art section via CI (e.g., a bot that checks for the section headers)?
 2. Should we maintain a living doc of "how OpenClaw/Hermes do X" to reduce per-PR research burden?
 3. Are there other mandatory reference projects beyond OpenClaw and Hermes?
 
----
+## Consequences
+
+- **Positive:** Higher-quality PRs, faster reviews, architectural consistency, less reinventing the wheel
+- **Negative:** Higher upfront cost for contributors; may slow down first-time contributions
+- **Mitigation:** Clear examples (PR #225), PR template auto-populates sections, consider tiered policy for trivial changes
 
 ## References
 
 - Issue #224 / PR #225 — exemplary prior art research (STT: OpenClaw vs Hermes Agent comparison)
 - [OpenClaw Channel & Messaging Deep Dive](https://avasdream.com/blog/openclaw-channels-messaging-deep-dive)
 - [Hermes Agent Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/)
-- RFC 001 — [Session Management](./001-session-management.md)

--- a/docs/adr/pr-contribution-guidelines.md
+++ b/docs/adr/pr-contribution-guidelines.md
@@ -1,6 +1,6 @@
 # ADR: PR Contribution Guidelines
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-13
 - **Author:** @chaodu-agent
 

--- a/docs/rfcs/002-pr-guidelines.md
+++ b/docs/rfcs/002-pr-guidelines.md
@@ -1,0 +1,166 @@
+# RFC 002: Pull Request Contribution Guidelines
+
+| Field | Value |
+|-------|-------|
+| **RFC** | 002 |
+| **Title** | Pull Request Contribution Guidelines |
+| **Author** | @chaodu-agent |
+| **Status** | Draft |
+| **Created** | 2026-04-13 |
+
+---
+
+## Summary
+
+Establish a standard PR template requiring contributors to research prior art (at minimum OpenClaw and Hermes Agent) before proposing solutions, and to document the problem, approach, tradeoffs, and alternatives in every PR description.
+
+## Motivation
+
+OpenAB is growing and accepting external contributions. Without a clear PR standard, we see PRs that:
+
+- Jump straight to implementation without explaining the problem
+- Don't research how existing projects solve the same problem
+- Don't justify why a particular approach was chosen over alternatives
+- Make review harder because reviewers must do the research themselves
+
+**Good example:** Issue #224 / PR #225 (voice message STT) included a thorough prior art investigation — comparing OpenClaw's `audio-transcription-runner.ts` preflight pipeline with Hermes Agent's `transcription_tools.py` local-first approach, producing a clear comparison table, and explaining why openab chose a simpler OpenAI-compatible endpoint design. This is the standard we want every PR to meet.
+
+**What we want to avoid:** PRs that jump straight to implementation without documenting how existing projects solve the same problem — forcing reviewers to do the research themselves during review.
+
+## Design
+
+### Required PR Sections
+
+Every PR must include these sections in its description:
+
+| # | Section | Purpose |
+|---|---------|---------|
+| 1 | **What problem does this solve?** | Pain point or requirement in plain language. Link the related issue. |
+| 2 | **At a Glance** | ASCII diagram showing the high-level flow, architecture, or where the change fits in the system. |
+| 3 | **Prior Art & Industry Research** | How OpenClaw and Hermes Agent handle the same problem. Links to code/docs. |
+| 4 | **Proposed Solution** | Technical approach, architecture decisions, key implementation details. |
+| 5 | **Why This Approach** | Why this over the alternatives from research. Tradeoffs and limitations. |
+| 6 | **Alternatives Considered** | Approaches evaluated but not chosen, and why. |
+| 7 | **Validation** | How do you prove it works? Unit tests, integration tests, manual testing steps, screenshots, logs. |
+
+### Mandatory Prior Art Research
+
+Contributors must research at minimum these two projects:
+
+| Project | Why it's mandatory |
+|---|---|
+| [OpenClaw](https://github.com/openclaw/openclaw) | Largest open-source AI agent gateway. Plugin architecture across 7+ messaging platforms. Mature patterns for media, security, session management. |
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Nous Research's self-hosted agent. Gateway architecture across 17+ platforms. Strong prior art on messaging, tool integration, and service management. |
+
+For each project, document:
+- How they solve the same problem (with links to source code or docs)
+- Key architectural decisions they made
+- What we can learn from their approach
+
+If neither project addresses the problem, state that explicitly with evidence.
+
+### Research Flow
+
+```
+Contributor researches prior art
+        │
+        ▼
+┌───────────────────────┐     ┌──────────────────────────────────┐
+│ Finds better pattern  │────►│ Adopts it (we benefit)           │
+└───────────┬───────────┘     └──────────────────────────────────┘
+            │
+            ▼
+┌───────────────────────────┐ ┌──────────────────────────────────┐
+│ Finds different pattern   │►│ Documents why we diverge         │
+└───────────┬───────────────┘ │ (reviewers understand tradeoff)  │
+            │                 └──────────────────────────────────┘
+            ▼
+┌───────────────────────────┐ ┌──────────────────────────────────┐
+│ Finds nothing relevant    │►│ States so explicitly             │
+└───────────────────────────┘ │ (saves reviewers from searching) │
+                              └──────────────────────────────────┘
+```
+
+## Implementation
+
+| Phase | Deliverable | Description |
+|-------|-------------|-------------|
+| **1** | `.github/pull_request_template.md` | Auto-populated PR form with all required sections |
+| **2** | `CONTRIBUTING.md` | Contributor guide explaining the guidelines and linking to this RFC |
+| **3** | Review process update | Reviewers check for prior art section completeness |
+
+### PR Template
+
+```markdown
+## What problem does this solve?
+
+<!-- Describe the pain point in plain language. Link the related issue. -->
+
+Closes #
+
+## At a Glance
+
+<!-- ASCII diagram showing the high-level flow or where this change fits in the system. Example:
+
+┌──────────────┐     ┌───────┐     ┌───────────┐
+│ Discord User │────►│ openab│────►│ ACP Agent │
+└──────────────┘     └───┬───┘     └───────────┘
+                         │
+                         ▼
+                  ┌──────────────┐
+                  │ your change  │
+                  └──────────────┘
+-->
+
+```
+(your diagram here)
+```
+
+## Prior Art & Industry Research
+
+<!-- Research how at least OpenClaw and Hermes Agent handle this problem. -->
+
+**OpenClaw:**
+<!-- How does OpenClaw solve this? Link to relevant code/docs. -->
+
+**Hermes Agent:**
+<!-- How does Hermes Agent solve this? Link to relevant code/docs. -->
+
+**Other references (optional):**
+
+## Proposed Solution
+
+<!-- Technical approach, architecture decisions, key implementation details. -->
+
+## Why This Approach
+
+<!-- Why this over the alternatives from your research? Tradeoffs? Limitations? -->
+
+## Alternatives Considered
+
+<!-- Approaches evaluated but not chosen, and why. -->
+
+## Validation
+
+<!-- How do you prove this works? Show, don't just tell. -->
+
+- [ ] `cargo check` passes
+- [ ] `cargo test` passes (including new tests)
+- [ ] Manual testing — describe the steps you took and what you observed
+- [ ] Screenshots, logs, or terminal output demonstrating the feature working end-to-end
+```
+
+## Open Questions
+
+1. Should we enforce the prior art section via CI (e.g., a bot that checks for the section headers)?
+2. Should we maintain a living doc of "how OpenClaw/Hermes do X" to reduce per-PR research burden?
+3. Are there other mandatory reference projects beyond OpenClaw and Hermes?
+
+---
+
+## References
+
+- Issue #224 / PR #225 — exemplary prior art research (STT: OpenClaw vs Hermes Agent comparison)
+- [OpenClaw Channel & Messaging Deep Dive](https://avasdream.com/blog/openclaw-channels-messaging-deep-dive)
+- [Hermes Agent Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/)
+- RFC 001 — [Session Management](./001-session-management.md)

--- a/docs/rfcs/002-pr-guidelines.md
+++ b/docs/rfcs/002-pr-guidelines.md
@@ -35,6 +35,7 @@ Every PR must include these sections in its description:
 
 | # | Section | Purpose |
 |---|---------|---------|
+| 0 | **Discord Discussion URL** | Link to the prior Discord discussion. PRs without one are auto-labeled `closing-soon` and closed after 3 days. |
 | 1 | **What problem does this solve?** | Pain point or requirement in plain language. Link the related issue. |
 | 2 | **At a Glance** | ASCII diagram showing the high-level flow, architecture, or where the change fits in the system. |
 | 3 | **Prior Art & Industry Research** | How OpenClaw and Hermes Agent handle the same problem. Links to code/docs. |
@@ -97,6 +98,8 @@ Contributor researches prior art
 <!-- Describe the pain point in plain language. Link the related issue. -->
 
 Closes #
+
+Discord Discussion URL: https://discord.com/channels/...
 
 ## At a Glance
 


### PR DESCRIPTION
## Summary

Rework of PR #302 by @chaodu-agent, addressing review feedback from @shaun-agent and @masami-agent.

The original PR established PR contribution guidelines (ADR + PR template + CONTRIBUTING.md) but implemented a strict-everywhere policy while the ADR itself recommended a tiered approach. This PR resolves that inconsistency and addresses all review items.

## Changes from #302

| Review Item | Before | After |
|---|---|---|
| Prior art research | Mandatory for all PRs | Required for architectural/runtime changes; N/A for docs/chore/CI |
| Validation section | Rust-only (`cargo check`, `cargo test`) | Multi-surface: Rust, Helm, CI, docs |
| Discord Discussion URL | Auto-close after 3 days if missing | Strongly recommended (no auto-close) |
| ADR link in CONTRIBUTING.md | Missing | Added |
| Trailing whitespace | Present on 2 lines | Fixed |
| ADR Option 3 | "recommended follow-up" | "adopted" |

## Files

| File | Purpose |
|---|---|
| `.github/pull_request_template.md` | Tiered PR form — prior art required for arch changes, N/A for docs/chore |
| `CONTRIBUTING.md` | Contributor guide with ADR link and multi-surface validation |
| `docs/adr/pr-contribution-guidelines.md` | ADR updated to reflect tiered policy as adopted approach |

## Prior Art & Industry Research

Not applicable — this is a docs/process PR that establishes contribution guidelines. No architectural or runtime changes.

## Validation

- [x] No trailing whitespace (`grep -n ' $'` clean)
- [x] All 3 files are internally consistent (ADR, template, and guide all describe the same tiered policy)
- [x] Links are valid
- [x] Renders correctly in GitHub preview

## Related

- Supersedes #302
- Discord discussion: https://discord.com/channels/1488041051187974246/1496080735461703813