### PR TITLE
fix(helm): add missing gateway env vars, deploy control, and sidecar support

### DIFF
--- a/charts/openab/templates/gateway-secret.yaml
+++ b/charts/openab/templates/gateway-secret.yaml
@@ -1,12 +1,12 @@
 {{- range $name, $cfg := .Values.agents }}
 {{- if and (ne (include "openab.agentEnabled" $cfg) "false") (($cfg.gateway).enabled) }}
-{{- if ne (toString (($cfg.gateway).deploy)) "false" }}
+{{- if ne (($cfg.gateway).deploy | toString) "false" }}
 {{- $gwCfg := omit $cfg "nameOverride" }}
 {{- $d := dict "ctx" $ "agent" (printf "%s-gateway" $name) "cfg" $gwCfg }}
 {{- $hasTeams := and (($cfg.gateway).teams).appId (($cfg.gateway).teams).appSecret }}
 {{- $hasFeishu := and (($cfg.gateway).feishu).appId (($cfg.gateway).feishu).appSecret }}
-{{- $hasTelegram := and (($cfg.gateway).telegram).botToken }}
-{{- $hasLine := and (($cfg.gateway).line).channelSecret }}
+{{- $hasTelegram := (($cfg.gateway).telegram).botToken }}
+{{- $hasLine := (($cfg.gateway).line).channelSecret }}
 {{- if or $hasTeams $hasFeishu $hasTelegram $hasLine }}
 ---
 apiVersion: v1

--- a/charts/openab/templates/gateway-secret.yaml
+++ b/charts/openab/templates/gateway-secret.yaml
@@ -1,10 +1,13 @@
 {{- range $name, $cfg := .Values.agents }}
-{{- if and (ne (include "openab.agentEnabled" $cfg) "false") ($cfg.gateway).enabled }}
+{{- if and (ne (include "openab.agentEnabled" $cfg) "false") (($cfg.gateway).enabled) }}
+{{- if ne (toString (($cfg.gateway).deploy)) "false" }}
 {{- $gwCfg := omit $cfg "nameOverride" }}
 {{- $d := dict "ctx" $ "agent" (printf "%s-gateway" $name) "cfg" $gwCfg }}
 {{- $hasTeams := and (($cfg.gateway).teams).appId (($cfg.gateway).teams).appSecret }}
 {{- $hasFeishu := and (($cfg.gateway).feishu).appId (($cfg.gateway).feishu).appSecret }}
-{{- if or $hasTeams $hasFeishu }}
+{{- $hasTelegram := and (($cfg.gateway).telegram).botToken }}
+{{- $hasLine := and (($cfg.gateway).line).channelSecret }}
+{{- if or $hasTeams $hasFeishu $hasTelegram $hasLine }}
 ---
 apiVersion: v1
 kind: Secret
@@ -28,6 +31,19 @@ data:
   feishu-encrypt-key: {{ ($cfg.gateway).feishu.encryptKey | b64enc | quote }}
   {{- end }}
   {{- end }}
+  {{- if $hasTelegram }}
+  telegram-bot-token: {{ (($cfg.gateway).telegram).botToken | b64enc | quote }}
+  {{- if (($cfg.gateway).telegram).secretToken }}
+  telegram-secret-token: {{ (($cfg.gateway).telegram).secretToken | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if $hasLine }}
+  line-channel-secret: {{ (($cfg.gateway).line).channelSecret | b64enc | quote }}
+  {{- if (($cfg.gateway).line).channelAccessToken }}
+  line-channel-access-token: {{ (($cfg.gateway).line).channelAccessToken | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openab/templates/gateway.yaml
+++ b/charts/openab/templates/gateway.yaml
@@ -194,9 +194,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if ($cfg.gateway).extraVolumes }}
+      {{- with ($cfg.gateway).extraVolumes }}
       volumes:
