### PR TITLE
feat(gateway): feishu rich text, streaming, slash commands, and bot-to-bot readiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,15 +508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,7 +1046,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openab"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1243,17 +1234,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags",
- "getopts",
  "memchr",
- "pulldown-cmark-escape",
  "unicase",
 ]
-
-[[package]]
-name = "pulldown-cmark-escape"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -102,14 +102,18 @@ To disable mention gating: `feishu.requireMention: false`.
 
 ## Slash Commands
 
-The gateway intercepts `/reset` and `/cancel` messages before they reach the agent:
+The gateway intercepts slash commands before they reach the agent:
 
 | Command | Action |
 |---------|--------|
-| `/reset` | Clears the conversation session. Equivalent to Discord's `/reset`. |
-| `/cancel` | Sends a cancel signal to the running agent. Equivalent to Discord's `/cancel`. |
+| `/reset` | Clears the conversation session. |
+| `/cancel` | Sends a cancel signal to the running agent. |
+| `/models` | Lists available models with current selection marked ✅. |
+| `/models <name>` | Switches to a model matching `<name>` (case-insensitive substring match). |
+| `/agents` | Lists available agents with current selection marked ✅. |
+| `/agents <name>` | Switches to an agent matching `<name>`. |
 
-These work in both DMs and group chats, across all gateway platforms (Feishu, LINE, Telegram).
+`/models` and `/agents` require an active session — send a message first to start one.
 
 ## Rich Text (Post) Messages
 

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -81,6 +81,7 @@ https://your-gateway-host/webhook/feishu
 | — | `FEISHU_TRUSTED_BOT_IDS` | — | Comma-separated open_id list of known bots |
 | — | `FEISHU_MAX_BOT_TURNS` | `20` | Max consecutive bot replies per channel before suppression |
 | `gateway.botUsername` | — | — | Set to bot's `open_id` for @mention gating |
+| `gateway.streaming` | — | `false` | Enable streaming (typewriter) mode |
 
 ## @mention Gating
 
@@ -108,12 +109,8 @@ The gateway intercepts slash commands before they reach the agent:
 |---------|--------|
 | `/reset` | Clears the conversation session. |
 | `/cancel` | Sends a cancel signal to the running agent. |
-| `/models` | Lists available models with current selection marked ✅. |
-| `/models <name>` | Switches to a model matching `<name>` (case-insensitive substring match). |
-| `/agents` | Lists available agents with current selection marked ✅. |
-| `/agents <name>` | Switches to an agent matching `<name>`. |
 
-`/models` and `/agents` require an active session — send a message first to start one.
+These work in both DMs and group chats, across all gateway platforms.
 
 ## Rich Text (Post) Messages
 
@@ -129,9 +126,16 @@ Inline Markdown formatting (`**bold**`, `*italic*`, `` `code` ``, `~~strike~~`) 
 
 Agent replies stream incrementally — a placeholder message appears immediately, then updates every ~1.5 seconds as the agent generates content. This matches Discord's streaming behavior.
 
-Streaming is enabled by default for Feishu. No configuration needed.
+To enable streaming, set `streaming = true` in the gateway config:
 
-How it works: the gateway sends a placeholder "…" message, receives the real `message_id` from Feishu, then updates the message in-place via `PUT /open-apis/im/v1/messages/{id}` as new content arrives.
+```toml
+[gateway]
+url = "ws://127.0.0.1:8080/ws"
+platform = "feishu"
+streaming = true
+```
+
+The gateway platform must support message editing (Feishu/Lark do). Platforms that don't support editing should leave `streaming = false` (default).
 
 ## Bot-to-Bot Collaboration
 

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -137,13 +137,15 @@ streaming = true
 
 The gateway platform must support message editing (Feishu/Lark do). Platforms that don't support editing should leave `streaming = false` (default).
 
-## Bot-to-Bot Collaboration
+## Bot-to-Bot Collaboration (Gateway-Side Only)
 
-Multi-bot support allows the gateway to process messages from other bots, matching Discord's `allow_bot_messages` feature.
+The gateway adapter includes bot identification and filtering scaffolding (`AllowBots` enum, `FEISHU_TRUSTED_BOT_IDS`, `FEISHU_MAX_BOT_TURNS` with human-reset safety valve), matching Discord's `allow_bot_messages` design.
 
 Bot identification requires explicit configuration via `FEISHU_TRUSTED_BOT_IDS` because Feishu marks other bots as `sender_type="user"` — they cannot be identified from the event alone.
 
-> **Feishu platform limitation:** Feishu does not deliver bot-sent messages to other bots' WebSocket connections. Bot-to-bot automatic collaboration is not currently possible. The gateway logic is ready if Feishu lifts this restriction in the future.
+> **Not yet functional.** Two blockers remain:
+> 1. **Feishu platform limitation:** Feishu does not deliver bot-sent messages to other bots' WebSocket connections.
+> 2. **OAB core limitation:** `src/gateway.rs` unconditionally drops `is_bot` events before they reach the router. When blocker 1 is lifted, the core guard must become adapter-aware to let gateway-filtered bot events through.
 
 ## Troubleshooting
 

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -121,6 +121,14 @@ Agent replies are sent as Feishu **post** (rich text) messages instead of plain 
 
 Inline Markdown formatting (`**bold**`, `*italic*`, `` `code` ``, `~~strike~~`) is stripped to plain text because Feishu's post format does not support inline styles.
 
