### PR TITLE
fix(discord): only send turn limit warning from participating bot

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -322,7 +322,15 @@ impl EventHandler for Handler {
                             }
                         }
                         if msg.author.id != bot_id && allowed_here {
-                            let _ = msg.channel_id.say(&ctx.http, &user_message).await;
+                            // Only warn if this bot actually participated in the
+                            // thread — prevents uninvolved bots from spamming
+                            // warnings in shared channels. (#727)
+                            let (participated, _) = self
+                                .bot_participated_in_thread(&ctx.http, msg.channel_id, bot_id)
+                                .await;
+                            if participated {
+                                let _ = msg.channel_id.say(&ctx.http, &user_message).await;
+                            }
                         }
                         return;
                     }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -325,6 +325,7 @@ impl EventHandler for Handler {
                             // Only warn if this bot actually participated in the
                             // thread — prevents uninvolved bots from spamming
                             // warnings in shared channels. (#727)
+                            // Second value is `is_multibot`; not needed here.
                             let (participated, _) = self
                                 .bot_participated_in_thread(&ctx.http, msg.channel_id, bot_id)
                                 .await;


### PR DESCRIPTION
## Context

When multiple bot instances share a channel, the bot turn limit warning (`⚠️ Bot turn limit reached`) is sent by **every** instance — not just the one that actually participated in the thread. This spams the thread with duplicate warnings and pulls uninvolved bots into the conversation.

Closes #727

## Summary

Gate the turn limit warning behind a `bot_participated_in_thread()` check so only the bot that actually replied in the thread sends the warning message.

## Changes

- Added `bot_participated_in_thread()` call in the `WarnAndStop` path before sending the warning message
- Uninvolved bots now silently return instead of posting a warning they have no business sending

## Notes

- `bot_participated_in_thread()` is fail-closed: on API error it returns `(false, false)`, so the warning is suppressed rather than sent — safe default
- The extra API call only happens on the `WarnAndStop` path (at most once per soft/hard limit per thread), so performance impact is negligible
- The method is already used in 3 other places in the same file with the same signature

Discord Discussion URL: https://discord.com/channels/1395707092077248593/1395707093364768850/1500805519630274701