-        {{- toYaml ($cfg.gateway).extraVolumes | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 ---
 apiVersion: v1

--- a/charts/openab/templates/gateway.yaml
+++ b/charts/openab/templates/gateway.yaml
@@ -1,12 +1,12 @@
 {{- range $name, $cfg := .Values.agents }}
 {{- if and (ne (include "openab.agentEnabled" $cfg) "false") ($cfg.gateway).enabled }}
-{{- if ne (toString (($cfg.gateway).deploy)) "false" }}
+{{- if ne (($cfg.gateway).deploy | toString) "false" }}
 {{- $gwCfg := omit $cfg "nameOverride" }}
 {{- $d := dict "ctx" $ "agent" (printf "%s-gateway" $name) "cfg" $gwCfg }}
 {{- $agentD := dict "ctx" $ "agent" $name "cfg" $cfg }}
 {{- $hasTeams := and (($cfg.gateway).teams).appId (($cfg.gateway).teams).appSecret }}
-{{- $hasTelegram := and (($cfg.gateway).telegram).botToken }}
-{{- $hasLine := and (($cfg.gateway).line).channelSecret }}
+{{- $hasTelegram := (($cfg.gateway).telegram).botToken }}
+{{- $hasLine := (($cfg.gateway).line).channelSecret }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/openab/templates/gateway.yaml
+++ b/charts/openab/templates/gateway.yaml
@@ -1,9 +1,12 @@
 {{- range $name, $cfg := .Values.agents }}
 {{- if and (ne (include "openab.agentEnabled" $cfg) "false") ($cfg.gateway).enabled }}
+{{- if ne (toString (($cfg.gateway).deploy)) "false" }}
 {{- $gwCfg := omit $cfg "nameOverride" }}
 {{- $d := dict "ctx" $ "agent" (printf "%s-gateway" $name) "cfg" $gwCfg }}
 {{- $agentD := dict "ctx" $ "agent" $name "cfg" $cfg }}
 {{- $hasTeams := and (($cfg.gateway).teams).appId (($cfg.gateway).teams).appSecret }}
+{{- $hasTelegram := and (($cfg.gateway).telegram).botToken }}
+{{- $hasLine := and (($cfg.gateway).line).channelSecret }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -43,12 +46,43 @@ spec:
               protocol: TCP
           env:
             {{- if ($cfg.gateway).token }}
-            {{- $agentD := dict "ctx" $ "agent" $name "cfg" $cfg }}
             - name: GATEWAY_WS_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "openab.agentFullname" $agentD }}
                   key: gateway-ws-token
+            {{- end }}
+            {{- if $hasTelegram }}
+            - name: TELEGRAM_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $d }}
+                  key: telegram-bot-token
+            {{- if (($cfg.gateway).telegram).secretToken }}
+            - name: TELEGRAM_SECRET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $d }}
+                  key: telegram-secret-token
+            {{- end }}
+            {{- if (($cfg.gateway).telegram).webhookPath }}
+            - name: TELEGRAM_WEBHOOK_PATH
+              value: {{ (($cfg.gateway).telegram).webhookPath | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if $hasLine }}
+            - name: LINE_CHANNEL_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $d }}
+                  key: line-channel-secret
+            {{- if (($cfg.gateway).line).channelAccessToken }}
+            - name: LINE_CHANNEL_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $d }}
+                  key: line-channel-access-token
+            {{- end }}
             {{- end }}
             {{- if $hasTeams }}
             - name: TEAMS_APP_ID
