### PR TITLE
feat(gateway): add Google Chat adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,7 +1046,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openab"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![OpenAB banner](images/banner.jpg)
 
-A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark**, and other webhook-based platforms are supported via the standalone [Custom Gateway](gateway/).
+A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](gateway/).
 
 🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://discord.gg/DmbhfDZjQS)** 🎉
 
@@ -23,6 +23,9 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 │   User       │            │  Custom Gateway  │
 ├──────────────┤            │  (standalone)    │
 │  Feishu/Lark │◄───WS──────│                  │
+│   User       │            │                  │
+├──────────────┤            │                  │
+│ Google Chat  │◄──webhook──│                  │
 │   User       │            └──────────────────┘
 └──────────────┘
 ```
@@ -93,6 +96,13 @@ See [docs/line.md](docs/line.md) for the full setup guide. Requires the standalo
 <summary><strong>Feishu/Lark</strong> (via Custom Gateway)</summary>
 
 See [docs/feishu.md](docs/feishu.md) for the full setup guide. Requires the standalone [Custom Gateway](gateway/) service. Supports WebSocket long-connection (default, no public URL needed) and HTTP webhook fallback.
+
+</details>
+
+<details>
+<summary><strong>Google Chat</strong> (via Custom Gateway)</summary>
+
+See [docs/google-chat.md](docs/google-chat.md) for the full setup guide. Requires the standalone [Custom Gateway](gateway/) service.
 
 </details>
 

--- a/charts/openab/templates/gateway-secret.yaml
+++ b/charts/openab/templates/gateway-secret.yaml
@@ -7,7 +7,8 @@
 {{- $hasFeishu := and (($cfg.gateway).feishu).appId (($cfg.gateway).feishu).appSecret }}
 {{- $hasTelegram := (($cfg.gateway).telegram).botToken }}
 {{- $hasLine := (($cfg.gateway).line).channelSecret }}
-{{- if or $hasTeams $hasFeishu $hasTelegram $hasLine }}
+{{- $hasGoogleChat := or (($cfg.gateway).googleChat).saKeyJson (($cfg.gateway).googleChat).accessToken }}
+{{- if or $hasTeams $hasFeishu $hasTelegram $hasLine $hasGoogleChat }}
 ---
 apiVersion: v1
 kind: Secret
@@ -41,6 +42,14 @@ data:
   line-channel-secret: {{ (($cfg.gateway).line).channelSecret | b64enc | quote }}
   {{- if (($cfg.gateway).line).channelAccessToken }}
   line-channel-access-token: {{ (($cfg.gateway).line).channelAccessToken | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if $hasGoogleChat }}
+  {{- if (($cfg.gateway).googleChat).saKeyJson }}
+  google-chat-sa-key-json: {{ ($cfg.gateway).googleChat.saKeyJson | b64enc | quote }}
+  {{- end }}
+  {{- if (($cfg.gateway).googleChat).accessToken }}
+  google-chat-access-token: {{ ($cfg.gateway).googleChat.accessToken | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/openab/templates/gateway.yaml
+++ b/charts/openab/templates/gateway.yaml
@@ -161,6 +161,10 @@ spec:
             {{- if $hasGoogleChat }}
             - name: GOOGLE_CHAT_ENABLED
               value: "true"
+            {{- if (($cfg.gateway).googleChat).audience }}
+            - name: GOOGLE_CHAT_AUDIENCE
+              value: {{ ($cfg.gateway).googleChat.audience | quote }}
+            {{- end }}
             {{- if (($cfg.gateway).googleChat).projectNumber }}
             - name: GOOGLE_CHAT_PROJECT_NUMBER
               value: {{ ($cfg.gateway).googleChat.projectNumber | quote }}

--- a/charts/openab/templates/gateway.yaml
+++ b/charts/openab/templates/gateway.yaml
@@ -157,7 +157,7 @@ spec:
               value: "false"
             {{- end }}
             {{- end }}
-            {{- $hasGoogleChat := or (($cfg.gateway).googleChat).saKeyJson (($cfg.gateway).googleChat).accessToken }}
+            {{- $hasGoogleChat := or (($cfg.gateway).googleChat).saKeyJson (($cfg.gateway).googleChat).accessToken (($cfg.gateway).googleChat).audience }}
             {{- if $hasGoogleChat }}
             - name: GOOGLE_CHAT_ENABLED
               value: "true"

--- a/charts/openab/templates/gateway.yaml
+++ b/charts/openab/templates/gateway.yaml
@@ -157,6 +157,29 @@ spec:
               value: "false"
             {{- end }}
             {{- end }}
+            {{- $hasGoogleChat := or (($cfg.gateway).googleChat).saKeyJson (($cfg.gateway).googleChat).accessToken }}
+            {{- if $hasGoogleChat }}
+            - name: GOOGLE_CHAT_ENABLED
+              value: "true"
+            {{- if (($cfg.gateway).googleChat).saKeyJson }}
+            - name: GOOGLE_CHAT_SA_KEY_JSON
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $d }}
+                  key: google-chat-sa-key-json
+            {{- end }}
+            {{- if (($cfg.gateway).googleChat).accessToken }}
+            - name: GOOGLE_CHAT_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $d }}
+                  key: google-chat-access-token
+            {{- end }}
+            {{- if (($cfg.gateway).googleChat).webhookPath }}
+            - name: GOOGLE_CHAT_WEBHOOK_PATH
+              value: {{ ($cfg.gateway).googleChat.webhookPath | quote }}
+            {{- end }}
+            {{- end }}
             - name: RUST_LOG
               value: {{ ($cfg.gateway).rustLog | default "info" | quote }}
           livenessProbe:

--- a/charts/openab/templates/gateway.yaml
+++ b/charts/openab/templates/gateway.yaml
@@ -161,6 +161,10 @@ spec:
             {{- if $hasGoogleChat }}
             - name: GOOGLE_CHAT_ENABLED
               value: "true"
+            {{- if (($cfg.gateway).googleChat).projectNumber }}
+            - name: GOOGLE_CHAT_PROJECT_NUMBER
+              value: {{ ($cfg.gateway).googleChat.projectNumber | quote }}
+            {{- end }}
             {{- if (($cfg.gateway).googleChat).saKeyJson }}
             - name: GOOGLE_CHAT_SA_KEY_JSON
               valueFrom:

--- a/charts/openab/templates/gateway.yaml
+++ b/charts/openab/templates/gateway.yaml
@@ -165,10 +165,6 @@ spec:
             - name: GOOGLE_CHAT_AUDIENCE
               value: {{ ($cfg.gateway).googleChat.audience | quote }}
             {{- end }}
-            {{- if (($cfg.gateway).googleChat).projectNumber }}
-            - name: GOOGLE_CHAT_PROJECT_NUMBER
-              value: {{ ($cfg.gateway).googleChat.projectNumber | quote }}
-            {{- end }}
             {{- if (($cfg.gateway).googleChat).saKeyJson }}
             - name: GOOGLE_CHAT_SA_KEY_JSON
               valueFrom:

--- a/charts/openab/tests/gateway_test.yaml
+++ b/charts/openab/tests/gateway_test.yaml
@@ -227,6 +227,91 @@ tests:
                 key: line-channel-access-token
         documentIndex: 0
 
+  # --- Google Chat deployment env var rendering ---
+
+  - it: enables Google Chat adapter when only audience is set (receive-only mode)
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.googleChat.audience: "https://example.com/webhook/googlechat"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CHAT_ENABLED
+            value: "true"
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CHAT_AUDIENCE
+            value: "https://example.com/webhook/googlechat"
+        documentIndex: 0
+
+  - it: enables Google Chat adapter when only saKeyJson is set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.googleChat.saKeyJson: '{"client_email":"x","private_key":"y"}'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CHAT_ENABLED
+            value: "true"
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CHAT_SA_KEY_JSON
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-kiro-gateway
+                key: google-chat-sa-key-json
+        documentIndex: 0
+
+  - it: injects GOOGLE_CHAT_ACCESS_TOKEN when accessToken is set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.googleChat.accessToken: "ya29.test"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CHAT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-kiro-gateway
+                key: google-chat-access-token
+        documentIndex: 0
+
+  - it: injects GOOGLE_CHAT_WEBHOOK_PATH when set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.googleChat.audience: "https://example.com/webhook/googlechat"
+      agents.kiro.gateway.googleChat.webhookPath: "/custom/gc"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CHAT_WEBHOOK_PATH
+            value: "/custom/gc"
+        documentIndex: 0
+
+  - it: does not inject Google Chat env vars when no googleChat fields are set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CHAT_ENABLED
+          any: true
+        documentIndex: 0
+
   - it: renders extraContainers as sidecars
     set:
       agents.kiro.gateway.enabled: true
@@ -351,6 +436,39 @@ tests:
       - equal:
           path: data["teams-app-secret"]
           value: "YXBwLXNlY3JldA=="
+
+  - it: renders Google Chat saKeyJson secret
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.googleChat.saKeyJson: '{"client_email":"x"}'
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data["google-chat-sa-key-json"]
+          value: "eyJjbGllbnRfZW1haWwiOiJ4In0="
+
+  - it: renders Google Chat accessToken secret
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.googleChat.accessToken: "ya29.test"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data["google-chat-access-token"]
+          value: "eWEyOS50ZXN0"
+
+  - it: does not render Google Chat secret when only audience is set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.googleChat.audience: "https://example.com/webhook/googlechat"
+    asserts:
+      - hasDocuments:
+          count: 0
 
   - it: does not render when no platform secrets configured
     set:

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -249,7 +249,8 @@ agents:
       # Google Chat adapter config (gateway-side env vars)
       # See docs/google-chat.md for full setup guide
       googleChat:
-        projectNumber: ""      # GCP project number → GOOGLE_CHAT_PROJECT_NUMBER (enables webhook JWT verification)
+        audience: ""           # JWT audience → GOOGLE_CHAT_AUDIENCE (your webhook URL, enables JWT verification)
+        projectNumber: ""      # GCP project number → GOOGLE_CHAT_PROJECT_NUMBER (fallback audience for "Project Number" auth mode)
         saKeyJson: ""          # Service account key JSON string → GOOGLE_CHAT_SA_KEY_JSON (recommended, auto-refresh)
         accessToken: ""        # Static OAuth2 access token → GOOGLE_CHAT_ACCESS_TOKEN (fallback, 1-hour TTL)
         webhookPath: ""        # Gateway default: /webhook/googlechat → GOOGLE_CHAT_WEBHOOK_PATH

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -246,6 +246,12 @@ agents:
         allowedGroups: []      # List of chat_id → FEISHU_ALLOWED_GROUPS
         allowedUsers: []       # List of open_id → FEISHU_ALLOWED_USERS
         requireMention: true   # Require @mention in groups → FEISHU_REQUIRE_MENTION
+      # Google Chat adapter config (gateway-side env vars)
+      # See docs/google-chat.md for full setup guide
+      googleChat:
+        saKeyJson: ""          # Service account key JSON string → GOOGLE_CHAT_SA_KEY_JSON (recommended, auto-refresh)
+        accessToken: ""        # Static OAuth2 access token → GOOGLE_CHAT_ACCESS_TOKEN (fallback, 1-hour TTL)
+        webhookPath: ""        # Gateway default: /webhook/googlechat → GOOGLE_CHAT_WEBHOOK_PATH
     # Scheduled messages — config-driven cron (ADR: basic-cronjob)
     # Each entry sends a message to the agent at the specified schedule.
     # Example:

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -249,6 +249,7 @@ agents:
       # Google Chat adapter config (gateway-side env vars)
       # See docs/google-chat.md for full setup guide
       googleChat:
+        projectNumber: ""      # GCP project number → GOOGLE_CHAT_PROJECT_NUMBER (enables webhook JWT verification)
         saKeyJson: ""          # Service account key JSON string → GOOGLE_CHAT_SA_KEY_JSON (recommended, auto-refresh)
         accessToken: ""        # Static OAuth2 access token → GOOGLE_CHAT_ACCESS_TOKEN (fallback, 1-hour TTL)
         webhookPath: ""        # Gateway default: /webhook/googlechat → GOOGLE_CHAT_WEBHOOK_PATH

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -249,8 +249,7 @@ agents:
       # Google Chat adapter config (gateway-side env vars)
       # See docs/google-chat.md for full setup guide
       googleChat:
-        audience: ""           # JWT audience → GOOGLE_CHAT_AUDIENCE (your webhook URL, enables JWT verification)
-        projectNumber: ""      # GCP project number → GOOGLE_CHAT_PROJECT_NUMBER (fallback audience for "Project Number" auth mode)
+        audience: ""           # JWT audience → GOOGLE_CHAT_AUDIENCE (set to your webhook URL to enable JWT verification)
         saKeyJson: ""          # Service account key JSON string → GOOGLE_CHAT_SA_KEY_JSON (recommended, auto-refresh)
         accessToken: ""        # Static OAuth2 access token → GOOGLE_CHAT_ACCESS_TOKEN (fallback, 1-hour TTL)
         webhookPath: ""        # Gateway default: /webhook/googlechat → GOOGLE_CHAT_WEBHOOK_PATH

--- a/config.toml.example
+++ b/config.toml.example
@@ -35,7 +35,7 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 
 # [gateway]
 # url = "ws://openab-gateway:8080/ws"  # WebSocket URL of the custom gateway
-# platform = "line"                     # "telegram" (default) | "line"
+# platform = "line"                     # "telegram" (default) | "line" | "googlechat"
 # token = "${GATEWAY_TOKEN}"            # shared token for WebSocket auth (optional but recommended)
 # bot_username = "my_bot"               # for @mention gating in groups
 # allow_all_channels = true             # true = allow all channels; false = only allowed_channels

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -65,12 +65,12 @@ Slack adapter using Socket Mode. Requires both a Bot User OAuth Token and an App
 
 ## `[gateway]`
 
-Custom Gateway adapter for platforms like Telegram, LINE, and Feishu/Lark. Connects to the gateway via WebSocket.
+Custom Gateway adapter for platforms like Telegram, LINE, Feishu/Lark, and Google Chat. Connects to the gateway via WebSocket.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `url` | string | *required* | WebSocket URL of the gateway (e.g. `ws://openab-gateway:8080/ws`). |
-| `platform` | string | `"telegram"` | Platform name for session key namespacing (e.g. `"telegram"`, `"line"`, `"feishu"`). |
+| `platform` | string | `"telegram"` | Platform name for session key namespacing (e.g. `"telegram"`, `"line"`, `"feishu"`, `"googlechat"`). |
 | `token` | string | — | Shared token for WebSocket authentication (optional but recommended). |
 | `bot_username` | string | — | Bot username for @mention gating in groups. |
 | `allow_all_channels` | bool \| omit | auto-detect | `true` = all channels; `false` = only `allowed_channels`. Omitted = inferred from list (non-empty → false, empty → true). |

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -128,7 +128,7 @@ working_dir = "/home/agent"
 
 - **DM chat** — send a direct message to the bot, get an AI agent response
 - **Space chat** — add the bot to a Google Chat Space, @mention it to start a conversation
