### PR TITLE
docs: add usercron path migration note to upgrade SOP

### DIFF
--- a/docs/ai-install-upgrade.md
+++ b/docs/ai-install-upgrade.md
@@ -151,8 +151,8 @@ rollback openab per the upgrade SOP — the upgrade to v0.7.7 failed
   │    the URL has rotated                           │
   │  ✓ (if usercron enabled) cronjob.toml loaded     │
   │    — check for "loaded usercron jobs" in logs;   │
-  │    if count=0, verify file is at                 │
-  │    $HOME/.openab/cronjob.toml (not $HOME/)       │
+  │    if you see "no cronjobs yet" instead, verify  │
+  │    file is at $HOME/.openab/cronjob.toml         │
   │                                                  │
   │  ALL PASS ──► proceed to 6. CLEANUP            │
   │  ANY FAIL ──► proceed to 5. ROLLBACK             │

--- a/docs/ai-install-upgrade.md
+++ b/docs/ai-install-upgrade.md
@@ -104,6 +104,13 @@ rollback openab per the upgrade SOP — the upgrade to v0.7.7 failed
 
 > **Gateway config migration (one-time, if applicable):** If you previously enabled a custom gateway by manually patching the ConfigMap (e.g. adding `[gateway]` to `config.toml` by hand), that block is not captured by `helm get values`. Before upgrading, copy the gateway settings into your `values.yaml` under `agents.<name>.gateway` and set `enabled: true` so they are preserved on every subsequent `helm upgrade`. See chart `values.yaml` for the field reference (`enabled`, `url`, `platform`, `token`, `botUsername`). After migrating, do not manually edit the ConfigMap again — manage gateway config through `values.yaml` only.
 
+> **Usercron path migration (v0.8.2+):** The usercron `cronjob.toml` path resolution changed from `$HOME/` to `$HOME/.openab/`. If you have an existing `cronjob.toml` in the agent's home directory, move it before upgrading:
+> ```
+> mkdir -p $HOME/.openab
+> mv $HOME/cronjob.toml $HOME/.openab/cronjob.toml
+> ```
+> The scheduler will not pick up the file from the old location. Hot-reload (polling every 60s) will detect the file once it is in the correct path.
+
 ---
 
 ## 3. Upgrade
@@ -142,6 +149,10 @@ rollback openab per the upgrade SOP — the upgrade to v0.7.7 failed
   │    errors in logs; verify Cloudflare tunnel URL  │
   │    is still reachable and update values.yaml if  │
   │    the URL has rotated                           │
+  │  ✓ (if usercron enabled) cronjob.toml loaded     │
+  │    — check for "loaded usercron jobs" in logs;   │
+  │    if count=0, verify file is at                 │
+  │    $HOME/.openab/cronjob.toml (not $HOME/)       │
   │                                                  │
   │  ALL PASS ──► proceed to 6. CLEANUP            │
   │  ANY FAIL ──► proceed to 5. ROLLBACK             │


### PR DESCRIPTION
## Summary

Add migration note and smoke test check for the usercron path change introduced in v0.8.2.

### Changes

1. **Backup section** — Added migration note explaining that `cronjob.toml` path resolution changed from `$HOME/` to `$HOME/.openab/` in v0.8.2, with the `mv` command to relocate the file.

2. **Smoke Test section** — Added checklist item to verify usercron jobs are loaded after upgrade, with guidance to check the file path if count=0.

### Context

Encountered during upgrade from 0.8.2-beta.7 → 0.8.2. The cron scheduler silently started with 0 jobs because `cronjob.toml` was still at the old `$HOME/` location. The scheduler logged `no cronjobs yet` without warning about the path change, making it easy to miss.

### Discord Discussion

https://discord.com/channels/1491295327620169908/1499962945524727988