### PR TITLE
fix(ci): label new PRs with pending-maintainer even without comments

### DIFF
--- a/.github/workflows/pending-maintainer.yml
+++ b/.github/workflows/pending-maintainer.yml
@@ -94,7 +94,10 @@ jobs:
                 issue_number: prNumber,
                 per_page: 100
               });
-              const humanComments = allComments.filter(c => !c.user.type || c.user.type !== 'Bot');
+              const EXCLUDED_BOTS = ['shaun-agent'];
+              const humanComments = allComments.filter(c =>
+                c.user.type !== 'Bot' && !EXCLUDED_BOTS.includes(c.user.login)
+              );
               // If there are human comments, check who spoke last.
               // Last comment by someone other than author = ball is with contributor, skip.
               // No human comments = new PR awaiting first review, fall through.

--- a/.github/workflows/pending-maintainer.yml
+++ b/.github/workflows/pending-maintainer.yml
@@ -95,12 +95,15 @@ jobs:
                 per_page: 100
               });
               const humanComments = allComments.filter(c => !c.user.type || c.user.type !== 'Bot');
-              if (humanComments.length === 0) continue;
+              // If there are human comments, check who spoke last.
+              // Last comment by someone other than author = ball is with contributor, skip.
+              // No human comments = new PR awaiting first review, fall through.
+              if (humanComments.length > 0) {
+                const lastCommenter = humanComments[humanComments.length - 1].user.login;
+                if (lastCommenter !== pr.user.login) continue;
+              }
 
-              const lastCommenter = humanComments[humanComments.length - 1].user.login;
-              if (lastCommenter !== pr.user.login) continue;
-
-              // All conditions met: not draft, no conflicts, CI green, author replied
+              // All conditions met: not draft, no conflicts, CI green, awaiting maintainer
               if (!labels.includes(MAINTAINER)) {
                 await github.rest.issues.addLabels({
                   ...context.repo,


### PR DESCRIPTION
## Summary

New PRs with no human comments were never labeled `pending-maintainer` because the workflow required the last commenter to be the PR author. Since PR authors don't normally leave a comment after opening a PR, these PRs would sit unlabeled indefinitely.

### Root Cause

```js
// Old logic — skips when no human comments exist
if (humanComments.length === 0) continue;
```

This treats "no comments" as "not ready for maintainer", but the correct interpretation is "new PR awaiting first review".

### Fix

```js
// New logic — only skip when last commenter is NOT the PR author
if (humanComments.length > 0) {
  const lastCommenter = humanComments[humanComments.length - 1].user.login;
  if (lastCommenter !== pr.user.login) continue;
}
```

| Scenario | Before | After |
|----------|--------|-------|
| New PR, no comments | ❌ skipped | ✅ `pending-maintainer` |
| Last comment by author | ✅ `pending-maintainer` | ✅ `pending-maintainer` |
| Last comment by maintainer | ✅ skipped | ✅ skipped |

### Context

Discovered while reviewing PR #696 — it had `pending-screening` but never got `pending-maintainer` because the author never commented.

### Discord Discussion

https://discord.com/channels/1490282656913559673/1500294765164498944