### PR TITLE
docs(kiro): add default agent resources section

### DIFF
--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -51,6 +51,43 @@ kubectl rollout restart deployment/openab-kiro
 | `~/.kiro/` | Settings, skills, sessions |
 | `~/.local/share/kiro-cli/` | OAuth tokens (`data.sqlite3` → `auth_kv` table), conversation history |
 
+## Default Agent Resources
+
+When Kiro CLI starts with the built-in `kiro_default` agent, it automatically reads the following resources into context:
+
+| Resource | Description |
+|----------|-------------|
+| `AGENTS.md` | Agent coordination file (if exists in working dir) |
+| `README.md` | Project readme (if exists in working dir) |
+| `.kiro/skills/*/SKILL.md` | Skill files (local and global `~/.kiro/skills/`) |
+| `.kiro/steering/**/*.md` | Steering docs (local and global, if exists) |
+| `AmazonQ.md` | Legacy prompt file (if exists in working dir) |
+
+> **Tip:** Place an `AGENTS.md` in the agent's working directory (default: `/home/agent`) to provide persistent context — identity, instructions, or project-specific knowledge — that the agent reads on every session start.
+
+### Customizing the Default Agent
+
+You can override the default agent by creating a custom agent config:
+
+```bash
+# Inside the pod or on the PVC
+cat > ~/.kiro/agents/my-agent.json << 'EOF'
+{
+  "name": "my-agent",
+  "prompt": "You are a helpful assistant.",
+  "tools": ["*"],
+  "resources": [
+    "file://AGENTS.md",
+    "file://README.md",
+    "skill://.kiro/skills/**/SKILL.md"
+  ]
+}
+EOF
+
+# Set as default
+kiro-cli settings chat.defaultAgent my-agent
+```
+
 ## Slash Commands
 
 | Command | Purpose | Status |

--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -63,7 +63,15 @@ When Kiro CLI starts with the built-in `kiro_default` agent, it automatically re
 | `.kiro/steering/**/*.md` | Steering docs (local and global, if exists) |
 | `AmazonQ.md` | Legacy prompt file (if exists in working dir) |
 
-> **Tip:** Place an `AGENTS.md` in the agent's working directory (default: `/home/agent`) to provide persistent context — identity, instructions, or project-specific knowledge — that the agent reads on every session start.
+> **Highly recommended:** `AGENTS.md` and `.kiro/steering/**/*.md` are the primary ways to give Kiro persistent memory. If you need Kiro to "memorize" something — best practices, guidelines, operational procedures, or project conventions — always first consider these two locations:
+>
+> - **`AGENTS.md`** — Place in the agent's working directory (default: `/home/agent`). Ideal for identity, role definition, and top-level instructions.
+> - **`.kiro/steering/**/*.md`** — Organize guidelines by topic, e.g.:
+>   - `.kiro/steering/operations/backup.md` — backup procedures
+>   - `.kiro/steering/coding/style.md` — code style rules
+>   - `.kiro/steering/security/secrets.md` — secret handling policy
+>
+> Both are read into context on every session start — no extra configuration needed.
 
 ### Customizing the Default Agent
 


### PR DESCRIPTION
## Summary

Add documentation about Kiro CLI's default agent resources — what files are automatically read into context on session start.

## Changes

- Add "Default Agent Resources" section listing auto-loaded files (`AGENTS.md`, `README.md`, skills, steering docs)
- Add tip about using `AGENTS.md` for persistent agent context
- Add "Customizing the Default Agent" subsection showing how to create and set a custom agent config

## Why

Users deploying OpenAB with Kiro CLI often ask how to provide persistent context to the agent. This documents the built-in behavior and how to customize it.