### PR TITLE
feat(helm): add secretEnv to avoid API keys in ConfigMap

### DIFF
--- a/charts/openab/templates/_helpers.tpl
+++ b/charts/openab/templates/_helpers.tpl
@@ -75,3 +75,13 @@ app.kubernetes.io/component: {{ .agent }}
 {{- define "openab.persistenceEnabled" -}}
 {{- if and . .persistence (eq (.persistence.enabled | toString) "false") }}false{{ else }}true{{ end }}
 {{- end }}
+
+{{/* Validate secretEnv entries: each must have name, secretName, and secretKey.
+     Call with: dict "secretEnv" $cfg.secretEnv "agentName" $name */}}
+{{- define "openab.validateSecretEnv" -}}
+{{- range .secretEnv }}
+{{- if not (and .name .secretName .secretKey) }}
+{{- fail (printf "agents.%s.secretEnv entries require name, secretName, and secretKey" $.agentName) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -106,7 +106,6 @@ data:
     {{- if $cfg.env }}
     env = { {{ $first := true }}{{ range $k, $v := $cfg.env }}{{ if not $first }}, {{ end }}{{ $k }} = {{ $v | toJson }}{{ $first = false }}{{ end }} }
     {{- end }}
-    {{- include "openab.validateSecretEnv" (dict "secretEnv" $cfg.secretEnv "agentName" $name) }}
     {{- range $cfg.secretEnv }}
     {{- if hasKey ($cfg.env | default dict) .name }}
     {{- fail (printf "agents.%s.secretEnv key %q also exists in env — remove it from env to avoid plaintext secret in ConfigMap" $name .name) }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -106,10 +106,8 @@ data:
     {{- if $cfg.env }}
     env = { {{ $first := true }}{{ range $k, $v := $cfg.env }}{{ if not $first }}, {{ end }}{{ $k }} = {{ $v | toJson }}{{ $first = false }}{{ end }} }
     {{- end }}
+    {{- include "openab.validateSecretEnv" (dict "secretEnv" $cfg.secretEnv "agentName" $name) }}
     {{- range $cfg.secretEnv }}
-    {{- if not (and .name .secretName .secretKey) }}
-    {{- fail (printf "agents.%s.secretEnv entries require name, secretName, and secretKey" $name) }}
-    {{- end }}
     {{- if hasKey ($cfg.env | default dict) .name }}
     {{- fail (printf "agents.%s.secretEnv key %q also exists in env — remove it from env to avoid plaintext secret in ConfigMap" $name .name) }}
     {{- end }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -106,8 +106,19 @@ data:
     {{- if $cfg.env }}
     env = { {{ $first := true }}{{ range $k, $v := $cfg.env }}{{ if not $first }}, {{ end }}{{ $k }} = {{ $v | toJson }}{{ $first = false }}{{ end }} }
     {{- end }}
-    {{- if $cfg.inheritEnv }}
-    inherit_env = {{ $cfg.inheritEnv | toJson }}
+    {{- range $cfg.secretEnv }}
+    {{- if not (and .name .secretName .secretKey) }}
+    {{- fail (printf "agents.%s.secretEnv entries require name, secretName, and secretKey" $name) }}
+    {{- end }}
+    {{- if hasKey ($cfg.env | default dict) .name }}
+    {{- fail (printf "agents.%s.secretEnv key %q also exists in env — remove it from env to avoid plaintext secret in ConfigMap" $name .name) }}
+    {{- end }}
+    {{- end }}
+    {{- $secretEnvKeys := list }}
+    {{- range $cfg.secretEnv }}{{ $secretEnvKeys = append $secretEnvKeys .name }}{{ end }}
+    {{- $mergedInheritEnv := concat ($cfg.inheritEnv | default list) $secretEnvKeys | uniq }}
+    {{- if $mergedInheritEnv }}
+    inherit_env = {{ $mergedInheritEnv | toJson }}
     {{- end }}
 
     [pool]

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -83,10 +83,8 @@ spec:
             - name: {{ $k }}
               value: {{ $v | quote }}
             {{- end }}
+            {{- include "openab.validateSecretEnv" (dict "secretEnv" $cfg.secretEnv "agentName" $name) }}
             {{- range $cfg.secretEnv }}
-            {{- if not (and .name .secretName .secretKey) }}
-            {{- fail (printf "agents.%s.secretEnv entries require name, secretName, and secretKey" $name) }}
-            {{- end }}
             - name: {{ .name }}
               valueFrom:
                 secretKeyRef:

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -87,8 +87,6 @@ spec:
             {{- if not (and .name .secretName .secretKey) }}
             {{- fail (printf "agents.%s.secretEnv entries require name, secretName, and secretKey" $name) }}
             {{- end }}
-            {{- end }}
-            {{- range $cfg.secretEnv }}
             - name: {{ .name }}
               valueFrom:
                 secretKeyRef:

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -83,6 +83,18 @@ spec:
             - name: {{ $k }}
               value: {{ $v | quote }}
             {{- end }}
+            {{- range $cfg.secretEnv }}
+            {{- if not (and .name .secretName .secretKey) }}
+            {{- fail (printf "agents.%s.secretEnv entries require name, secretName, and secretKey" $name) }}
+            {{- end }}
+            {{- end }}
+            {{- range $cfg.secretEnv }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .secretKey }}
+            {{- end }}
           {{- with $cfg.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/openab/tests/secretenv_deployment_test.yaml
+++ b/charts/openab/tests/secretenv_deployment_test.yaml
@@ -1,0 +1,78 @@
+suite: secretEnv — Deployment rendering and field validation
+templates:
+  - templates/deployment.yaml
+
+tests:
+  # ── valueFrom.secretKeyRef rendering ──────────────────────────────────────
+
+  - it: renders secretEnv as valueFrom.secretKeyRef in Deployment
+    set:
+      agents.kiro.secretEnv:
+        - name: GEMINI_API_KEY
+          secretName: openab-secrets
+          secretKey: GEMINI_API_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GEMINI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: openab-secrets
+                key: GEMINI_API_KEY
+
+  - it: renders multiple secretEnv entries as separate secretKeyRef vars
+    set:
+      agents.kiro.secretEnv:
+        - name: GEMINI_API_KEY
+          secretName: openab-secrets
+          secretKey: GEMINI_API_KEY
+        - name: OPENAI_API_KEY
+          secretName: openab-secrets
+          secretKey: OPENAI_API_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GEMINI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: openab-secrets
+                key: GEMINI_API_KEY
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OPENAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: openab-secrets
+                key: OPENAI_API_KEY
+
+  # ── field validation guards ────────────────────────────────────────────────
+
+  - it: fails when secretEnv entry is missing secretKey
+    set:
+      agents.kiro.secretEnv:
+        - name: GEMINI_API_KEY
+          secretName: openab-secrets
+    asserts:
+      - failedTemplate:
+          errorPattern: "secretEnv entries require name, secretName, and secretKey"
+
+  - it: fails when secretEnv entry is missing secretName
+    set:
+      agents.kiro.secretEnv:
+        - name: GEMINI_API_KEY
+          secretKey: GEMINI_API_KEY
+    asserts:
+      - failedTemplate:
+          errorPattern: "secretEnv entries require name, secretName, and secretKey"
+
+  - it: fails when secretEnv entry is missing name
+    set:
+      agents.kiro.secretEnv:
+        - secretName: openab-secrets
+          secretKey: GEMINI_API_KEY
+    asserts:
+      - failedTemplate:
+          errorPattern: "secretEnv entries require name, secretName, and secretKey"

--- a/charts/openab/tests/secretenv_test.yaml
+++ b/charts/openab/tests/secretenv_test.yaml
@@ -39,7 +39,13 @@ tests:
     asserts:
       - matchRegex:
           path: data["config.toml"]
-          pattern: 'inherit_env = \["GEMINI_API_KEY","API_BASE_URL"\]'
+          pattern: 'inherit_env = \[.*"GEMINI_API_KEY".*\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'inherit_env = \[.*"API_BASE_URL".*\]'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: '"GEMINI_API_KEY"[^"]*"GEMINI_API_KEY"'
 
   - it: renders multiple secretEnv keys in inherit_env
     set:

--- a/charts/openab/tests/secretenv_test.yaml
+++ b/charts/openab/tests/secretenv_test.yaml
@@ -1,0 +1,78 @@
+suite: secretEnv — ConfigMap rendering (inherit_env merge, no plaintext)
+templates:
+  - templates/configmap.yaml
+
+tests:
+  # ── inherit_env merge ──────────────────────────────────────────────────────
+
+  - it: adds secretEnv key to inherit_env in ConfigMap
+    set:
+      agents.kiro.secretEnv:
+        - name: GEMINI_API_KEY
+          secretName: openab-secrets
+          secretKey: GEMINI_API_KEY
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'inherit_env = \["GEMINI_API_KEY"\]'
+
+  - it: does not render the secret value in ConfigMap
+    set:
+      agents.kiro.secretEnv:
+        - name: GEMINI_API_KEY
+          secretName: openab-secrets
+          secretKey: GEMINI_API_KEY
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'GEMINI_API_KEY\s*='
+
+  - it: merges secretEnv keys with existing inheritEnv and deduplicates
+    set:
+      agents.kiro.inheritEnv:
+        - GEMINI_API_KEY
+        - API_BASE_URL
+      agents.kiro.secretEnv:
+        - name: GEMINI_API_KEY
+          secretName: openab-secrets
+          secretKey: GEMINI_API_KEY
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'inherit_env = \["GEMINI_API_KEY","API_BASE_URL"\]'
+
+  - it: renders multiple secretEnv keys in inherit_env
+    set:
+      agents.kiro.secretEnv:
+        - name: GEMINI_API_KEY
+          secretName: openab-secrets
+          secretKey: GEMINI_API_KEY
+        - name: OPENAI_API_KEY
+          secretName: openab-secrets
+          secretKey: OPENAI_API_KEY
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'inherit_env = \["GEMINI_API_KEY","OPENAI_API_KEY"\]'
+
+  # ── conflict guard (env collision) ─────────────────────────────────────────
+
+  - it: fails when secretEnv key conflicts with env
+    set:
+      agents.kiro.env:
+        GEMINI_API_KEY: plaintext-value
+      agents.kiro.secretEnv:
+        - name: GEMINI_API_KEY
+          secretName: openab-secrets
+          secretKey: GEMINI_API_KEY
+    asserts:
+      - failedTemplate:
+          errorPattern: 'also exists in env'
+
+  # ── backward compat ────────────────────────────────────────────────────────
+
+  - it: does not render inherit_env when neither inheritEnv nor secretEnv is set
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'inherit_env'

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -42,6 +42,14 @@ agents:
     #   nameOverride: ""
     #   env: {}
     #   envFrom: []
+    #   # secretEnv: inject API keys from a Kubernetes Secret without storing them in the ConfigMap.
+    #   # Each entry renders as valueFrom.secretKeyRef in the Deployment and auto-adds the key name
+    #   # to inherit_env in config.toml. ⚠️ Do NOT also list the same key in env — use one or the other.
+    #   # secretEnv:
+    #   #   - name: GEMINI_API_KEY
+    #   #     secretName: my-secrets
+    #   #     secretKey: GEMINI_API_KEY
+    #   secretEnv: []
     #   pool:
     #     maxSessions: 10
     #     sessionTtlHours: 24
@@ -76,6 +84,7 @@ agents:
     #   workingDir: /home/node
     #   env: {}
     #   envFrom: []
+    #   secretEnv: []
     #   pool:
     #     maxSessions: 10
     #     sessionTtlHours: 24
@@ -107,6 +116,7 @@ agents:
     #   workingDir: /home/agent
     #   env: {}
     #   envFrom: []
+    #   secretEnv: []
     #   pool:
     #     maxSessions: 10
     #     sessionTtlHours: 24
@@ -178,6 +188,7 @@ agents:
     workingDir: /home/agent
     env: {}
     envFrom: []
+    secretEnv: []  # list of {name, secretName, secretKey} — rendered as valueFrom.secretKeyRef; keys auto-added to inherit_env
     pool:
       maxSessions: 10
       sessionTtlHours: 24


### PR DESCRIPTION
## Summary

Closes #729

## Problem

`[agent].env` values are rendered directly into the ConfigMap as plaintext, exposing API keys to anyone with `kubectl get configmap` access:

```toml
# ConfigMap — visible to all cluster users
[agent]
env = { GEMINI_API_KEY = "AIzaSy..." }
```

## Solution

Add a `secretEnv` field that renders as `valueFrom.secretKeyRef` in the Deployment and automatically adds the key name to `inherit_env` in config.toml:

```yaml
agents:
  gemini:
    secretEnv:
      - name: GEMINI_API_KEY
        secretName: openab-secrets
        secretKey: GEMINI_API_KEY
```

**Deployment** (secret value, not plaintext):
```yaml
- name: GEMINI_API_KEY
  valueFrom:
    secretKeyRef:
      name: openab-secrets
      key: GEMINI_API_KEY
```

**ConfigMap** (no secret value):
```toml
[agent]
inherit_env = ["GEMINI_API_KEY"]
```

The secret flows: k8s Secret → Deployment env → openab process → `inherit_env` → agent subprocess. The ConfigMap stays clean.

## Changes

- `charts/openab/templates/deployment.yaml` — render `secretEnv` as `valueFrom.secretKeyRef`
- `charts/openab/templates/configmap.yaml` — merge `secretEnv` key names into `inherit_env`

## Testing

```bash
helm template test ./charts/openab \
  --set agents.gemini.secretEnv[0].name=GEMINI_API_KEY \
  --set agents.gemini.secretEnv[0].secretName=openab-secrets \
  --set agents.gemini.secretEnv[0].secretKey=GEMINI_API_KEY
```

Verified ConfigMap contains `inherit_env = ["GEMINI_API_KEY"]` and Deployment contains `valueFrom.secretKeyRef`.

## Discord Discussion

https://discord.com/channels/1491295327620169908/1491365157010542652