+## Streaming (Typewriter)
+
+Agent replies stream incrementally — a placeholder message appears immediately, then updates every ~1.5 seconds as the agent generates content. This matches Discord's streaming behavior.
+
+Streaming is enabled by default for Feishu. No configuration needed.
+
+How it works: the gateway sends a placeholder "…" message, receives the real `message_id` from Feishu, then updates the message in-place via `PUT /open-apis/im/v1/messages/{id}` as new content arrives.
+
 ## Bot-to-Bot Collaboration
 
 Multi-bot support allows the gateway to process messages from other bots, matching Discord's `allow_bot_messages` feature.

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -137,11 +137,7 @@ How it works: the gateway sends a placeholder "…" message, receives the real `
 
 Multi-bot support allows the gateway to process messages from other bots, matching Discord's `allow_bot_messages` feature.
 
-| Env Var | Default | Description |
-|---------|---------|-------------|
-| `FEISHU_ALLOW_BOTS` | `off` | `off` — ignore bot messages. `mentions` — process if this bot is @mentioned. `all` — process all bot messages. |
-| `FEISHU_TRUSTED_BOT_IDS` | — | Comma-separated open_id list. If empty and `FEISHU_ALLOWED_USERS` is set, any sender not in the user allowlist is treated as a bot. |
-| `FEISHU_MAX_BOT_TURNS` | `20` | Max consecutive bot replies per channel. A human message resets the counter. |
+Bot identification requires explicit configuration via `FEISHU_TRUSTED_BOT_IDS` because Feishu marks other bots as `sender_type="user"` — they cannot be identified from the event alone.
 
 > **Feishu platform limitation:** Feishu does not deliver bot-sent messages to other bots' WebSocket connections. Bot-to-bot automatic collaboration is not currently possible. The gateway logic is ready if Feishu lifts this restriction in the future.
 

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -77,6 +77,9 @@ https://your-gateway-host/webhook/feishu
 | `feishu.requireMention` | `FEISHU_REQUIRE_MENTION` | `true` | Require @mention in groups |
 | — | `FEISHU_DEDUPE_TTL_SECS` | `300` | Event deduplication cache TTL (seconds) |
 | — | `FEISHU_MESSAGE_LIMIT` | `4000` | Max message length before auto-splitting (bytes) |
+| — | `FEISHU_ALLOW_BOTS` | `off` | Bot message handling: `off` / `mentions` / `all` |
+| — | `FEISHU_TRUSTED_BOT_IDS` | — | Comma-separated open_id list of known bots |
+| — | `FEISHU_MAX_BOT_TURNS` | `20` | Max consecutive bot replies per channel before suppression |
 | `gateway.botUsername` | — | — | Set to bot's `open_id` for @mention gating |
 
 ## @mention Gating
@@ -96,6 +99,39 @@ To disable mention gating: `feishu.requireMention: false`.
 - `appSecret`, `verificationToken`, and `encryptKey` are stored in a Kubernetes Secret, not in ConfigMap.
 - In webhook mode, always set both `verificationToken` and `encryptKey` for production.
 - The gateway enforces a 1 MB body size limit and per-IP rate limiting (120 req/60s) on the webhook endpoint.
+
+## Slash Commands
+
+The gateway intercepts `/reset` and `/cancel` messages before they reach the agent:
+
+| Command | Action |
+|---------|--------|
+| `/reset` | Clears the conversation session. Equivalent to Discord's `/reset`. |
+| `/cancel` | Sends a cancel signal to the running agent. Equivalent to Discord's `/cancel`. |
+
+These work in both DMs and group chats, across all gateway platforms (Feishu, LINE, Telegram).
+
+## Rich Text (Post) Messages
+
+Agent replies are sent as Feishu **post** (rich text) messages instead of plain text. This enables:
+
+- Fenced code blocks with syntax highlighting
+- Clickable hyperlinks
+- Proper line breaks and paragraph structure
+
+Inline Markdown formatting (`**bold**`, `*italic*`, `` `code` ``, `~~strike~~`) is stripped to plain text because Feishu's post format does not support inline styles.
+
+## Bot-to-Bot Collaboration
+
+Multi-bot support allows the gateway to process messages from other bots, matching Discord's `allow_bot_messages` feature.
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `FEISHU_ALLOW_BOTS` | `off` | `off` — ignore bot messages. `mentions` — process if this bot is @mentioned. `all` — process all bot messages. |
+| `FEISHU_TRUSTED_BOT_IDS` | — | Comma-separated open_id list. If empty and `FEISHU_ALLOWED_USERS` is set, any sender not in the user allowlist is treated as a bot. |
+| `FEISHU_MAX_BOT_TURNS` | `20` | Max consecutive bot replies per channel. A human message resets the counter. |
+
+> **Feishu platform limitation:** Feishu does not deliver bot-sent messages to other bots' WebSocket connections. Bot-to-bot automatic collaboration is not currently possible. The gateway logic is ready if Feishu lifts this restriction in the future.
 
 ## Troubleshooting
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -61,6 +61,9 @@ url = "ws://gateway:8080/ws"
 | `FEISHU_REQUIRE_MENTION` | `true` | Require @mention in groups |
 | `FEISHU_DEDUPE_TTL_SECS` | `300` | Event deduplication cache TTL (seconds) |
 | `FEISHU_MESSAGE_LIMIT` | `4000` | Max message length before auto-splitting (bytes) |
+| `FEISHU_ALLOW_BOTS` | `off` | Bot message handling: `off` / `mentions` / `all` |
+| `FEISHU_TRUSTED_BOT_IDS` | (optional) | Comma-separated open_id list of known bots |
+| `FEISHU_MAX_BOT_TURNS` | `20` | Max consecutive bot replies per channel |
 
 ### Endpoints
 

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -268,18 +268,24 @@ mod event_types {
         }
 
         // Check if sender is a known bot:
+        // Bot identification:
         // 1. If trusted_bot_ids is configured, check against it
-        // 2. If trusted_bot_ids is empty but allowed_users is configured,
-        //    any sender NOT in allowed_users is treated as a bot
-        //    (Feishu marks other bots as sender_type="user", so this is
-        //    the only reliable way to identify them)
+        // 2. If trusted_bot_ids is empty, we cannot reliably identify bots
+        //    (Feishu marks other bots as sender_type="user")
         let is_bot_sender = if !config.trusted_bot_ids.is_empty() {
             config.trusted_bot_ids.iter().any(|id| id == sender_open_id)
-        } else if !config.allowed_users.is_empty() {
-            !config.allowed_users.iter().any(|u| u == sender_open_id)
         } else {
             false
         };
+
+        // User allowlist: if configured, only allow listed users.
+        // Trusted bots bypass user allowlist (same as Discord behavior).
+        if !is_bot_sender
+            && !config.allowed_users.is_empty()
+            && !config.allowed_users.iter().any(|u| u == sender_open_id)
+        {
+            return None;
+        }
 
         if is_bot_sender {
             match config.allow_bots {
@@ -288,15 +294,6 @@ mod event_types {
                     // Allowed — will check mentions below for Mentions mode
                 }
             }
-        }
-
-        // User allowlist: if configured, only allow listed users
-        // Trusted bots bypass user allowlist (same as Discord behavior)
-        if !is_bot_sender
-            && !config.allowed_users.is_empty()
-            && !config.allowed_users.iter().any(|u| u == sender_open_id)
-        {
-            return None;
         }
 
         let chat_id = msg.chat_id.as_deref()?;
@@ -344,7 +341,9 @@ mod event_types {
         }
 
         // Bot-to-bot mention gating: in AllowBots::Mentions mode,
-        // bot messages must @mention this bot (like Discord "mentions" mode)
+        // bot messages must @mention this bot (like Discord "mentions" mode).
+        // Note: in DMs there is no @mention mechanism, so bot DMs are
+        // silently dropped in Mentions mode. Use AllowBots::All for DM bots.
         if is_bot_sender && config.allow_bots == AllowBots::Mentions {
             if let Some(bot_id) = bot_open_id {
                 let bot_mentioned = mention_ids.iter().any(|id| id == bot_id);
@@ -356,7 +355,7 @@ mod event_types {
 
         let thread_id = msg.root_id.clone().or_else(|| msg.parent_id.clone());
 
-        let mut event = GatewayEvent::new(
+        let event = GatewayEvent::new(
             "feishu",
             ChannelInfo {
                 id: chat_id.to_string(),
@@ -549,7 +548,7 @@ pub struct FeishuAdapter {
     pub name_cache: Arc<std::sync::Mutex<HashMap<String, String>>>,
     /// Per-channel bot turn counter. Key = chat_id, Value = (count, last_reset).
     /// Human message resets count to 0. Prevents runaway bot-to-bot loops.
-    pub bot_turns: Arc<std::sync::Mutex<HashMap<String, u32>>>,
+    pub bot_turns: Arc<std::sync::Mutex<HashMap<String, u32>>>, // TODO: add TTL eviction for long-running deploys
     pub client: reqwest::Client,
 }
 
@@ -967,10 +966,6 @@ async fn edit_feishu_message(adapter: &FeishuAdapter, message_id: &str, text: &s
 /// Unsupported inline formatting (bold, italic, etc.) is stripped to plain text.
 fn markdown_to_post(md: &str) -> serde_json::Value {
     let mut lines: Vec<Vec<serde_json::Value>> = Vec::new();
-    let mut chars = md.chars().peekable();
-    let mut i = 0;
-    let bytes = md.as_bytes();
-    let len = md.len();
 
     // We work byte-offset based for code fence detection, line-based otherwise.
     let raw_lines: Vec<&str> = md.split('\n').collect();
@@ -1121,7 +1116,13 @@ pub async fn send_post_message(
     {
         Ok(resp) => {
             if resp.status().is_success() {
-                let resp_body: serde_json::Value = resp.json().await.unwrap_or_default();
+                let resp_body: serde_json::Value = match resp.json().await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::warn!(err = %e, "feishu post: failed to parse response body");
+                        serde_json::Value::default()
+                    }
+                };
                 let msg_id = resp_body
                     .pointer("/data/message_id")
                     .and_then(|v| v.as_str())
@@ -1146,6 +1147,8 @@ pub async fn send_post_message(
 
 /// Send a text message to a feishu chat_id.
 /// Returns the sent message_id on success (for self-echo dedupe), None on failure.
+/// Kept for webhook fallback and tests; normal reply path uses send_post_message.
+#[allow(dead_code)]
 pub async fn send_text_message(
     client: &reqwest::Client,
     api_base: &str,

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -1068,14 +1068,45 @@ fn parse_inline(line: &str) -> Vec<serde_json::Value> {
             }
             continue;
         }
-        // Strip ** (bold), * (italic), ~~ (strikethrough) markers
+        // Strip paired markdown markers: **bold**, *italic*, ~~strike~~
+        // Unpaired markers are kept as literal text (e.g. ~/.ssh, *.rs, 3 * 4)
         if chars[i] == '*' || chars[i] == '~' {
             let ch = chars[i];
             let mut run = 0;
             while i + run < len && chars[i + run] == ch {
                 run += 1;
             }
-            i += run;
+            // Look ahead for a matching closing run of same length
+            let after = i + run;
+            let mut scan = after;
+            let mut found_close = false;
+            while scan < len {
+                if chars[scan] == ch {
+                    let mut close_run = 0;
+                    while scan + close_run < len && chars[scan + close_run] == ch {
+                        close_run += 1;
+                    }
+                    if close_run == run {
+                        // Found matching close — strip both, keep inner text
+                        for j in after..scan {
+                            buf.push(chars[j]);
+                        }
+                        i = scan + close_run;
+                        found_close = true;
+                        break;
+                    }
+                    scan += close_run;
+                } else {
+                    scan += 1;
+                }
+            }
+            if !found_close {
+                // No matching close — keep markers as literal
+                for _ in 0..run {
+                    buf.push(ch);
+                }
+                i += run;
+            }
             continue;
         }
         buf.push(chars[i]);
@@ -1374,20 +1405,38 @@ pub async fn handle_reply(
     // self-echo (Feishu pushes bot's own messages back via WebSocket)
     // Use post (rich text) format for markdown rendering.
     if text.len() <= limit {
-        if let Some(msg_id) = send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, text).await {
-            adapter.dedupe.is_duplicate(&msg_id);
-            // Send response with message_id back to OAB core (for streaming edit)
-            if let Some(ref req_id) = reply.request_id {
-                let resp = crate::schema::GatewayResponse {
-                    schema: "openab.gateway.response.v1".into(),
-                    request_id: req_id.clone(),
-                    success: true,
-                    thread_id: None,
-                    message_id: Some(msg_id),
-                    error: None,
-                };
-                if let Ok(json) = serde_json::to_string(&resp) {
-                    let _ = event_tx.send(json);
+        match send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, text).await {
+            Some(msg_id) => {
+                adapter.dedupe.is_duplicate(&msg_id);
+                // Send response with message_id back to OAB core (for streaming edit)
+                if let Some(ref req_id) = reply.request_id {
+                    let resp = crate::schema::GatewayResponse {
+                        schema: "openab.gateway.response.v1".into(),
+                        request_id: req_id.clone(),
+                        success: true,
+                        thread_id: None,
+                        message_id: Some(msg_id),
+                        error: None,
+                    };
+                    if let Ok(json) = serde_json::to_string(&resp) {
+                        let _ = event_tx.send(json);
+                    }
+                }
+            }
+            None => {
+                // Send failure response so core doesn't wait 5s for timeout
+                if let Some(ref req_id) = reply.request_id {
+                    let resp = crate::schema::GatewayResponse {
+                        schema: "openab.gateway.response.v1".into(),
+                        request_id: req_id.clone(),
+                        success: false,
+                        thread_id: None,
+                        message_id: None,
+                        error: Some("send_post_message failed".into()),
+                    };
+                    if let Ok(json) = serde_json::to_string(&resp) {
+                        let _ = event_tx.send(json);
+                    }
                 }
             }
         }

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -924,6 +924,40 @@ async fn resolve_user_name(
 
 // ---------------------------------------------------------------------------
 // Send message
+/// Edit (update) an existing feishu message in-place for streaming.
+async fn edit_feishu_message(adapter: &FeishuAdapter, message_id: &str, text: &str) {
+    let token = match adapter.token_cache.get_token(&adapter.client).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!(err = %e, "feishu: cannot get token for edit");
+            return;
+        }
+    };
+    let api_base = adapter.config.api_base();
+    let url = format!("{}/open-apis/im/v1/messages/{}", api_base, message_id);
+    let post_content = markdown_to_post(text);
+    let body = serde_json::json!({
+        "msg_type": "post",
+        "content": post_content.to_string(),
+    });
+    match adapter.client.put(&url).bearer_auth(&token)
+        .header("Content-Type", "application/json; charset=utf-8")
+        .json(&body).send().await
+    {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::trace!(message_id = %message_id, "feishu message edited");
+        }
+        Ok(resp) => {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            tracing::error!(status = %status, body = %body, "feishu edit message failed");
+        }
+        Err(e) => {
+            tracing::error!(err = %e, "feishu edit message request failed");
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Markdown → Feishu post conversion
 // ---------------------------------------------------------------------------
@@ -1260,6 +1294,7 @@ async fn remove_reaction(adapter: &FeishuAdapter, message_id: &str, emoji: &str)
 pub async fn handle_reply(
     reply: &GatewayReply,
     adapter: &FeishuAdapter,
+    event_tx: &tokio::sync::broadcast::Sender<String>,
 ) {
     // Handle reactions — add/remove emoji on the original message
     if let Some(ref cmd) = reply.command {
@@ -1270,6 +1305,10 @@ pub async fn handle_reply(
             }
             "remove_reaction" => {
                 remove_reaction(adapter, &reply.reply_to, &reply.content.text).await;
+                return;
+            }
+            "edit_message" => {
+                edit_feishu_message(adapter, &reply.reply_to, &reply.content.text).await;
                 return;
             }
             "create_topic" | "set_reaction" => {
@@ -1298,6 +1337,20 @@ pub async fn handle_reply(
     if text.len() <= limit {
         if let Some(msg_id) = send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, text).await {
             adapter.dedupe.is_duplicate(&msg_id);
+            // Send response with message_id back to OAB core (for streaming edit)
+            if let Some(ref req_id) = reply.request_id {
+                let resp = crate::schema::GatewayResponse {
+                    schema: "openab.gateway.response.v1".into(),
+                    request_id: req_id.clone(),
+                    success: true,
+                    thread_id: None,
+                    message_id: Some(msg_id),
+                    error: None,
+                };
+                if let Ok(json) = serde_json::to_string(&resp) {
+                    let _ = event_tx.send(json);
+                }
+            }
         }
     } else {
         for chunk in split_text(text, limit) {

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -61,6 +61,13 @@ pub enum ConnectionMode {
     Webhook,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum AllowBots {
+    Off,
+    Mentions,
+    All,
+}
+
 #[derive(Debug, Clone)]
 pub struct FeishuConfig {
     pub app_id: String,
@@ -73,6 +80,9 @@ pub struct FeishuConfig {
     pub allowed_groups: Vec<String>,
     pub allowed_users: Vec<String>,
     pub require_mention: bool,
+    pub allow_bots: AllowBots,
+    pub trusted_bot_ids: Vec<String>,
+    pub max_bot_turns: u32,
     pub dedupe_ttl_secs: u64,
     pub message_limit: usize,
 }
@@ -105,6 +115,20 @@ impl FeishuConfig {
         let require_mention = std::env::var("FEISHU_REQUIRE_MENTION")
             .map(|v| v != "false" && v != "0")
             .unwrap_or(true);
+        let allow_bots = match std::env::var("FEISHU_ALLOW_BOTS")
+            .unwrap_or_else(|_| "off".into())
+            .to_lowercase()
+            .as_str()
+        {
+            "mentions" => AllowBots::Mentions,
+            "all" => AllowBots::All,
+            _ => AllowBots::Off,
+        };
+        let trusted_bot_ids = parse_csv("FEISHU_TRUSTED_BOT_IDS");
+        let max_bot_turns = std::env::var("FEISHU_MAX_BOT_TURNS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(20);
         let dedupe_ttl_secs = std::env::var("FEISHU_DEDUPE_TTL_SECS")
             .ok()
             .and_then(|v| v.parse().ok())
@@ -125,6 +149,9 @@ impl FeishuConfig {
             allowed_groups,
             allowed_users,
             require_mention,
+            allow_bots,
+            trusted_bot_ids,
+            max_bot_turns,
             dedupe_ttl_secs,
             message_limit,
         })
@@ -227,20 +254,46 @@ mod event_types {
         if msg.message_type.as_deref() != Some("text") {
             return None;
         }
-        // Skip bot messages (sender_type: "bot" or "app")
+        // Skip bot messages with explicit sender_type
         if matches!(sender.sender_type.as_deref(), Some("bot") | Some("app")) {
             return None;
         }
 
         let sender_open_id = sender.sender_id.as_ref()?.open_id.as_deref()?;
+        // Skip messages from self
         if let Some(bot_id) = bot_open_id {
             if sender_open_id == bot_id {
                 return None;
             }
         }
 
+        // Check if sender is a known bot:
+        // 1. If trusted_bot_ids is configured, check against it
+        // 2. If trusted_bot_ids is empty but allowed_users is configured,
+        //    any sender NOT in allowed_users is treated as a bot
+        //    (Feishu marks other bots as sender_type="user", so this is
+        //    the only reliable way to identify them)
+        let is_bot_sender = if !config.trusted_bot_ids.is_empty() {
+            config.trusted_bot_ids.iter().any(|id| id == sender_open_id)
+        } else if !config.allowed_users.is_empty() {
+            !config.allowed_users.iter().any(|u| u == sender_open_id)
+        } else {
+            false
+        };
+
+        if is_bot_sender {
+            match config.allow_bots {
+                AllowBots::Off => return None,
+                AllowBots::Mentions | AllowBots::All => {
+                    // Allowed — will check mentions below for Mentions mode
+                }
+            }
+        }
+
         // User allowlist: if configured, only allow listed users
-        if !config.allowed_users.is_empty()
+        // Trusted bots bypass user allowlist (same as Discord behavior)
+        if !is_bot_sender
+            && !config.allowed_users.is_empty()
             && !config.allowed_users.iter().any(|u| u == sender_open_id)
         {
             return None;
@@ -280,8 +333,19 @@ mod event_types {
         };
 
         // Gateway-side mention gating: in groups, skip if require_mention
-        // is true and bot is not mentioned
-        if channel_type == "group" && config.require_mention {
+        // is true and bot is not mentioned (for human senders)
+        if channel_type == "group" && !is_bot_sender && config.require_mention {
+            if let Some(bot_id) = bot_open_id {
+                let bot_mentioned = mention_ids.iter().any(|id| id == bot_id);
+                if !bot_mentioned {
+                    return None;
+                }
+            }
+        }
+
+        // Bot-to-bot mention gating: in AllowBots::Mentions mode,
+        // bot messages must @mention this bot (like Discord "mentions" mode)
+        if is_bot_sender && config.allow_bots == AllowBots::Mentions {
             if let Some(bot_id) = bot_open_id {
                 let bot_mentioned = mention_ids.iter().any(|id| id == bot_id);
                 if !bot_mentioned {
@@ -292,7 +356,7 @@ mod event_types {
 
         let thread_id = msg.root_id.clone().or_else(|| msg.parent_id.clone());
 
-        Some(GatewayEvent::new(
+        let mut event = GatewayEvent::new(
             "feishu",
             ChannelInfo {
                 id: chat_id.to_string(),
@@ -303,12 +367,13 @@ mod event_types {
                 id: sender_open_id.to_string(),
                 name: sender_open_id.to_string(),
                 display_name: sender_open_id.to_string(),
-                is_bot: false,
+                is_bot: is_bot_sender,
             },
             clean_text.trim(),
             message_id,
             mention_ids,
-        ))
+        );
+        Some(event)
     }
 
     fn extract_mentions(
@@ -482,6 +547,9 @@ pub struct FeishuAdapter {
     pub dedupe: Arc<DedupeCache>,
     pub rate_limiter: Arc<RateLimiter>,
     pub name_cache: Arc<std::sync::Mutex<HashMap<String, String>>>,
+    /// Per-channel bot turn counter. Key = chat_id, Value = (count, last_reset).
+    /// Human message resets count to 0. Prevents runaway bot-to-bot loops.
+    pub bot_turns: Arc<std::sync::Mutex<HashMap<String, u32>>>,
     pub client: reqwest::Client,
 }
 
@@ -497,6 +565,7 @@ impl FeishuAdapter {
             rate_limiter,
             bot_open_id: Arc::new(RwLock::new(None)),
             name_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            bot_turns: Arc::new(std::sync::Mutex::new(HashMap::new())),
             client: reqwest::Client::new(),
         }
     }
@@ -589,6 +658,7 @@ pub async fn start_websocket(
     let config = adapter.config.clone();
     let client = adapter.client.clone();
     let name_cache = adapter.name_cache.clone();
+    let bot_turns = adapter.bot_turns.clone();
 
     let handle = tokio::spawn(async move {
         let mut backoff_secs = 1u64;
@@ -602,6 +672,7 @@ pub async fn start_websocket(
                 &event_tx,
                 &mut shutdown_rx,
                 &name_cache,
+                &bot_turns,
             )
             .await;
 
@@ -641,6 +712,7 @@ async fn ws_connect_loop(
     event_tx: &broadcast::Sender<String>,
     shutdown_rx: &mut watch::Receiver<bool>,
     name_cache: &Arc<std::sync::Mutex<HashMap<String, String>>>,
+    bot_turns: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
 ) -> anyhow::Result<()> {
     let api_base = config.api_base();
 
@@ -668,7 +740,7 @@ async fn ws_connect_loop(
                     Some(Ok(tokio_tungstenite::tungstenite::Message::Text(text))) => {
                         handle_ws_message(
                             &text, bot_open_id_store, dedupe, config, event_tx,
-                            name_cache, token_cache, client,
+                            name_cache, token_cache, client, bot_turns,
                         ).await;
                     }
                     Some(Ok(tokio_tungstenite::tungstenite::Message::Ping(data))) => {
@@ -689,7 +761,7 @@ async fn ws_connect_loop(
                                         if let Ok(text) = String::from_utf8(payload.clone()) {
                                             handle_ws_message(
                                                 &text, bot_open_id_store, dedupe, config, event_tx,
-                                                name_cache, token_cache, client,
+                                                name_cache, token_cache, client, bot_turns,
                                             ).await;
                                         }
                                     }
@@ -728,6 +800,7 @@ async fn handle_ws_message(
     name_cache: &Arc<std::sync::Mutex<HashMap<String, String>>>,
     token_cache: &Arc<FeishuTokenCache>,
     client: &reqwest::Client,
+    bot_turns: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
 ) {
     let envelope: FeishuEventEnvelope = match serde_json::from_str(text) {
         Ok(e) => e,
@@ -768,6 +841,29 @@ async fn handle_ws_message(
         if dedupe.is_duplicate(&gateway_event.message_id) {
             return;
         }
+
+        // Bot turn tracking: prevent runaway bot-to-bot loops
+        let channel_id = &gateway_event.channel.id;
+        {
+            let mut turns = bot_turns.lock().unwrap_or_else(|e| e.into_inner());
+            if gateway_event.sender.is_bot {
+                let count = turns.entry(channel_id.to_string()).or_insert(0);
+                *count += 1;
+                if *count > config.max_bot_turns {
+                    warn!(
+                        channel = %channel_id,
+                        count = *count,
+                        max = config.max_bot_turns,
+                        "feishu: bot turn limit reached, dropping message"
+                    );
+                    return;
+                }
+            } else {
+                // Human message resets bot turn counter
+                turns.remove(channel_id.as_str());
+            }
+        }
+
         // Resolve sender display name (lazy, cached)
         let name = resolve_user_name(
             &gateway_event.sender.id, name_cache, token_cache, client, &config.api_base(),
@@ -828,6 +924,190 @@ async fn resolve_user_name(
 
 // ---------------------------------------------------------------------------
 // Send message
+// ---------------------------------------------------------------------------
+// Markdown → Feishu post conversion
+// ---------------------------------------------------------------------------
+
+/// Convert markdown text to feishu post content JSON.
+/// Supported: code blocks → code_block tag, links → a tag, @mentions preserved.
+/// Unsupported inline formatting (bold, italic, etc.) is stripped to plain text.
+fn markdown_to_post(md: &str) -> serde_json::Value {
+    let mut lines: Vec<Vec<serde_json::Value>> = Vec::new();
+    let mut chars = md.chars().peekable();
+    let mut i = 0;
+    let bytes = md.as_bytes();
+    let len = md.len();
+
+    // We work byte-offset based for code fence detection, line-based otherwise.
+    let raw_lines: Vec<&str> = md.split('\n').collect();
+    let mut li = 0;
+    while li < raw_lines.len() {
+        let line = raw_lines[li];
+        // Detect fenced code block
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") {
+            let lang = trimmed[3..].trim().to_string();
+            let mut code = String::new();
+            li += 1;
+            while li < raw_lines.len() {
+                if raw_lines[li].trim_start().starts_with("```") {
+                    break;
+                }
+                if !code.is_empty() {
+                    code.push('\n');
+                }
+                code.push_str(raw_lines[li]);
+                li += 1;
+            }
+            li += 1; // skip closing ```
+            let mut block = serde_json::json!({"tag": "code_block", "text": code});
+            if !lang.is_empty() {
+                block["language"] = serde_json::Value::String(lang);
+            }
+            lines.push(vec![block]);
+            continue;
+        }
+        // Normal line: parse inline elements
+        let elems = parse_inline(line);
+        lines.push(elems);
+        li += 1;
+    }
+
+    serde_json::json!({
+        "zh_cn": {
+            "content": lines
+        }
+    })
+}
+
+/// Parse inline markdown elements in a single line.
+/// Extracts links [text](url) → a tag, strips bold/italic/strikethrough markers.
+fn parse_inline(line: &str) -> Vec<serde_json::Value> {
+    let mut elems = Vec::new();
+    let mut buf = String::new();
+    let chars: Vec<char> = line.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        // Link: [text](url)
+        if chars[i] == '[' {
+            if let Some((text, url, end)) = try_parse_link(&chars, i) {
+                if !buf.is_empty() {
+                    elems.push(serde_json::json!({"tag": "text", "text": buf}));
+                    buf.clear();
+                }
+                elems.push(serde_json::json!({"tag": "a", "text": text, "href": url}));
+                i = end;
+                continue;
+            }
+        }
+        // Strip ** (bold), * (italic), ~~ (strikethrough), ` (inline code)
+        if chars[i] == '*' || chars[i] == '~' || chars[i] == '`' {
+            let ch = chars[i];
+            let mut run = 0;
+            while i + run < len && chars[i + run] == ch {
+                run += 1;
+            }
+            // For inline code `, keep the content as-is but strip the backticks
+            i += run;
+            continue;
+        }
+        buf.push(chars[i]);
+        i += 1;
+    }
+    if !buf.is_empty() {
+        elems.push(serde_json::json!({"tag": "text", "text": buf}));
+    }
+    if elems.is_empty() {
+        elems.push(serde_json::json!({"tag": "text", "text": ""}));
+    }
+    elems
+}
+
+/// Try to parse a markdown link starting at position `start` (which is '[').
+/// Returns (text, url, next_index) on success.
+fn try_parse_link(chars: &[char], start: usize) -> Option<(String, String, usize)> {
+    let len = chars.len();
+    // Find closing ]
+    let mut i = start + 1;
+    let mut text = String::new();
+    while i < len && chars[i] != ']' {
+        text.push(chars[i]);
+        i += 1;
+    }
+    if i >= len {
+        return None;
+    }
+    i += 1; // skip ]
+    if i >= len || chars[i] != '(' {
+        return None;
+    }
+    i += 1; // skip (
+    let mut url = String::new();
+    while i < len && chars[i] != ')' {
+        url.push(chars[i]);
+        i += 1;
+    }
+    if i >= len {
+        return None;
+    }
+    i += 1; // skip )
+    Some((text, url, i))
+}
+
+/// Send a post (rich text) message to a feishu chat_id.
+/// Returns the sent message_id on success, None on failure.
+pub async fn send_post_message(
+    client: &reqwest::Client,
+    api_base: &str,
+    token: &str,
+    chat_id: &str,
+    text: &str,
+) -> Option<String> {
+    let url = format!(
+        "{}/open-apis/im/v1/messages?receive_id_type=chat_id",
+        api_base
+    );
+    let post_content = markdown_to_post(text);
+    let content = post_content.to_string();
+    let body = serde_json::json!({
+        "receive_id": chat_id,
+        "msg_type": "post",
+        "content": content,
+    });
+
+    match client
+        .post(&url)
+        .bearer_auth(token)
+        .header("Content-Type", "application/json; charset=utf-8")
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            if resp.status().is_success() {
+                let resp_body: serde_json::Value = resp.json().await.unwrap_or_default();
+                let msg_id = resp_body
+                    .pointer("/data/message_id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                info!(chat_id = %chat_id, message_id = ?msg_id, "feishu post message sent");
+                msg_id
+            } else {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                tracing::error!(status = %status, body = %text, "feishu send post message failed");
+                None
+            }
+        }
+        Err(e) => {
+            tracing::error!(err = %e, "feishu send post message request failed");
+            None
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 
 /// Send a text message to a feishu chat_id.
@@ -1014,13 +1294,14 @@ pub async fn handle_reply(
 
     // Split long messages; store sent message_ids in dedupe to prevent
     // self-echo (Feishu pushes bot's own messages back via WebSocket)
+    // Use post (rich text) format for markdown rendering.
     if text.len() <= limit {
-        if let Some(msg_id) = send_text_message(&adapter.client, &api_base, &token, &reply.channel.id, text).await {
+        if let Some(msg_id) = send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, text).await {
             adapter.dedupe.is_duplicate(&msg_id);
         }
     } else {
         for chunk in split_text(text, limit) {
-            if let Some(msg_id) = send_text_message(&adapter.client, &api_base, &token, &reply.channel.id, chunk).await {
+            if let Some(msg_id) = send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, chunk).await {
                 adapter.dedupe.is_duplicate(&msg_id);
             }
         }
@@ -1340,6 +1621,9 @@ mod tests {
             allowed_groups: vec![],
             allowed_users: vec![],
             require_mention: true,
+            allow_bots: AllowBots::Off,
+            trusted_bot_ids: vec![],
+            max_bot_turns: 20,
             dedupe_ttl_secs: 300,
             message_limit: 4000,
         }

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -1031,14 +1031,50 @@ fn parse_inline(line: &str) -> Vec<serde_json::Value> {
                 continue;
             }
         }
-        // Strip ** (bold), * (italic), ~~ (strikethrough), ` (inline code)
-        if chars[i] == '*' || chars[i] == '~' || chars[i] == '`' {
+        // Inline code: find matching closing backtick(s), preserve content literally
+        if chars[i] == '`' {
+            let mut ticks = 0;
+            while i + ticks < len && chars[i + ticks] == '`' {
+                ticks += 1;
+            }
+            i += ticks;
+            // Find matching closing backtick sequence of same length
+            let mut end = i;
+            'outer: while end < len {
+                if chars[end] == '`' {
+                    let mut close_ticks = 0;
+                    while end + close_ticks < len && chars[end + close_ticks] == '`' {
+                        close_ticks += 1;
+                    }
+                    if close_ticks == ticks {
+                        // Found matching close — content between is literal
+                        for j in i..end {
+                            buf.push(chars[j]);
+                        }
+                        i = end + close_ticks;
+                        break 'outer;
+                    }
+                    end += close_ticks;
+                } else {
+                    end += 1;
+                }
+            }
+            if end >= len {
+                // No matching close — treat backticks as literal
+                for j in i..len {
+                    buf.push(chars[j]);
+                }
+                i = len;
+            }
+            continue;
+        }
+        // Strip ** (bold), * (italic), ~~ (strikethrough) markers
+        if chars[i] == '*' || chars[i] == '~' {
             let ch = chars[i];
             let mut run = 0;
             while i + run < len && chars[i + run] == ch {
                 run += 1;
             }
-            // For inline code `, keep the content as-is but strip the backticks
             i += run;
             continue;
         }

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -163,6 +163,7 @@ pub async fn handle_reply(
                         request_id: req_id,
                         success: true,
                         thread_id: tid,
+                        message_id: None,
                         error: None,
                     }
                 } else {
@@ -176,6 +177,7 @@ pub async fn handle_reply(
                         request_id: req_id,
                         success: false,
                         thread_id: None,
+                        message_id: None,
                         error: Some(err),
                     }
                 }
@@ -185,6 +187,7 @@ pub async fn handle_reply(
                 request_id: req_id,
                 success: false,
                 thread_id: None,
+                message_id: None,
                 error: Some(e.to_string()),
             },
         };

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -157,7 +157,7 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                             }
                             "feishu" => {
                                 if let Some(ref feishu) = state_for_recv.feishu {
-                                    adapters::feishu::handle_reply(&reply, feishu).await;
+                                    adapters::feishu::handle_reply(&reply, feishu, &state_for_recv.event_tx).await;
                                 } else {
                                     warn!("reply for feishu but adapter not configured");
                                 }

--- a/gateway/src/schema.rs
+++ b/gateway/src/schema.rs
@@ -67,6 +67,7 @@ pub struct GatewayResponse {
     pub request_id: String,
     pub success: bool,
     pub thread_id: Option<String>,
+    pub message_id: Option<String>,
     pub error: Option<String>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,6 +202,9 @@ pub struct GatewayConfig {
     pub allowed_channels: Vec<String>,
     #[serde(default)]
     pub allowed_users: Vec<String>,
+    /// Enable streaming (typewriter) mode — requires gateway platform to support message editing.
+    #[serde(default)]
+    pub streaming: bool,
 }
 
 fn default_gateway_platform() -> String {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -93,16 +93,15 @@ struct GatewayResponse {
 // --- GatewayAdapter: ChatAdapter over WebSocket ---
 
 type PendingRequests = Arc<Mutex<HashMap<String, tokio::sync::oneshot::Sender<GatewayResponse>>>>;
+type SharedWsTx = Arc<Mutex<futures_util::stream::SplitSink<
+    tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    Message,
+>>>;
 
 pub struct GatewayAdapter {
-    ws_tx: Mutex<
-        futures_util::stream::SplitSink<
-            tokio_tungstenite::WebSocketStream<
-                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-            >,
-            Message,
-        >,
-    >,
+    ws_tx: SharedWsTx,
     pending: PendingRequests,
     platform_name: &'static str,
     streaming: bool,
@@ -110,23 +109,45 @@ pub struct GatewayAdapter {
 
 impl GatewayAdapter {
     fn new(
-        ws_tx: futures_util::stream::SplitSink<
-            tokio_tungstenite::WebSocketStream<
-                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-            >,
-            Message,
-        >,
+        ws_tx: SharedWsTx,
         pending: PendingRequests,
         platform_name: &'static str,
         streaming: bool,
     ) -> Self {
         Self {
-            ws_tx: Mutex::new(ws_tx),
+            ws_tx,
             pending,
             platform_name,
             streaming,
         }
     }
+}
+
+/// Send a fire-and-forget reply via the shared WebSocket (no request-response).
+/// Used for slash command responses where we don't need message_id back.
+async fn send_fire_and_forget(
+    ws_tx: &SharedWsTx,
+    channel: &ChannelRef,
+    content: &str,
+) -> Result<()> {
+    let reply = GatewayReply {
+        schema: "openab.gateway.reply.v1".into(),
+        reply_to: channel.origin_event_id.clone().unwrap_or_default(),
+        platform: channel.platform.clone(),
+        channel: ReplyChannel {
+            id: channel.channel_id.clone(),
+            thread_id: channel.thread_id.clone(),
+        },
+        content: ReplyContent {
+            content_type: "text".into(),
+            text: content.into(),
+        },
+        command: None,
+        request_id: None,
+    };
+    let json = serde_json::to_string(&reply)?;
+    ws_tx.lock().await.send(Message::Text(json)).await?;
+    Ok(())
 }
 
 #[async_trait]
@@ -381,9 +402,11 @@ pub async fn run_gateway_adapter(
         };
 
         let (ws_tx, mut ws_rx) = ws_stream.split();
+        let ws_tx: SharedWsTx = Arc::new(Mutex::new(ws_tx));
         let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
         let adapter: Arc<dyn ChatAdapter> =
-            Arc::new(GatewayAdapter::new(ws_tx, pending.clone(), platform, streaming));
+            Arc::new(GatewayAdapter::new(ws_tx.clone(), pending.clone(), platform, streaming));
+        let slash_ws_tx = ws_tx.clone(); // for fire-and-forget slash command responses
         let mut tasks: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
 
         loop {
@@ -474,6 +497,8 @@ pub async fn run_gateway_adapter(
 
                                     // Slash command interception for gateway platforms
                                     // (Feishu/LINE/Telegram don't have native slash commands)
+                                    // Use fire-and-forget send — slash command responses don't
+                                    // need message_id for streaming edits.
                                     let trimmed = prompt.trim();
                                     if trimmed == "/reset" {
                                         let thread_key = format!("{}:{}", event.platform, event.channel.thread_id.as_deref().unwrap_or(&event.channel.id));
@@ -481,7 +506,7 @@ pub async fn run_gateway_adapter(
                                             Ok(()) => "🔄 Session reset. Start a new conversation!",
                                             Err(_) => "⚠️ No active session to reset.",
                                         };
-                                        let _ = adapter.send_message(&channel, msg).await;
+                                        let _ = send_fire_and_forget(&slash_ws_tx, &channel, msg).await;
                                         continue;
                                     }
                                     if trimmed == "/cancel" {
@@ -490,7 +515,7 @@ pub async fn run_gateway_adapter(
                                             Ok(()) => "🛑 Cancel signal sent.".to_string(),
                                             Err(e) => format!("⚠️ {e}"),
                                         };
-                                        let _ = adapter.send_message(&channel, &msg).await;
+                                        let _ = send_fire_and_forget(&slash_ws_tx, &channel, &msg).await;
                                         continue;
                                     }
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -105,6 +105,7 @@ pub struct GatewayAdapter {
     >,
     pending: PendingRequests,
     platform_name: &'static str,
+    streaming: bool,
 }
 
 impl GatewayAdapter {
@@ -117,11 +118,13 @@ impl GatewayAdapter {
         >,
         pending: PendingRequests,
         platform_name: &'static str,
+        streaming: bool,
     ) -> Self {
         Self {
             ws_tx: Mutex::new(ws_tx),
             pending,
             platform_name,
+            streaming,
         }
     }
 }
@@ -137,20 +140,9 @@ impl ChatAdapter for GatewayAdapter {
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
-        let needs_msg_id = self.supports_streaming();
-        let req_id = if needs_msg_id {
-            Some(format!("req_{}", uuid::Uuid::new_v4()))
-        } else {
-            None
-        };
-
-        let pending_rx = if let Some(ref id) = req_id {
-            let (tx, rx) = tokio::sync::oneshot::channel();
-            self.pending.lock().await.insert(id.clone(), tx);
-            Some(rx)
-        } else {
-            None
-        };
+        let req_id = format!("req_{}", uuid::Uuid::new_v4());
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.pending.lock().await.insert(req_id.clone(), tx);
 
         let reply = GatewayReply {
             schema: "openab.gateway.reply.v1".into(),
@@ -165,21 +157,20 @@ impl ChatAdapter for GatewayAdapter {
                 text: content.into(),
             },
             command: None,
-            request_id: req_id.clone(),
+            request_id: Some(req_id.clone()),
         };
         let json = serde_json::to_string(&reply)?;
         self.ws_tx.lock().await.send(Message::Text(json)).await?;
 
-        let msg_id = if let (Some(rx), Some(ref id)) = (pending_rx, &req_id) {
-            match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
-                Ok(Ok(resp)) if resp.success => resp.message_id.unwrap_or_else(|| "gw_sent".into()),
-                _ => {
-                    self.pending.lock().await.remove(id);
-                    "gw_sent".into()
-                }
+        // All platforms use request-response with timeout fallback.
+        // Platforms that return message_id enable streaming edit;
+        // others timeout gracefully and fall back to "gw_sent".
+        let msg_id = match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
+            Ok(Ok(resp)) if resp.success => resp.message_id.unwrap_or_else(|| "gw_sent".into()),
+            _ => {
+                self.pending.lock().await.remove(&req_id);
+                "gw_sent".into()
             }
-        } else {
-            "gw_sent".into()
         };
 
         Ok(MessageRef {
@@ -302,16 +293,7 @@ impl ChatAdapter for GatewayAdapter {
     }
 
     fn use_streaming(&self, _other_bot_present: bool) -> bool {
-        self.supports_streaming()
-    }
-}
-
-impl GatewayAdapter {
-    /// Whether this gateway platform supports message editing (for streaming).
-    /// Platforms that support edit get request-response send_message (real message_id)
-    /// and streaming edit loop. Others use fire-and-forget.
-    fn supports_streaming(&self) -> bool {
-        matches!(self.platform_name, "feishu" | "lark")
+        self.streaming
     }
 }
 
@@ -327,6 +309,7 @@ pub struct GatewayParams {
     pub allowed_channels: Vec<String>,
     pub allow_all_users: bool,
     pub allowed_users: Vec<String>,
+    pub streaming: bool,
 }
 
 pub async fn run_gateway_adapter(
@@ -343,6 +326,7 @@ pub async fn run_gateway_adapter(
     let allowed_channels = params.allowed_channels;
     let allow_all_users = params.allow_all_users;
     let allowed_users = params.allowed_users;
+    let streaming = params.streaming;
 
     let connect_url = match &params.token {
         Some(token) => {
@@ -386,7 +370,7 @@ pub async fn run_gateway_adapter(
         let (ws_tx, mut ws_rx) = ws_stream.split();
         let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
         let adapter: Arc<dyn ChatAdapter> =
-            Arc::new(GatewayAdapter::new(ws_tx, pending.clone(), platform));
+            Arc::new(GatewayAdapter::new(ws_tx, pending.clone(), platform, streaming));
         let mut tasks: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
 
         loop {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -86,6 +86,7 @@ struct GatewayResponse {
     request_id: String,
     success: bool,
     thread_id: Option<String>,
+    message_id: Option<String>,
     error: Option<String>,
 }
 
@@ -136,6 +137,21 @@ impl ChatAdapter for GatewayAdapter {
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
+        let needs_msg_id = channel.platform == "feishu";
+        let req_id = if needs_msg_id {
+            Some(format!("req_{}", uuid::Uuid::new_v4()))
+        } else {
+            None
+        };
+
+        let pending_rx = if let Some(ref id) = req_id {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            self.pending.lock().await.insert(id.clone(), tx);
+            Some(rx)
+        } else {
+            None
+        };
+
         let reply = GatewayReply {
             schema: "openab.gateway.reply.v1".into(),
             reply_to: channel.origin_event_id.clone().unwrap_or_default(),
@@ -149,13 +165,26 @@ impl ChatAdapter for GatewayAdapter {
                 text: content.into(),
             },
             command: None,
-            request_id: None,
+            request_id: req_id.clone(),
         };
         let json = serde_json::to_string(&reply)?;
         self.ws_tx.lock().await.send(Message::Text(json)).await?;
+
+        let msg_id = if let (Some(rx), Some(ref id)) = (pending_rx, &req_id) {
+            match tokio::time::timeout(std::time::Duration::from_secs(10), rx).await {
+                Ok(Ok(resp)) if resp.success => resp.message_id.unwrap_or_else(|| "gw_sent".into()),
+                _ => {
+                    self.pending.lock().await.remove(id);
+                    "gw_sent".into()
+                }
+            }
+        } else {
+            "gw_sent".into()
+        };
+
         Ok(MessageRef {
             channel: channel.clone(),
-            message_id: "gw_sent".into(),
+            message_id: msg_id,
         })
     }
 
@@ -251,8 +280,29 @@ impl ChatAdapter for GatewayAdapter {
         Ok(())
     }
 
+    async fn edit_message(&self, msg: &MessageRef, content: &str) -> Result<()> {
+        let reply = GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: msg.message_id.clone(),
+            platform: msg.channel.platform.clone(),
+            channel: ReplyChannel {
+                id: msg.channel.channel_id.clone(),
+                thread_id: msg.channel.thread_id.clone(),
+            },
+            content: ReplyContent {
+                content_type: "text".into(),
+                text: content.into(),
+            },
+            command: Some("edit_message".into()),
+            request_id: None,
+        };
+        let json = serde_json::to_string(&reply)?;
+        self.ws_tx.lock().await.send(Message::Text(json)).await?;
+        Ok(())
+    }
+
     fn use_streaming(&self, _other_bot_present: bool) -> bool {
-        false // send-once for Telegram
+        self.platform_name == "feishu"
     }
 }
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -493,7 +493,7 @@ pub async fn run_gateway_adapter(
                                         } else {
                                             ("agent", "agent")
                                         };
-                                        let arg = trimmed.splitn(2, ' ').nth(1).unwrap_or("").trim();
+                                        let arg = trimmed.split_once(' ').map(|x| x.1.trim()).unwrap_or("");
                                         let thread_key = format!("{}:{}", event.platform, event.channel.thread_id.as_deref().unwrap_or(&event.channel.id));
                                         let options = router.pool().get_config_options(&thread_key).await;
                                         let filtered: Vec<_> = options.iter()

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -171,7 +171,7 @@ impl ChatAdapter for GatewayAdapter {
         self.ws_tx.lock().await.send(Message::Text(json)).await?;
 
         let msg_id = if let (Some(rx), Some(ref id)) = (pending_rx, &req_id) {
-            match tokio::time::timeout(std::time::Duration::from_secs(10), rx).await {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
                 Ok(Ok(resp)) if resp.success => resp.message_id.unwrap_or_else(|| "gw_sent".into()),
                 _ => {
                     self.pending.lock().await.remove(id);
@@ -470,7 +470,7 @@ pub async fn run_gateway_adapter(
                                     // (Feishu/LINE/Telegram don't have native slash commands)
                                     let trimmed = prompt.trim();
                                     if trimmed == "/reset" {
-                                        let thread_key = format!("{}:{}", event.platform, event.channel.id);
+                                        let thread_key = format!("{}:{}", event.platform, event.channel.thread_id.as_deref().unwrap_or(&event.channel.id));
                                         let msg = match router.pool().reset_session(&thread_key).await {
                                             Ok(()) => "🔄 Session reset. Start a new conversation!",
                                             Err(_) => "⚠️ No active session to reset.",
@@ -479,12 +479,65 @@ pub async fn run_gateway_adapter(
                                         continue;
                                     }
                                     if trimmed == "/cancel" {
-                                        let thread_key = format!("{}:{}", event.platform, event.channel.id);
+                                        let thread_key = format!("{}:{}", event.platform, event.channel.thread_id.as_deref().unwrap_or(&event.channel.id));
                                         let msg = match router.pool().cancel_session(&thread_key).await {
-                                            Ok(()) => "🛑 Cancel signal sent.",
-                                            Err(e) => &format!("⚠️ {e}"),
+                                            Ok(()) => "🛑 Cancel signal sent.".to_string(),
+                                            Err(e) => format!("⚠️ {e}"),
                                         };
-                                        let _ = adapter.send_message(&channel, msg).await;
+                                        let _ = adapter.send_message(&channel, &msg).await;
+                                        continue;
+                                    }
+                                    if trimmed.starts_with("/models") || trimmed.starts_with("/agents") {
+                                        let (category, label) = if trimmed.starts_with("/models") {
+                                            ("model", "model")
+                                        } else {
+                                            ("agent", "agent")
+                                        };
+                                        let arg = trimmed.splitn(2, ' ').nth(1).unwrap_or("").trim();
+                                        let thread_key = format!("{}:{}", event.platform, event.channel.thread_id.as_deref().unwrap_or(&event.channel.id));
+                                        let options = router.pool().get_config_options(&thread_key).await;
+                                        let filtered: Vec<_> = options.iter()
+                                            .filter(|o| o.category.as_deref() == Some(category))
+                                            .collect();
+
+                                        let msg = if filtered.is_empty() {
+                                            format!("⚠️ No {label} options available. Start a conversation first.")
+                                        } else if arg.is_empty() {
+                                            // List options
+                                            let mut lines = vec![format!("🔧 Available {label}s:")];
+                                            for opt in &filtered {
+                                                for v in &opt.options {
+                                                    let marker = if v.value == opt.current_value { " ✅" } else { "" };
+                                                    lines.push(format!("  • {}{}", v.name, marker));
+                                                }
+                                            }
+                                            lines.push(format!("\nUsage: /{label}s <name>"));
+                                            lines.join("\n")
+                                        } else {
+                                            // Find matching option (case-insensitive substring)
+                                            let arg_lower = arg.to_lowercase();
+                                            let mut found = None;
+                                            for opt in &filtered {
+                                                for v in &opt.options {
+                                                    if v.value.to_lowercase().contains(&arg_lower)
+                                                        || v.name.to_lowercase().contains(&arg_lower)
+                                                    {
+                                                        found = Some((opt.id.clone(), v.value.clone(), v.name.clone()));
+                                                        break;
+                                                    }
+                                                }
+                                                if found.is_some() { break; }
+                                            }
+                                            if let Some((config_id, value, name)) = found {
+                                                match router.pool().set_config_option(&thread_key, &config_id, &value).await {
+                                                    Ok(_) => format!("✅ Switched to **{}**", name),
+                                                    Err(e) => format!("❌ Failed to switch: {e}"),
+                                                }
+                                            } else {
+                                                format!("⚠️ No {label} matching \"{arg}\". Use /{label}s to see options.")
+                                            }
+                                        };
+                                        let _ = adapter.send_message(&channel, &msg).await;
                                         continue;
                                     }
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -137,7 +137,7 @@ impl ChatAdapter for GatewayAdapter {
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
-        let needs_msg_id = channel.platform == "feishu";
+        let needs_msg_id = self.supports_streaming();
         let req_id = if needs_msg_id {
             Some(format!("req_{}", uuid::Uuid::new_v4()))
         } else {
@@ -302,7 +302,16 @@ impl ChatAdapter for GatewayAdapter {
     }
 
     fn use_streaming(&self, _other_bot_present: bool) -> bool {
-        self.platform_name == "feishu"
+        self.supports_streaming()
+    }
+}
+
+impl GatewayAdapter {
+    /// Whether this gateway platform supports message editing (for streaming).
+    /// Platforms that support edit get request-response send_message (real message_id)
+    /// and streaming edit loop. Others use fire-and-forget.
+    fn supports_streaming(&self) -> bool {
+        matches!(self.platform_name, "feishu" | "lark")
     }
 }
 
@@ -483,59 +492,6 @@ pub async fn run_gateway_adapter(
                                         let msg = match router.pool().cancel_session(&thread_key).await {
                                             Ok(()) => "🛑 Cancel signal sent.".to_string(),
                                             Err(e) => format!("⚠️ {e}"),
-                                        };
-                                        let _ = adapter.send_message(&channel, &msg).await;
-                                        continue;
-                                    }
-                                    if trimmed.starts_with("/models") || trimmed.starts_with("/agents") {
-                                        let (category, label) = if trimmed.starts_with("/models") {
-                                            ("model", "model")
-                                        } else {
-                                            ("agent", "agent")
-                                        };
-                                        let arg = trimmed.split_once(' ').map(|x| x.1.trim()).unwrap_or("");
-                                        let thread_key = format!("{}:{}", event.platform, event.channel.thread_id.as_deref().unwrap_or(&event.channel.id));
-                                        let options = router.pool().get_config_options(&thread_key).await;
-                                        let filtered: Vec<_> = options.iter()
-                                            .filter(|o| o.category.as_deref() == Some(category))
-                                            .collect();
-
-                                        let msg = if filtered.is_empty() {
-                                            format!("⚠️ No {label} options available. Start a conversation first.")
-                                        } else if arg.is_empty() {
-                                            // List options
-                                            let mut lines = vec![format!("🔧 Available {label}s:")];
-                                            for opt in &filtered {
-                                                for v in &opt.options {
-                                                    let marker = if v.value == opt.current_value { " ✅" } else { "" };
-                                                    lines.push(format!("  • {}{}", v.name, marker));
-                                                }
-                                            }
-                                            lines.push(format!("\nUsage: /{label}s <name>"));
-                                            lines.join("\n")
-                                        } else {
-                                            // Find matching option (case-insensitive substring)
-                                            let arg_lower = arg.to_lowercase();
-                                            let mut found = None;
-                                            for opt in &filtered {
-                                                for v in &opt.options {
-                                                    if v.value.to_lowercase().contains(&arg_lower)
-                                                        || v.name.to_lowercase().contains(&arg_lower)
-                                                    {
-                                                        found = Some((opt.id.clone(), v.value.clone(), v.name.clone()));
-                                                        break;
-                                                    }
-                                                }
-                                                if found.is_some() { break; }
-                                            }
-                                            if let Some((config_id, value, name)) = found {
-                                                match router.pool().set_config_option(&thread_key, &config_id, &value).await {
-                                                    Ok(_) => format!("✅ Switched to **{}**", name),
-                                                    Err(e) => format!("❌ Failed to switch: {e}"),
-                                                }
-                                            } else {
-                                                format!("⚠️ No {label} matching \"{arg}\". Use /{label}s to see options.")
-                                            }
                                         };
                                         let _ = adapter.send_message(&channel, &msg).await;
                                         continue;

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -428,8 +428,13 @@ pub async fn run_gateway_adapter(
 
                             match serde_json::from_str::<GatewayEvent>(text_str) {
                                 Ok(event) => {
+                                    // TODO: gateway adapters (feishu) do their own bot filtering
+                                    // via AllowBots + trusted_bot_ids, but Telegram does not.
+                                    // When Feishu lifts the bot-to-bot delivery restriction,
+                                    // this guard needs to become adapter-aware (e.g. a field on
+                                    // GatewayEvent indicating the adapter already filtered bots).
                                     if event.sender.is_bot {
-                                        continue; // skip bot messages
+                                        continue;
                                     }
 
                                     // Channel allowlist gate

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -416,6 +416,28 @@ pub async fn run_gateway_adapter(
                                     let router = router.clone();
                                     let prompt = event.content.text.clone();
 
+                                    // Slash command interception for gateway platforms
+                                    // (Feishu/LINE/Telegram don't have native slash commands)
+                                    let trimmed = prompt.trim();
+                                    if trimmed == "/reset" {
+                                        let thread_key = format!("{}:{}", event.platform, event.channel.id);
+                                        let msg = match router.pool().reset_session(&thread_key).await {
+                                            Ok(()) => "🔄 Session reset. Start a new conversation!",
+                                            Err(_) => "⚠️ No active session to reset.",
+                                        };
+                                        let _ = adapter.send_message(&channel, msg).await;
+                                        continue;
+                                    }
+                                    if trimmed == "/cancel" {
+                                        let thread_key = format!("{}:{}", event.platform, event.channel.id);
+                                        let msg = match router.pool().cancel_session(&thread_key).await {
+                                            Ok(()) => "🛑 Cancel signal sent.",
+                                            Err(e) => &format!("⚠️ {e}"),
+                                        };
+                                        let _ = adapter.send_message(&channel, msg).await;
+                                        continue;
+                                    }
+
                                     tasks.spawn(async move {
                                         // If supergroup with no thread_id, create a forum topic
                                         let thread_channel = if event.channel.channel_type == "supergroup"

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -140,9 +140,19 @@ impl ChatAdapter for GatewayAdapter {
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
-        let req_id = format!("req_{}", uuid::Uuid::new_v4());
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        self.pending.lock().await.insert(req_id.clone(), tx);
+        let req_id = if self.streaming {
+            Some(format!("req_{}", uuid::Uuid::new_v4()))
+        } else {
+            None
+        };
+
+        let pending_rx = if let Some(ref id) = req_id {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            self.pending.lock().await.insert(id.clone(), tx);
+            Some(rx)
+        } else {
+            None
+        };
 
         let reply = GatewayReply {
             schema: "openab.gateway.reply.v1".into(),
@@ -157,20 +167,23 @@ impl ChatAdapter for GatewayAdapter {
                 text: content.into(),
             },
             command: None,
-            request_id: Some(req_id.clone()),
+            request_id: req_id.clone(),
         };
         let json = serde_json::to_string(&reply)?;
         self.ws_tx.lock().await.send(Message::Text(json)).await?;
 
-        // All platforms use request-response with timeout fallback.
-        // Platforms that return message_id enable streaming edit;
-        // others timeout gracefully and fall back to "gw_sent".
-        let msg_id = match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
-            Ok(Ok(resp)) if resp.success => resp.message_id.unwrap_or_else(|| "gw_sent".into()),
-            _ => {
-                self.pending.lock().await.remove(&req_id);
-                "gw_sent".into()
+        // When streaming is enabled, wait for gateway to return real message_id
+        // (needed for edit_message). Otherwise fire-and-forget.
+        let msg_id = if let (Some(rx), Some(ref id)) = (pending_rx, &req_id) {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
+                Ok(Ok(resp)) if resp.success => resp.message_id.unwrap_or_else(|| "gw_sent".into()),
+                _ => {
+                    self.pending.lock().await.remove(id);
+                    "gw_sent".into()
+                }
             }
+        } else {
+            "gw_sent".into()
         };
 
         Ok(MessageRef {

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,7 @@ async fn main() -> anyhow::Result<()> {
             allowed_channels: gw_cfg.allowed_channels,
             allow_all_users: config::resolve_allow_all(gw_cfg.allow_all_users, &gw_cfg.allowed_users),
             allowed_users: gw_cfg.allowed_users,
+            streaming: gw_cfg.streaming,
         };
         Some(tokio::spawn(async move {
             if let Err(e) = gateway::run_gateway_adapter(params, router, shutdown_rx).await {


### PR DESCRIPTION
## Summary

Follow-up to #704. Adds streaming, rich text, slash commands (`/reset`, `/cancel`), and gateway-side bot-to-bot scaffolding for the Feishu/Lark gateway adapter.

```
Agent reply (Markdown)                    Feishu client
  │                                          │
  ▼                                          │
Gateway ──markdown_to_post()──► POST msg ──►│ placeholder "…"
  │                                          │
  ├─ edit_message(partial) ──► PUT msg ────►│ update 1
  ├─ edit_message(partial) ──► PUT msg ────►│ update 2
  ├─ edit_message(final) ────► PUT msg ────►│ final rendered post
```

## Changes

| File | Change | Description |
|------|--------|-------------|
| `gateway/src/adapters/feishu.rs` | MOD | Rich text: `markdown_to_post()` + `send_post_message()`. Streaming: `edit_feishu_message()` via PUT API, `handle_reply` returns `message_id` in response. Bot-to-bot: `AllowBots` enum, `FEISHU_TRUSTED_BOT_IDS`, `FEISHU_MAX_BOT_TURNS`, bot detection, turn tracking |
| `src/gateway.rs` ⚠️ **OAB core** | MOD | Slash commands (`/reset`, `/cancel`) via fire-and-forget. Streaming: `send_message` uses request-response with 5s timeout only when `streaming=true`, `edit_message` override, `use_streaming` reads config. `SharedWsTx` type alias for shared WebSocket writer. `GatewayResponse` adds `message_id` field |
| `src/config.rs` | MOD | `GatewayConfig` adds `streaming: bool` (default false) |
| `src/main.rs` | MOD | Pass `streaming` to `GatewayParams` |
| `gateway/src/main.rs` | MOD | Pass `event_tx` to feishu `handle_reply` |
| `gateway/src/schema.rs` | MOD | `GatewayResponse` adds `message_id: Option<String>` |
| `gateway/src/adapters/telegram.rs` | MOD | Schema compat: `message_id: None` in existing constructions |
| `docs/feishu.md` | MOD | Add streaming, slash commands, rich text, bot-to-bot sections |
| `gateway/README.md` | MOD | Add bot-to-bot env vars |
| `Cargo.lock` | MOD | Dependency lockfile |

> **⚠️ Core change note (`src/gateway.rs`):**
> - `send_message()`: when `streaming=true`, uses request-response with 5s timeout to get `message_id` back for streaming edits. When `streaming=false` (default), remains fire-and-forget. Slash command responses (`/reset`, `/cancel`) always use fire-and-forget via `send_fire_and_forget()` helper, regardless of streaming config.
> - `edit_message()`: new override, sends `command: "edit_message"` via WebSocket.
> - `use_streaming()`: reads `self.streaming` field from config (`gateway.streaming`). No platform name checks in core.
> - `SharedWsTx`: `ws_tx` wrapped in `Arc<Mutex<SplitSink>>` so event loop and adapter can share the WebSocket writer.
> - `GatewayResponse`: adds `message_id: Option<String>`. Backward compatible.

## Features

**1. Streaming (typewriter)**

Agent replies stream incrementally via placeholder → edit loop → final edit. Controlled by `gateway.streaming = true` in config (default false). Core has zero platform-specific logic — streaming capability is declared in config, not inferred from platform name.

**2. Rich text (post) messaging**

Agent replies sent as Feishu `post` format. `markdown_to_post()` converts code blocks → `code_block` tag, links → `a` tag, inline formatting stripped (Feishu post doesn't support inline styles).

**3. Slash commands (`/reset`, `/cancel`)**

Gateway-level interception before `router.handle_message()`. Benefits all gateway platforms. 22 lines, pure additive.

**4. Bot-to-bot scaffolding (gateway-side only)**

`AllowBots` enum (`Off`/`Mentions`/`All`), `FEISHU_TRUSTED_BOT_IDS`, `FEISHU_MAX_BOT_TURNS` with human-reset safety valve. User allowlist checked before bot classification — no bypass possible.

> **Not yet functional.** Two blockers remain:
> 1. **Feishu platform limitation:** bot-sent messages are not delivered to other bots' WebSocket connections.
> 2. **OAB core limitation:** `src/gateway.rs` unconditionally drops `is_bot` events before they reach the router. When blocker 1 is lifted, the core guard must become adapter-aware.

## Testing

| Scenario | Result |
|----------|--------|
| `/reset` with no active session | PASS |
| `/reset` with active session | PASS |
| `/cancel` | PASS |
| Streaming: placeholder → incremental updates → final | PASS |
| Rich text: code blocks, links rendered | PASS |
| Rich text: inline formatting stripped cleanly | PASS |
| Post @mention with open_id | PASS |
| Bot-to-bot: Bot1 sends @Bot2 (rendered) | PASS |
| Bot-to-bot: Bot2 receives Bot1's message | FAIL — Feishu platform limitation |
| Group: no @mention → no reply | PASS |
| No self-echo loop | PASS |
| No restart replay | PASS |
| `cargo test` — 66 passed, 0 failed | PASS |

## Breaking Changes

`GatewayResponse` schema adds optional `message_id` field — backward compatible. `send_message` uses request-response only when `gateway.streaming = true` (to obtain `message_id` for edit). Default (`streaming = false`) remains fire-and-forget with no behavioral change.

## Prior Art & Industry Research

### OpenClaw (Feishu channel)

OpenClaw's Feishu integration is the most mature reference:

- **Rich text / Markdown:** Auto-detects markdown in outbound text and sends as Feishu `post` message. Falls back to plain text if the API rejects the payload. Our `markdown_to_post()` takes a similar approach but converts explicitly to post JSON structure (code_block, a, text tags) rather than relying on Feishu's markdown rendering.
- **Streaming:** Uses interactive cards with real-time updates (`streaming: true`, `blockStreaming: true`, both default true). Our approach uses the simpler `PUT /messages/{id}` edit API on post messages, which avoids the complexity of card templates but doesn't support block-level streaming.
- **Slash commands:** Feishu has no native slash-command menus, so OpenClaw sends `/status`, `/reset`, `/model` as plain text messages — same approach we use for `/reset` and `/cancel`.
- **Bot-to-bot:** Not documented in OpenClaw's Feishu channel docs. No equivalent of `allow_bots` / `trusted_bot_ids` / `max_bot_turns`.
- **Thread sessions:** Uses `thread_id` (`omt_*`) for topic groups and reply root message ID (`om_*`) for normal group replies. This informs our upcoming thread support design.

### Hermes Agent (Feishu adapter)

Hermes Agent's Feishu adapter is comprehensive (531 lines of docs):

- **Rich text / Markdown:** Auto-detects markdown and sends as post with embedded `md` tag. Falls back to plain text on API rejection. Similar to OpenClaw's approach.
- **Streaming:** Not documented for Feishu — Hermes appears to use send-once for Feishu replies (no interactive card or edit-based streaming mentioned).
- **Slash commands:** Not documented for Feishu. Hermes uses `/set-home` and `/card` commands but these appear to be Hermes-specific, not general session control.
- **Bot-to-bot:** `FEISHU_ALLOW_BOTS` with `none`/`mentions`/`all` — directly matches our `AllowBots` enum design. Hermes notes that peer bots don't need to be in `FEISHU_ALLOWED_USERS` (human-only allowlist). Our implementation now checks allowlist before bot classification, achieving the same separation.
- **Deduplication:** Persists seen message IDs to disk with 24h TTL and 2048 entry cap. Our in-memory dedupe with configurable TTL is simpler but doesn't survive restarts (noted as future improvement).
- **Text batching:** Hermes debounces rapid messages (0.6s quiet period, max 8 messages). We don't have this yet — could be a future enhancement.

### Key takeaways

| Feature | OpenClaw | Hermes Agent | OpenAB (this PR) |
|---------|----------|--------------|------------------|
| Rich text | Auto-detect + post | Auto-detect + md tag | Explicit markdown_to_post() |
| Streaming | Interactive cards | Not documented | PUT edit on post messages |
| Slash commands | Plain text | Platform-specific | Plain text (gateway-level) |
| Bot-to-bot | Not documented | allow_bots enum | AllowBots enum + turn tracking |
| Loop prevention | N/A | N/A | max_bot_turns with human reset |
| Dedup persistence | Unknown | Disk-persisted | In-memory (TODO: persist) |

## Discord Discussion URL

https://discord.com/channels/1491295327620169908/1500160821567684660

