### PR TITLE
fix: bump CLI versions — codex 0.128.0, claude 2.1.124, gemini 0.40.1, copilot 1.0.40, cursor 2026.04.30, opencode 1.14.31

### DIFF
--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # Without CLAUDE_CODE_EXECUTABLE the adapter uses its own bundled SDK cli.js,
 # ignoring the globally installed claude-code binary (see #418).
 ARG CLAUDE_AGENT_ACP_VERSION=0.29.2
-ARG CLAUDE_CODE_VERSION=2.1.116
+ARG CLAUDE_CODE_VERSION=2.1.124
 RUN npm install -g @agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION} @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} --retry 3
 ENV CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude
 

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 
 # Pre-install codex-acp and codex CLI globally
 ARG CODEX_ACP_VERSION=0.11.1
-ARG CODEX_VERSION=0.125.0
+ARG CODEX_VERSION=0.128.0
 RUN npm install -g @zed-industries/codex-acp@${CODEX_ACP_VERSION} @openai/codex@${CODEX_VERSION} --retry 3
 
 # Install gh CLI

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
-ARG COPILOT_VERSION=1.0.39
+ARG COPILOT_VERSION=1.0.40
 RUN npm install -g @github/copilot@${COPILOT_VERSION} --retry 3
 
 # Install gh CLI (for auth and token management)

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # URL scheme scraped from Cursor's official downloads page — no apt/yum package exists.
 # If Cursor changes this pattern, the build fails with curl 404. Monitor
 # https://cursor.com/cli or https://docs.cursor.com/cli for version/URL updates.
-ARG CURSOR_VERSION=2026.04.29-c83a488
+ARG CURSOR_VERSION=2026.04.30-4edb302
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
     curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
-ARG GEMINI_CLI_VERSION=0.40.0
+ARG GEMINI_CLI_VERSION=0.40.1
 RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} --retry 3
 
 # Install gh CLI

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -26,7 +26,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install opencode
-ARG OPENCODE_VERSION=1.14.28
+ARG OPENCODE_VERSION=1.14.31
 RUN npm install -g opencode-ai@${OPENCODE_VERSION} --retry 3
 
 # Install gh CLI (matches Dockerfile.claude / Dockerfile.gemini / Dockerfile.codex)


### PR DESCRIPTION
## Summary

Bump all pinned CLI versions in Dockerfiles after investigating latest releases and upstream bug trackers.

Discord Discussion URL: N/A

## Changes

| Dockerfile | CLI | Old | New | Notes |
|---|---|---|---|---|
| `Dockerfile.codex` | `@openai/codex` | 0.125.0 | **0.128.0** | bwrap regression (#20590) does not affect openab — Docker image has no bwrap |
| `Dockerfile.claude` | `@anthropic-ai/claude-code` | 2.1.116 | **2.1.124** | ⚠️ Safe ceiling — 2.1.126 has critical Linux regression (#55297) |
| `Dockerfile.gemini` | `@google/gemini-cli` | 0.40.0 | **0.40.1** | Zero open regressions, zero bugs |
| `Dockerfile.copilot` | `@github/copilot` | 1.0.39 | **1.0.40** | No public issue tracker; patch bump, low risk |
| `Dockerfile.cursor` | Cursor Agent CLI | 2026.04.29-c83a488 | **2026.04.30-4edb302** | From official install script |
| `Dockerfile.opencode` | `opencode-ai` | 1.14.28 | **1.14.31** | Zero regressions; all bugs are Windows/web/TUI |

## NOT updated (intentionally)

| Dockerfile | Dependency | Pinned | Why |
|---|---|---|---|
| `Dockerfile` | kiro-cli | 2.2.0 | Already at latest |
| `Dockerfile.codex` | `codex-acp` | 0.11.1 | No new release needed |
| `Dockerfile.claude` | `claude-agent-acp` | 0.29.2 | Still current |

## claude-code risk assessment

**⛔ 2.1.126 is NOT safe for openab.** Critical Linux regression [#55297](https://github.com/anthropics/claude-code/issues/55297):

- `claude -p` (non-interactive mode) with active Agent Teams fires a `<system-reminder>` on **every assistant turn** instructing the model to shut down its team
- The reminder persists even after team cleanup via `rm -rf`
- On Opus 4.7, this causes premature panic-shutdown ~30 seconds after team creation
- Regression introduced in **2.1.126**, last working version confirmed: **2.1.123**
- This is exactly how openab uses claude-code (headless `claude -p` via ACP)

**Safe ceiling: 2.1.124** (last published version before 2.1.126).

Other open regressions on 2.1.117–2.1.126 are all `platform:macos`, `platform:windows`, `area:desktop`, `area:tui`, or `platform:web` — none affect Linux/headless.

## codex risk assessment

Open regressions with `regression` label (20 total) — **all** are:
- Windows app/extension: #19399, #19249, #19192, #19181, #18259, #18252, #18163, #17649, #17530, #17412, #17329, #17213
- macOS TUI: #17139
- VS Code extension: #17527
- Codex Web: #16721
- exec mode on older versions: #16685 (pre-0.125), #19309 (0.124.0)
- Sandbox/bwrap: #20590 (`--perms` unknown, 0.128.0), #16451 (`/dev/null` denied, 0.118.0), #16536 (0.118.0)

The bwrap regressions (#20590, #16451) require bubblewrap to be installed. openab `Dockerfile.codex` does **not** install bwrap — codex falls back to no-sandbox mode in Docker. **Safe to upgrade.**

## opencode note

3 patch versions (1.14.28 → 1.14.31). Zero regressions. All open bugs are Windows/web/TUI/opentui. Minor ACP bug [#25127](https://github.com/anomalyco/opencode/issues/25127) (images not in ACP tool content) on 1.14.30 but does not affect openab text-based workflows.

## How to verify

```bash
# npm packages
curl -fsSL "https://registry.npmjs.org/@openai%2fcodex/latest" | grep -o '\"version\":\"[^\"]*\"'
curl -fsSL "https://registry.npmjs.org/@anthropic-ai%2fclaude-code/latest" | grep -o '\"version\":\"[^\"]*\"'
curl -fsSL "https://registry.npmjs.org/@google%2fgemini-cli/latest" | grep -o '\"version\":\"[^\"]*\"'
curl -fsSL "https://registry.npmjs.org/@github%2fcopilot/latest" | grep -o '\"version\":\"[^\"]*\"'
curl -fsSL "https://registry.npmjs.org/opencode-ai/latest" | grep -o '\"version\":\"[^\"]*\"'

# kiro-cli
curl -fsSL https://prod.download.cli.kiro.dev/stable/latest/manifest.json | grep -o '\"version\":\"[^\"]*\"'

# cursor
curl -fsSL https://cursor.com/install | grep "2026\."
```

Ref: #573