### PR TITLE
docs: add agent-installable tools guide and sidecar extension patterns

### DIFF
--- a/docs/agent-installable-tools.md
+++ b/docs/agent-installable-tools.md
@@ -1,0 +1,149 @@
+# Agent-Installable Tools
+
+> **Audience:** AI agents (not humans). Feed this doc to your coding agent when it needs to install additional tools inside an OpenAB pod.
+
+## Philosophy
+
+OpenAB keeps its Docker image minimal — only the essentials ship in the Dockerfile. Everything else (AWS CLI, GitLab CLI, OpenSSH, language runtimes, etc.) is installed **at runtime by the agent** into `~/bin/`. This means:
+
+- **No Dockerfile changes** — the image stays lean and universal
+- **Persistent across restarts** — `~/bin/` lives on the PVC, so tools survive pod restarts
+- **One prompt to install** — tell your agent _"per docs/agent-installable-tools.md, install X for me"_ and it handles the rest
+- **Any tool, same pattern** — AWS CLI, glab, wrangler, terraform, kubectl — all follow the same flow
+
+## What Ships in the Image
+
+| Tool | Why it's built-in |
+|------|-------------------|
+| `curl`, `unzip` | Bootstrap — needed to download everything else |
+| `gh` (GitHub CLI) | Core workflow — OpenAB repos are on GitHub; agents push reviews and PRs |
+| `ripgrep` | Core workflow — fast code search inside the pod |
+| `procps`, `tini` | Runtime — healthcheck and process management |
+| `kiro-cli` | Core workflow — the coding agent runtime |
+
+Everything else is **agent-installable**.
+
+## Installation Pattern
+
+All tools follow the same steps:
+
+```
+1. Download the prebuilt binary (or .deb / .tar.gz)
+2. Extract to ~/bin/
+3. Verify it works
+```
+
+### Generic Template
+
+```bash
+mkdir -p ~/bin
+# Download
+curl -fsSL -o /tmp/tool.tar.gz "<release-url>"
+# Extract (adapt to archive format)
+tar -xzf /tmp/tool.tar.gz -C /tmp/tool-extract
+cp /tmp/tool-extract/<binary> ~/bin/
+chmod +x ~/bin/<binary>
+# Verify
+export PATH="$HOME/bin:$PATH"
+<binary> --version
+# Clean up
+rm -rf /tmp/tool.tar.gz /tmp/tool-extract
+```
+
+### For `.deb` Packages (no sudo needed)
+
+```bash
+mkdir -p ~/bin /tmp/deb-extract
+curl -fsSL -o /tmp/package.deb "<deb-url>"
+dpkg-deb -x /tmp/package.deb /tmp/deb-extract
+cp /tmp/deb-extract/usr/bin/<binary> ~/bin/
+chmod +x ~/bin/<binary>
+export PATH="$HOME/bin:$PATH"
+<binary> --version
+rm -rf /tmp/package.deb /tmp/deb-extract
+```
+
+## Examples
+
+### OpenSSH Client
+
+See [docs/refarch/remote-ssh-debugging.md](refarch/remote-ssh-debugging.md) for the full guide. Quick version:
+
+```bash
+mkdir -p ~/bin /tmp/ssh-extract
+# Find current .deb URL at: https://packages.debian.org/bookworm/amd64/openssh-client/download
+curl -fsSL -o /tmp/openssh-client.deb "<url from download page>"
+dpkg-deb -x /tmp/openssh-client.deb /tmp/ssh-extract
+cp /tmp/ssh-extract/usr/bin/{ssh,ssh-keygen,scp} ~/bin/
+chmod +x ~/bin/{ssh,ssh-keygen,scp}
+export PATH="$HOME/bin:$PATH"
+ssh -V
+```
+
+### GitLab CLI (glab)
+
+```bash
+mkdir -p ~/bin /tmp/glab-extract
+ARCH=$(uname -m)
+# Map architecture
+if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; elif [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; fi
+# Get latest version
+GLAB_VERSION=$(curl -fsSL https://gitlab.com/api/v4/projects/34675721/releases | grep -o '"tag_name":"v[^"]*"' | head -1 | grep -o '[0-9][0-9.]*')
+curl -fsSL -o /tmp/glab.tar.gz \
+  "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${ARCH}.tar.gz"
+tar -xzf /tmp/glab.tar.gz -C /tmp/glab-extract
+cp /tmp/glab-extract/bin/glab ~/bin/
+chmod +x ~/bin/glab
+export PATH="$HOME/bin:$PATH"
+glab --version
+rm -rf /tmp/glab.tar.gz /tmp/glab-extract
+```
+
+### AWS CLI v2
+
+```bash
+mkdir -p ~/bin /tmp/aws-extract
+ARCH=$(uname -m)
+curl -fsSL -o /tmp/awscli.zip \
+  "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip"
+unzip -q /tmp/awscli.zip -d /tmp/aws-extract
+/tmp/aws-extract/aws/install --install-dir ~/aws-cli --bin-dir ~/bin
+export PATH="$HOME/bin:$PATH"
+aws --version
+rm -rf /tmp/awscli.zip /tmp/aws-extract
+```
+
+## Persistence
+
+`~/bin/` is part of the agent's home directory, which is mounted on a PVC. This means:
+
+- **Pod restart** — tools are still there
+- **Helm upgrade** — tools are still there (PVC is retained)
+- **New version of a tool** — just re-run the install commands to overwrite
+
+The only time tools are lost is if the PVC is deleted.
+
+## Adding a New Tool Doc
+
+If you're contributing a doc for a new tool (e.g., `docs/gitlab.md`, `docs/cloudflare.md`), follow this structure:
+
+1. **Reference this doc** — link back to `docs/agent-installable-tools.md` for the general pattern
+2. **Provide the exact install commands** — copy-paste ready, with architecture detection
+3. **Include a verification step** — `<tool> --version` or equivalent
+4. **Keep it short** — the general pattern is already documented here; your doc only needs the tool-specific bits
+
+## Prompt Pattern
+
+Users should be able to install any documented tool with a single prompt:
+
+```
+per docs/agent-installable-tools.md from OpenAB repo, install <tool> for me
+```
+
+Or for a specific tool doc:
+
+```
+per docs/gitlab.md from OpenAB repo, install GitLab CLI for me
+```
+
+The agent reads the doc, follows the steps, and the tool is ready to use.