-- **Thread replies** — in Spaces, bot replies are posted in the same thread as the user's message
+- **Thread replies** — in Spaces, bot replies are posted in the same thread as the user's message (note: @mention is required for every message in a Space, even within a thread — this is a Google Chat platform limitation)
 - **`argument_text` extraction** — strips the @mention prefix to get the clean user message
 - **Bot message filtering** — bot messages (`user_type: "BOT"`) are filtered at the gateway level
 - **Message splitting** — long replies (>4096 chars) are automatically split at newline/space boundaries

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -1,0 +1,162 @@
+# Google Chat Setup
+
+Connect a Google Chat app to OpenAB via the Custom Gateway.
+
+```
+Google Chat ──POST──▶ Gateway (:8080) ◀──WebSocket── OAB Pod
+                                          (OAB connects out)
+```
+
+## Prerequisites
+
+- A running OAB instance (with kiro-cli or any ACP agent authenticated)
+- The Custom Gateway deployed ([gateway/README.md](../gateway/README.md))
+- A Google Cloud project with the Google Chat API enabled
+- A Google Cloud Service Account with the Chat Bot scope
+
+## 1. Create a Google Chat App
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/) and create or select a project.
+2. Enable the **Google Chat API** under **APIs & Services → Library**.
+3. Go to **APIs & Services → Google Chat API → Configuration**:
+   - **App name**: your bot name (e.g. "OpenAB")
+   - **Avatar URL**: any public image URL
+   - **Description**: anything
+   - **Interactive features**: Enable
+   - **Connection settings**: select **App URL** and enter your gateway's webhook URL:
+     ```
+     https://your-gateway-host/webhook/googlechat
+     ```
+   - **Visibility**: select the users or domains that can use the bot
+4. Click **Save**.
+
+## 2. Create a Service Account
+
+Google Chat uses a service account to authenticate outbound API calls (bot replies).
+
+1. Go to **IAM & Admin → Service Accounts** → **Create Service Account**.
+2. Name it (e.g. `openab-google-chat`) and grant it no special roles.
+3. After creation, click the service account → **Keys** → **Add Key** → **Create New Key** → JSON.
+4. Save the downloaded JSON file securely.
+
+## 3. Generate an Access Token
+
+The gateway needs an OAuth2 access token to send replies. Generate one from the service account key:
+
+```bash
+# Using Node.js
+node -e "
+const crypto = require('crypto');
+const https = require('https');
+const sa = require('./service-account-key.json');
+const header = Buffer.from(JSON.stringify({alg:'RS256',typ:'JWT'})).toString('base64url');
+const now = Math.floor(Date.now()/1000);
+const claims = Buffer.from(JSON.stringify({
+  iss: sa.client_email,
+  scope: 'https://www.googleapis.com/auth/chat.bot',
+  aud: 'https://oauth2.googleapis.com/token',
+  iat: now, exp: now + 3600
+})).toString('base64url');
+const sig = crypto.sign('sha256', Buffer.from(header+'.'+claims), sa.private_key).toString('base64url');
+const body = 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion='+header+'.'+claims+'.'+sig;
+const req = https.request('https://oauth2.googleapis.com/token', {method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'}}, res => {
+  let d=''; res.on('data',c=>d+=c); res.on('end',()=>console.log(JSON.parse(d).access_token));
+});
+req.write(body); req.end();
+"
+```
+
+> **Note:** Access tokens expire after 1 hour. For production, implement automatic token refresh. Phase 2 of this adapter will add built-in service account JWT token refresh.
+
+## 4. Configure the Gateway
+
+```bash
+# Docker
+docker run -d --name openab-gateway \
+  -e GOOGLE_CHAT_ENABLED=true \
+  -e GOOGLE_CHAT_ACCESS_TOKEN="ya29.c..." \
+  -e GATEWAY_WS_TOKEN="your-ws-auth-token" \
+  -p 8080:8080 \
+  ghcr.io/openabdev/openab-gateway:latest
+
+# Local development
+export GOOGLE_CHAT_ENABLED=true
+export GOOGLE_CHAT_ACCESS_TOKEN="ya29.c..."
+cargo run --release
+```
+
+## 5. Expose the Gateway (for local dev)
+
+Google Chat requires a public HTTPS endpoint for webhooks.
+
+### Cloudflare Tunnel (quickest)
+
+```bash
+cloudflared tunnel --url http://localhost:8080
+# Copy the https://xxx.trycloudflare.com URL
+```
+
+Then update the webhook URL in the Google Chat API Configuration page:
+```
+https://xxx.trycloudflare.com/webhook/googlechat
+```
+
+### Reverse proxy (production)
+
+Use nginx, Caddy, or a cloud load balancer with TLS termination pointing to the gateway's `:8080`.
+
+## 6. Configure OAB
+
+```toml
+[gateway]
+url = "ws://openab-gateway:8080/ws"
+platform = "googlechat"
+allow_all_channels = true
+allow_all_users = true
+
+[agent]
+command = "kiro-cli"
+args = ["acp", "--trust-all-tools"]
+working_dir = "/home/agent"
+```
+
+## Features
+
+### Supported
+
+- **DM chat** — send a direct message to the bot, get an AI agent response
+- **Space chat** — add the bot to a Google Chat Space, @mention it to start a conversation
+- **Thread replies** — in Spaces, bot replies are posted in the same thread as the user's message
+- **`argument_text` extraction** — strips the @mention prefix to get the clean user message
+
+### Not Supported
+
+- **Reactions** — Google Chat API does not support message reactions on behalf of bots
+- **Markdown rendering** — replies are sent as plain text (Google Chat uses its own card markup)
+- **File/image attachments** — not yet implemented
+- **Auto token refresh** — access tokens must be refreshed manually (1-hour TTL); built-in refresh is planned
+
+## Environment Variables (Gateway)
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `GOOGLE_CHAT_ENABLED` | Yes | `false` | Set to `true` or `1` to enable the adapter |
+| `GOOGLE_CHAT_ACCESS_TOKEN` | No | — | OAuth2 access token for Chat API replies |
+| `GOOGLE_CHAT_WEBHOOK_PATH` | No | `/webhook/googlechat` | Webhook endpoint path |
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| Bot doesn't respond | Check `GOOGLE_CHAT_ENABLED=true` is set. Check gateway logs for parse errors. |
+| "not responding" in Google Chat | Ensure the gateway returns a `200` with `{}` body. Check gateway is reachable via the webhook URL. |
+| Replies not sent | Check `GOOGLE_CHAT_ACCESS_TOKEN` is set and not expired (1-hour TTL). Regenerate from service account. |
+| Replies not in thread | Verify the thread name is passed correctly. The gateway appends `?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD` automatically. |
+| Bot responds to its own messages | Bot messages have `user_type: "BOT"` and are filtered out automatically. |
+| Webhook returns 400 | Check the Google Chat API configuration uses **App URL** (not Dialogflow or Cloud Pub/Sub). The webhook expects the v2 envelope format with a `chat` wrapper. |
+
+## References
+
+- [Google Chat API Documentation](https://developers.google.com/workspace/chat/api/reference/rest)
+- [Google Chat App Setup](https://developers.google.com/workspace/chat/overview)
+- [Service Account Authentication](https://developers.google.com/workspace/chat/authenticate-authorize-chat-app)

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -145,10 +145,31 @@ working_dir = "/home/agent"
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `GOOGLE_CHAT_ENABLED` | Yes | `false` | Set to `true` or `1` to enable the adapter |
+| `GOOGLE_CHAT_PROJECT_NUMBER` | Recommended | — | GCP project number — enables JWT verification of inbound webhooks |
 | `GOOGLE_CHAT_SA_KEY_JSON` | No | — | Service account key JSON string (enables auto-refresh) |
 | `GOOGLE_CHAT_SA_KEY_FILE` | No | — | Path to service account key JSON file (alternative to `SA_KEY_JSON`) |
 | `GOOGLE_CHAT_ACCESS_TOKEN` | No | — | Static OAuth2 access token (fallback, expires in 1 hour) |
 | `GOOGLE_CHAT_WEBHOOK_PATH` | No | `/webhook/googlechat` | Webhook endpoint path |
+
+## Security: Webhook Verification
+
+Google Chat signs every webhook request with a JWT Bearer token. The gateway verifies this token to ensure requests actually come from Google.
+
+**Setup:**
+
+1. Find your GCP **Project Number** (not Project ID) in the Google Cloud Console → Dashboard.
+2. In the Google Chat API Configuration, set **Authentication Audience** to **Project Number**.
+3. Set the environment variable:
+   ```bash
+   export GOOGLE_CHAT_PROJECT_NUMBER="123456789012"
+   ```
+
+The gateway will:
+- Reject requests without a valid `Authorization: Bearer <jwt>` header
+- Verify the JWT signature against Google's public keys (JWKS, cached for 1 hour)
+- Validate `iss == chat@system.gserviceaccount.com` and `aud == <your project number>`
+
+If `GOOGLE_CHAT_PROJECT_NUMBER` is not set, the gateway logs a warning and accepts all requests (insecure — for local development only).
 
 ## Troubleshooting
 

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -39,49 +39,51 @@ Google Chat uses a service account to authenticate outbound API calls (bot repli
 3. After creation, click the service account → **Keys** → **Add Key** → **Create New Key** → JSON.
 4. Save the downloaded JSON file securely.
 
-## 3. Generate an Access Token
+## 3. Configure the Gateway
 
-The gateway needs an OAuth2 access token to send replies. Generate one from the service account key:
+The gateway supports two authentication methods for sending replies:
+
+### Option A: Service Account Key (recommended — auto-refresh)
+
+Pass the service account JSON key directly. The gateway handles JWT signing and token refresh automatically.
 
 ```bash
-# Using Node.js
-node -e "
-const crypto = require('crypto');
-const https = require('https');
-const sa = require('./service-account-key.json');
-const header = Buffer.from(JSON.stringify({alg:'RS256',typ:'JWT'})).toString('base64url');
-const now = Math.floor(Date.now()/1000);
-const claims = Buffer.from(JSON.stringify({
-  iss: sa.client_email,
-  scope: 'https://www.googleapis.com/auth/chat.bot',
-  aud: 'https://oauth2.googleapis.com/token',
-  iat: now, exp: now + 3600
-})).toString('base64url');
-const sig = crypto.sign('sha256', Buffer.from(header+'.'+claims), sa.private_key).toString('base64url');
-const body = 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion='+header+'.'+claims+'.'+sig;
-const req = https.request('https://oauth2.googleapis.com/token', {method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'}}, res => {
-  let d=''; res.on('data',c=>d+=c); res.on('end',()=>console.log(JSON.parse(d).access_token));
-});
-req.write(body); req.end();
-"
+# Via JSON string
+docker run -d --name openab-gateway \
+  -e GOOGLE_CHAT_ENABLED=true \
+  -e GOOGLE_CHAT_SA_KEY_JSON='{"type":"service_account","client_email":"...","private_key":"..."}' \
+  -e GATEWAY_WS_TOKEN="your-ws-auth-token" \
+  -p 8080:8080 \
+  ghcr.io/openabdev/openab-gateway:latest
+
+# Via file path
+docker run -d --name openab-gateway \
+  -e GOOGLE_CHAT_ENABLED=true \
+  -e GOOGLE_CHAT_SA_KEY_FILE="/secrets/service-account.json" \
+  -v /path/to/service-account.json:/secrets/service-account.json:ro \
+  -e GATEWAY_WS_TOKEN="your-ws-auth-token" \
+  -p 8080:8080 \
+  ghcr.io/openabdev/openab-gateway:latest
 ```
 
-> **Note:** Access tokens expire after 1 hour. For production, implement automatic token refresh. Phase 2 of this adapter will add built-in service account JWT token refresh.
+### Option B: Static Access Token (for quick testing)
 
-## 4. Configure the Gateway
+Generate a token manually. It expires after 1 hour.
 
 ```bash
-# Docker
 docker run -d --name openab-gateway \
   -e GOOGLE_CHAT_ENABLED=true \
   -e GOOGLE_CHAT_ACCESS_TOKEN="ya29.c..." \
   -e GATEWAY_WS_TOKEN="your-ws-auth-token" \
   -p 8080:8080 \
   ghcr.io/openabdev/openab-gateway:latest
+```
 
-# Local development
+### Local development
+
+```bash
 export GOOGLE_CHAT_ENABLED=true
-export GOOGLE_CHAT_ACCESS_TOKEN="ya29.c..."
+export GOOGLE_CHAT_SA_KEY_FILE="/path/to/service-account.json"
 cargo run --release
 ```
 
@@ -128,20 +130,24 @@ working_dir = "/home/agent"
 - **Space chat** — add the bot to a Google Chat Space, @mention it to start a conversation
 - **Thread replies** — in Spaces, bot replies are posted in the same thread as the user's message
 - **`argument_text` extraction** — strips the @mention prefix to get the clean user message
+- **Bot message filtering** — bot messages (`user_type: "BOT"`) are filtered at the gateway level
+- **Message splitting** — long replies (>4096 chars) are automatically split at newline/space boundaries
+- **Token auto-refresh** — service account JWT tokens are refreshed automatically before expiry
 
 ### Not Supported
 
 - **Reactions** — Google Chat API does not support message reactions on behalf of bots
 - **Markdown rendering** — replies are sent as plain text (Google Chat uses its own card markup)
 - **File/image attachments** — not yet implemented
-- **Auto token refresh** — access tokens must be refreshed manually (1-hour TTL); built-in refresh is planned
 
 ## Environment Variables (Gateway)
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `GOOGLE_CHAT_ENABLED` | Yes | `false` | Set to `true` or `1` to enable the adapter |
-| `GOOGLE_CHAT_ACCESS_TOKEN` | No | — | OAuth2 access token for Chat API replies |
+| `GOOGLE_CHAT_SA_KEY_JSON` | No | — | Service account key JSON string (enables auto-refresh) |
+| `GOOGLE_CHAT_SA_KEY_FILE` | No | — | Path to service account key JSON file (alternative to `SA_KEY_JSON`) |
+| `GOOGLE_CHAT_ACCESS_TOKEN` | No | — | Static OAuth2 access token (fallback, expires in 1 hour) |
 | `GOOGLE_CHAT_WEBHOOK_PATH` | No | `/webhook/googlechat` | Webhook endpoint path |
 
 ## Troubleshooting
@@ -150,7 +156,7 @@ working_dir = "/home/agent"
 |---|---|
 | Bot doesn't respond | Check `GOOGLE_CHAT_ENABLED=true` is set. Check gateway logs for parse errors. |
 | "not responding" in Google Chat | Ensure the gateway returns a `200` with `{}` body. Check gateway is reachable via the webhook URL. |
-| Replies not sent | Check `GOOGLE_CHAT_ACCESS_TOKEN` is set and not expired (1-hour TTL). Regenerate from service account. |
+| Replies not sent | Use `GOOGLE_CHAT_SA_KEY_JSON` or `GOOGLE_CHAT_SA_KEY_FILE` for auto-refresh. If using static token, check it hasn't expired (1-hour TTL). |
 | Replies not in thread | Verify the thread name is passed correctly. The gateway appends `?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD` automatically. |
 | Bot responds to its own messages | Bot messages have `user_type: "BOT"` and are filtered out automatically. |
 | Webhook returns 400 | Check the Google Chat API configuration uses **App URL** (not Dialogflow or Cloud Pub/Sub). The webhook expects the v2 envelope format with a `chat` wrapper. |

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -167,11 +167,11 @@ The gateway will:
 - Reject requests without a valid `Authorization: Bearer <jwt>` header
 - Verify the JWT signature against Google's public keys (JWKS, cached for 1 hour)
 - Validate `iss == https://accounts.google.com` and `aud` matches the configured webhook URL
-- Validate `email == chat@system.gserviceaccount.com` (proves the token came from Google Chat, not another Google service)
+- Validate `email` ends with `@gcp-sa-gsuiteaddons.iam.gserviceaccount.com` (proves the token came from Google Chat, not another Google service)
 
 If `GOOGLE_CHAT_AUDIENCE` is not set, the gateway logs a warning and accepts all requests (insecure — for local development only).
 
-> **Note:** The "Project Number" Authentication Audience mode is not supported. It uses a different JWT issuer (`chat@system.gserviceaccount.com`) and JWKS endpoint that this adapter does not implement. Use the default "HTTP Endpoint URL" mode.
+> **Note:** Only the "HTTP Endpoint URL" Authentication Audience mode is supported. The "Project Number" mode uses a different JWT flow that this adapter does not implement.
 
 ## Troubleshooting
 

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -145,7 +145,8 @@ working_dir = "/home/agent"
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `GOOGLE_CHAT_ENABLED` | Yes | `false` | Set to `true` or `1` to enable the adapter |
-| `GOOGLE_CHAT_PROJECT_NUMBER` | Recommended | — | GCP project number — enables JWT verification of inbound webhooks |
+| `GOOGLE_CHAT_AUDIENCE` | Recommended | — | JWT audience for webhook verification (your webhook URL or GCP project number, depending on Authentication Audience setting) |
+| `GOOGLE_CHAT_PROJECT_NUMBER` | No | — | GCP project number — fallback for `GOOGLE_CHAT_AUDIENCE` when using "Project Number" auth mode |
 | `GOOGLE_CHAT_SA_KEY_JSON` | No | — | Service account key JSON string (enables auto-refresh) |
 | `GOOGLE_CHAT_SA_KEY_FILE` | No | — | Path to service account key JSON file (alternative to `SA_KEY_JSON`) |
 | `GOOGLE_CHAT_ACCESS_TOKEN` | No | — | Static OAuth2 access token (fallback, expires in 1 hour) |
@@ -153,23 +154,29 @@ working_dir = "/home/agent"
 
 ## Security: Webhook Verification
 
-Google Chat signs every webhook request with a JWT Bearer token. The gateway verifies this token to ensure requests actually come from Google.
+Google Chat signs every webhook request with a JWT Bearer token (issued by `https://accounts.google.com`). The gateway verifies this token to ensure requests actually come from Google.
 
 **Setup:**
 
-1. Find your GCP **Project Number** (not Project ID) in the Google Cloud Console → Dashboard.
-2. In the Google Chat API Configuration, set **Authentication Audience** to **Project Number**.
-3. Set the environment variable:
-   ```bash
-   export GOOGLE_CHAT_PROJECT_NUMBER="123456789012"
-   ```
+The JWT `aud` (audience) claim depends on your Google Chat API **Authentication Audience** setting:
+
+- **HTTP Endpoint URL** (default): `aud` = your configured webhook URL → set `GOOGLE_CHAT_AUDIENCE` to the full URL
+- **Project Number**: `aud` = your GCP project number → set `GOOGLE_CHAT_PROJECT_NUMBER`
+
+```bash
+# Option 1: HTTP Endpoint URL mode (default)
+export GOOGLE_CHAT_AUDIENCE="https://your-domain.com/webhook/googlechat"
+
+# Option 2: Project Number mode
+export GOOGLE_CHAT_PROJECT_NUMBER="123456789012"
+```
 
 The gateway will:
 - Reject requests without a valid `Authorization: Bearer <jwt>` header
 - Verify the JWT signature against Google's public keys (JWKS, cached for 1 hour)
-- Validate `iss == chat@system.gserviceaccount.com` and `aud == <your project number>`
+- Validate `iss == https://accounts.google.com` and `aud` matches the configured audience
 
-If `GOOGLE_CHAT_PROJECT_NUMBER` is not set, the gateway logs a warning and accepts all requests (insecure — for local development only).
+If neither `GOOGLE_CHAT_AUDIENCE` nor `GOOGLE_CHAT_PROJECT_NUMBER` is set, the gateway logs a warning and accepts all requests (insecure — for local development only).
 
 ## Troubleshooting
 

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -87,7 +87,7 @@ export GOOGLE_CHAT_SA_KEY_FILE="/path/to/service-account.json"
 cargo run --release
 ```
 
-## 5. Expose the Gateway (for local dev)
+## 4. Expose the Gateway (for local dev)
 
 Google Chat requires a public HTTPS endpoint for webhooks.
 
@@ -107,7 +107,7 @@ https://xxx.trycloudflare.com/webhook/googlechat
 
 Use nginx, Caddy, or a cloud load balancer with TLS termination pointing to the gateway's `:8080`.
 
-## 6. Configure OAB
+## 5. Configure OAB
 
 ```toml
 [gateway]
@@ -145,8 +145,7 @@ working_dir = "/home/agent"
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `GOOGLE_CHAT_ENABLED` | Yes | `false` | Set to `true` or `1` to enable the adapter |
-| `GOOGLE_CHAT_AUDIENCE` | Recommended | — | JWT audience for webhook verification (your webhook URL or GCP project number, depending on Authentication Audience setting) |
-| `GOOGLE_CHAT_PROJECT_NUMBER` | No | — | GCP project number — fallback for `GOOGLE_CHAT_AUDIENCE` when using "Project Number" auth mode |
+| `GOOGLE_CHAT_AUDIENCE` | Recommended | — | JWT audience for webhook verification — set to your full webhook URL (e.g. `https://your-domain.com/webhook/googlechat`) |
 | `GOOGLE_CHAT_SA_KEY_JSON` | No | — | Service account key JSON string (enables auto-refresh) |
 | `GOOGLE_CHAT_SA_KEY_FILE` | No | — | Path to service account key JSON file (alternative to `SA_KEY_JSON`) |
 | `GOOGLE_CHAT_ACCESS_TOKEN` | No | — | Static OAuth2 access token (fallback, expires in 1 hour) |
@@ -154,29 +153,25 @@ working_dir = "/home/agent"
 
 ## Security: Webhook Verification
 
-Google Chat signs every webhook request with a JWT Bearer token (issued by `https://accounts.google.com`). The gateway verifies this token to ensure requests actually come from Google.
+Google Chat signs every webhook request with a JWT Bearer token. The gateway verifies this token to ensure requests come from Google Chat specifically (not just any Google service).
 
 **Setup:**
 
-The JWT `aud` (audience) claim depends on your Google Chat API **Authentication Audience** setting:
-
-- **HTTP Endpoint URL** (default): `aud` = your configured webhook URL → set `GOOGLE_CHAT_AUDIENCE` to the full URL
-- **Project Number**: `aud` = your GCP project number → set `GOOGLE_CHAT_PROJECT_NUMBER`
+In the Google Chat API **Configuration** page, leave **Authentication Audience** at its default — **HTTP Endpoint URL**. Then set `GOOGLE_CHAT_AUDIENCE` to your full webhook URL:
 
 ```bash
-# Option 1: HTTP Endpoint URL mode (default)
 export GOOGLE_CHAT_AUDIENCE="https://your-domain.com/webhook/googlechat"
-
-# Option 2: Project Number mode
-export GOOGLE_CHAT_PROJECT_NUMBER="123456789012"
 ```
 
 The gateway will:
 - Reject requests without a valid `Authorization: Bearer <jwt>` header
 - Verify the JWT signature against Google's public keys (JWKS, cached for 1 hour)
-- Validate `iss == https://accounts.google.com` and `aud` matches the configured audience
+- Validate `iss == https://accounts.google.com` and `aud` matches the configured webhook URL
+- Validate `email == chat@system.gserviceaccount.com` (proves the token came from Google Chat, not another Google service)
 
-If neither `GOOGLE_CHAT_AUDIENCE` nor `GOOGLE_CHAT_PROJECT_NUMBER` is set, the gateway logs a warning and accepts all requests (insecure — for local development only).
+If `GOOGLE_CHAT_AUDIENCE` is not set, the gateway logs a warning and accepts all requests (insecure — for local development only).
+
+> **Note:** The "Project Number" Authentication Audience mode is not supported. It uses a different JWT issuer (`chat@system.gserviceaccount.com`) and JWKS endpoint that this adapter does not implement. Use the default "HTTP Endpoint URL" mode.
 
 ## Troubleshooting
 

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -12,7 +12,7 @@ Google Chat ──POST──▶ Gateway (:8080) ◀──WebSocket── OAB Pod
 - A running OAB instance (with kiro-cli or any ACP agent authenticated)
 - The Custom Gateway deployed ([gateway/README.md](../gateway/README.md))
 - A Google Cloud project with the Google Chat API enabled
-- A Google Cloud Service Account with the Chat Bot scope
+- A Google Cloud Service Account (JSON key recommended; no special IAM roles needed)
 
 ## 1. Create a Google Chat App
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -61,11 +61,8 @@ url = "ws://gateway:8080/ws"
 | `FEISHU_REQUIRE_MENTION` | `true` | Require @mention in groups |
 | `FEISHU_DEDUPE_TTL_SECS` | `300` | Event deduplication cache TTL (seconds) |
 | `FEISHU_MESSAGE_LIMIT` | `4000` | Max message length before auto-splitting (bytes) |
-| `FEISHU_ALLOW_BOTS` | `off` | Bot message handling: `off` / `mentions` / `all` |
-| `FEISHU_TRUSTED_BOT_IDS` | (optional) | Comma-separated open_id list of known bots |
-| `FEISHU_MAX_BOT_TURNS` | `20` | Max consecutive bot replies per channel |
 | `GOOGLE_CHAT_ENABLED` | `false` | Set to `true` or `1` to enable the Google Chat adapter |
-| `GOOGLE_CHAT_AUDIENCE` | (optional) | JWT audience for webhook verification (full webhook URL, e.g. `https://your-domain.com/webhook/googlechat`) |
+| `GOOGLE_CHAT_PROJECT_NUMBER` | (optional) | GCP project number — enables JWT verification of inbound webhooks |
 | `GOOGLE_CHAT_SA_KEY_JSON` | (optional) | Service account key JSON string (enables token auto-refresh) |
 | `GOOGLE_CHAT_SA_KEY_FILE` | (optional) | Path to service account key JSON file (alternative to `SA_KEY_JSON`) |
 | `GOOGLE_CHAT_ACCESS_TOKEN` | (optional) | Static OAuth2 access token (fallback, expires in 1 hour) |

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -62,8 +62,7 @@ url = "ws://gateway:8080/ws"
 | `FEISHU_DEDUPE_TTL_SECS` | `300` | Event deduplication cache TTL (seconds) |
 | `FEISHU_MESSAGE_LIMIT` | `4000` | Max message length before auto-splitting (bytes) |
 | `GOOGLE_CHAT_ENABLED` | `false` | Set to `true` or `1` to enable the Google Chat adapter |
-| `GOOGLE_CHAT_AUDIENCE` | (optional) | JWT audience for webhook verification (webhook URL or project number) |
-| `GOOGLE_CHAT_PROJECT_NUMBER` | (optional) | GCP project number — fallback audience for JWT verification |
+| `GOOGLE_CHAT_AUDIENCE` | (optional) | JWT audience for webhook verification (full webhook URL, e.g. `https://your-domain.com/webhook/googlechat`) |
 | `GOOGLE_CHAT_SA_KEY_JSON` | (optional) | Service account key JSON string (enables token auto-refresh) |
 | `GOOGLE_CHAT_SA_KEY_FILE` | (optional) | Path to service account key JSON file (alternative to `SA_KEY_JSON`) |
 | `GOOGLE_CHAT_ACCESS_TOKEN` | (optional) | Static OAuth2 access token (fallback, expires in 1 hour) |

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -64,6 +64,12 @@ url = "ws://gateway:8080/ws"
 | `FEISHU_ALLOW_BOTS` | `off` | Bot message handling: `off` / `mentions` / `all` |
 | `FEISHU_TRUSTED_BOT_IDS` | (optional) | Comma-separated open_id list of known bots |
 | `FEISHU_MAX_BOT_TURNS` | `20` | Max consecutive bot replies per channel |
+| `GOOGLE_CHAT_ENABLED` | `false` | Set to `true` or `1` to enable the Google Chat adapter |
+| `GOOGLE_CHAT_AUDIENCE` | (optional) | JWT audience for webhook verification (full webhook URL, e.g. `https://your-domain.com/webhook/googlechat`) |
+| `GOOGLE_CHAT_SA_KEY_JSON` | (optional) | Service account key JSON string (enables token auto-refresh) |
+| `GOOGLE_CHAT_SA_KEY_FILE` | (optional) | Path to service account key JSON file (alternative to `SA_KEY_JSON`) |
+| `GOOGLE_CHAT_ACCESS_TOKEN` | (optional) | Static OAuth2 access token (fallback, expires in 1 hour) |
+| `GOOGLE_CHAT_WEBHOOK_PATH` | `/webhook/googlechat` | Webhook endpoint path |
 
 ### Endpoints
 
@@ -72,6 +78,7 @@ url = "ws://gateway:8080/ws"
 | `POST /webhook/telegram` | Telegram webhook receiver |
 | `POST /webhook/line` | LINE webhook receiver |
 | `POST /webhook/feishu` | Feishu webhook receiver (when `FEISHU_CONNECTION_MODE=webhook`) |
+| `POST /webhook/googlechat` | Google Chat webhook receiver |
 | `GET /ws` | WebSocket server (OAB connects here) |
 | `GET /health` | Health check |
 
@@ -101,16 +108,19 @@ url = "ws://gateway:8080/ws"
 
 5. For supergroup forum topics (thread isolation like Discord), give the bot **Manage Topics** permission in the group settings.
 
-### LINE (TBD)
+### LINE
 
-LINE adapter is planned. It will follow the same pattern:
-- Webhook at `/webhook/line`
-- Signature validation via `X-Line-Signature` header
-- Reply via LINE Push Message API
+See [docs/line.md](../docs/line.md) for the full setup guide.
 
-See [ADR: LINE Adapter](../docs/adr/line-adapter.md) for the design.
+### Feishu/Lark
 
-### Other Platforms (TBD)
+See [docs/feishu.md](../docs/feishu.md) for the full setup guide.
+
+### Google Chat
+
+See [docs/google-chat.md](../docs/google-chat.md) for the full setup guide.
+
+### Other Platforms
 
 GitHub webhooks, CI/CD events, monitoring alerts — any HTTP event source can be added as a gateway adapter. See the ADR for the adapter interface.
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -62,7 +62,8 @@ url = "ws://gateway:8080/ws"
 | `FEISHU_DEDUPE_TTL_SECS` | `300` | Event deduplication cache TTL (seconds) |
 | `FEISHU_MESSAGE_LIMIT` | `4000` | Max message length before auto-splitting (bytes) |
 | `GOOGLE_CHAT_ENABLED` | `false` | Set to `true` or `1` to enable the Google Chat adapter |
-| `GOOGLE_CHAT_PROJECT_NUMBER` | (optional) | GCP project number — enables JWT verification of inbound webhooks |
+| `GOOGLE_CHAT_AUDIENCE` | (optional) | JWT audience for webhook verification (webhook URL or project number) |
+| `GOOGLE_CHAT_PROJECT_NUMBER` | (optional) | GCP project number — fallback audience for JWT verification |
 | `GOOGLE_CHAT_SA_KEY_JSON` | (optional) | Service account key JSON string (enables token auto-refresh) |
 | `GOOGLE_CHAT_SA_KEY_FILE` | (optional) | Path to service account key JSON file (alternative to `SA_KEY_JSON`) |
 | `GOOGLE_CHAT_ACCESS_TOKEN` | (optional) | Static OAuth2 access token (fallback, expires in 1 hour) |

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -1,28 +1,37 @@
 use crate::schema::*;
 use axum::extract::State;
-use axum::Json;
 use serde::Deserialize;
 use std::sync::Arc;
 use tracing::{error, info};
 
 pub const GOOGLE_CHAT_API_BASE: &str = "https://chat.googleapis.com/v1";
 
-// --- Google Chat types ---
+// --- Google Chat types (v2 envelope format) ---
 
 #[derive(Debug, Deserialize)]
-pub struct GoogleChatEvent {
-    #[serde(rename = "type")]
-    pub event_type: String,
-    pub message: Option<GoogleChatMessage>,
+pub struct GoogleChatEnvelope {
+    pub chat: Option<ChatPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatPayload {
     pub user: Option<GoogleChatUser>,
+    pub message_payload: Option<MessagePayload>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessagePayload {
+    pub message: Option<GoogleChatMessage>,
     pub space: Option<GoogleChatSpace>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GoogleChatMessage {
     pub name: String,
     pub text: Option<String>,
-    #[serde(rename = "argumentText")]
     pub argument_text: Option<String>,
     pub sender: Option<GoogleChatUser>,
     pub thread: Option<GoogleChatThread>,
@@ -30,9 +39,9 @@ pub struct GoogleChatMessage {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GoogleChatUser {
     pub name: String,
-    #[serde(rename = "displayName")]
     pub display_name: String,
     #[serde(rename = "type")]
     pub user_type: String,
@@ -44,23 +53,38 @@ pub struct GoogleChatThread {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GoogleChatSpace {
     pub name: String,
     #[serde(rename = "type")]
     pub space_type: Option<String>,
+    pub space_type_renamed: Option<String>,
 }
 
 // --- Webhook handler ---
 
 pub async fn webhook(
     State(state): State<Arc<crate::AppState>>,
-    Json(event): Json<GoogleChatEvent>,
+    body: axum::body::Bytes,
 ) -> axum::http::StatusCode {
-    if event.event_type != "MESSAGE" {
-        return axum::http::StatusCode::OK;
-    }
+    info!("googlechat webhook received ({} bytes)", body.len());
 
-    let Some(ref msg) = event.message else {
+    let envelope: GoogleChatEnvelope = match serde_json::from_slice(&body) {
+        Ok(e) => e,
+        Err(e) => {
+            let body_str = String::from_utf8_lossy(&body);
+            error!(body = %body_str, "googlechat webhook parse error: {e}");
+            return axum::http::StatusCode::BAD_REQUEST;
+        }
+    };
+
+    let Some(chat) = envelope.chat else {
+        return axum::http::StatusCode::OK;
+    };
+    let Some(payload) = chat.message_payload else {
+        return axum::http::StatusCode::OK;
+    };
+    let Some(ref msg) = payload.message else {
         return axum::http::StatusCode::OK;
     };
 
@@ -73,8 +97,8 @@ pub async fn webhook(
         return axum::http::StatusCode::OK;
     }
 
-    let sender = msg.sender.as_ref().or(event.user.as_ref());
-    let space = msg.space.as_ref().or(event.space.as_ref());
+    let sender = msg.sender.as_ref().or(chat.user.as_ref());
+    let space = msg.space.as_ref().or(payload.space.as_ref());
 
     let sender_id = sender.map(|s| s.name.clone()).unwrap_or_default();
     let display_name = sender

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -1,11 +1,13 @@
 use crate::schema::*;
 use axum::extract::State;
+use axum::http::HeaderMap;
 use axum::response::IntoResponse;
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::Deserialize;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::RwLock;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 pub const GOOGLE_CHAT_API_BASE: &str = "https://chat.googleapis.com/v1";
 const GOOGLE_CHAT_MESSAGE_LIMIT: usize = 4096;
@@ -65,13 +67,132 @@ pub struct GoogleChatSpace {
     pub space_type_renamed: Option<String>,
 }
 
+// --- Webhook JWT verification ---
+
+const GOOGLE_CHAT_ISSUER: &str = "chat@system.gserviceaccount.com";
+const GOOGLE_CHAT_JWKS_URL: &str =
+    "https://www.googleapis.com/service_accounts/v1/jwk/chat@system.gserviceaccount.com";
+const JWKS_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(3600);
+
+#[derive(Debug, Clone, Deserialize)]
+struct JwkKey {
+    kid: Option<String>,
+    n: String,
+    e: String,
+    kty: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct JwksResponse {
+    keys: Vec<JwkKey>,
+}
+
+pub struct GoogleChatJwtVerifier {
+    audience: String,
+    client: reqwest::Client,
+    jwks_cache: RwLock<Option<(Vec<JwkKey>, Instant)>>,
+}
+
+impl GoogleChatJwtVerifier {
+    pub fn new(audience: String) -> Self {
+        Self {
+            audience,
+            client: reqwest::Client::new(),
+            jwks_cache: RwLock::new(None),
+        }
+    }
+
+    async fn get_jwks(&self) -> Result<Vec<JwkKey>, String> {
+        {
+            let cache = self.jwks_cache.read().await;
+            if let Some((ref keys, fetched_at)) = *cache {
+                if fetched_at.elapsed() < JWKS_CACHE_TTL {
+                    return Ok(keys.clone());
+                }
+            }
+        }
+        let jwks: JwksResponse = self
+            .client
+            .get(GOOGLE_CHAT_JWKS_URL)
+            .send()
+            .await
+            .map_err(|e| format!("JWKS fetch error: {e}"))?
+            .json()
+            .await
+            .map_err(|e| format!("JWKS parse error: {e}"))?;
+
+        let keys = jwks.keys;
+        *self.jwks_cache.write().await = Some((keys.clone(), Instant::now()));
+        Ok(keys)
+    }
+
+    pub async fn verify(&self, auth_header: &str) -> Result<(), String> {
+        let token = auth_header
+            .strip_prefix("Bearer ")
+            .ok_or("missing Bearer prefix")?;
+
+        let header =
+            jsonwebtoken::decode_header(token).map_err(|e| format!("invalid JWT header: {e}"))?;
+        let kid = header.kid.ok_or("no kid in JWT header")?;
+
+        let keys = self.get_jwks().await?;
+        let key = match keys.iter().find(|k| k.kid.as_deref() == Some(&kid)) {
+            Some(k) => k.clone(),
+            None => {
+                // Key rotation: invalidate cache and retry
+                *self.jwks_cache.write().await = None;
+                let refreshed = self.get_jwks().await?;
+                refreshed
+                    .into_iter()
+                    .find(|k| k.kid.as_deref() == Some(&kid))
+                    .ok_or_else(|| format!("no matching JWK for kid={kid}"))?
+            }
+        };
+
+        if key.kty != "RSA" {
+            return Err(format!("unsupported key type: {}", key.kty));
+        }
+
+        let decoding_key = DecodingKey::from_rsa_components(&key.n, &key.e)
+            .map_err(|e| format!("RSA key decode error: {e}"))?;
+
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_audience(&[&self.audience]);
+        validation.set_issuer(&[GOOGLE_CHAT_ISSUER]);
+        validation.validate_exp = true;
+
+        decode::<serde_json::Value>(token, &decoding_key, &validation)
+            .map_err(|e| format!("JWT validation failed: {e}"))?;
+
+        Ok(())
+    }
+}
+
 // --- Webhook handler ---
 
 pub async fn webhook(
     State(state): State<Arc<crate::AppState>>,
+    headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> axum::response::Response {
     info!("googlechat webhook received ({} bytes)", body.len());
+
+    if let Some(ref verifier) = state.google_chat_jwt_verifier {
+        let auth_header = match headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+        {
+            Some(h) => h,
+            None => {
+                warn!("googlechat webhook: missing authorization header");
+                return (axum::http::StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+            }
+        };
+        if let Err(e) = verifier.verify(auth_header).await {
+            warn!(error = %e, "googlechat webhook JWT verification failed");
+            return (axum::http::StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+        }
+    }
 
     let envelope: GoogleChatEnvelope = match serde_json::from_slice(&body) {
         Ok(e) => e,
@@ -639,6 +760,30 @@ mod tests {
             .or(chat.user.as_ref());
         let is_bot = sender.map(|s| s.user_type == "BOT").unwrap_or(false);
         assert!(is_bot);
+    }
+
+    // --- JWT verifier tests ---
+
+    #[tokio::test]
+    async fn jwt_rejects_missing_bearer_prefix() {
+        let verifier = GoogleChatJwtVerifier::new("123456".into());
+        let result = verifier.verify("NotBearer xyz").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Bearer"));
+    }
+
+    #[tokio::test]
+    async fn jwt_rejects_invalid_token() {
+        let verifier = GoogleChatJwtVerifier::new("123456".into());
+        let result = verifier.verify("Bearer not.a.valid.jwt").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn jwt_rejects_empty_bearer() {
+        let verifier = GoogleChatJwtVerifier::new("123456".into());
+        let result = verifier.verify("Bearer ").await;
+        assert!(result.is_err());
     }
 
     #[test]

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -69,9 +69,8 @@ pub struct GoogleChatSpace {
 
 // --- Webhook JWT verification ---
 
-const GOOGLE_CHAT_ISSUER: &str = "chat@system.gserviceaccount.com";
-const GOOGLE_CHAT_JWKS_URL: &str =
-    "https://www.googleapis.com/service_accounts/v1/jwk/chat@system.gserviceaccount.com";
+const GOOGLE_CHAT_ISSUER: &str = "https://accounts.google.com";
+const GOOGLE_CHAT_JWKS_URL: &str = "https://www.googleapis.com/oauth2/v3/certs";
 const JWKS_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(3600);
 
 #[derive(Debug, Clone, Deserialize)]

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -1,5 +1,6 @@
 use crate::schema::*;
 use axum::extract::State;
+use axum::response::IntoResponse;
 use serde::Deserialize;
 use std::sync::Arc;
 use tracing::{error, info};
@@ -66,7 +67,7 @@ pub struct GoogleChatSpace {
 pub async fn webhook(
     State(state): State<Arc<crate::AppState>>,
     body: axum::body::Bytes,
-) -> axum::http::StatusCode {
+) -> axum::response::Response {
     info!("googlechat webhook received ({} bytes)", body.len());
 
     let envelope: GoogleChatEnvelope = match serde_json::from_slice(&body) {
@@ -74,18 +75,18 @@ pub async fn webhook(
         Err(e) => {
             let body_str = String::from_utf8_lossy(&body);
             error!(body = %body_str, "googlechat webhook parse error: {e}");
-            return axum::http::StatusCode::BAD_REQUEST;
+            return (axum::http::StatusCode::BAD_REQUEST, "bad request").into_response();
         }
     };
 
     let Some(chat) = envelope.chat else {
-        return axum::http::StatusCode::OK;
+        return empty_json_response();
     };
     let Some(payload) = chat.message_payload else {
-        return axum::http::StatusCode::OK;
+        return empty_json_response();
     };
     let Some(ref msg) = payload.message else {
-        return axum::http::StatusCode::OK;
+        return empty_json_response();
     };
 
     let text = msg
@@ -94,7 +95,7 @@ pub async fn webhook(
         .or(msg.text.as_deref())
         .unwrap_or("");
     if text.trim().is_empty() {
-        return axum::http::StatusCode::OK;
+        return empty_json_response();
     }
 
     let sender = msg.sender.as_ref().or(chat.user.as_ref());
@@ -145,7 +146,16 @@ pub async fn webhook(
     let json = serde_json::to_string(&gw_event).unwrap();
     info!(space = %space_name, sender = %sender_name, "googlechat → gateway");
     let _ = state.event_tx.send(json);
-    axum::http::StatusCode::OK
+    empty_json_response()
+}
+
+fn empty_json_response() -> axum::response::Response {
+    use axum::response::IntoResponse;
+    (
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        "{}",
+    )
+        .into_response()
 }
 
 // --- Reply handler ---

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -3,9 +3,12 @@ use axum::extract::State;
 use axum::response::IntoResponse;
 use serde::Deserialize;
 use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::RwLock;
 use tracing::{error, info};
 
 pub const GOOGLE_CHAT_API_BASE: &str = "https://chat.googleapis.com/v1";
+const GOOGLE_CHAT_MESSAGE_LIMIT: usize = 4096;
 
 // --- Google Chat types (v2 envelope format) ---
 
@@ -101,6 +104,11 @@ pub async fn webhook(
     let sender = msg.sender.as_ref().or(chat.user.as_ref());
     let space = msg.space.as_ref().or(payload.space.as_ref());
 
+    let is_bot = sender.map(|s| s.user_type == "BOT").unwrap_or(false);
+    if is_bot {
+        return empty_json_response();
+    }
+
     let sender_id = sender.map(|s| s.name.clone()).unwrap_or_default();
     let display_name = sender
         .map(|s| s.display_name.clone())
@@ -109,7 +117,6 @@ pub async fn webhook(
         .strip_prefix("users/")
         .unwrap_or(&sender_id)
         .to_string();
-    let is_bot = sender.map(|s| s.user_type == "BOT").unwrap_or(false);
 
     let space_name = space.map(|s| s.name.clone()).unwrap_or_default();
     let space_type = space
@@ -136,7 +143,7 @@ pub async fn webhook(
             id: sender_id,
             name: sender_name.clone(),
             display_name,
-            is_bot,
+            is_bot: false,
         },
         text,
         &message_id,
@@ -158,11 +165,123 @@ fn empty_json_response() -> axum::response::Response {
         .into_response()
 }
 
+// --- Token cache with JWT auto-refresh ---
+
+pub struct GoogleChatTokenCache {
+    token: RwLock<Option<(String, Instant, u64)>>,
+    sa_email: String,
+    private_key: String,
+}
+
+const TOKEN_REFRESH_MARGIN_SECS: u64 = 300;
+
+impl GoogleChatTokenCache {
+    pub fn new(sa_key_json: &str) -> Result<Self, String> {
+        let key: serde_json::Value =
+            serde_json::from_str(sa_key_json).map_err(|e| format!("invalid SA key JSON: {e}"))?;
+        let email = key
+            .get("client_email")
+            .and_then(|v| v.as_str())
+            .ok_or("missing client_email in SA key")?
+            .to_string();
+        let pkey = key
+            .get("private_key")
+            .and_then(|v| v.as_str())
+            .ok_or("missing private_key in SA key")?
+            .to_string();
+        Ok(Self {
+            token: RwLock::new(None),
+            sa_email: email,
+            private_key: pkey,
+        })
+    }
+
+    pub async fn get_token(&self, client: &reqwest::Client) -> Result<String, String> {
+        {
+            let guard = self.token.read().await;
+            if let Some((ref tok, ref ts, ttl)) = *guard {
+                if ts.elapsed().as_secs() < ttl.saturating_sub(TOKEN_REFRESH_MARGIN_SECS) {
+                    return Ok(tok.clone());
+                }
+            }
+        }
+        let mut guard = self.token.write().await;
+        if let Some((ref tok, ref ts, ttl)) = *guard {
+            if ts.elapsed().as_secs() < ttl.saturating_sub(TOKEN_REFRESH_MARGIN_SECS) {
+                return Ok(tok.clone());
+            }
+        }
+        let (new_token, expire) = self.refresh(client).await?;
+        *guard = Some((new_token.clone(), Instant::now(), expire));
+        info!("googlechat access token refreshed (expires in {expire}s)");
+        Ok(new_token)
+    }
+
+    async fn refresh(&self, client: &reqwest::Client) -> Result<(String, u64), String> {
+        let jwt = self.build_jwt().map_err(|e| format!("JWT build error: {e}"))?;
+        let resp = client
+            .post("https://oauth2.googleapis.com/token")
+            .form(&[
+                ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+                ("assertion", &jwt),
+            ])
+            .send()
+            .await
+            .map_err(|e| format!("token exchange request failed: {e}"))?;
+
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("token exchange parse failed: {e}"))?;
+
+        let token = body
+            .get("access_token")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                let err = body
+                    .get("error_description")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown error");
+                format!("token exchange failed: {err}")
+            })?
+            .to_string();
+
+        let expires_in = body
+            .get("expires_in")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(3600);
+
+        Ok((token, expires_in))
+    }
+
+    fn build_jwt(&self) -> Result<String, String> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| e.to_string())?
+            .as_secs();
+
+        let claims = serde_json::json!({
+            "iss": self.sa_email,
+            "scope": "https://www.googleapis.com/auth/chat.bot",
+            "aud": "https://oauth2.googleapis.com/token",
+            "iat": now,
+            "exp": now + 3600,
+        });
+
+        let key = jsonwebtoken::EncodingKey::from_rsa_pem(self.private_key.as_bytes())
+            .map_err(|e| format!("RSA key parse error: {e}"))?;
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
+        jsonwebtoken::encode(&header, &claims, &key)
+            .map_err(|e| format!("JWT encode error: {e}"))
+    }
+}
+
 // --- Reply handler ---
 
 pub async fn handle_reply(
     reply: &GatewayReply,
-    access_token: Option<&str>,
+    token_cache: Option<&GoogleChatTokenCache>,
+    static_token: Option<&str>,
     client: &reqwest::Client,
 ) {
     if reply.command.as_deref() == Some("add_reaction")
@@ -181,7 +300,17 @@ pub async fn handle_reply(
         "gateway → googlechat"
     );
 
-    let Some(token) = access_token else {
+    let token = if let Some(cache) = token_cache {
+        match cache.get_token(client).await {
+            Ok(t) => t,
+            Err(e) => {
+                error!("googlechat token refresh failed: {e}");
+                return;
+            }
+        }
+    } else if let Some(t) = static_token {
+        t.to_string()
+    } else {
         info!(
             text = %reply.content.text,
             "googlechat reply (dry-run, no credentials configured)"
@@ -189,24 +318,75 @@ pub async fn handle_reply(
         return;
     };
 
-    let mut url = format!("{}/{}/messages", GOOGLE_CHAT_API_BASE, reply.channel.id);
+    let text = &reply.content.text;
+    let chunks = split_text(text, GOOGLE_CHAT_MESSAGE_LIMIT);
+
+    for chunk in chunks {
+        send_message(client, &token, &reply.channel.id, reply.channel.thread_id.as_deref(), chunk).await;
+    }
+}
+
+async fn send_message(
+    client: &reqwest::Client,
+    token: &str,
+    space: &str,
+    thread_id: Option<&str>,
+    text: &str,
+) {
+    let mut url = format!("{}/{}/messages", GOOGLE_CHAT_API_BASE, space);
 
     let mut body = serde_json::json!({
-        "text": reply.content.text,
+        "text": text,
     });
 
-    if let Some(ref thread_id) = reply.channel.thread_id {
+    if let Some(thread_id) = thread_id {
         body["thread"] = serde_json::json!({
             "name": thread_id,
         });
         url.push_str("?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
     }
 
-    let _ = client
+    let resp = client
         .post(&url)
         .bearer_auth(token)
         .json(&body)
         .send()
-        .await
-        .map_err(|e| error!("googlechat send error: {e}"));
+        .await;
+
+    match resp {
+        Ok(r) if !r.status().is_success() => {
+            let status = r.status();
+            let body = r.text().await.unwrap_or_default();
+            error!(status = %status, body = %body, "googlechat send error");
+        }
+        Err(e) => error!("googlechat send error: {e}"),
+        _ => {}
+    }
+}
+
+fn split_text(text: &str, limit: usize) -> Vec<&str> {
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < text.len() {
+        if start + limit >= text.len() {
+            chunks.push(&text[start..]);
+            break;
+        }
+        let mut end = start + limit;
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        let mut search_start = if end > start + 200 { end - 200 } else { start };
+        while search_start < end && !text.is_char_boundary(search_start) {
+            search_start += 1;
+        }
+        let break_at = text[search_start..end]
+            .rfind('\n')
+            .or_else(|| text[search_start..end].rfind(' '))
+            .map(|pos| search_start + pos + 1)
+            .unwrap_or(end);
+        chunks.push(&text[start..break_at]);
+        start = break_at;
+    }
+    chunks
 }

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -390,3 +390,269 @@ fn split_text(text: &str, limit: usize) -> Vec<&str> {
     }
     chunks
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Webhook parsing tests ---
+
+    fn make_envelope(
+        text: &str,
+        argument_text: Option<&str>,
+        sender_type: &str,
+        space_type: &str,
+        thread_name: Option<&str>,
+    ) -> String {
+        let arg_field = argument_text
+            .map(|a| format!(r#""argumentText": "{a}","#))
+            .unwrap_or_default();
+        let thread_field = thread_name
+            .map(|t| format!(r#","thread": {{"name": "{t}"}}"#))
+            .unwrap_or_default();
+        format!(
+            r#"{{
+                "chat": {{
+                    "user": {{
+                        "name": "users/111",
+                        "displayName": "Test",
+                        "type": "{sender_type}"
+                    }},
+                    "messagePayload": {{
+                        "message": {{
+                            "name": "spaces/SP/messages/msg1",
+                            "text": "{text}",
+                            {arg_field}
+                            "sender": {{
+                                "name": "users/111",
+                                "displayName": "Test",
+                                "type": "{sender_type}"
+                            }},
+                            "space": {{
+                                "name": "spaces/SP",
+                                "type": "{space_type}"
+                            }}
+                            {thread_field}
+                        }},
+                        "space": {{
+                            "name": "spaces/SP",
+                            "type": "{space_type}"
+                        }}
+                    }}
+                }}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn parse_dm_message() {
+        let json = make_envelope("hello", None, "HUMAN", "DM", None);
+        let envelope: GoogleChatEnvelope = serde_json::from_str(&json).unwrap();
+        let chat = envelope.chat.unwrap();
+        let msg = chat.message_payload.unwrap().message.unwrap();
+        assert_eq!(msg.text.as_deref(), Some("hello"));
+        assert_eq!(msg.sender.unwrap().user_type, "HUMAN");
+    }
+
+    #[test]
+    fn parse_space_message_with_thread() {
+        let json = make_envelope(
+            "@Bot hi",
+            Some("hi"),
+            "HUMAN",
+            "ROOM",
+            Some("spaces/SP/threads/t1"),
+        );
+        let envelope: GoogleChatEnvelope = serde_json::from_str(&json).unwrap();
+        let chat = envelope.chat.unwrap();
+        let payload = chat.message_payload.unwrap();
+        let msg = payload.message.as_ref().unwrap();
+        assert_eq!(msg.argument_text.as_deref(), Some("hi"));
+        assert_eq!(msg.thread.as_ref().unwrap().name, "spaces/SP/threads/t1");
+        assert_eq!(payload.space.as_ref().unwrap().space_type.as_deref(), Some("ROOM"));
+    }
+
+    #[test]
+    fn parse_bot_message_detected() {
+        let json = make_envelope("bot says hi", None, "BOT", "DM", None);
+        let envelope: GoogleChatEnvelope = serde_json::from_str(&json).unwrap();
+        let chat = envelope.chat.unwrap();
+        let user = chat.user.unwrap();
+        assert_eq!(user.user_type, "BOT");
+    }
+
+    #[test]
+    fn parse_missing_chat_field() {
+        let json = r#"{"type": "ADDED_TO_SPACE"}"#;
+        let envelope: GoogleChatEnvelope = serde_json::from_str(json).unwrap();
+        assert!(envelope.chat.is_none());
+    }
+
+    #[test]
+    fn parse_missing_message_payload() {
+        let json = r#"{"chat": {"user": {"name": "u/1", "displayName": "X", "type": "HUMAN"}}}"#;
+        let envelope: GoogleChatEnvelope = serde_json::from_str(json).unwrap();
+        assert!(envelope.chat.unwrap().message_payload.is_none());
+    }
+
+    #[test]
+    fn parse_invalid_json() {
+        let result: Result<GoogleChatEnvelope, _> = serde_json::from_str("not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn argument_text_preferred_over_text() {
+        let json = make_envelope("@Bot explain", Some("explain"), "HUMAN", "ROOM", None);
+        let envelope: GoogleChatEnvelope = serde_json::from_str(&json).unwrap();
+        let msg = envelope
+            .chat
+            .unwrap()
+            .message_payload
+            .unwrap()
+            .message
+            .unwrap();
+        let text = msg
+            .argument_text
+            .as_deref()
+            .or(msg.text.as_deref())
+            .unwrap();
+        assert_eq!(text, "explain");
+    }
+
+    #[test]
+    fn sender_name_strips_users_prefix() {
+        let sender_id = "users/123456";
+        let name = sender_id.strip_prefix("users/").unwrap_or(sender_id);
+        assert_eq!(name, "123456");
+    }
+
+    #[test]
+    fn message_id_extracts_last_segment() {
+        let msg_name = "spaces/SP/messages/abc123";
+        let id = msg_name.rsplit('/').next().unwrap_or(msg_name);
+        assert_eq!(id, "abc123");
+    }
+
+    // --- split_text tests ---
+
+    #[test]
+    fn split_text_short() {
+        let chunks = split_text("hello", 100);
+        assert_eq!(chunks, vec!["hello"]);
+    }
+
+    #[test]
+    fn split_text_exact_limit() {
+        let text = "a".repeat(100);
+        let chunks = split_text(&text, 100);
+        assert_eq!(chunks.len(), 1);
+    }
+
+    #[test]
+    fn split_text_over_limit() {
+        let text = "a".repeat(150);
+        let chunks = split_text(&text, 100);
+        assert_eq!(chunks.len(), 2);
+        let reassembled: String = chunks.concat();
+        assert_eq!(reassembled, text);
+    }
+
+    #[test]
+    fn split_text_breaks_at_newline() {
+        let text = format!("{}\n{}", "a".repeat(50), "b".repeat(50));
+        let chunks = split_text(&text, 60);
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks[0].ends_with('\n'));
+    }
+
+    #[test]
+    fn split_text_breaks_at_space() {
+        let text = format!("{} {}", "a".repeat(50), "b".repeat(50));
+        let chunks = split_text(&text, 60);
+        assert_eq!(chunks.len(), 2);
+    }
+
+    #[test]
+    fn split_text_chinese_utf8_safe() {
+        let text = "你好世界測試谷歌聊天中文消息分割安全驗證完成";
+        let chunks = split_text(text, 10);
+        assert!(chunks.len() > 1);
+        let reassembled: String = chunks.concat();
+        assert_eq!(reassembled, text);
+    }
+
+    #[test]
+    fn split_text_search_start_char_boundary() {
+        let text: String = "谷歌".repeat(150); // 300 chars, 900 bytes
+        let chunks = split_text(&text, 500);
+        assert!(chunks.len() >= 2);
+        let reassembled: String = chunks.concat();
+        assert_eq!(reassembled, text);
+    }
+
+    #[test]
+    fn split_text_empty() {
+        let chunks = split_text("", 100);
+        assert!(chunks.is_empty());
+    }
+
+    // --- Token cache tests ---
+
+    #[test]
+    fn token_cache_rejects_invalid_json() {
+        let result = GoogleChatTokenCache::new("not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn token_cache_rejects_missing_fields() {
+        match GoogleChatTokenCache::new(r#"{"type": "service_account"}"#) {
+            Err(e) => assert!(e.contains("client_email"), "unexpected error: {e}"),
+            Ok(_) => panic!("expected error for missing client_email"),
+        }
+    }
+
+    #[test]
+    fn token_cache_accepts_valid_sa_key() {
+        let key = r#"{
+            "type": "service_account",
+            "client_email": "test@test.iam.gserviceaccount.com",
+            "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALvRE+oCMiEhtfO5ufaVc9wGPUMgPGxmVFiMPC/NMxmCSiMGNO9h\nCOyByeF78QHp4gOW/lgVU8MJkv33hVMbOr0CAwEAAQJAD2k/cFR5MIkw1PFcm98K\n9MqYKGpJCmGBjFY0ek0FHoC14d/hpAGaoWMjNaAyjU/IbGv1fj8C5MfFRal0fV/L\nAQIhAP0T6FPJMm3O4bM18kMHnOP2+Y5kxMpVxCCjkVNH7D09AiEAvXEQJYwR+PFs\njDDhEm4VPmk+lKJoQlopj8TN5gQV8DECIBcXbU+LPWx4H+qRElhCB1B5a9mYmpY\nV6LFPnvSfHqNAiEAiNj5+A6E7WJ50il+5NG5yn7gXh8vNxdCYIw5qx6C2bECIBmW\nVGVRhSmNsmDMJFsGIdKJsnEXpizIVHtfpXsS4j9X\n-----END RSA PRIVATE KEY-----\n"
+        }"#;
+        let result = GoogleChatTokenCache::new(key);
+        assert!(result.is_ok());
+    }
+
+    // --- Bot filtering logic test ---
+
+    #[test]
+    fn bot_user_type_detected() {
+        let json = make_envelope("hello", None, "BOT", "DM", None);
+        let envelope: GoogleChatEnvelope = serde_json::from_str(&json).unwrap();
+        let chat = envelope.chat.unwrap();
+        let sender = chat
+            .message_payload
+            .as_ref()
+            .and_then(|p| p.message.as_ref())
+            .and_then(|m| m.sender.as_ref())
+            .or(chat.user.as_ref());
+        let is_bot = sender.map(|s| s.user_type == "BOT").unwrap_or(false);
+        assert!(is_bot);
+    }
+
+    #[test]
+    fn human_user_type_not_filtered() {
+        let json = make_envelope("hello", None, "HUMAN", "DM", None);
+        let envelope: GoogleChatEnvelope = serde_json::from_str(&json).unwrap();
+        let chat = envelope.chat.unwrap();
+        let sender = chat
+            .message_payload
+            .as_ref()
+            .and_then(|p| p.message.as_ref())
+            .and_then(|m| m.sender.as_ref())
+            .or(chat.user.as_ref());
+        let is_bot = sender.map(|s| s.user_type == "BOT").unwrap_or(false);
+        assert!(!is_bot);
+    }
+}

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -71,20 +71,20 @@ pub struct GoogleChatSpace {
 
 const GOOGLE_CHAT_ISSUER: &str = "https://accounts.google.com";
 const GOOGLE_CHAT_JWKS_URL: &str = "https://www.googleapis.com/oauth2/v3/certs";
-const GOOGLE_CHAT_SERVICE_ACCOUNT_EMAIL: &str = "chat@system.gserviceaccount.com";
+const GOOGLE_CHAT_EMAIL_SUFFIX: &str = "@gcp-sa-gsuiteaddons.iam.gserviceaccount.com";
 const JWKS_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(3600);
 
-/// Verify the JWT's `email` claim equals the Google Chat service account address.
-/// Without this check, any Google-issued ID token (e.g. Sign-In) would be accepted —
-/// `iss=accounts.google.com` alone doesn't prove the request came from Google Chat.
+/// Verify the JWT's `email` claim belongs to a Google Chat service account.
+/// Google Chat webhooks use `service-{PROJECT_NUMBER}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`.
+/// Without this check, any Google-issued ID token would be accepted.
 fn verify_email_claim(claims: &serde_json::Value) -> Result<(), String> {
     let email = claims
         .get("email")
         .and_then(|v| v.as_str())
         .ok_or("missing email claim")?;
-    if email != GOOGLE_CHAT_SERVICE_ACCOUNT_EMAIL {
+    if !email.ends_with(GOOGLE_CHAT_EMAIL_SUFFIX) {
         return Err(format!(
-            "email claim mismatch: expected {GOOGLE_CHAT_SERVICE_ACCOUNT_EMAIL}, got {email}"
+            "email claim mismatch: expected *{GOOGLE_CHAT_EMAIL_SUFFIX}, got {email}"
         ));
     }
     Ok(())
@@ -831,8 +831,8 @@ mod tests {
     }
 
     #[test]
-    fn email_claim_accepts_chat_system_account() {
-        let claims = serde_json::json!({"email": "chat@system.gserviceaccount.com"});
+    fn email_claim_accepts_gsuite_addons_account() {
+        let claims = serde_json::json!({"email": "service-123456@gcp-sa-gsuiteaddons.iam.gserviceaccount.com"});
         assert!(verify_email_claim(&claims).is_ok());
     }
 
@@ -841,6 +841,12 @@ mod tests {
         let claims = serde_json::json!({"email": "attacker@example.iam.gserviceaccount.com"});
         let err = verify_email_claim(&claims).unwrap_err();
         assert!(err.contains("email claim mismatch"));
+    }
+
+    #[test]
+    fn email_claim_rejects_unrelated_gserviceaccount() {
+        let claims = serde_json::json!({"email": "my-sa@my-project.iam.gserviceaccount.com"});
+        assert!(verify_email_claim(&claims).is_err());
     }
 
     #[test]

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -167,6 +167,80 @@ impl GoogleChatJwtVerifier {
     }
 }
 
+// --- Adapter (encapsulates all Google Chat state) ---
+
+pub struct GoogleChatAdapter {
+    pub token_cache: Option<GoogleChatTokenCache>,
+    pub access_token: Option<String>,
+    pub jwt_verifier: Option<GoogleChatJwtVerifier>,
+    pub client: reqwest::Client,
+}
+
+impl GoogleChatAdapter {
+    pub fn new(
+        token_cache: Option<GoogleChatTokenCache>,
+        access_token: Option<String>,
+        jwt_verifier: Option<GoogleChatJwtVerifier>,
+    ) -> Self {
+        Self {
+            token_cache,
+            access_token,
+            jwt_verifier,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    async fn get_token(&self) -> Option<String> {
+        if let Some(ref cache) = self.token_cache {
+            match cache.get_token(&self.client).await {
+                Ok(t) => return Some(t),
+                Err(e) => {
+                    error!("googlechat token refresh failed: {e}");
+                    return None;
+                }
+            }
+        }
+        self.access_token.clone()
+    }
+
+    pub async fn handle_reply(&self, reply: &GatewayReply) {
+        if matches!(
+            reply.command.as_deref(),
+            Some("add_reaction") | Some("remove_reaction") | Some("create_topic")
+        ) {
+            return;
+        }
+
+        info!(
+            space = %reply.channel.id,
+            thread_id = ?reply.channel.thread_id,
+            "gateway → googlechat"
+        );
+
+        let Some(token) = self.get_token().await else {
+            info!(
+                text = %reply.content.text,
+                "googlechat reply (dry-run, no credentials configured)"
+            );
+            return;
+        };
+
+        let text = &reply.content.text;
+        let chunks = split_text(text, GOOGLE_CHAT_MESSAGE_LIMIT);
+
+        for chunk in chunks {
+            send_message(
+                &self.client,
+                &token,
+                &reply.channel.id,
+                reply.channel.thread_id.as_deref(),
+                chunk,
+            )
+            .await;
+        }
+    }
+}
+
 // --- Webhook handler ---
 
 pub async fn webhook(
@@ -176,20 +250,22 @@ pub async fn webhook(
 ) -> axum::response::Response {
     info!("googlechat webhook received ({} bytes)", body.len());
 
-    if let Some(ref verifier) = state.google_chat_jwt_verifier {
-        let auth_header = match headers
-            .get("authorization")
-            .and_then(|v| v.to_str().ok())
-        {
-            Some(h) => h,
-            None => {
-                warn!("googlechat webhook: missing authorization header");
+    if let Some(ref adapter) = state.google_chat {
+        if let Some(ref verifier) = adapter.jwt_verifier {
+            let auth_header = match headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+            {
+                Some(h) => h,
+                None => {
+                    warn!("googlechat webhook: missing authorization header");
+                    return (axum::http::StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+                }
+            };
+            if let Err(e) = verifier.verify(auth_header).await {
+                warn!(error = %e, "googlechat webhook JWT verification failed");
                 return (axum::http::StatusCode::UNAUTHORIZED, "unauthorized").into_response();
             }
-        };
-        if let Err(e) = verifier.verify(auth_header).await {
-            warn!(error = %e, "googlechat webhook JWT verification failed");
-            return (axum::http::StatusCode::UNAUTHORIZED, "unauthorized").into_response();
         }
     }
 
@@ -393,56 +469,6 @@ impl GoogleChatTokenCache {
         let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
         jsonwebtoken::encode(&header, &claims, &key)
             .map_err(|e| format!("JWT encode error: {e}"))
-    }
-}
-
-// --- Reply handler ---
-
-pub async fn handle_reply(
-    reply: &GatewayReply,
-    token_cache: Option<&GoogleChatTokenCache>,
-    static_token: Option<&str>,
-    client: &reqwest::Client,
-) {
-    if reply.command.as_deref() == Some("add_reaction")
-        || reply.command.as_deref() == Some("remove_reaction")
-    {
-        return;
-    }
-
-    if reply.command.as_deref() == Some("create_topic") {
-        return;
-    }
-
-    info!(
-        space = %reply.channel.id,
-        thread_id = ?reply.channel.thread_id,
-        "gateway → googlechat"
-    );
-
-    let token = if let Some(cache) = token_cache {
-        match cache.get_token(client).await {
-            Ok(t) => t,
-            Err(e) => {
-                error!("googlechat token refresh failed: {e}");
-                return;
-            }
-        }
-    } else if let Some(t) = static_token {
-        t.to_string()
-    } else {
-        info!(
-            text = %reply.content.text,
-            "googlechat reply (dry-run, no credentials configured)"
-        );
-        return;
-    };
-
-    let text = &reply.content.text;
-    let chunks = split_text(text, GOOGLE_CHAT_MESSAGE_LIMIT);
-
-    for chunk in chunks {
-        send_message(client, &token, &reply.channel.id, reply.channel.thread_id.as_deref(), chunk).await;
     }
 }
 

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -179,7 +179,7 @@ pub async fn handle_reply(
         return;
     };
 
-    let url = format!("{}/{}/messages", GOOGLE_CHAT_API_BASE, reply.channel.id);
+    let mut url = format!("{}/{}/messages", GOOGLE_CHAT_API_BASE, reply.channel.id);
 
     let mut body = serde_json::json!({
         "text": reply.content.text,
@@ -189,6 +189,7 @@ pub async fn handle_reply(
         body["thread"] = serde_json::json!({
             "name": thread_id,
         });
+        url.push_str("?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
     }
 
     let _ = client

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -71,7 +71,24 @@ pub struct GoogleChatSpace {
 
 const GOOGLE_CHAT_ISSUER: &str = "https://accounts.google.com";
 const GOOGLE_CHAT_JWKS_URL: &str = "https://www.googleapis.com/oauth2/v3/certs";
+const GOOGLE_CHAT_SERVICE_ACCOUNT_EMAIL: &str = "chat@system.gserviceaccount.com";
 const JWKS_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(3600);
+
+/// Verify the JWT's `email` claim equals the Google Chat service account address.
+/// Without this check, any Google-issued ID token (e.g. Sign-In) would be accepted —
+/// `iss=accounts.google.com` alone doesn't prove the request came from Google Chat.
+fn verify_email_claim(claims: &serde_json::Value) -> Result<(), String> {
+    let email = claims
+        .get("email")
+        .and_then(|v| v.as_str())
+        .ok_or("missing email claim")?;
+    if email != GOOGLE_CHAT_SERVICE_ACCOUNT_EMAIL {
+        return Err(format!(
+            "email claim mismatch: expected {GOOGLE_CHAT_SERVICE_ACCOUNT_EMAIL}, got {email}"
+        ));
+    }
+    Ok(())
+}
 
 #[derive(Debug, Clone, Deserialize)]
 struct JwkKey {
@@ -160,8 +177,10 @@ impl GoogleChatJwtVerifier {
         validation.set_issuer(&[GOOGLE_CHAT_ISSUER]);
         validation.validate_exp = true;
 
-        decode::<serde_json::Value>(token, &decoding_key, &validation)
+        let token_data = decode::<serde_json::Value>(token, &decoding_key, &validation)
             .map_err(|e| format!("JWT validation failed: {e}"))?;
+
+        verify_email_claim(&token_data.claims)?;
 
         Ok(())
     }
@@ -809,6 +828,32 @@ mod tests {
         let verifier = GoogleChatJwtVerifier::new("123456".into());
         let result = verifier.verify("Bearer ").await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn email_claim_accepts_chat_system_account() {
+        let claims = serde_json::json!({"email": "chat@system.gserviceaccount.com"});
+        assert!(verify_email_claim(&claims).is_ok());
+    }
+
+    #[test]
+    fn email_claim_rejects_other_google_email() {
+        let claims = serde_json::json!({"email": "attacker@example.iam.gserviceaccount.com"});
+        let err = verify_email_claim(&claims).unwrap_err();
+        assert!(err.contains("email claim mismatch"));
+    }
+
+    #[test]
+    fn email_claim_rejects_missing_email() {
+        let claims = serde_json::json!({"sub": "123", "iss": "accounts.google.com"});
+        let err = verify_email_claim(&claims).unwrap_err();
+        assert!(err.contains("missing email"));
+    }
+
+    #[test]
+    fn email_claim_rejects_non_string_email() {
+        let claims = serde_json::json!({"email": 12345});
+        assert!(verify_email_claim(&claims).is_err());
     }
 
     #[test]

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -1,0 +1,177 @@
+use crate::schema::*;
+use axum::extract::State;
+use axum::Json;
+use serde::Deserialize;
+use std::sync::Arc;
+use tracing::{error, info};
+
+pub const GOOGLE_CHAT_API_BASE: &str = "https://chat.googleapis.com/v1";
+
+// --- Google Chat types ---
+
+#[derive(Debug, Deserialize)]
+pub struct GoogleChatEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub message: Option<GoogleChatMessage>,
+    pub user: Option<GoogleChatUser>,
+    pub space: Option<GoogleChatSpace>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GoogleChatMessage {
+    pub name: String,
+    pub text: Option<String>,
+    #[serde(rename = "argumentText")]
+    pub argument_text: Option<String>,
+    pub sender: Option<GoogleChatUser>,
+    pub thread: Option<GoogleChatThread>,
+    pub space: Option<GoogleChatSpace>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GoogleChatUser {
+    pub name: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    #[serde(rename = "type")]
+    pub user_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GoogleChatThread {
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GoogleChatSpace {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub space_type: Option<String>,
+}
+
+// --- Webhook handler ---
+
+pub async fn webhook(
+    State(state): State<Arc<crate::AppState>>,
+    Json(event): Json<GoogleChatEvent>,
+) -> axum::http::StatusCode {
+    if event.event_type != "MESSAGE" {
+        return axum::http::StatusCode::OK;
+    }
+
+    let Some(ref msg) = event.message else {
+        return axum::http::StatusCode::OK;
+    };
+
+    let text = msg
+        .argument_text
+        .as_deref()
+        .or(msg.text.as_deref())
+        .unwrap_or("");
+    if text.trim().is_empty() {
+        return axum::http::StatusCode::OK;
+    }
+
+    let sender = msg.sender.as_ref().or(event.user.as_ref());
+    let space = msg.space.as_ref().or(event.space.as_ref());
+
+    let sender_id = sender.map(|s| s.name.clone()).unwrap_or_default();
+    let display_name = sender
+        .map(|s| s.display_name.clone())
+        .unwrap_or_else(|| "Unknown".into());
+    let sender_name = sender_id
+        .strip_prefix("users/")
+        .unwrap_or(&sender_id)
+        .to_string();
+    let is_bot = sender.map(|s| s.user_type == "BOT").unwrap_or(false);
+
+    let space_name = space.map(|s| s.name.clone()).unwrap_or_default();
+    let space_type = space
+        .and_then(|s| s.space_type.clone())
+        .unwrap_or_else(|| "ROOM".into());
+
+    let thread_id = msg.thread.as_ref().map(|t| t.name.clone());
+
+    let message_id = msg
+        .name
+        .rsplit('/')
+        .next()
+        .unwrap_or(&msg.name)
+        .to_string();
+
+    let gw_event = GatewayEvent::new(
+        "googlechat",
+        ChannelInfo {
+            id: space_name.clone(),
+            channel_type: space_type,
+            thread_id,
+        },
+        SenderInfo {
+            id: sender_id,
+            name: sender_name.clone(),
+            display_name,
+            is_bot,
+        },
+        text,
+        &message_id,
+        vec![],
+    );
+
+    let json = serde_json::to_string(&gw_event).unwrap();
+    info!(space = %space_name, sender = %sender_name, "googlechat → gateway");
+    let _ = state.event_tx.send(json);
+    axum::http::StatusCode::OK
+}
+
+// --- Reply handler ---
+
+pub async fn handle_reply(
+    reply: &GatewayReply,
+    access_token: Option<&str>,
+    client: &reqwest::Client,
+) {
+    if reply.command.as_deref() == Some("add_reaction")
+        || reply.command.as_deref() == Some("remove_reaction")
+    {
+        return;
+    }
+
+    if reply.command.as_deref() == Some("create_topic") {
+        return;
+    }
+
+    info!(
+        space = %reply.channel.id,
+        thread_id = ?reply.channel.thread_id,
+        "gateway → googlechat"
+    );
+
+    let Some(token) = access_token else {
+        info!(
+            text = %reply.content.text,
+            "googlechat reply (dry-run, no credentials configured)"
+        );
+        return;
+    };
+
+    let url = format!("{}/{}/messages", GOOGLE_CHAT_API_BASE, reply.channel.id);
+
+    let mut body = serde_json::json!({
+        "text": reply.content.text,
+    });
+
+    if let Some(ref thread_id) = reply.channel.thread_id {
+        body["thread"] = serde_json::json!({
+            "name": thread_id,
+        });
+    }
+
+    let _ = client
+        .post(&url)
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| error!("googlechat send error: {e}"));
+}

--- a/gateway/src/adapters/mod.rs
+++ b/gateway/src/adapters/mod.rs
@@ -1,4 +1,5 @@
 pub mod feishu;
+pub mod googlechat;
 pub mod line;
 pub mod teams;
 pub mod telegram;

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -48,7 +48,9 @@ pub struct AppState {
     pub teams_service_urls: Mutex<HashMap<String, (String, Instant)>>,
     /// Feishu adapter (None if Feishu disabled)
     pub feishu: Option<adapters::feishu::FeishuAdapter>,
-    /// Google Chat access token for reply API (None if not configured)
+    /// Google Chat token cache for auto-refresh (from service account key)
+    pub google_chat_token_cache: Option<adapters::googlechat::GoogleChatTokenCache>,
+    /// Google Chat static access token (fallback if no SA key)
     pub google_chat_access_token: Option<String>,
     /// WebSocket authentication token
     pub ws_token: Option<String>,
@@ -167,6 +169,7 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                             "googlechat" => {
                                 adapters::googlechat::handle_reply(
                                     &reply,
+                                    state_for_recv.google_chat_token_cache.as_ref(),
                                     state_for_recv.google_chat_access_token.as_deref(),
                                     &client,
                                 )
@@ -273,6 +276,18 @@ async fn main() -> Result<()> {
 
     // Google Chat adapter
     let google_chat_access_token = std::env::var("GOOGLE_CHAT_ACCESS_TOKEN").ok();
+    let google_chat_token_cache = std::env::var("GOOGLE_CHAT_SA_KEY_JSON")
+        .ok()
+        .or_else(|| {
+            std::env::var("GOOGLE_CHAT_SA_KEY_FILE")
+                .ok()
+                .and_then(|path| std::fs::read_to_string(&path).ok())
+        })
+        .and_then(|json| {
+            adapters::googlechat::GoogleChatTokenCache::new(&json)
+                .map_err(|e| warn!("googlechat SA key error: {e}"))
+                .ok()
+        });
     let google_chat_enabled = std::env::var("GOOGLE_CHAT_ENABLED")
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false);
@@ -281,8 +296,12 @@ async fn main() -> Result<()> {
             .unwrap_or_else(|_| "/webhook/googlechat".into());
         info!(path = %webhook_path, "googlechat adapter enabled");
         app = app.route(&webhook_path, post(adapters::googlechat::webhook));
-        if google_chat_access_token.is_none() {
-            warn!("GOOGLE_CHAT_ACCESS_TOKEN not set — replies will be logged but not sent");
+        if google_chat_token_cache.is_some() {
+            info!("googlechat service account configured — token auto-refresh enabled");
+        } else if google_chat_access_token.is_some() {
+            warn!("googlechat using static access token — will expire in ~1 hour");
+        } else {
+            warn!("GOOGLE_CHAT_ACCESS_TOKEN / GOOGLE_CHAT_SA_KEY_JSON not set — replies will be logged but not sent");
         }
     }
 
@@ -303,6 +322,7 @@ async fn main() -> Result<()> {
         teams,
         teams_service_urls: Mutex::new(HashMap::new()),
         feishu,
+        google_chat_token_cache,
         google_chat_access_token,
         ws_token,
         event_tx,

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -290,11 +290,12 @@ async fn main() -> Result<()> {
                 .map_err(|e| warn!("googlechat SA key error: {e}"))
                 .ok()
         });
-    let google_chat_jwt_verifier = std::env::var("GOOGLE_CHAT_PROJECT_NUMBER")
+    let google_chat_jwt_verifier = std::env::var("GOOGLE_CHAT_AUDIENCE")
+        .or_else(|_| std::env::var("GOOGLE_CHAT_PROJECT_NUMBER"))
         .ok()
-        .map(|pn| {
-            info!("googlechat webhook JWT verification enabled (project_number={pn})");
-            adapters::googlechat::GoogleChatJwtVerifier::new(pn)
+        .map(|aud| {
+            info!("googlechat webhook JWT verification enabled (audience={aud})");
+            adapters::googlechat::GoogleChatJwtVerifier::new(aud)
         });
     let google_chat_enabled = std::env::var("GOOGLE_CHAT_ENABLED")
         .map(|v| v == "true" || v == "1")

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -52,6 +52,8 @@ pub struct AppState {
     pub google_chat_token_cache: Option<adapters::googlechat::GoogleChatTokenCache>,
     /// Google Chat static access token (fallback if no SA key)
     pub google_chat_access_token: Option<String>,
+    /// Google Chat webhook JWT verifier (validates inbound requests from Google)
+    pub google_chat_jwt_verifier: Option<adapters::googlechat::GoogleChatJwtVerifier>,
     /// WebSocket authentication token
     pub ws_token: Option<String>,
     /// Broadcast channel: gateway → OAB (events from all platforms)
@@ -288,6 +290,12 @@ async fn main() -> Result<()> {
                 .map_err(|e| warn!("googlechat SA key error: {e}"))
                 .ok()
         });
+    let google_chat_jwt_verifier = std::env::var("GOOGLE_CHAT_PROJECT_NUMBER")
+        .ok()
+        .map(|pn| {
+            info!("googlechat webhook JWT verification enabled (project_number={pn})");
+            adapters::googlechat::GoogleChatJwtVerifier::new(pn)
+        });
     let google_chat_enabled = std::env::var("GOOGLE_CHAT_ENABLED")
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false);
@@ -302,6 +310,9 @@ async fn main() -> Result<()> {
             warn!("googlechat using static access token — will expire in ~1 hour");
         } else {
             warn!("GOOGLE_CHAT_ACCESS_TOKEN / GOOGLE_CHAT_SA_KEY_JSON not set — replies will be logged but not sent");
+        }
+        if google_chat_jwt_verifier.is_none() {
+            warn!("GOOGLE_CHAT_PROJECT_NUMBER not set — webhook requests are NOT authenticated (insecure)");
         }
     }
 
@@ -324,6 +335,7 @@ async fn main() -> Result<()> {
         feishu,
         google_chat_token_cache,
         google_chat_access_token,
+        google_chat_jwt_verifier,
         ws_token,
         event_tx,
         reply_token_cache,

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -48,12 +48,8 @@ pub struct AppState {
     pub teams_service_urls: Mutex<HashMap<String, (String, Instant)>>,
     /// Feishu adapter (None if Feishu disabled)
     pub feishu: Option<adapters::feishu::FeishuAdapter>,
-    /// Google Chat token cache for auto-refresh (from service account key)
-    pub google_chat_token_cache: Option<adapters::googlechat::GoogleChatTokenCache>,
-    /// Google Chat static access token (fallback if no SA key)
-    pub google_chat_access_token: Option<String>,
-    /// Google Chat webhook JWT verifier (validates inbound requests from Google)
-    pub google_chat_jwt_verifier: Option<adapters::googlechat::GoogleChatJwtVerifier>,
+    /// Google Chat adapter (None if Google Chat disabled)
+    pub google_chat: Option<adapters::googlechat::GoogleChatAdapter>,
     /// WebSocket authentication token
     pub ws_token: Option<String>,
     /// Broadcast channel: gateway → OAB (events from all platforms)
@@ -169,13 +165,11 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                                 }
                             }
                             "googlechat" => {
-                                adapters::googlechat::handle_reply(
-                                    &reply,
-                                    state_for_recv.google_chat_token_cache.as_ref(),
-                                    state_for_recv.google_chat_access_token.as_deref(),
-                                    &client,
-                                )
-                                .await;
+                                if let Some(ref gc) = state_for_recv.google_chat {
+                                    gc.handle_reply(&reply).await;
+                                } else {
+                                    warn!("reply for googlechat but adapter not configured");
+                                }
                             }
                             other => warn!(platform = other, "unknown reply platform"),
                         }
@@ -277,51 +271,57 @@ async fn main() -> Result<()> {
     }
 
     // Google Chat adapter
-    let google_chat_access_token = std::env::var("GOOGLE_CHAT_ACCESS_TOKEN").ok();
-    let google_chat_token_cache = std::env::var("GOOGLE_CHAT_SA_KEY_JSON")
-        .ok()
-        .or_else(|| {
-            std::env::var("GOOGLE_CHAT_SA_KEY_FILE")
-                .ok()
-                .and_then(|path| std::fs::read_to_string(&path).ok())
-        })
-        .and_then(|json| {
-            adapters::googlechat::GoogleChatTokenCache::new(&json)
-                .map_err(|e| warn!("googlechat SA key error: {e}"))
-                .ok()
-        });
-    let google_chat_jwt_verifier = std::env::var("GOOGLE_CHAT_AUDIENCE")
-        .or_else(|_| std::env::var("GOOGLE_CHAT_PROJECT_NUMBER"))
-        .ok()
-        .map(|aud| {
-            info!("googlechat webhook JWT verification enabled (audience={aud})");
-            adapters::googlechat::GoogleChatJwtVerifier::new(aud)
-        });
     let google_chat_enabled = std::env::var("GOOGLE_CHAT_ENABLED")
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false);
-    if google_chat_enabled {
+    let google_chat = if google_chat_enabled {
+        let token_cache = std::env::var("GOOGLE_CHAT_SA_KEY_JSON")
+            .ok()
+            .or_else(|| {
+                std::env::var("GOOGLE_CHAT_SA_KEY_FILE")
+                    .ok()
+                    .and_then(|path| std::fs::read_to_string(&path).ok())
+            })
+            .and_then(|json| {
+                adapters::googlechat::GoogleChatTokenCache::new(&json)
+                    .map_err(|e| warn!("googlechat SA key error: {e}"))
+                    .ok()
+            });
+        let access_token = std::env::var("GOOGLE_CHAT_ACCESS_TOKEN").ok();
+        let jwt_verifier = std::env::var("GOOGLE_CHAT_AUDIENCE")
+            .or_else(|_| std::env::var("GOOGLE_CHAT_PROJECT_NUMBER"))
+            .ok()
+            .map(|aud| {
+                info!("googlechat webhook JWT verification enabled (audience={aud})");
+                adapters::googlechat::GoogleChatJwtVerifier::new(aud)
+            });
+
         let webhook_path = std::env::var("GOOGLE_CHAT_WEBHOOK_PATH")
             .unwrap_or_else(|_| "/webhook/googlechat".into());
         info!(path = %webhook_path, "googlechat adapter enabled");
         app = app.route(&webhook_path, post(adapters::googlechat::webhook));
-        if google_chat_token_cache.is_some() {
+
+        if token_cache.is_some() {
             info!("googlechat service account configured — token auto-refresh enabled");
-        } else if google_chat_access_token.is_some() {
+        } else if access_token.is_some() {
             warn!("googlechat using static access token — will expire in ~1 hour");
         } else {
             warn!("GOOGLE_CHAT_ACCESS_TOKEN / GOOGLE_CHAT_SA_KEY_JSON not set — replies will be logged but not sent");
         }
-        if google_chat_jwt_verifier.is_none() {
+        if jwt_verifier.is_none() {
             warn!("GOOGLE_CHAT_PROJECT_NUMBER not set — webhook requests are NOT authenticated (insecure)");
         }
-    }
+
+        Some(adapters::googlechat::GoogleChatAdapter::new(token_cache, access_token, jwt_verifier))
+    } else {
+        None
+    };
 
     if telegram_bot_token.is_none()
         && line_access_token.is_none()
         && teams.is_none()
         && feishu.is_none()
-        && !google_chat_enabled
+        && google_chat.is_none()
     {
         warn!("no adapters configured — set TELEGRAM_BOT_TOKEN, LINE_CHANNEL_ACCESS_TOKEN, TEAMS_APP_ID + TEAMS_APP_SECRET, FEISHU_APP_ID + FEISHU_APP_SECRET, and/or GOOGLE_CHAT_ENABLED=true");
     }
@@ -334,9 +334,7 @@ async fn main() -> Result<()> {
         teams,
         teams_service_urls: Mutex::new(HashMap::new()),
         feishu,
-        google_chat_token_cache,
-        google_chat_access_token,
-        google_chat_jwt_verifier,
+        google_chat,
         ws_token,
         event_tx,
         reply_token_cache,

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -48,6 +48,8 @@ pub struct AppState {
     pub teams_service_urls: Mutex<HashMap<String, (String, Instant)>>,
     /// Feishu adapter (None if Feishu disabled)
     pub feishu: Option<adapters::feishu::FeishuAdapter>,
+    /// Google Chat access token for reply API (None if not configured)
+    pub google_chat_access_token: Option<String>,
     /// WebSocket authentication token
     pub ws_token: Option<String>,
     /// Broadcast channel: gateway → OAB (events from all platforms)
@@ -162,6 +164,14 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                                     warn!("reply for feishu but adapter not configured");
                                 }
                             }
+                            "googlechat" => {
+                                adapters::googlechat::handle_reply(
+                                    &reply,
+                                    state_for_recv.google_chat_access_token.as_deref(),
+                                    &client,
+                                )
+                                .await;
+                            }
                             other => warn!(platform = other, "unknown reply platform"),
                         }
                     }
@@ -261,12 +271,28 @@ async fn main() -> Result<()> {
         f.resolve_bot_identity().await;
     }
 
+    // Google Chat adapter
+    let google_chat_access_token = std::env::var("GOOGLE_CHAT_ACCESS_TOKEN").ok();
+    let google_chat_enabled = std::env::var("GOOGLE_CHAT_ENABLED")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
+    if google_chat_enabled {
+        let webhook_path = std::env::var("GOOGLE_CHAT_WEBHOOK_PATH")
+            .unwrap_or_else(|_| "/webhook/googlechat".into());
+        info!(path = %webhook_path, "googlechat adapter enabled");
+        app = app.route(&webhook_path, post(adapters::googlechat::webhook));
+        if google_chat_access_token.is_none() {
+            warn!("GOOGLE_CHAT_ACCESS_TOKEN not set — replies will be logged but not sent");
+        }
+    }
+
     if telegram_bot_token.is_none()
         && line_access_token.is_none()
         && teams.is_none()
         && feishu.is_none()
+        && !google_chat_enabled
     {
-        warn!("no adapters configured — set TELEGRAM_BOT_TOKEN, LINE_CHANNEL_ACCESS_TOKEN, TEAMS_APP_ID + TEAMS_APP_SECRET, and/or FEISHU_APP_ID + FEISHU_APP_SECRET");
+        warn!("no adapters configured — set TELEGRAM_BOT_TOKEN, LINE_CHANNEL_ACCESS_TOKEN, TEAMS_APP_ID + TEAMS_APP_SECRET, FEISHU_APP_ID + FEISHU_APP_SECRET, and/or GOOGLE_CHAT_ENABLED=true");
     }
 
     let state = Arc::new(AppState {
@@ -277,6 +303,7 @@ async fn main() -> Result<()> {
         teams,
         teams_service_urls: Mutex::new(HashMap::new()),
         feishu,
+        google_chat_access_token,
         ws_token,
         event_tx,
         reply_token_cache,

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -288,13 +288,10 @@ async fn main() -> Result<()> {
                     .ok()
             });
         let access_token = std::env::var("GOOGLE_CHAT_ACCESS_TOKEN").ok();
-        let jwt_verifier = std::env::var("GOOGLE_CHAT_AUDIENCE")
-            .or_else(|_| std::env::var("GOOGLE_CHAT_PROJECT_NUMBER"))
-            .ok()
-            .map(|aud| {
-                info!("googlechat webhook JWT verification enabled (audience={aud})");
-                adapters::googlechat::GoogleChatJwtVerifier::new(aud)
-            });
+        let jwt_verifier = std::env::var("GOOGLE_CHAT_AUDIENCE").ok().map(|aud| {
+            info!("googlechat webhook JWT verification enabled (audience={aud})");
+            adapters::googlechat::GoogleChatJwtVerifier::new(aud)
+        });
 
         let webhook_path = std::env::var("GOOGLE_CHAT_WEBHOOK_PATH")
             .unwrap_or_else(|_| "/webhook/googlechat".into());
@@ -309,7 +306,7 @@ async fn main() -> Result<()> {
             warn!("GOOGLE_CHAT_ACCESS_TOKEN / GOOGLE_CHAT_SA_KEY_JSON not set — replies will be logged but not sent");
         }
         if jwt_verifier.is_none() {
-            warn!("GOOGLE_CHAT_PROJECT_NUMBER not set — webhook requests are NOT authenticated (insecure)");
+            warn!("GOOGLE_CHAT_AUDIENCE not set — webhook requests are NOT authenticated (insecure)");
         }
 
         Some(adapters::googlechat::GoogleChatAdapter::new(token_cache, access_token, jwt_verifier))


### PR DESCRIPTION
## Summary

Adds Google Chat support to the Custom Gateway. Users can chat with OAB agents via Google Chat DMs and Spaces.

```
Google Chat ──POST──▶ ┌──────────────────┐
                      │  Custom Gateway  │ ◀──WebSocket── OAB Pod
                      │     :8080        │   (OAB connects out)
                      └──────────────────┘
```

## Changes

| File | Change | Description |
|------|--------|-------------|
| `gateway/src/adapters/googlechat.rs` | NEW | Google Chat adapter: webhook handler, JWT verification (Google OIDC), SA key auth, token cache, message splitting, bot filtering, thread replies |
| `gateway/src/adapters/mod.rs` | MOD | Add `pub mod googlechat` |
| `gateway/src/main.rs` | MOD | AppState + reply router + GoogleChatAdapter initialization |
| `gateway/README.md` | MOD | Add Google Chat env vars and `/webhook/googlechat` endpoint |
| `docs/google-chat.md` | NEW | Operator guide: prerequisites, setup, config reference, security, troubleshooting |
| `docs/config-reference.md` | MOD | Add `"googlechat"` to gateway platform values |
| `charts/openab/values.yaml` | MOD | Add `googleChat` config block under `gateway` |
| `charts/openab/templates/gateway.yaml` | MOD | Inject Google Chat env vars (secrets via secretKeyRef) |
| `charts/openab/templates/gateway-secret.yaml` | MOD | Add `google-chat-sa-key-json` and `google-chat-access-token` to unified Secret |
| `charts/openab/tests/gateway_test.yaml` | NEW | Helm rendering tests for Google Chat gateway configuration |
| `README.md` | MOD | Add Google Chat to architecture diagram and platform list |

## Key Design Decisions

1. **JWT verification via Google OIDC** — Webhook requests are signed by `https://accounts.google.com` (not `chat@system.gserviceaccount.com`). Verification uses Google's public JWKS at `googleapis.com/oauth2/v3/certs`, validates issuer, audience (webhook URL), and email suffix (`@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`).

2. **Service Account key auth** — Google Chat doesn't support client credentials flow (unlike Teams/Feishu). The adapter signs JWTs with the SA private key to obtain access tokens, with automatic refresh before expiry.

3. **GoogleChatAdapter struct** — Encapsulates `token_cache`, `access_token`, `jwt_verifier`, and `client` in a single struct, following the same pattern as Teams and Feishu adapters.

4. **Audience-based JWT verification** — `GOOGLE_CHAT_AUDIENCE` env var (full webhook URL) is used as the expected JWT `aud` claim. If unset, verification is skipped with a warning (for local dev only).

5. **Message splitting** — Replies exceeding 4096 chars are split at newline/space boundaries to comply with Google Chat API limits.

## Testing

Verified end-to-end on k3s with Helm chart deployment:

| Scenario | Result |
|----------|--------|
| DM text message send/receive | PASS |
| Space @mention → agent reply in thread | PASS |
| JWT verification (valid token) | PASS |
| JWT rejection (missing/invalid token) | PASS |
| Bot message filtering (no self-echo) | PASS |
| Message splitting (>4096 chars) | PASS |
| Token auto-refresh (SA key) | PASS |
| `cargo test` — 91 gateway tests passed | PASS |

## Configuration

```yaml
# Helm values.yaml
agents:
  kiro:
    gateway:
      enabled: true
      deploy: true
      url: "ws://openab-kiro-gateway:8080/ws"
      googleChat:
        saKeyJson: '{"type":"service_account",...}'
        audience: "https://your-domain.com/webhook/googlechat"
```

## Not Yet Supported

- **Reactions** — Google Chat API only supports reactions with user auth, not service accounts
- **File/image/voice attachments** — attachment download + processing not yet implemented
- **Markdown rendering** — replies sent as plain text (Google Chat uses its own card markup)

## Test plan

- [x] CI build + `cargo test` passes
- [x] Helm template rendering tests pass (7 suites, 74 tests)
- [x] Deploy to a test cluster and verify DM + Space messages work
- [x] Verify JWT verification rejects unsigned requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)