### PR TITLE
feat(gateway): feishu thread (topic) reply support

### DIFF
--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -137,6 +137,18 @@ streaming = true
 
 The gateway platform must support message editing (Feishu/Lark do). Platforms that don't support editing should leave `streaming = false` (default).
 
+## Thread (Topic) Replies
+
+When a user replies to a bot message in a group chat, Feishu creates a thread (topic). The bot replies within the same thread, and each thread gets its own independent session.
+
+To start a threaded conversation: reply to any bot message in a group chat (long-press or hover → Reply). The bot's response will appear in the same thread. Subsequent messages in the thread still require @mention (same as group chat).
+
+**How it works:** Feishu reply events include a `root_id` (the original message that started the thread). The gateway uses this as `thread_id` for session isolation. Replies are sent via `POST /im/v1/messages/{root_id}/reply` to stay in the thread.
+
+**Limitation:** Messages sent directly in the Feishu thread panel (not via the "Reply" action) do not include `root_id` and will be treated as regular group messages. Use the "Reply" action to ensure thread context is preserved.
+
+Streaming (typewriter) mode works in threads — edits target the same message regardless of thread context.
+
 ## Bot-to-Bot Collaboration (Gateway-Side Only)
 
 The gateway adapter includes bot identification and filtering scaffolding (`AllowBots` enum, `FEISHU_TRUSTED_BOT_IDS`, `FEISHU_MAX_BOT_TURNS` with human-reset safety valve), matching Discord's `allow_bot_messages` design.

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -298,7 +298,6 @@ mod event_types {
 
         let chat_id = msg.chat_id.as_deref()?;
         let message_id = msg.message_id.as_deref()?;
-
         // Group allowlist: if configured, only allow listed groups
         let is_group = msg.chat_type.as_deref() != Some("p2p");
         if is_group
@@ -329,8 +328,10 @@ mod event_types {
             _ => "group",
         };
 
+        let thread_id = msg.root_id.clone().or_else(|| msg.parent_id.clone());
+
         // Gateway-side mention gating: in groups, skip if require_mention
-        // is true and bot is not mentioned (for human senders)
+        // is true and bot is not mentioned (for human senders).
         if channel_type == "group" && !is_bot_sender && config.require_mention {
             if let Some(bot_id) = bot_open_id {
                 let bot_mentioned = mention_ids.iter().any(|id| id == bot_id);
@@ -352,8 +353,6 @@ mod event_types {
                 }
             }
         }
-
-        let thread_id = msg.root_id.clone().or_else(|| msg.parent_id.clone());
 
         let event = GatewayEvent::new(
             "feishu",
@@ -872,6 +871,7 @@ async fn handle_ws_message(
         let json = serde_json::to_string(&gateway_event).unwrap();
         info!(
             channel = %gateway_event.channel.id,
+            thread_id = ?gateway_event.channel.thread_id,
             sender = %gateway_event.sender.id,
             "feishu → gateway"
         );
@@ -1154,24 +1154,34 @@ fn try_parse_link(chars: &[char], start: usize) -> Option<(String, String, usize
 
 /// Send a post (rich text) message to a feishu chat_id.
 /// Returns the sent message_id on success, None on failure.
+/// When `reply_to` is Some(root_id), uses the reply API to stay in a thread.
+/// When `reply_to` is None, sends a new message to the chat.
 pub async fn send_post_message(
     client: &reqwest::Client,
     api_base: &str,
     token: &str,
     chat_id: &str,
+    reply_to: Option<&str>,
     text: &str,
 ) -> Option<String> {
-    let url = format!(
-        "{}/open-apis/im/v1/messages?receive_id_type=chat_id",
-        api_base
-    );
-    let post_content = markdown_to_post(text);
-    let content = post_content.to_string();
-    let body = serde_json::json!({
-        "receive_id": chat_id,
-        "msg_type": "post",
-        "content": content,
-    });
+    let (url, body) = if let Some(root_id) = reply_to {
+        (
+            format!("{}/open-apis/im/v1/messages/{}/reply", api_base, root_id),
+            serde_json::json!({
+                "msg_type": "post",
+                "content": markdown_to_post(text).to_string(),
+            }),
+        )
+    } else {
+        (
+            format!("{}/open-apis/im/v1/messages?receive_id_type=chat_id", api_base),
+            serde_json::json!({
+                "receive_id": chat_id,
+                "msg_type": "post",
+                "content": markdown_to_post(text).to_string(),
+            }),
+        )
+    };
 
     match client
         .post(&url)
@@ -1194,7 +1204,7 @@ pub async fn send_post_message(
                     .pointer("/data/message_id")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
-                info!(chat_id = %chat_id, message_id = ?msg_id, "feishu post message sent");
+                info!(chat_id = %chat_id, reply_to = ?reply_to, message_id = ?msg_id, "feishu post message sent");
                 msg_id
             } else {
                 let status = resp.status();
@@ -1393,6 +1403,19 @@ pub async fn handle_reply(
         Ok(t) => t,
         Err(e) => {
             tracing::error!(err = %e, "feishu: cannot get token for reply");
+            if let Some(ref req_id) = reply.request_id {
+                let resp = crate::schema::GatewayResponse {
+                    schema: "openab.gateway.response.v1".into(),
+                    request_id: req_id.clone(),
+                    success: false,
+                    thread_id: None,
+                    message_id: None,
+                    error: Some(format!("token error: {e}")),
+                };
+                if let Ok(json) = serde_json::to_string(&resp) {
+                    let _ = event_tx.send(json);
+                }
+            }
             return;
         }
     };
@@ -1400,12 +1423,14 @@ pub async fn handle_reply(
     let api_base = adapter.config.api_base();
     let text = &reply.content.text;
     let limit = adapter.config.message_limit;
+    let thread_id = reply.channel.thread_id.as_deref();
 
     // Split long messages; store sent message_ids in dedupe to prevent
     // self-echo (Feishu pushes bot's own messages back via WebSocket)
     // Use post (rich text) format for markdown rendering.
+    // When in a thread (thread_id present), use reply API to stay in the same thread.
     if text.len() <= limit {
-        match send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, text).await {
+        match send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, thread_id, text).await {
             Some(msg_id) => {
                 adapter.dedupe.is_duplicate(&msg_id);
                 // Send response with message_id back to OAB core (for streaming edit)
@@ -1442,7 +1467,7 @@ pub async fn handle_reply(
         }
     } else {
         for chunk in split_text(text, limit) {
-            if let Some(msg_id) = send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, chunk).await {
+            if let Some(msg_id) = send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, thread_id, chunk).await {
                 adapter.dedupe.is_duplicate(&msg_id);
             }
         }


### PR DESCRIPTION
## Summary

Adds thread (topic) reply support for the Feishu adapter. When a user replies to a bot message, the bot responds within the same thread, and each thread gets its own independent session.

```
Group chat                          Feishu
  │                                   │
  ├─ User replies to bot msg ────────►│ thread created (root_id = om_xxx)
  │                                   │
  ├─ Gateway receives event ──────────│ root_id extracted as thread_id
  │   session key: feishu:om_xxx      │
  │                                   │
  ├─ Bot reply ───────────────────────│ POST /messages/{root_id}/reply
  │                                   │ → appears in same thread
```

## Changes

| File | Change | Description |
|------|--------|-------------|
| `gateway/src/adapters/feishu.rs` | MOD | `reply_post_message()`: new function using `POST /messages/{root_id}/reply`. `handle_reply`: routes to reply API when `thread_id` is present. Thread_id logged in `feishu → gateway` info line. |
| `docs/feishu.md` | MOD | Add Thread (Topic) Replies section |

## How it works

**Receiving:** `parse_message_event` already extracts `root_id` (or `parent_id` fallback) as `thread_id` (done in PR #706). OAB core uses `thread_id.unwrap_or(channel_id)` as session key — each thread gets an independent session automatically.

**Sending:** New `reply_post_message()` sends via `POST /im/v1/messages/{root_id}/reply` instead of the regular send API. `handle_reply` checks `reply.channel.thread_id` — present → reply API, absent → regular send. Streaming `edit_message` is unaffected (edits the same message_id regardless of thread).

## Known limitation

Messages sent directly in the Feishu thread panel (not via the "Reply" action) do not include `root_id`/`parent_id` in the event payload. These are treated as regular group messages. This is a Feishu platform behavior — OpenClaw documents the same limitation.

This PR does NOT add `create_topic` support — threads are created by user reply action, not by the bot. The `create_topic` command remains skipped (logged as unsupported).

## Prior Art

- **OpenClaw:** Uses `thread_id` (`omt_*`) for topic groups and reply root message ID (`om_*`) for normal group replies. Same approach as this PR.
- **Hermes Agent:** Thread-aware media replies documented. Uses similar root_id-based session isolation.

## Testing

| Scenario | Result |
|----------|--------|
| Regular group @Bot1 → normal reply (no thread) | PASS |
| Reply to bot message → bot replies in thread | PASS |
| Thread: @Bot1 → only Bot1 replies | PASS |
| Thread: @Bot2 → only Bot2 replies | PASS |
| Private chat thread → bot replies in thread | PASS |
| Thread panel direct message → no root_id, treated as group msg | PASS (known limitation) |
| Streaming edit in thread → works correctly | PASS |
| `cargo test` — 96 passed | PASS |

End-to-end tested on Feishu.

## Breaking Changes

None. Regular (non-thread) messages are unaffected.

## Discord Discussion URL

https://discord.com/channels/1491295327620169908/1500160821567684660
