### PR TITLE
docs(codex): add missing discord.enabled flag to Helm example

### DIFF
--- a/docs/codex.md
+++ b/docs/codex.md
@@ -18,6 +18,7 @@ The image installs `@zed-industries/codex-acp` and `@openai/codex` globally via 
 ```bash
 helm install openab openab/openab \
   --set agents.kiro.enabled=false \
+  --set agents.codex.discord.enabled=true \
   --set agents.codex.discord.botToken="$DISCORD_BOT_TOKEN" \
   --set-string 'agents.codex.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agents.codex.image=ghcr.io/openabdev/openab-codex:latest \


### PR DESCRIPTION
## What problem does this solve?

The Helm install example in `docs/codex.md` is missing `--set agents.codex.discord.enabled=true`. Without this flag, the rendered config.toml has no `[discord]` section and the pod crashes on startup:

```
Error: no adapter configured — add [discord], [slack], and/or [gateway] to config.toml
```

## Fix

Add one line to the Helm install example:

```diff
 helm install openab openab/openab \\
   --set agents.kiro.enabled=false \\
+  --set agents.codex.discord.enabled=true \\
   --set agents.codex.discord.botToken="$DISCORD_BOT_TOKEN" \\
```

## Validated

Reproduced and fix-validated on a fresh k3s cluster. See [issue #695 comment](https://github.com/openabdev/openab/issues/695#issuecomment-4363358568) for full reproduction steps.

Closes #695