### PR TITLE
fix(gateway): prevent feishu bot self-echo message loop

### DIFF
--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -831,14 +831,14 @@ async fn resolve_user_name(
 // ---------------------------------------------------------------------------
 
 /// Send a text message to a feishu chat_id.
-/// Returns true on success.
+/// Returns the sent message_id on success (for self-echo dedupe), None on failure.
 pub async fn send_text_message(
     client: &reqwest::Client,
     api_base: &str,
     token: &str,
     chat_id: &str,
     text: &str,
-) -> bool {
+) -> Option<String> {
     let url = format!(
         "{}/open-apis/im/v1/messages?receive_id_type=chat_id",
         api_base
@@ -860,18 +860,23 @@ pub async fn send_text_message(
     {
         Ok(resp) => {
             if resp.status().is_success() {
-                info!(chat_id = %chat_id, "feishu message sent");
-                true
+                let resp_body: serde_json::Value = resp.json().await.unwrap_or_default();
+                let msg_id = resp_body
+                    .pointer("/data/message_id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                info!(chat_id = %chat_id, message_id = ?msg_id, "feishu message sent");
+                msg_id
             } else {
                 let status = resp.status();
                 let text = resp.text().await.unwrap_or_default();
                 tracing::error!(status = %status, body = %text, "feishu send message failed");
-                false
+                None
             }
         }
         Err(e) => {
             tracing::error!(err = %e, "feishu send message request failed");
-            false
+            None
         }
     }
 }
@@ -1002,12 +1007,17 @@ pub async fn handle_reply(
     let text = &reply.content.text;
     let limit = adapter.config.message_limit;
 
-    // Split long messages
+    // Split long messages; store sent message_ids in dedupe to prevent
+    // self-echo (Feishu pushes bot's own messages back via WebSocket)
     if text.len() <= limit {
-        send_text_message(&adapter.client, &api_base, &token, &reply.channel.id, text).await;
+        if let Some(msg_id) = send_text_message(&adapter.client, &api_base, &token, &reply.channel.id, text).await {
+            adapter.dedupe.is_duplicate(&msg_id);
+        }
     } else {
         for chunk in split_text(text, limit) {
-            send_text_message(&adapter.client, &api_base, &token, &reply.channel.id, chunk).await;
+            if let Some(msg_id) = send_text_message(&adapter.client, &api_base, &token, &reply.channel.id, chunk).await {
+                adapter.dedupe.is_duplicate(&msg_id);
+            }
         }
     }
 }
@@ -1400,14 +1410,15 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "code": 0,
                 "msg": "success",
+                "data": {"message_id": "om_test123"}
             })))
             .expect(1)
             .mount(&server)
             .await;
 
         let client = reqwest::Client::new();
-        let ok = send_text_message(&client, &server.uri(), "t-tok", "oc_chat1", "hello").await;
-        assert!(ok);
+        let msg_id = send_text_message(&client, &server.uri(), "t-tok", "oc_chat1", "hello").await;
+        assert_eq!(msg_id.as_deref(), Some("om_test123"));
     }
 
     #[tokio::test]
@@ -1421,8 +1432,8 @@ mod tests {
             .await;
 
         let client = reqwest::Client::new();
-        let ok = send_text_message(&client, &server.uri(), "t-tok", "oc_chat1", "hello").await;
-        assert!(!ok);
+        let msg_id = send_text_message(&client, &server.uri(), "t-tok", "oc_chat1", "hello").await;
+        assert!(msg_id.is_none());
     }
 
     // --- Split text tests ---

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -860,11 +860,16 @@ pub async fn send_text_message(
     {
         Ok(resp) => {
             if resp.status().is_success() {
-                let resp_body: serde_json::Value = resp.json().await.unwrap_or_default();
-                let msg_id = resp_body
-                    .pointer("/data/message_id")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+                let msg_id = match resp.json::<serde_json::Value>().await {
+                    Ok(body) => body
+                        .pointer("/data/message_id")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                    Err(e) => {
+                        warn!(chat_id = %chat_id, err = %e, "feishu 200 response not valid JSON, self-echo dedupe will be skipped");
+                        None
+                    }
+                };
                 info!(chat_id = %chat_id, message_id = ?msg_id, "feishu message sent");
                 msg_id
             } else {

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -1441,6 +1441,39 @@ mod tests {
         assert!(msg_id.is_none());
     }
 
+    #[tokio::test]
+    async fn send_text_message_invalid_json_returns_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let msg_id = send_text_message(&client, &server.uri(), "t-tok", "oc_chat1", "hello").await;
+        assert!(msg_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn send_text_message_missing_message_id_returns_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 0,
+                "msg": "success",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let msg_id = send_text_message(&client, &server.uri(), "t-tok", "oc_chat1", "hello").await;
+        assert!(msg_id.is_none());
+    }
+
     // --- Split text tests ---
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a message loop where the Feishu bot's own replies are pushed back via WebSocket and processed as new inbound messages.

```
User sends message
  --> Gateway receives via WebSocket
  --> OAB processes, agent replies
  --> Gateway sends reply via REST API
  --> Feishu pushes bot reply back via WebSocket  <-- problem
  --> Gateway processes it as new message
  --> OAB processes again --> infinite loop
```

### Root Cause

Feishu WebSocket pushes ALL messages in a chat back to the subscribing app — including messages the app itself sent. Unlike Discord (where `author.bot=true`), Feishu marks these with `sender_type="user"` and the sender open_id is the original user, not the bot. No existing filter (sender_type, bot_open_id, allowed_users) can catch this.

### Fix

`send_text_message` now extracts the `message_id` from the Feishu API response and inserts it into the dedupe cache. When the echo event arrives via WebSocket, the dedupe check catches it.

## Changes

| File | Change | Description |
|------|--------|-------------|
| `gateway/src/adapters/feishu.rs` | MOD | `send_text_message` returns `Option<String>` (message_id); `handle_reply` stores sent IDs in dedupe cache; tests updated |

## Testing

- 64 tests passed (2 updated for new return type)
- Live verified: bot replies once, no loop
- Restart verified: no stale replay (ACK still works)

## Discord Discussion URL

https://discord.com/channels/1491295327620169908/1500160821567684660