@@ -141,6 +175,29 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with ($cfg.gateway).extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with ($cfg.gateway).extraContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ($cfg.gateway).nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ($cfg.gateway).affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ($cfg.gateway).tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if ($cfg.gateway).extraVolumes }}
+      volumes:
+        {{- toYaml ($cfg.gateway).extraVolumes | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -157,5 +214,6 @@ spec:
       name: http
   selector:
     {{- include "openab.selectorLabels" $d | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openab/tests/gateway_test.yaml
+++ b/charts/openab/tests/gateway_test.yaml
@@ -87,3 +87,275 @@ tests:
       - matchRegex:
           path: data["config.toml"]
           pattern: 'platform = "line"'
+
+  # --- [gateway] config still renders when deploy=false (config-only mode) ---
+  - it: renders [gateway] config when deploy is false
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.deploy: false
+      agents.kiro.gateway.url: "ws://external-gateway:8080/ws"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[gateway\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'url = "ws://external-gateway:8080/ws"'
+
+---
+suite: gateway deployment rendering
+templates:
+  - templates/gateway.yaml
+tests:
+  - it: does not render when gateway not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders Deployment and Service when gateway enabled
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Deployment
+        documentIndex: 0
+      - isKind:
+          of: Service
+        documentIndex: 1
+
+  - it: does not render Deployment when deploy is false
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.deploy: false
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: injects TELEGRAM_BOT_TOKEN when telegram.botToken is set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.telegram.botToken: "123:ABC"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TELEGRAM_BOT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-kiro-gateway
+                key: telegram-bot-token
+        documentIndex: 0
+
+  - it: injects TELEGRAM_SECRET_TOKEN when set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.telegram.botToken: "123:ABC"
+      agents.kiro.gateway.telegram.secretToken: "my-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TELEGRAM_SECRET_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-kiro-gateway
+                key: telegram-secret-token
+        documentIndex: 0
+
+  - it: injects TELEGRAM_WEBHOOK_PATH when set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.telegram.botToken: "123:ABC"
+      agents.kiro.gateway.telegram.webhookPath: "/custom/webhook"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TELEGRAM_WEBHOOK_PATH
+            value: "/custom/webhook"
+        documentIndex: 0
+
+  - it: does not inject telegram env vars when botToken not set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TELEGRAM_BOT_TOKEN
+          any: true
+        documentIndex: 0
+
+  - it: injects LINE_CHANNEL_SECRET when set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.line.channelSecret: "line-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LINE_CHANNEL_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-kiro-gateway
+                key: line-channel-secret
+        documentIndex: 0
+
+  - it: injects LINE_CHANNEL_ACCESS_TOKEN when set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.line.channelSecret: "line-secret"
+      agents.kiro.gateway.line.channelAccessToken: "line-token"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LINE_CHANNEL_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-kiro-gateway
+                key: line-channel-access-token
+        documentIndex: 0
+
+  - it: renders extraContainers as sidecars
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.extraContainers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:latest
+          args: ["tunnel", "run"]
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: cloudflared
+            image: cloudflare/cloudflared:latest
+            args: ["tunnel", "run"]
+        documentIndex: 0
+
+  - it: renders extraVolumes and extraVolumeMounts
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.extraVolumeMounts:
+        - name: tunnel-creds
+          mountPath: /etc/cloudflared
+          readOnly: true
+      agents.kiro.gateway.extraVolumes:
+        - name: tunnel-creds
+          secret:
+            secretName: cloudflared-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tunnel-creds
+            mountPath: /etc/cloudflared
+            readOnly: true
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tunnel-creds
+            secret:
+              secretName: cloudflared-creds
+        documentIndex: 0
+
+  - it: renders nodeSelector when set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.nodeSelector:
+        kubernetes.io/arch: amd64
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/arch: amd64
+        documentIndex: 0
+
+---
+suite: gateway secret rendering
+templates:
+  - templates/gateway-secret.yaml
+tests:
+  - it: does not render when gateway not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when deploy is false
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.deploy: false
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.telegram.botToken: "123:ABC"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders telegram secrets
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.telegram.botToken: "123:ABC"
+      agents.kiro.gateway.telegram.secretToken: "my-secret"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: data["telegram-bot-token"]
+          value: "MTIzOkFCQw=="
+      - equal:
+          path: data["telegram-secret-token"]
+          value: "bXktc2VjcmV0"
+
+  - it: renders LINE secrets
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.line.channelSecret: "line-secret"
+      agents.kiro.gateway.line.channelAccessToken: "line-token"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data["line-channel-secret"]
+          value: "bGluZS1zZWNyZXQ="
+      - equal:
+          path: data["line-channel-access-token"]
+          value: "bGluZS10b2tlbg=="
+
+  - it: renders Teams secret only
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.teams.appId: "app-id"
+      agents.kiro.gateway.teams.appSecret: "app-secret"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data["teams-app-secret"]
+          value: "YXBwLXNlY3JldA=="
+
+  - it: does not render when no platform secrets configured
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -194,7 +194,8 @@ agents:
       model: "whisper-large-v3-turbo"
       baseUrl: "https://api.groq.com/openai/v1"
     gateway:
-      enabled: false    # set to true + provide url to enable
+      enabled: false    # set to true + provide url to enable the [gateway] config block
+      deploy: true      # set to false to skip Gateway Deployment/Service (config-only mode)
       url: ""           # e.g. ws://openab-gateway:8080/ws
       platform: "telegram"  # default platform when gateway is enabled
       token: ""         # optional shared secret (injected via GATEWAY_WS_TOKEN env var)
@@ -203,7 +204,25 @@ agents:
       tag: ""           # defaults to Chart.AppVersion
       strategy: "Recreate"  # Recreate (default, prevents concurrent WS conflicts) or RollingUpdate
       resources: {}     # e.g. { requests: { cpu: 50m, memory: 64Mi }, limits: { memory: 128Mi } }
-      rustLog: "info"  # RUST_LOG for gateway container (e.g. "openab_gateway=debug")
+      rustLog: "info"   # RUST_LOG for gateway container (e.g. "openab_gateway=debug")
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+      # extraContainers adds sidecar containers (e.g. cloudflared tunnel)
+      extraContainers: []
+      # extraVolumeMounts adds volume mounts to the gateway container
+      extraVolumeMounts: []
+      # extraVolumes adds volumes to the gateway pod
+      extraVolumes: []
+      # Telegram adapter config (gateway-side env vars)
+      telegram:
+        botToken: ""           # → TELEGRAM_BOT_TOKEN (use --set-literal or external secret mgmt)
+        secretToken: ""        # → TELEGRAM_SECRET_TOKEN (webhook validation)
+        webhookPath: ""        # Gateway default: /webhook/telegram → TELEGRAM_WEBHOOK_PATH
+      # LINE adapter config (gateway-side env vars)
+      line:
+        channelSecret: ""      # → LINE_CHANNEL_SECRET (webhook signature validation)
+        channelAccessToken: "" # → LINE_CHANNEL_ACCESS_TOKEN (reply/push API)
       # MS Teams adapter config (gateway-side env vars)
       # See docs/msteams-enterprise.md for full setup guide
       teams:


### PR DESCRIPTION
## Context
Closes #692, Closes #694

The v0.8.2 Helm chart gateway templates (added in #677) are missing critical env var injection for Telegram and LINE adapters, have no sidecar support, and couple config generation with deployment creation.

## Summary
This PR fixes all four issues reported in #692:

1. **P0: Missing env vars** — Gateway template now injects `TELEGRAM_BOT_TOKEN`, `TELEGRAM_SECRET_TOKEN`, `TELEGRAM_WEBHOOK_PATH`, `LINE_CHANNEL_SECRET`, `LINE_CHANNEL_ACCESS_TOKEN` via `secretKeyRef`
2. **Config/deployment coupling** — New `gateway.deploy` flag (default: `true`). Set to `false` for config-only mode (agent gets `[gateway]` config block without creating Gateway Deployment/Service)
3. **No sidecar support** — Added `extraContainers`, `extraVolumes`, `extraVolumeMounts` to gateway Deployment (e.g. for cloudflared tunnel sidecar)
4. **Per-agent deployment** — Users can set `deploy: false` on all but one agent to share a single gateway instance

## Changes
- `charts/openab/templates/gateway.yaml` — Add telegram/LINE env vars, `deploy` guard, extraContainers/extraVolumes/extraVolumeMounts, nodeSelector/affinity/tolerations
- `charts/openab/templates/gateway-secret.yaml` — Add telegram-bot-token, telegram-secret-token, line-channel-secret, line-channel-access-token keys
- `charts/openab/values.yaml` — Add `deploy`, `telegram.*`, `line.*`, `extraContainers`, `extraVolumeMounts`, `extraVolumes`, `nodeSelector`, `tolerations`, `affinity` fields with documentation comments
- `charts/openab/tests/gateway_test.yaml` — Add 18 new tests across 3 suites (config rendering, deployment rendering, secret rendering). 28 gateway tests total, 64/64 chart-wide passing.

## Design Decisions
- **`gateway.deploy` instead of top-level shared gateway**: Minimal change that solves the coupling problem. Users who want a shared gateway set `deploy: false` on all agents except one (or deploy gateway externally). A top-level shared gateway abstraction is a larger architectural change better suited for a follow-up.
- **Secrets in gateway Secret, not agent Secret**: Telegram/LINE credentials are gateway-side (the gateway binary reads them), so they belong in the gateway Secret. `GATEWAY_WS_TOKEN` remains in the agent Secret (shared between agent and gateway) — single source of truth preserved.
- **No `required` validation on telegram.botToken**: The latest gateway binary uses `.ok()` (optional) for `TELEGRAM_BOT_TOKEN`, not `.expect()`. Missing token means the Telegram adapter is simply not enabled, not a crash. Adding `required` would block Teams-only or LINE-only deployments.

## Verification: `deploy: false` does not break agent Secret

When `gateway.deploy: false`:
- **Skipped**: Gateway Deployment, Gateway Service, Gateway Secret (telegram/LINE/Teams credentials)
- **Not affected**: Agent Secret (`secret.yaml`) which holds `gateway-ws-token` — this is controlled by `gateway.enabled` + `gateway.token`, independent of `gateway.deploy`
- **Not affected**: Agent ConfigMap `[gateway]` config block — still rendered when `gateway.enabled: true`
- **Result**: Agent can connect to an external gateway using the `[gateway]` config and `GATEWAY_WS_TOKEN` from its own Secret. No dangling `secretKeyRef` references.

Verified by helm-unittest: `does not render Deployment when deploy is false` and `does not render when deploy is false` (Secret) both pass while config rendering tests confirm `[gateway]` block is still generated.

## Note on P0 severity
Issue #692 reported `TELEGRAM_BOT_TOKEN` as causing `panic` on startup. This was true in older gateway versions, but the current `main` branch (`gateway/src/main.rs`) uses `std::env::var("TELEGRAM_BOT_TOKEN").ok()` — the adapter is silently disabled rather than crashing. The fix is still necessary (users cannot configure Telegram via Helm without it), but severity is P1 (silent feature failure) rather than P0 (startup crash).

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1499911655142985888