--- a/docs/agent-installable-tools.md
+++ b/docs/agent-installable-tools.md
@@ -140,3 +140,7 @@ If you're contributing a doc for a new tool (e.g., `docs/gitlab.md`, `docs/cloud
 1. **Keep it short** — provide the install commands with architecture detection and a verification step
 2. **Reference this doc** — link back here for the general pattern and philosophy
 3. **Test the prompt** — verify that asking your agent _"per docs/your-tool.md from OpenAB repo, install X for me"_ actually works end-to-end
+
+## Advanced: Sidecars and Init Containers
+
+For use cases that go beyond installing CLI tools — such as running a network tunnel, a database sidecar, or pre-installing a deterministic toolset via init containers — see [docs/sidecar.md](sidecar.md).

--- a/docs/agent-installable-tools.md
+++ b/docs/agent-installable-tools.md
@@ -63,11 +63,26 @@ export PATH="$HOME/bin:$PATH"
 rm -rf /tmp/package.deb /tmp/deb-extract
 ```
 
-## Examples
+## Common Tools
+
+| Tool | Type | Install |
+|------|------|---------|
+| **OpenSSH** (`ssh`, `scp`, `ssh-keygen`) | `.deb` extract | See [remote-ssh-debugging.md](refarch/remote-ssh-debugging.md) |
+| **AWS CLI v2** (`aws`) | Installer | [Install steps](#aws-cli-v2) |
+| **GitLab CLI** (`glab`) | `.tar.gz` | [Install steps](#gitlab-cli-glab) |
+| **Cloudflare Wrangler** (`wrangler`) | `npm` | [Install steps](#cloudflare-wrangler) |
+| **Terraform** (`terraform`) | `.zip` | [Install steps](#terraform) |
+| **kubectl** | Binary | [Install steps](#kubectl) |
+
+> All examples below auto-detect architecture (ARM64 / AMD64).
+
+## Install Steps
 
 ### OpenSSH Client
 
-See [docs/refarch/remote-ssh-debugging.md](refarch/remote-ssh-debugging.md) for the full guide. Quick version:
+Full guide with SSH key setup and remote host config: [docs/refarch/remote-ssh-debugging.md](refarch/remote-ssh-debugging.md)
+
+Quick install:
 
 ```bash
 mkdir -p ~/bin /tmp/ssh-extract
@@ -78,25 +93,7 @@ cp /tmp/ssh-extract/usr/bin/{ssh,ssh-keygen,scp} ~/bin/
 chmod +x ~/bin/{ssh,ssh-keygen,scp}
 export PATH="$HOME/bin:$PATH"
 ssh -V
