### PR TITLE
docs(codex): clarify image generation uses gpt-image-2

### DIFF
--- a/docs/codex.md
+++ b/docs/codex.md
@@ -61,8 +61,9 @@ kubectl rollout restart deployment/openab-codex
 
 ## Image Generation
 
-Codex image generation is controlled by the Codex CLI feature flag
-`image_generation`. Enable it once inside the pod:
+Codex built-in image generation uses the **`gpt-image-2`** model under the hood.
+It is controlled by the Codex CLI feature flag `image_generation`. Enable it
+once inside the pod:
 
 ```bash
 kubectl exec -it deployment/openab-codex -- \


### PR DESCRIPTION
The Image Generation section in `docs/codex.md` did not mention which model Codex uses under the hood. Per the [official Codex CLI docs](https://developers.openai.com/codex/cli/features), built-in image generation uses `gpt-image-2`.

This PR adds a one-liner at the top of the section to make that explicit.

## Changes
- `docs/codex.md`: Added note that Codex built-in image generation uses the `gpt-image-2` model.