### PR TITLE
fix(discord): backfill sender_context.thread_id on first turn

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -627,6 +627,16 @@ impl EventHandler for Handler {
             cache.contains_key(&msg.channel_id.to_string())
         };
 
+        // Backfill thread_id: when OAB just created a new thread, the sender
+        // was built before the thread existed. Patch it so the agent sees
+        // thread_id on the very first turn.
+        let mut sender = sender;
+        if sender.thread_id.is_none() {
+            if let Some(ref _parent) = thread_channel.parent_id {
+                sender.thread_id = Some(thread_channel.channel_id.clone());
+            }
+        }
+
         let router = self.router.clone();
         tokio::spawn(async move {
             let sender_json = serde_json::to_string(&sender).unwrap();

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -631,10 +631,8 @@ impl EventHandler for Handler {
         // was built before the thread existed. Patch it so the agent sees
         // thread_id on the very first turn.
         let mut sender = sender;
-        if sender.thread_id.is_none() {
-            if let Some(ref _parent) = thread_channel.parent_id {
-                sender.thread_id = Some(thread_channel.channel_id.clone());
-            }
+        if sender.thread_id.is_none() && thread_channel.parent_id.is_some() {
+            sender.thread_id = Some(thread_channel.channel_id.clone());
         }
 
         let router = self.router.clone();


### PR DESCRIPTION
## Context

Fixes a bug where `sender_context.thread_id` is always `None` on the first turn when OAB creates a new thread from a main-channel message. Closes #710

## Summary

`build_sender_context()` runs before `get_or_create_thread()`, so the sender context is built when no thread exists yet. After the thread is created, `thread_id` was never backfilled. This patch adds a 4-line backfill after thread creation so the agent sees `thread_id` from the very first turn.

## Changes

- After `get_or_create_thread()` returns, check if `sender.thread_id` is `None` and `thread_channel.parent_id` is `Some` (indicating OAB just created a new thread). If so, backfill `sender.thread_id` with the new thread's channel ID.

Discord Discussion URL: https://discord.com/channels/1494155456468222022/1500411844907630683