### PR TITLE
feat(cron)!: resolve usercron relative path from $HOME/.openab/ (BREAKING CHANGE)

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -128,7 +128,7 @@ error_hold_ms = 2500
 
 # [cron]
 # usercron_enabled = true                      # enable hot-reload (default: false)
-# usercron_path = "cronjob.toml"               # relative to $HOME, or absolute
+# usercron_path = "cronjob.toml"               # relative to $HOME/.openab/, or absolute
 
 # [[cron.jobs]]
 # enabled = true                               # optional, default: true

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -211,7 +211,7 @@ Everything cron-related lives under `[cron]`.
 ```toml
 [cron]
 usercron_enabled = true                      # enable hot-reload (default: false)
-usercron_path = "cronjob.toml"               # relative to $HOME, or absolute
+usercron_path = "cronjob.toml"               # relative to $HOME/.openab/, or absolute
 
 [[cron.jobs]]
 enabled = true                               # optional, default: true
@@ -236,7 +236,7 @@ timezone = "UTC"
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `usercron_enabled` | bool | `false` | Enable usercron hot-reload. Must be explicitly set to `true`. |
-| `usercron_path` | string | — | Path to the external `cronjob.toml`. Relative paths resolve from `$HOME`. |
+| `usercron_path` | string | — | Path to the external `cronjob.toml`. Relative paths resolve from `$HOME/.openab/`. |
 
 ### `[[cron.jobs]]` fields
 

--- a/docs/cronjob.md
+++ b/docs/cronjob.md
@@ -169,12 +169,22 @@ working_dir = "/home/agent"
 
 [cron]
 usercron_enabled = true
-usercron_path = "cronjob.toml"    # → $HOME/cronjob.toml
+usercron_path = "cronjob.toml"    # → $HOME/.openab/cronjob.toml
 ```
 
 > Note: Everything cron-related lives under `[cron]` — both usercron settings and baseline `[[cron.jobs]]`.
 
-The path is relative to `$HOME` (e.g. `"cronjob.toml"` resolves to `$HOME/cronjob.toml`). Absolute paths are used as-is. The scheduler starts watching immediately, even if the file doesn't exist yet.
+The path is relative to `$HOME/.openab/` (e.g. `"cronjob.toml"` resolves to `$HOME/.openab/cronjob.toml`). Absolute paths are used as-is. The scheduler starts watching immediately, even if the file doesn't exist yet.
+
+> **New installations**: If `~/.openab/` does not exist yet, the scheduler silently skips the file and continues running. Once you create the directory and place `cronjob.toml` inside, it will be picked up automatically on the next tick — no restart required.
+
+> [!CAUTION]
+> **Breaking Change** — `usercron_path` relative path base changed from `$HOME` to `$HOME/.openab/`.
+> If you are upgrading from a previous version, move your existing file:
+> ```bash
+> mkdir -p ~/.openab
+> mv ~/cronjob.toml ~/.openab/cronjob.toml
+> ```
 
 ### Create `cronjob.toml`
 
@@ -200,7 +210,7 @@ timezone = "Asia/Taipei"
 ### How It Works
 
 ```
-                         config.toml                        $HOME/cronjob.toml
+                         config.toml                   $HOME/.openab/cronjob.toml
                     ┌──────────────────┐                 ┌──────────────────────┐
                     │ [cron]           │                 │ [[jobs]]             │
                     │ usercron_enabled │                 │ schedule = "* * * *" │
@@ -254,7 +264,7 @@ Mount `cronjob.toml` on a PVC so it persists across pod restarts, and set `userc
 # config.toml
 [cron]
 usercron_enabled = true
-# Relative to $HOME — resolves to $HOME/cronjob.toml
+# Relative to $HOME/.openab/ — resolves to $HOME/.openab/cronjob.toml
 usercron_path = "cronjob.toml"
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,10 +243,11 @@ async fn main() -> anyhow::Result<()> {
             if path.is_absolute() {
                 path
             } else {
-                // Relative paths resolve from $HOME (e.g. "cronjob.toml" → "$HOME/cronjob.toml")
+                // Relative paths resolve from $HOME/.openab/ (e.g. "cronjob.toml" → "$HOME/.openab/cronjob.toml")
                 std::env::var("HOME")
                     .map(std::path::PathBuf::from)
                     .unwrap_or_default()
+                    .join(".openab")
                     .join(path)
             }
         })


### PR DESCRIPTION
## Summary

Change the base directory for relative `usercron_path` resolution from `$HOME` to `$HOME/.openab/` to consolidate all OpenAB user files under a single dot-directory.

Closes #680

## Changes

- **`src/main.rs`** — relative path now resolves from `$HOME/.openab/` instead of `$HOME`
- **`docs/cronjob.md`** — updated documentation (path references, ASCII diagram, K8s example, migration callout)
- **`docs/config-reference.md`** — updated path description and table
- **`config.toml.example`** — updated example comment

## Behavior

| Before | After |
|--------|-------|
| `usercron_path = "cronjob.toml"` → `$HOME/cronjob.toml` | `usercron_path = "cronjob.toml"` → `$HOME/.openab/cronjob.toml` |

Absolute paths remain unchanged.

## ⚠️ Breaking Change — Migration Required

Existing users with `cronjob.toml` at `$HOME/cronjob.toml` must move the file after upgrading:

```bash
mkdir -p ~/.openab
mv ~/cronjob.toml ~/.openab/cronjob.toml
```

## New installations

If `~/.openab/` does not exist yet, the scheduler silently skips the file and continues running. Once the directory is created and `cronjob.toml` is placed inside, it will be picked up automatically on the next tick — no restart required. This is handled by the existing `NotFound` error handling in `load_usercron_file()`.

Discord Discussion URL: https://discord.com/channels/1486155598964719616/1499746839820370060