-```
-
-### GitLab CLI (glab)
-
-```bash
-mkdir -p ~/bin /tmp/glab-extract
-ARCH=$(uname -m)
-# Map architecture
-if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; elif [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; fi
-# Get latest version
-GLAB_VERSION=$(curl -fsSL https://gitlab.com/api/v4/projects/34675721/releases | grep -o '"tag_name":"v[^"]*"' | head -1 | grep -o '[0-9][0-9.]*')
-curl -fsSL -o /tmp/glab.tar.gz \
-  "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${ARCH}.tar.gz"
-tar -xzf /tmp/glab.tar.gz -C /tmp/glab-extract
-cp /tmp/glab-extract/bin/glab ~/bin/
-chmod +x ~/bin/glab
-export PATH="$HOME/bin:$PATH"
-glab --version
-rm -rf /tmp/glab.tar.gz /tmp/glab-extract
+rm -rf /tmp/openssh-client.deb /tmp/ssh-extract
 ```
 
 ### AWS CLI v2
@@ -111,6 +108,65 @@ unzip -q /tmp/awscli.zip -d /tmp/aws-extract
 export PATH="$HOME/bin:$PATH"
 aws --version
 rm -rf /tmp/awscli.zip /tmp/aws-extract
+```
+
+### GitLab CLI (glab)
+
+```bash
+mkdir -p ~/bin /tmp/glab-extract
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; elif [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; fi
+GLAB_VERSION=$(curl -fsSL https://gitlab.com/api/v4/projects/34675721/releases | grep -o '"tag_name":"v[^"]*"' | head -1 | grep -o '[0-9][0-9.]*')
+curl -fsSL -o /tmp/glab.tar.gz \
+  "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${ARCH}.tar.gz"
+tar -xzf /tmp/glab.tar.gz -C /tmp/glab-extract
+cp /tmp/glab-extract/bin/glab ~/bin/
+chmod +x ~/bin/glab
+export PATH="$HOME/bin:$PATH"
+glab --version
+rm -rf /tmp/glab.tar.gz /tmp/glab-extract
+```
+
+### Cloudflare Wrangler
+
+```bash
+mkdir -p ~/bin
+npm install -g wrangler --prefix ~/npm-global
+ln -sf ~/npm-global/bin/wrangler ~/bin/wrangler
+export PATH="$HOME/bin:$PATH"
+wrangler --version
+```
+
+> Requires Node.js. If Node.js is not available, install it first with the [generic template](#generic-template) using the [official prebuilt binaries](https://nodejs.org/en/download).
+
+### Terraform
+
+```bash
+mkdir -p ~/bin
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; elif [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; fi
+TF_VERSION=$(curl -fsSL https://checkpoint-api.hashicorp.com/v1/check/terraform | grep -o '"current_version":"[^"]*"' | grep -o '[0-9][0-9.]*')
+curl -fsSL -o /tmp/terraform.zip \
+  "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${ARCH}.zip"
+unzip -o /tmp/terraform.zip -d ~/bin
+chmod +x ~/bin/terraform
+export PATH="$HOME/bin:$PATH"
+terraform --version
+rm -f /tmp/terraform.zip
+```
+
+### kubectl
+
+```bash
+mkdir -p ~/bin
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; elif [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; fi
+KUBECTL_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
+curl -fsSL -o ~/bin/kubectl \
+  "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+chmod +x ~/bin/kubectl
+export PATH="$HOME/bin:$PATH"
+kubectl version --client
 ```
 
 ## Persistence

--- a/docs/agent-installable-tools.md
+++ b/docs/agent-installable-tools.md
@@ -123,7 +123,7 @@ Everything under `~/` is mounted on a PVC — see the migration diagram above. K
 
 ```
 ~/bin/           → all installed tool binaries
-~/aws-cli/       → AWS CLI installation
+~/.aws/          → AWS CLI config and credentials
 ~/npm-global/    → npm-installed tools (wrangler, etc.)
 ~/.ssh/          → SSH keys and config
 ~/.config/       → tool configs (glab, wrangler, etc.)

--- a/docs/agent-installable-tools.md
+++ b/docs/agent-installable-tools.md
@@ -128,6 +128,7 @@ Everything under `~/` is mounted on a PVC — see the migration diagram above. K
 ~/.ssh/          → SSH keys and config
 ~/.config/       → tool configs (glab, wrangler, etc.)
 ~/.kiro/         → agent steering docs and memory
+~/.openab/       → OpenAB runtime data (cronjobs, etc.)
 ```
 
 The only time tools are lost is if the PVC itself is deleted.

--- a/docs/agent-installable-tools.md
+++ b/docs/agent-installable-tools.md
@@ -10,6 +10,47 @@ per docs/* from OpenAB GitHub repo, how to install <TOOL_NAME> for my OAB agent
 
 Your agent will query the relevant docs under `docs/`, find the recommended approach, and guide you through the entire installation — or just do it for you. That's it. One prompt, done.
 
+## How It Works
+
+```
+  Human                        Agent                         OpenAB Pod
+  ┌─────────────────┐         ┌──────────────────┐          ┌──────────────────────────┐
+  │                  │         │                  │          │  Container (read-only)   │
+  │ "install glab   │────────►│ reads docs/*     │          │  ┌────────────────────┐  │
+  │  for my OAB     │         │ from OpenAB repo │          │  │ curl, gh, rg, tini │  │
+  │  agent"         │         │                  │          │  │ (built-in, minimal)│  │
+  │                  │         │ finds install    │          │  └────────────────────┘  │
+  │                  │         │ steps for glab   │          │                          │
+  │                  │         │                  │          │  PVC (persistent ~/):    │
+  │                  │         │ executes:        │          │  ┌────────────────────┐  │
+  │                  │         │  curl ─► extract │─────────►│  │ ~/bin/             │  │
+  │                  │         │  ─► ~/bin/glab   │          │  │  ├── glab    ✅ new│  │
+  │                  │         │  ─► verify       │          │  │  ├── aws          │  │
+  │                  │         │                  │          │  │  ├── ssh          │  │
+  │  "done! glab    │◄────────│ "glab v1.46      │          │  │  ├── terraform    │  │
+  │   ready to use" │         │  installed ✅"    │          │  │  └── kubectl      │  │
+  │                  │         │                  │          │  │                    │  │
+  └─────────────────┘         └──────────────────┘          │  │ ~/.ssh/  ~/.config/│  │
+                                                            │  │ ~/.kiro/ ~/aws-cli/│  │
+                                                            │  └────────────────────┘  │
+                                                            └──────────────────────────┘
+
+  ┌─────────────────────────────────────────────────────────────────────────────┐
+  │  Migration: move PVC to new node / cluster / cloud                         │
+  │                                                                            │
+  │  Old Cluster              PVC                    New Cluster               │
+  │  ┌──────────┐     ┌────────────────┐     ┌──────────────┐                 │
+  │  │ Pod ──────┼────►│ ~/bin/         │────►│ New Pod      │                 │
+  │  │ (delete)  │     │ ~/.ssh/        │     │ (attach PVC) │                 │
+  │  └──────────┘     │ ~/.config/     │     │              │                 │
+  │                    │ ~/.kiro/       │     │ Everything   │                 │
+  │                    │ ~/aws-cli/     │     │ just works™  │                 │
+  │                    └────────────────┘     └──────────────┘                 │
+  │                                                                            │
+  │  Zero reinstallation. All tools, configs, keys, and agent memory persist. │
+  └─────────────────────────────────────────────────────────────────────────────┘
+```
+
 ## Why This Pattern
 
 OpenAB keeps its Docker image minimal — only the essentials ship in the Dockerfile. Everything else is installed **at runtime by the agent** into the home directory (`~/bin/`). This is a deliberate design choice:
@@ -184,7 +225,7 @@ kubectl version --client
 
 ## Persistence & Portability
 
-Everything under `~/` is mounted on a PVC. When you migrate your OpenAB deployment — move the PVC to a new node, a new cluster, or even a new cloud provider — your agent's entire environment comes along:
+Everything under `~/` is mounted on a PVC — see the migration diagram above. Key directories that persist:
 
 ```
 ~/bin/           → all installed tool binaries
@@ -194,8 +235,6 @@ Everything under `~/` is mounted on a PVC. When you migrate your OpenAB deployme
 ~/.config/       → tool configs (glab, wrangler, etc.)
 ~/.kiro/         → agent steering docs and memory
 ```
-
-No reinstallation needed. Attach the PVC, start the pod, and everything works.
 
 The only time tools are lost is if the PVC itself is deleted.
 

--- a/docs/agent-installable-tools.md
+++ b/docs/agent-installable-tools.md
@@ -77,34 +77,36 @@ OpenAB keeps its Docker image minimal — only the essentials ship in the Docker
 
 Everything else is **agent-installable**.
 
-## Installation Pattern
+## Common Tools
 
-All tools follow the same steps:
+The following tools are commonly installed by agents. This doc does **not** hardcode install commands — they change over time. Instead, the agent should look up the **official upstream install instructions** and adapt them to the [constraints](#constraints-for-agents) below.
 
-```
-1. Download the prebuilt binary (or .deb / .tar.gz)
-2. Extract to ~/bin/
-3. Verify it works
-```
+| Tool | Upstream Install Docs |
+|------|----------------------|
+| **OpenSSH** (`ssh`, `scp`, `ssh-keygen`) | [packages.debian.org/bookworm/openssh-client](https://packages.debian.org/bookworm/amd64/openssh-client/download) — use `.deb` extract pattern. Also see [remote-ssh-debugging.md](refarch/remote-ssh-debugging.md) for SSH key setup. |
+| **AWS CLI v2** (`aws`) | [docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html) |
+| **GitLab CLI** (`glab`) | [gitlab.com/gitlab-org/cli/-/releases](https://gitlab.com/gitlab-org/cli/-/releases) |
+| **Cloudflare Wrangler** (`wrangler`) | [developers.cloudflare.com/workers/wrangler/install-and-update](https://developers.cloudflare.com/workers/wrangler/install-and-update/) |
+| **Terraform** (`terraform`) | [developer.hashicorp.com/terraform/install](https://developer.hashicorp.com/terraform/install) |
+| **kubectl** | [kubernetes.io/docs/tasks/tools/install-kubectl-linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/) |
 
-### Generic Template
+> This is not an exhaustive list. Any tool with a prebuilt Linux binary can be installed using this pattern.
 
-```bash
-mkdir -p ~/bin
-# Download
-curl -fsSL -o /tmp/tool.tar.gz "<release-url>"
-# Extract (adapt to archive format)
-tar -xzf /tmp/tool.tar.gz -C /tmp/tool-extract
-cp /tmp/tool-extract/<binary> ~/bin/
-chmod +x ~/bin/<binary>
-# Verify
-export PATH="$HOME/bin:$PATH"
-<binary> --version
-# Clean up
-rm -rf /tmp/tool.tar.gz /tmp/tool-extract
-```
+## Constraints for Agents
 
-### For `.deb` Packages (no sudo needed)
+When installing any tool, the agent **must** follow these rules:
+
+1. **No `sudo`** — the container has no root access and a read-only root filesystem
+2. **Install to `~/bin/`** (binaries) or `~/` (larger installs like `~/aws-cli/`) — never write to `/usr/`, `/opt/`, or other system paths
+3. **Detect architecture** — the pod may be ARM64 (`aarch64`) or AMD64 (`x86_64`). Always check `uname -m` and download the correct binary.
+4. **Use `/tmp/` for scratch** — download and extract in `/tmp/`, copy the final binary to `~/bin/`, then clean up `/tmp/`
+5. **Verify after install** — run `<tool> --version` or equivalent to confirm it works
+6. **`export PATH="$HOME/bin:$PATH"`** — ensure `~/bin/` is in PATH before verification
+7. **Look up the latest version from upstream** — do not hardcode version numbers; always fetch the latest stable release
+
+### `.deb` Package Pattern (for tools without standalone binaries)
+
+Some tools (like OpenSSH) are only distributed as `.deb` packages. Extract without `sudo`:
 
 ```bash
 mkdir -p ~/bin /tmp/deb-extract
@@ -112,115 +114,7 @@ curl -fsSL -o /tmp/package.deb "<deb-url>"
 dpkg-deb -x /tmp/package.deb /tmp/deb-extract
 cp /tmp/deb-extract/usr/bin/<binary> ~/bin/
 chmod +x ~/bin/<binary>
-export PATH="$HOME/bin:$PATH"
-<binary> --version
 rm -rf /tmp/package.deb /tmp/deb-extract
-```
-
-## Common Tools
-
-| Tool | Type | Install |
-|------|------|---------|
-| **OpenSSH** (`ssh`, `scp`, `ssh-keygen`) | `.deb` extract | See [remote-ssh-debugging.md](refarch/remote-ssh-debugging.md) |
-| **AWS CLI v2** (`aws`) | Installer | [Install steps](#aws-cli-v2) |
-| **GitLab CLI** (`glab`) | `.tar.gz` | [Install steps](#gitlab-cli-glab) |
-| **Cloudflare Wrangler** (`wrangler`) | `npm` | [Install steps](#cloudflare-wrangler) |
-| **Terraform** (`terraform`) | `.zip` | [Install steps](#terraform) |
-| **kubectl** | Binary | [Install steps](#kubectl) |
-
-> All examples below auto-detect architecture (ARM64 / AMD64).
-
-## Install Steps
-
-### OpenSSH Client
-
-Full guide with SSH key setup and remote host config: [docs/refarch/remote-ssh-debugging.md](refarch/remote-ssh-debugging.md)
-
-Quick install:
-
-```bash
-mkdir -p ~/bin /tmp/ssh-extract
-# Find current .deb URL at: https://packages.debian.org/bookworm/amd64/openssh-client/download
-curl -fsSL -o /tmp/openssh-client.deb "<url from download page>"
-dpkg-deb -x /tmp/openssh-client.deb /tmp/ssh-extract
-cp /tmp/ssh-extract/usr/bin/{ssh,ssh-keygen,scp} ~/bin/
-chmod +x ~/bin/{ssh,ssh-keygen,scp}
-export PATH="$HOME/bin:$PATH"
-ssh -V
-rm -rf /tmp/openssh-client.deb /tmp/ssh-extract
-```
-
-### AWS CLI v2
-
-```bash
-mkdir -p ~/bin /tmp/aws-extract
-ARCH=$(uname -m)
-curl -fsSL -o /tmp/awscli.zip \
-  "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip"
-unzip -q /tmp/awscli.zip -d /tmp/aws-extract
-/tmp/aws-extract/aws/install --install-dir ~/aws-cli --bin-dir ~/bin
-export PATH="$HOME/bin:$PATH"
-aws --version
-rm -rf /tmp/awscli.zip /tmp/aws-extract
-```
-
-### GitLab CLI (glab)
-
-```bash
-mkdir -p ~/bin /tmp/glab-extract
-ARCH=$(uname -m)
-if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; elif [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; fi
-GLAB_VERSION=$(curl -fsSL https://gitlab.com/api/v4/projects/34675721/releases | grep -o '"tag_name":"v[^"]*"' | head -1 | grep -o '[0-9][0-9.]*')
-curl -fsSL -o /tmp/glab.tar.gz \
-  "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${ARCH}.tar.gz"
-tar -xzf /tmp/glab.tar.gz -C /tmp/glab-extract
-cp /tmp/glab-extract/bin/glab ~/bin/
-chmod +x ~/bin/glab
-export PATH="$HOME/bin:$PATH"
-glab --version
-rm -rf /tmp/glab.tar.gz /tmp/glab-extract
-```
-
-### Cloudflare Wrangler
-
-```bash
-mkdir -p ~/bin
-npm install -g wrangler --prefix ~/npm-global
-ln -sf ~/npm-global/bin/wrangler ~/bin/wrangler
-export PATH="$HOME/bin:$PATH"
-wrangler --version
-```
-
-> Requires Node.js. If Node.js is not available, install it first with the [generic template](#generic-template) using the [official prebuilt binaries](https://nodejs.org/en/download).
-
-### Terraform
-
-```bash
-mkdir -p ~/bin
-ARCH=$(uname -m)
-if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; elif [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; fi
-TF_VERSION=$(curl -fsSL https://checkpoint-api.hashicorp.com/v1/check/terraform | grep -o '"current_version":"[^"]*"' | grep -o '[0-9][0-9.]*')
-curl -fsSL -o /tmp/terraform.zip \
-  "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${ARCH}.zip"
-unzip -o /tmp/terraform.zip -d ~/bin
-chmod +x ~/bin/terraform
-export PATH="$HOME/bin:$PATH"
-terraform --version
-rm -f /tmp/terraform.zip
-```
-
-### kubectl
-
-```bash
-mkdir -p ~/bin
-ARCH=$(uname -m)
-if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; elif [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; fi
-KUBECTL_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
-curl -fsSL -o ~/bin/kubectl \
-  "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
-chmod +x ~/bin/kubectl
-export PATH="$HOME/bin:$PATH"
-kubectl version --client
 ```
 
 ## Persistence & Portability

--- a/docs/agent-installable-tools.md
+++ b/docs/agent-installable-tools.md
@@ -1,15 +1,28 @@
 # Agent-Installable Tools
 
-> **Audience:** AI agents (not humans). Feed this doc to your coding agent when it needs to install additional tools inside an OpenAB pod.
+## How to Install Extra Tools
 
-## Philosophy
+You don't need to read this doc yourself. Just ask your agent:
 
-OpenAB keeps its Docker image minimal — only the essentials ship in the Dockerfile. Everything else (AWS CLI, GitLab CLI, OpenSSH, language runtimes, etc.) is installed **at runtime by the agent** into `~/bin/`. This means:
+```
+per docs/* from OpenAB GitHub repo, how to install <TOOL_NAME> for my OAB agent
+```
 
-- **No Dockerfile changes** — the image stays lean and universal
-- **Persistent across restarts** — `~/bin/` lives on the PVC, so tools survive pod restarts
-- **One prompt to install** — tell your agent _"per docs/agent-installable-tools.md, install X for me"_ and it handles the rest
-- **Any tool, same pattern** — AWS CLI, glab, wrangler, terraform, kubectl — all follow the same flow
+Your agent will query the relevant docs under `docs/`, find the recommended approach, and guide you through the entire installation — or just do it for you. That's it. One prompt, done.
+
+## Why This Pattern
+
+OpenAB keeps its Docker image minimal — only the essentials ship in the Dockerfile. Everything else is installed **at runtime by the agent** into the home directory (`~/bin/`). This is a deliberate design choice:
+
+- **Lean image, infinite extensibility** — the Dockerfile never grows. Need AWS CLI today, Terraform tomorrow, glab next week? Same image, same pattern. No rebuild, no redeploy.
+- **Doc-driven, AI-first** — documentation is written for agents to consume. Humans just say what they need; the agent reads the docs and executes.
+- **No gatekeeping** — adding a new tool doesn't require a PR to the Dockerfile, a new Docker build, or a Helm upgrade. Any agent can install any tool at any time.
+- **Full persistence on PVC** — everything installed to `~/bin/` and `~/` lives on the Persistent Volume Claim. This means:
+  - **Pod restart** — tools are still there
+  - **Helm upgrade** — tools are still there
+  - **Migrate the PVC to a new node / new cluster** — tools, configs, credentials, SSH keys — everything moves with it. Your agent's entire environment is portable.
+  - **Upgrade a tool** — just re-run the install. The old binary is overwritten in place.
+- **No Dockerfile sprawl** — if we baked GitLab CLI into the image, we'd have no reason to reject AWS CLI, gcloud, azure CLI, wrangler, kubectl, terraform... The image would bloat endlessly. This pattern keeps the core small and lets each deployment customize itself.
 
 ## What Ships in the Image
 
@@ -169,37 +182,27 @@ export PATH="$HOME/bin:$PATH"
 kubectl version --client
 ```
 
-## Persistence
+## Persistence & Portability
 
-`~/bin/` is part of the agent's home directory, which is mounted on a PVC. This means:
+Everything under `~/` is mounted on a PVC. When you migrate your OpenAB deployment — move the PVC to a new node, a new cluster, or even a new cloud provider — your agent's entire environment comes along:
 
-- **Pod restart** — tools are still there
-- **Helm upgrade** — tools are still there (PVC is retained)
-- **New version of a tool** — just re-run the install commands to overwrite
+```
+~/bin/           → all installed tool binaries
+~/aws-cli/       → AWS CLI installation
+~/npm-global/    → npm-installed tools (wrangler, etc.)
+~/.ssh/          → SSH keys and config
+~/.config/       → tool configs (glab, wrangler, etc.)
+~/.kiro/         → agent steering docs and memory
+```
 
-The only time tools are lost is if the PVC is deleted.
+No reinstallation needed. Attach the PVC, start the pod, and everything works.
+
+The only time tools are lost is if the PVC itself is deleted.
 
 ## Adding a New Tool Doc
 
-If you're contributing a doc for a new tool (e.g., `docs/gitlab.md`, `docs/cloudflare.md`), follow this structure:
+If you're contributing a doc for a new tool (e.g., `docs/gitlab.md`, `docs/cloudflare.md`):
 
-1. **Reference this doc** — link back to `docs/agent-installable-tools.md` for the general pattern
-2. **Provide the exact install commands** — copy-paste ready, with architecture detection
-3. **Include a verification step** — `<tool> --version` or equivalent
-4. **Keep it short** — the general pattern is already documented here; your doc only needs the tool-specific bits
-
-## Prompt Pattern
-
-Users should be able to install any documented tool with a single prompt:
-
-```
-per docs/agent-installable-tools.md from OpenAB repo, install <tool> for me
-```
-
-Or for a specific tool doc:
-
-```
-per docs/gitlab.md from OpenAB repo, install GitLab CLI for me
-```
-
-The agent reads the doc, follows the steps, and the tool is ready to use.
+1. **Keep it short** — provide the install commands with architecture detection and a verification step
+2. **Reference this doc** — link back here for the general pattern and philosophy
+3. **Test the prompt** — verify that asking your agent _"per docs/your-tool.md from OpenAB repo, install X for me"_ actually works end-to-end

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -1,0 +1,139 @@
+# Extending OpenAB with Sidecars and Init Containers
+
+## Overview
+
+OpenAB's Helm chart supports **init containers** and **sidecar containers** via `extraInitContainers`, `extraContainers`, `extraVolumes`, and `extraVolumeMounts`. This is an advanced pattern for cases where the [agent-installable tools](agent-installable-tools.md) approach isn't sufficient.
+
+```
+  ┌─────────────────────────────────────────────────────────┐
+  │  Pod                                                    │
+  │                                                         │
+  │  ┌─────────────────┐    ┌─────────────────────────────┐│
+  │  │  Init Container  │───►│  Main Container (openab)    ││
+  │  │                  │    │                              ││
+  │  │  Runs BEFORE the │    │  Agent runtime + tools from ││
+  │  │  main container. │    │  ~/bin/ (PVC)               ││
+  │  │  Pre-install     │    │                              ││
+  │  │  tools, seed     │    └─────────────────────────────┘│
+  │  │  configs, etc.   │                                   │
+  │  └─────────────────┘    ┌─────────────────────────────┐│
+  │                          │  Sidecar Container          ││
+  │                          │                              ││
+  │                          │  Runs ALONGSIDE the main    ││
+  │                          │  container. Proxies, tunnels,││
+  │                          │  log shippers, daemons, etc. ││
+  │                          └─────────────────────────────┘│
+  │                                                         │
+  │  Shared: volumes, network (localhost), PVC              │
+  └─────────────────────────────────────────────────────────┘
+```
+
+## When to Use What
+
+| Approach | Use When |
+|----------|----------|
+| **Agent-installable tools** ([docs](agent-installable-tools.md)) | Installing CLI tools, binaries, libraries. One prompt, agent handles it. **Start here.** |
+| **Init container** | You need tools pre-installed before the agent starts, or you want a deterministic setup that doesn't depend on agent behavior. |
+| **Sidecar container** | You need a long-running process alongside the agent — a proxy, tunnel, database, daemon, or service that the agent connects to via localhost. |
+
+## Init Containers
+
+Init containers run **before** the main OpenAB container starts. They share volumes with the main container, so they can pre-install tools to `~/bin/` on the PVC.
+
+### Example: Pre-install a tool
+
+```yaml
+agents:
+  kiro:
+    extraVolumeMounts:
+      - name: agent-home
+        mountPath: /home/agent
+    extraInitContainers:
+      - name: install-mytool
+        image: curlimages/curl:latest
+        command:
+          - sh
+          - -c
+          - |
+            mkdir -p /home/agent/bin
+            curl -fsSL -o /home/agent/bin/mytool "https://example.com/mytool-linux-$(uname -m)"
+            chmod +x /home/agent/bin/mytool
+        volumeMounts:
+          - name: agent-home
+            mountPath: /home/agent
+```
+
+> The init container writes to the same PVC that the main container uses. When the agent starts, `~/bin/mytool` is already there.
+
+### When init containers make sense
+
+- **Deterministic setup** — the tool is always there, regardless of agent behavior
+- **Heavy downloads** — large tools (hundreds of MB) that you don't want the agent to re-download on every fresh session
+- **Team standardization** — ensure every agent pod starts with the same toolset
+
+## Sidecar Containers
+
+Sidecar containers run **alongside** the main container for the lifetime of the pod. They share the pod's network (localhost) and can share volumes.
+
+### Example: Cloudflare Tunnel
+
+```yaml
+agents:
+  kiro:
+    extraContainers:
+      - name: cloudflared
+        image: cloudflare/cloudflared:latest
+        args:
+          - tunnel
+          - --no-autoupdate
+          - run
+          - --token
+          - "$(CLOUDFLARE_TUNNEL_TOKEN)"
+        env:
+          - name: CLOUDFLARE_TUNNEL_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: cloudflare-secret
+                key: tunnel-token
+```
+
+### When sidecars make sense
+
+- **Network proxies / tunnels** — Cloudflare Tunnel, ngrok, Tailscale
+- **Databases** — local Redis, SQLite server, or other data stores the agent needs
+- **Log shippers** — Fluent Bit, Vector, or other observability agents
+- **Auth proxies** — OAuth2 proxy, IAM auth sidecar
+
+## Helm Values Reference
+
+All fields are under `agents.<name>`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `extraInitContainers` | list | Init containers — run before the main container |
+| `extraContainers` | list | Sidecar containers — run alongside the main container |
+| `extraVolumes` | list | Additional volumes for the pod |
+| `extraVolumeMounts` | list | Additional volume mounts for the main container |
+
+These accept standard Kubernetes container and volume specs. See the [Kubernetes docs](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) for the full spec.
+
+## Combining Both Patterns
+
+The agent-installable tools pattern and sidecars are complementary:
+
+```
+  ┌──────────────────────────────────────────────────────────────┐
+  │                                                              │
+  │  Agent-Installable Tools          Sidecars / Init Containers │
+  │  ─────────────────────            ──────────────────────────│
+  │  • CLI tools (aws, glab, ssh)     • Long-running daemons    │
+  │  • One prompt to install          • Network tunnels/proxies │
+  │  • Agent-driven, on-demand        • Pre-installed toolsets  │
+  │  • No Helm/YAML changes           • Requires values.yaml   │
+  │  • Persists on PVC                • Recreated each pod start│
+  │                                                              │
+  │  Start here ──────────────────►  Use when needed            │
+  └──────────────────────────────────────────────────────────────┘
+```
+
+Most users will never need sidecars. Start with the [agent-installable tools](agent-installable-tools.md) pattern — it covers the vast majority of use cases with zero YAML.

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -1,8 +1,10 @@
 # Extending OpenAB with Sidecars and Init Containers
 
+> This is an **advanced** pattern. For most tool installations, start with [agent-installable tools](agent-installable-tools.md) — one prompt, zero YAML.
+
 ## Overview
 
-OpenAB's Helm chart supports **init containers** and **sidecar containers** via `extraInitContainers`, `extraContainers`, `extraVolumes`, and `extraVolumeMounts`. This is an advanced pattern for cases where the [agent-installable tools](agent-installable-tools.md) approach isn't sufficient.
+OpenAB's Helm chart supports **init containers** and **sidecar containers** for cases where the agent-installable tools pattern isn't sufficient — when you need a long-running process, a deterministic pre-installed toolset, or a service running alongside the agent.
 
 ```
   ┌─────────────────────────────────────────────────────────┐
@@ -28,54 +30,24 @@ OpenAB's Helm chart supports **init containers** and **sidecar containers** via 
   └─────────────────────────────────────────────────────────┘
 ```
 
-## When to Use What
+## Common Scenarios
 
-| Approach | Use When |
-|----------|----------|
-| **Agent-installable tools** ([docs](agent-installable-tools.md)) | Installing CLI tools, binaries, libraries. One prompt, agent handles it. **Start here.** |
-| **Init container** | You need tools pre-installed before the agent starts, or you want a deterministic setup that doesn't depend on agent behavior. |
-| **Sidecar container** | You need a long-running process alongside the agent — a proxy, tunnel, database, daemon, or service that the agent connects to via localhost. |
+| # | Scenario | Type | Why a sidecar / init container? |
+|---|----------|------|---------------------------------|
+| 1 | [Expose agent via Cloudflare Tunnel](#1-cloudflare-tunnel) | Sidecar | Long-running tunnel process that must stay alive alongside the agent |
+| 2 | [Expose agent via ngrok / Tailscale](#2-ngrok--tailscale) | Sidecar | Same as above — persistent network tunnel |
+| 3 | [Pre-install a standard toolset](#3-pre-install-a-standard-toolset) | Init | Deterministic setup — tools are guaranteed before the agent starts |
+| 4 | [Local database or cache](#4-local-database-or-cache) | Sidecar | Agent needs a data store accessible via localhost |
+| 5 | [Log shipping and observability](#5-log-shipping-and-observability) | Sidecar | Continuous log/metric forwarding independent of the agent |
+| 6 | [GPU / ML model serving](#6-gpu--ml-model-serving) | Sidecar | Serve a model via HTTP on localhost; agent calls it as needed |
 
-## Init Containers
+---
 
-Init containers run **before** the main OpenAB container starts. They share volumes with the main container, so they can pre-install tools to `~/bin/` on the PVC.
+## 1. Cloudflare Tunnel
 
-### Example: Pre-install a tool
+**Problem:** You want to expose your agent's webhook or API to the internet without a public IP or LoadBalancer.
 
-```yaml
-agents:
-  kiro:
-    extraVolumeMounts:
-      - name: agent-home
-        mountPath: /home/agent
-    extraInitContainers:
-      - name: install-mytool
-        image: curlimages/curl:latest
-        command:
-          - sh
-          - -c
-          - |
-            mkdir -p /home/agent/bin
-            curl -fsSL -o /home/agent/bin/mytool "https://example.com/mytool-linux-$(uname -m)"
-            chmod +x /home/agent/bin/mytool
-        volumeMounts:
-          - name: agent-home
-            mountPath: /home/agent
-```
-
-> The init container writes to the same PVC that the main container uses. When the agent starts, `~/bin/mytool` is already there.
-
-### When init containers make sense
-
-- **Deterministic setup** — the tool is always there, regardless of agent behavior
-- **Heavy downloads** — large tools (hundreds of MB) that you don't want the agent to re-download on every fresh session
-- **Team standardization** — ensure every agent pod starts with the same toolset
-
-## Sidecar Containers
-
-Sidecar containers run **alongside** the main container for the lifetime of the pod. They share the pod's network (localhost) and can share volumes.
-
-### Example: Cloudflare Tunnel
+**Solution:** Run `cloudflared` as a sidecar. It creates an outbound tunnel to Cloudflare's edge, making your agent reachable via a Cloudflare domain.
 
 ```yaml
 agents:
@@ -87,22 +59,206 @@ agents:
           - tunnel
           - --no-autoupdate
           - run
-          - --token
-          - "$(CLOUDFLARE_TUNNEL_TOKEN)"
         env:
-          - name: CLOUDFLARE_TUNNEL_TOKEN
+          - name: TUNNEL_TOKEN
             valueFrom:
               secretKeyRef:
                 name: cloudflare-secret
                 key: tunnel-token
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
 ```
 
-### When sidecars make sense
+**How it works:** The tunnel connects outbound to Cloudflare. Incoming requests are routed to `localhost:<port>` inside the pod, where the agent (or gateway) is listening. No ingress, no LoadBalancer, no firewall rules needed.
 
-- **Network proxies / tunnels** — Cloudflare Tunnel, ngrok, Tailscale
-- **Databases** — local Redis, SQLite server, or other data stores the agent needs
-- **Log shippers** — Fluent Bit, Vector, or other observability agents
-- **Auth proxies** — OAuth2 proxy, IAM auth sidecar
+---
+
+## 2. ngrok / Tailscale
+
+**Problem:** Same as Cloudflare Tunnel, but you prefer ngrok or Tailscale for your network layer.
+
+### ngrok
+
+```yaml
+agents:
+  kiro:
+    extraContainers:
+      - name: ngrok
+        image: ngrok/ngrok:latest
+        args:
+          - http
+          - --authtoken=$(NGROK_AUTHTOKEN)
+          - "8080"
+        env:
+          - name: NGROK_AUTHTOKEN
+            valueFrom:
+              secretKeyRef:
+                name: ngrok-secret
+                key: authtoken
+```
+
+### Tailscale
+
+```yaml
+agents:
+  kiro:
+    extraContainers:
+      - name: tailscale
+        image: tailscale/tailscale:latest
+        env:
+          - name: TS_AUTHKEY
+            valueFrom:
+              secretKeyRef:
+                name: tailscale-secret
+                key: authkey
+          - name: TS_USERSPACE
+            value: "true"
+        securityContext:
+          runAsUser: 1000
+```
+
+**When to choose which:**
+- **Cloudflare Tunnel** — free, production-grade, custom domains, access policies
+- **ngrok** — quick dev/testing, instant public URL, built-in inspection UI
+- **Tailscale** — private mesh network, no public exposure, zero-config VPN between your devices and the agent
+
+---
+
+## 3. Pre-install a Standard Toolset
+
+**Problem:** You want every agent pod to start with a specific set of tools already installed, without relying on the agent to install them at runtime.
+
+**Solution:** Use an init container that writes to the agent's PVC before the main container starts.
+
+```yaml
+agents:
+  kiro:
+    extraInitContainers:
+      - name: install-tools
+        image: curlimages/curl:latest
+        command:
+          - sh
+          - -c
+          - |
+            set -e
+            mkdir -p /home/agent/bin
+
+            # Skip if tools already exist (PVC is persistent)
+            if [ -f /home/agent/bin/.tools-installed ]; then
+              echo "Tools already installed, skipping"
+              exit 0
+            fi
+
+            ARCH=$(uname -m)
+            if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; elif [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; fi
+
+            # Install kubectl
+            KUBECTL_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
+            curl -fsSL -o /home/agent/bin/kubectl \
+              "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+            chmod +x /home/agent/bin/kubectl
+
+            # Add more tools here...
+
+            touch /home/agent/bin/.tools-installed
+        volumeMounts:
+          - name: agent-home
+            mountPath: /home/agent
+```
+
+**Key detail:** The init container checks for a marker file (`.tools-installed`) so it doesn't re-download on every pod restart — the PVC already has the tools.
+
+**When to use this over agent-installable tools:**
+- **Team standardization** — every pod gets the same toolset, no variance
+- **Offline / air-gapped** — pre-bake tools from a private registry
+- **Large tools** — avoid the agent spending time downloading hundreds of MB on first run
+
+---
+
+## 4. Local Database or Cache
+
+**Problem:** Your agent needs a database or cache (Redis, SQLite server, DuckDB, etc.) accessible via localhost.
+
+**Solution:** Run it as a sidecar. The agent connects to `localhost:<port>`.
+
+```yaml
+agents:
+  kiro:
+    extraContainers:
+      - name: redis
+        image: redis:7-alpine
+        ports:
+          - containerPort: 6379
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 256Mi
+```
+
+The agent can then use `redis-cli -h localhost` or connect programmatically to `localhost:6379`.
+
+**Use cases:**
+- Caching API responses or embeddings
+- Session storage for multi-turn workflows
+- Temporary data processing (agent writes data, queries it)
+
+---
+
+## 5. Log Shipping and Observability
+
+**Problem:** You want to ship agent logs, metrics, or traces to an external system (Datadog, Grafana, CloudWatch, etc.) without modifying the agent itself.
+
+**Solution:** Run a log shipper as a sidecar that reads from shared volumes or stdout.
+
+```yaml
+agents:
+  kiro:
+    extraContainers:
+      - name: fluent-bit
+        image: fluent/fluent-bit:latest
+        volumeMounts:
+          - name: agent-home
+            mountPath: /home/agent
+            readOnly: true
+        env:
+          - name: OUTPUT_HOST
+            value: "your-log-endpoint.example.com"
+```
+
+**Alternatives:** Fluent Bit, Vector, OpenTelemetry Collector, Datadog Agent.
+
+---
+
+## 6. GPU / ML Model Serving
+
+**Problem:** Your agent needs access to a local ML model (e.g., for embeddings, classification, or code analysis) without calling an external API.
+
+**Solution:** Run a model server as a sidecar. The agent calls it via `localhost`.
+
+```yaml
+agents:
+  kiro:
+    extraContainers:
+      - name: embedding-server
+        image: your-registry/embedding-server:latest
+        ports:
+          - containerPort: 8000
+        resources:
+          limits:
+            nvidia.com/gpu: 1
+```
+
+The agent calls `curl localhost:8000/embed -d '{"text": "..."}'` to get embeddings locally.
+
+> Requires GPU-enabled nodes and the NVIDIA device plugin. This is a niche use case.
+
+---
 
 ## Helm Values Reference
 
@@ -117,9 +273,7 @@ All fields are under `agents.<name>`:
 
 These accept standard Kubernetes container and volume specs. See the [Kubernetes docs](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) for the full spec.
 
-## Combining Both Patterns
-
-The agent-installable tools pattern and sidecars are complementary:
+## When to Use What
 
 ```
   ┌──────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
## Summary

Add two new docs that formalize how to extend OpenAB without modifying the Dockerfile or Helm chart:

- **`docs/agent-installable-tools.md`** — the recommended pattern for installing additional tools (AWS CLI, glab, OpenSSH, wrangler, terraform, kubectl, etc.) at runtime via a single prompt
- **`docs/sidecar.md`** — advanced extension patterns using init containers and sidecar containers

## Motivation

From the discussion on PR #714: contributors were adding tools directly to the Dockerfile. OpenAB follows a **doc-driven, AI-first, lean Dockerfile** philosophy — the image stays minimal, and agents install what they need at runtime into `~/bin/` on the PVC.

These docs formalize that pattern so:
- Contributors know not to modify the Dockerfile for new tools
- Users can install any tool with one prompt: `per docs/* from OpenAB repo, how to install <TOOL> for my OAB agent`
- Advanced users have a clear guide for sidecar/init container extensions

## What's in `docs/agent-installable-tools.md`

- Recommended developer experience (one-prompt install)
- ASCII diagrams: install flow + PVC migration
- Why this pattern (lean image, AI-first, no gatekeeping, PVC portability)
- Common tools table with upstream doc links (not hardcoded install commands)
- Agent constraints (no sudo, `~/bin/`, detect arch, verify, latest version from upstream)
- `.deb` extract pattern for tools without standalone binaries
- PVC persistence & portability (migrate across nodes/clusters/clouds)

## What's in `docs/sidecar.md`

Six common scenarios with deep-dive Helm examples:
1. Cloudflare Tunnel — expose agent without public IP
2. ngrok / Tailscale — alternative tunnel options with comparison
3. Pre-install standard toolset — deterministic init container setup
4. Local database or cache — Redis sidecar via localhost
5. Log shipping and observability — Fluent Bit / Vector
6. GPU / ML model serving — local inference sidecar

## Related

- PR #714 (discussion that motivated this)
- `docs/refarch/remote-ssh-debugging.md` (existing OpenSSH install pattern)