### PR TITLE
feat(gateway): feishu image and text file attachment support

### DIFF
--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -122,6 +122,23 @@ Agent replies are sent as Feishu **post** (rich text) messages instead of plain 
 
 Inline Markdown formatting (`**bold**`, `*italic*`, `` `code` ``, `~~strike~~`) is stripped to plain text because Feishu's post format does not support inline styles.
 
+## Image & File Attachments
+
+The gateway downloads and forwards image and text file attachments to the AI agent, matching Discord's attachment handling.
+
+**Supported message types:**
+
+| Feishu msg_type | Handling |
+|-----------------|----------|
+| `text` | Text extracted, forwarded as prompt |
+| `image` | Image downloaded, resized (max 1200px), JPEG compressed, base64 encoded → `ContentBlock::Image` |
+| `file` | Text files only (`.txt`, `.py`, `.rs`, `.md`, `.json`, etc., max 512KB). Non-text files (`.pdf`, `.zip`, etc.) are silently ignored. |
+| `post` | Rich text: text nodes extracted as prompt, `img` nodes downloaded as image attachments. This is the format Feishu uses when @mention + paste image in a group. |
+
+**Group chat limitation:** Feishu does not allow @mention and image upload in the same message. However, @mention + paste (Ctrl+V) an image works — Feishu sends this as a `post` message containing both the mention and the image. Direct image upload (via the attachment button) cannot include @mention, so the bot will not respond in groups.
+
+**Processing pipeline:** Gateway downloads media using `GET /im/v1/messages/{message_id}/resources/{key}?type=image` with `tenant_access_token`, resizes to max 1200px, compresses to JPEG (quality 75), base64 encodes, and embeds in the `GatewayEvent.content.attachments` field. OAB core decodes attachments into `ContentBlock::Image` or `ContentBlock::Text` for the AI agent.
+
 ## Streaming (Typewriter)
 
 Agent replies stream incrementally — a placeholder message appears immediately, then updates every ~1.5 seconds as the agent generates content. This matches Discord's streaming behavior.

--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,10 +157,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -218,6 +236,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -320,10 +353,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -482,6 +534,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -779,6 +841,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +1021,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +1039,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1012,6 +1122,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "hmac",
+ "image",
  "jsonwebtoken",
  "prost",
  "reqwest",
@@ -1071,6 +1182,19 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1137,6 +1261,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -1565,6 +1701,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple_asn1"
@@ -2221,6 +2363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,3 +2814,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -24,6 +24,7 @@ aes = "0.8"
 cbc = "0.1"
 prost = "0.13"
 subtle = "2"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -1328,7 +1328,17 @@ pub async fn download_feishu_image(
         tracing::warn!(image_key, status = %resp.status(), "feishu image download failed");
         return None;
     }
+    // Early gate: reject oversized downloads before buffering the full body
+    if let Some(cl) = resp.headers().get(reqwest::header::CONTENT_LENGTH) {
+        if let Ok(size) = cl.to_str().unwrap_or("0").parse::<u64>() {
+            if size > IMAGE_MAX_DOWNLOAD {
+                tracing::warn!(image_key, size, "feishu image Content-Length exceeds 10MB limit, skipping download");
+                return None;
+            }
+        }
+    }
     let bytes = resp.bytes().await.ok()?;
+    // Fallback check (Content-Length may be absent or misreported)
     if bytes.len() as u64 > IMAGE_MAX_DOWNLOAD {
         tracing::warn!(image_key, size = bytes.len(), "feishu image exceeds 10MB limit");
         return None;
@@ -1386,7 +1396,17 @@ pub async fn download_feishu_file(
         tracing::warn!(file_name, status = %resp.status(), "feishu file download failed");
         return None;
     }
+    // Early gate: reject oversized downloads before buffering the full body
+    if let Some(cl) = resp.headers().get(reqwest::header::CONTENT_LENGTH) {
+        if let Ok(size) = cl.to_str().unwrap_or("0").parse::<u64>() {
+            if size > FILE_MAX_DOWNLOAD {
+                tracing::warn!(file_name, size, "feishu file Content-Length exceeds 512KB limit, skipping download");
+                return None;
+            }
+        }
+    }
     let bytes = resp.bytes().await.ok()?;
+    // Fallback check (Content-Length may be absent or misreported)
     if bytes.len() as u64 > FILE_MAX_DOWNLOAD {
         tracing::warn!(file_name, size = bytes.len(), "feishu file exceeds 512KB limit");
         return None;

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -240,18 +240,20 @@ mod event_types {
     }
 
     /// Parse a feishu im.message.receive_v1 event into a GatewayEvent.
-    /// Returns None if the event should be skipped (non-text, bot message, etc).
+    /// Returns None if the event should be skipped (unsupported type, bot message, etc).
+    /// The Vec<MediaRef> contains references to media that need async download.
     pub fn parse_message_event(
         envelope: &FeishuEventEnvelope,
         bot_open_id: Option<&str>,
         config: &FeishuConfig,
-    ) -> Option<GatewayEvent> {
+    ) -> Option<(GatewayEvent, Vec<MediaRef>)> {
         let _header = envelope.header.as_ref()?;
         let event = envelope.event.as_ref()?;
         let msg = event.message.as_ref()?;
         let sender = event.sender.as_ref()?;
 
-        if msg.message_type.as_deref() != Some("text") {
+        let msg_type = msg.message_type.as_deref().unwrap_or("text");
+        if !matches!(msg_type, "text" | "image" | "file" | "post") {
             return None;
         }
         // Skip bot messages with explicit sender_type
@@ -297,7 +299,6 @@ mod event_types {
         }
 
         let chat_id = msg.chat_id.as_deref()?;
-        let message_id = msg.message_id.as_deref()?;
         // Group allowlist: if configured, only allow listed groups
         let is_group = msg.chat_type.as_deref() != Some("p2p");
         if is_group
@@ -309,19 +310,95 @@ mod event_types {
 
         let content_json: serde_json::Value = msg.content.as_deref()
             .and_then(|s| serde_json::from_str(s).ok())?;
-        let raw_text = content_json.get("text")?.as_str()?;
-        if raw_text.trim().is_empty() {
-            return None;
-        }
 
-        let (clean_text, mention_ids) = extract_mentions(
-            raw_text,
-            msg.mentions.as_deref().unwrap_or(&[]),
-            bot_open_id,
-        );
-        if clean_text.trim().is_empty() {
-            return None;
-        }
+        let message_id = msg.message_id.as_deref()?;
+
+        // Parse content based on message type
+        let (clean_text, mention_ids, media_refs) = match msg_type {
+            "image" => {
+                let image_key = content_json.get("image_key")?.as_str()?;
+                let mentions = extract_mentions(
+                    "", msg.mentions.as_deref().unwrap_or(&[]), bot_open_id,
+                );
+                let refs = vec![MediaRef::Image {
+                    message_id: message_id.to_string(),
+                    image_key: image_key.to_string(),
+                }];
+                (String::new(), mentions.1, refs)
+            }
+            "file" => {
+                let file_key = content_json.get("file_key")?.as_str()?;
+                let file_name = content_json.get("file_name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                let mentions = extract_mentions(
+                    "", msg.mentions.as_deref().unwrap_or(&[]), bot_open_id,
+                );
+                let refs = vec![MediaRef::File {
+                    message_id: message_id.to_string(),
+                    file_key: file_key.to_string(),
+                    file_name: file_name.to_string(),
+                }];
+                (String::new(), mentions.1, refs)
+            }
+            "post" => {
+                // Rich text: content is {"title":"...","content":[[{tag,text,...},{tag,image_key,...}]]}
+                let mut texts = Vec::new();
+                let mut refs = Vec::new();
+                if let Some(rows) = content_json.get("content").and_then(|v| v.as_array()) {
+                    for row in rows {
+                        if let Some(elements) = row.as_array() {
+                            for el in elements {
+                                match el.get("tag").and_then(|v| v.as_str()) {
+                                    Some("text") => {
+                                        if let Some(t) = el.get("text").and_then(|v| v.as_str()) {
+                                            texts.push(t.to_string());
+                                        }
+                                    }
+                                    Some("img") => {
+                                        if let Some(key) = el.get("image_key").and_then(|v| v.as_str()) {
+                                            refs.push(MediaRef::Image {
+                                                message_id: message_id.to_string(),
+                                                image_key: key.to_string(),
+                                            });
+                                        }
+                                    }
+                                    Some("a") => {
+                                        if let Some(t) = el.get("text").and_then(|v| v.as_str()) {
+                                            texts.push(t.to_string());
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
+                }
+                let raw_text = texts.join("");
+                let (clean, ids) = extract_mentions(
+                    &raw_text,
+                    msg.mentions.as_deref().unwrap_or(&[]),
+                    bot_open_id,
+                );
+                (clean, ids, refs)
+            }
+            _ => {
+                // text
+                let raw_text = content_json.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                if raw_text.trim().is_empty() {
+                    return None;
+                }
+                let (clean, ids) = extract_mentions(
+                    raw_text,
+                    msg.mentions.as_deref().unwrap_or(&[]),
+                    bot_open_id,
+                );
+                if clean.trim().is_empty() {
+                    return None;
+                }
+                (clean, ids, Vec::new())
+            }
+        };
 
         let channel_type = match msg.chat_type.as_deref() {
             Some("p2p") => "direct",
@@ -371,7 +448,7 @@ mod event_types {
             message_id,
             mention_ids,
         );
-        Some(event)
+        Some((event, media_refs))
     }
 
     fn extract_mentions(
@@ -834,7 +911,7 @@ async fn handle_ws_message(
     let bot_id = bot_open_id_store.read().await;
     let bot_id_ref = bot_id.as_deref();
 
-    if let Some(mut gateway_event) = parse_message_event(&envelope, bot_id_ref, config) {
+    if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, config) {
         // Also dedupe by message_id
         if dedupe.is_duplicate(&gateway_event.message_id) {
             return;
@@ -868,6 +945,39 @@ async fn handle_ws_message(
         ).await;
         gateway_event.sender.name = name.clone();
         gateway_event.sender.display_name = name;
+
+        // Download media attachments (images, text files)
+        if !media_refs.is_empty() {
+            let token = match token_cache.get_token(client).await {
+                Ok(t) => t,
+                Err(e) => {
+                    tracing::warn!(error = %e, "feishu: cannot get token for media download");
+                    String::new()
+                }
+            };
+            if !token.is_empty() {
+                let api_base = config.api_base();
+                for media_ref in &media_refs {
+                    let attachment = match media_ref {
+                        MediaRef::Image { message_id, image_key } => {
+                            download_feishu_image(client, &api_base, &token, message_id, image_key).await
+                        }
+                        MediaRef::File { message_id, file_key, file_name } => {
+                            download_feishu_file(client, &api_base, &token, message_id, file_key, file_name).await
+                        }
+                    };
+                    if let Some(att) = attachment {
+                        gateway_event.content.attachments.push(att);
+                    }
+                }
+            }
+        }
+
+        // Skip if no text and no attachments (e.g. unsupported file type)
+        if gateway_event.content.text.trim().is_empty() && gateway_event.content.attachments.is_empty() {
+            return;
+        }
+
         let json = serde_json::to_string(&gateway_event).unwrap();
         info!(
             channel = %gateway_event.channel.id,
@@ -1150,6 +1260,147 @@ fn try_parse_link(chars: &[char], start: usize) -> Option<(String, String, usize
     }
     i += 1; // skip )
     Some((text, url, i))
+}
+
+// ---------------------------------------------------------------------------
+// Media helpers
+// ---------------------------------------------------------------------------
+
+/// Reference to a media resource that needs async download after parse_message_event.
+pub enum MediaRef {
+    Image { message_id: String, image_key: String },
+    File { message_id: String, file_key: String, file_name: String },
+}
+
+const IMAGE_MAX_DIMENSION_PX: u32 = 1200;
+const IMAGE_JPEG_QUALITY: u8 = 75;
+const IMAGE_MAX_DOWNLOAD: u64 = 10 * 1024 * 1024; // 10 MB
+const FILE_MAX_DOWNLOAD: u64 = 512 * 1024; // 512 KB
+
+/// Resize image so longest side <= 1200px, then encode as JPEG.
+/// GIFs are passed through unchanged to preserve animation.
+fn resize_and_compress(raw: &[u8]) -> Result<(Vec<u8>, String), image::ImageError> {
+    use image::ImageReader;
+    use std::io::Cursor;
+
+    let reader = ImageReader::new(Cursor::new(raw)).with_guessed_format()?;
+    let format = reader.format();
+    if format == Some(image::ImageFormat::Gif) {
+        return Ok((raw.to_vec(), "image/gif".to_string()));
+    }
+    let img = reader.decode()?;
+    let (w, h) = (img.width(), img.height());
+    let img = if w > IMAGE_MAX_DIMENSION_PX || h > IMAGE_MAX_DIMENSION_PX {
+        let max_side = std::cmp::max(w, h);
+        let ratio = f64::from(IMAGE_MAX_DIMENSION_PX) / f64::from(max_side);
+        let new_w = (f64::from(w) * ratio) as u32;
+        let new_h = (f64::from(h) * ratio) as u32;
+        img.resize(new_w, new_h, image::imageops::FilterType::Lanczos3)
+    } else {
+        img
+    };
+    let mut buf = Cursor::new(Vec::new());
+    let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, IMAGE_JPEG_QUALITY);
+    img.write_with_encoder(encoder)?;
+    Ok((buf.into_inner(), "image/jpeg".to_string()))
+}
+
+/// Download a Feishu image by message_id + image_key → resize/compress → base64 Attachment.
+pub async fn download_feishu_image(
+    client: &reqwest::Client,
+    api_base: &str,
+    token: &str,
+    message_id: &str,
+    image_key: &str,
+) -> Option<crate::schema::Attachment> {
+    let url = format!(
+        "{}/open-apis/im/v1/messages/{}/resources/{}?type=image",
+        api_base, message_id, image_key
+    );
+    let resp = match client.get(&url).bearer_auth(token).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(image_key, error = %e, "feishu image download failed");
+            return None;
+        }
+    };
+    if !resp.status().is_success() {
+        tracing::warn!(image_key, status = %resp.status(), "feishu image download failed");
+        return None;
+    }
+    let bytes = resp.bytes().await.ok()?;
+    if bytes.len() as u64 > IMAGE_MAX_DOWNLOAD {
+        tracing::warn!(image_key, size = bytes.len(), "feishu image exceeds 10MB limit");
+        return None;
+    }
+    let (compressed, mime) = match resize_and_compress(&bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(image_key, error = %e, "feishu image resize failed");
+            return None;
+        }
+    };
+    use base64::Engine;
+    let data = base64::engine::general_purpose::STANDARD.encode(&compressed);
+    Some(crate::schema::Attachment {
+        attachment_type: "image".into(),
+        filename: format!("{}.jpg", image_key),
+        mime_type: mime,
+        data,
+        size: compressed.len() as u64,
+    })
+}
+
+/// Download a Feishu file by message_id + file_key → base64 Attachment (text files only).
+pub async fn download_feishu_file(
+    client: &reqwest::Client,
+    api_base: &str,
+    token: &str,
+    message_id: &str,
+    file_key: &str,
+    file_name: &str,
+) -> Option<crate::schema::Attachment> {
+    // Only download text-like files
+    let ext = file_name.rsplit('.').next().unwrap_or("").to_lowercase();
+    const TEXT_EXTS: &[&str] = &[
+        "txt", "csv", "log", "md", "json", "jsonl", "yaml", "yml", "toml", "xml",
+        "rs", "py", "js", "ts", "jsx", "tsx", "go", "java", "c", "cpp", "h", "hpp",
+        "rb", "sh", "bash", "sql", "html", "css", "ini", "cfg", "conf", "env",
+    ];
+    if !TEXT_EXTS.contains(&ext.as_str()) {
+        tracing::debug!(file_name, "skipping non-text file attachment");
+        return None;
+    }
+    let url = format!(
+        "{}/open-apis/im/v1/messages/{}/resources/{}?type=file",
+        api_base, message_id, file_key
+    );
+    let resp = match client.get(&url).bearer_auth(token).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(file_name, error = %e, "feishu file download failed");
+            return None;
+        }
+    };
+    if !resp.status().is_success() {
+        tracing::warn!(file_name, status = %resp.status(), "feishu file download failed");
+        return None;
+    }
+    let bytes = resp.bytes().await.ok()?;
+    if bytes.len() as u64 > FILE_MAX_DOWNLOAD {
+        tracing::warn!(file_name, size = bytes.len(), "feishu file exceeds 512KB limit");
+        return None;
+    }
+    let text = String::from_utf8_lossy(&bytes);
+    use base64::Engine;
+    let data = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+    Some(crate::schema::Attachment {
+        attachment_type: "text_file".into(),
+        filename: file_name.to_string(),
+        mime_type: "text/plain".into(),
+        data,
+        size: bytes.len() as u64,
+    })
 }
 
 /// Send a post (rich text) message to a feishu chat_id.
@@ -1744,7 +1995,7 @@ pub async fn webhook(
     let bot_id = feishu.bot_open_id.read().await;
     let bot_id_ref = bot_id.as_deref();
 
-    if let Some(mut gateway_event) = parse_message_event(&envelope, bot_id_ref, &feishu.config) {
+    if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, &feishu.config) {
         if !feishu.dedupe.is_duplicate(&gateway_event.message_id) {
             let name = resolve_user_name(
                 &gateway_event.sender.id, &feishu.name_cache, &feishu.token_cache,
@@ -1752,6 +2003,32 @@ pub async fn webhook(
             ).await;
             gateway_event.sender.name = name.clone();
             gateway_event.sender.display_name = name;
+
+            // Download media attachments
+            if !media_refs.is_empty() {
+                if let Ok(token) = feishu.token_cache.get_token(&feishu.client).await {
+                    let api_base = feishu.config.api_base();
+                    for media_ref in &media_refs {
+                        let attachment = match media_ref {
+                            MediaRef::Image { message_id, image_key } => {
+                                download_feishu_image(&feishu.client, &api_base, &token, message_id, image_key).await
+                            }
+                            MediaRef::File { message_id, file_key, file_name } => {
+                                download_feishu_file(&feishu.client, &api_base, &token, message_id, file_key, file_name).await
+                            }
+                        };
+                        if let Some(att) = attachment {
+                            gateway_event.content.attachments.push(att);
+                        }
+                    }
+                }
+            }
+
+            // Skip if no text and no attachments (e.g. unsupported file type)
+            if gateway_event.content.text.trim().is_empty() && gateway_event.content.attachments.is_empty() {
+                return axum::http::StatusCode::OK.into_response();
+            }
+
             let json = serde_json::to_string(&gateway_event).unwrap();
             info!(
                 channel = %gateway_event.channel.id,
@@ -2010,7 +2287,7 @@ mod tests {
     fn parse_dm_text() {
         let env = make_envelope("p2p", "hello", "ou_user1", None);
         let cfg = test_config();
-        let evt = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
+        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
         assert_eq!(evt.platform, "feishu");
         assert_eq!(evt.channel.channel_type, "direct");
         assert_eq!(evt.channel.id, "oc_chat1");
@@ -2030,7 +2307,7 @@ mod tests {
         }];
         let env = make_envelope("group", "@_user_1 explain VPC", "ou_user1", Some(mentions));
         let cfg = test_config();
-        let evt = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
+        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
         assert_eq!(evt.channel.channel_type, "group");
         assert_eq!(evt.content.text, "explain VPC");
         assert_eq!(evt.mentions, vec!["ou_bot"]);
@@ -2071,7 +2348,7 @@ mod tests {
     #[test]
     fn parse_skips_non_text_message() {
         let mut env = make_envelope("p2p", "hello", "ou_user1", None);
-        env.event.as_mut().unwrap().message.as_mut().unwrap().message_type = Some("image".into());
+        env.event.as_mut().unwrap().message.as_mut().unwrap().message_type = Some("sticker".into());
         let cfg = test_config();
         assert!(parse_message_event(&env, Some("ou_bot"), &cfg).is_none());
     }
@@ -2212,7 +2489,7 @@ mod tests {
         }];
         let env = make_envelope("group", "@_user_1 tell me about @_user_1 patterns", "ou_user1", Some(mentions));
         let cfg = test_config();
-        let evt = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
+        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
         // Only first @_user_1 removed, second preserved
         assert!(evt.content.text.contains("@_user_1"));
     }
@@ -2317,7 +2594,7 @@ mod tests {
         let mut env = make_envelope("p2p", "reply", "ou_user1", None);
         env.event.as_mut().unwrap().message.as_mut().unwrap().root_id = Some("om_root".into());
         let cfg = test_config();
-        let evt = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
+        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
         assert_eq!(evt.channel.thread_id, Some("om_root".into()));
     }
 
@@ -2326,7 +2603,7 @@ mod tests {
         let mut env = make_envelope("p2p", "reply", "ou_user1", None);
         env.event.as_mut().unwrap().message.as_mut().unwrap().parent_id = Some("om_parent".into());
         let cfg = test_config();
-        let evt = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
+        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
         assert_eq!(evt.channel.thread_id, Some("om_parent".into()));
     }
 

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -368,6 +368,9 @@ mod event_types {
                                             texts.push(t.to_string());
                                         }
                                     }
+                                    Some("at") => {
+                                        // Mentions handled via msg.mentions at envelope level
+                                    }
                                     _ => {}
                                 }
                             }
@@ -948,14 +951,7 @@ async fn handle_ws_message(
 
         // Download media attachments (images, text files)
         if !media_refs.is_empty() {
-            let token = match token_cache.get_token(client).await {
-                Ok(t) => t,
-                Err(e) => {
-                    tracing::warn!(error = %e, "feishu: cannot get token for media download");
-                    String::new()
-                }
-            };
-            if !token.is_empty() {
+            if let Ok(token) = token_cache.get_token(client).await {
                 let api_base = config.api_base();
                 for media_ref in &media_refs {
                     let attachment = match media_ref {
@@ -1352,9 +1348,10 @@ pub async fn download_feishu_image(
     };
     use base64::Engine;
     let data = base64::engine::general_purpose::STANDARD.encode(&compressed);
+    let ext = if mime == "image/gif" { "gif" } else { "jpg" };
     Some(crate::schema::Attachment {
         attachment_type: "image".into(),
-        filename: format!("{}.jpg", image_key),
+        filename: format!("{}.{}", image_key, ext),
         mime_type: mime,
         data,
         size: compressed.len() as u64,

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -423,6 +423,7 @@ mod tests {
             content: schema::Content {
                 content_type: "text".into(),
                 text: "hello".into(),
+                attachments: Vec::new(),
             },
             command: None,
             request_id: None,

--- a/gateway/src/schema.rs
+++ b/gateway/src/schema.rs
@@ -37,6 +37,18 @@ pub struct Content {
     #[serde(rename = "type")]
     pub content_type: String,
     pub text: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<Attachment>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Attachment {
+    #[serde(rename = "type")]
+    pub attachment_type: String, // "image", "text_file"
+    pub filename: String,
+    pub mime_type: String,
+    pub data: String, // base64 encoded
+    pub size: u64,    // size in bytes (after compression for images)
 }
 
 // --- Reply schema (ADR openab.gateway.reply.v1) ---
@@ -91,6 +103,7 @@ impl GatewayEvent {
             content: Content {
                 content_type: "text".into(),
                 text: text.into(),
+                attachments: Vec::new(),
             },
             mentions,
             message_id: message_id.into(),

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1,3 +1,4 @@
+use crate::acp::ContentBlock;
 use crate::adapter::{AdapterRouter, ChannelRef, ChatAdapter, MessageRef, SenderContext};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -50,6 +51,19 @@ struct GwContent {
     #[serde(rename = "type")]
     content_type: String,
     text: String,
+    #[serde(default)]
+    attachments: Vec<GwAttachment>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GwAttachment {
+    #[serde(rename = "type")]
+    attachment_type: String,
+    filename: String,
+    mime_type: String,
+    data: String,
+    #[allow(dead_code)]
+    size: u64,
 }
 
 #[derive(Serialize)]
@@ -500,6 +514,29 @@ pub async fn run_gateway_adapter(
                                     let router = router.clone();
                                     let prompt = event.content.text.clone();
 
+                                    // Convert gateway attachments to ContentBlocks
+                                    let mut extra_blocks = Vec::new();
+                                    for att in &event.content.attachments {
+                                        match att.attachment_type.as_str() {
+                                            "image" => {
+                                                extra_blocks.push(ContentBlock::Image {
+                                                    media_type: att.mime_type.clone(),
+                                                    data: att.data.clone(),
+                                                });
+                                            }
+                                            "text_file" => {
+                                                use base64::Engine;
+                                                if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(&att.data) {
+                                                    let text = String::from_utf8_lossy(&bytes);
+                                                    extra_blocks.push(ContentBlock::Text {
+                                                        text: format!("```{}\n{}\n```", att.filename, text),
+                                                    });
+                                                }
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+
                                     // Slash command interception for gateway platforms
                                     // (Feishu/LINE/Telegram don't have native slash commands)
                                     // Use fire-and-forget send — slash command responses don't
@@ -547,7 +584,7 @@ pub async fn run_gateway_adapter(
                                                 &thread_channel,
                                                 &sender_json,
                                                 &prompt,
-                                                vec![],
+                                                extra_blocks,
                                                 &trigger_msg,
                                                 false,
                                             )


### PR DESCRIPTION
## Summary

Adds image and text file attachment support for the Feishu gateway adapter. Images are downloaded, resized, compressed, and forwarded to the AI agent as `ContentBlock::Image`. Text files are downloaded and forwarded as `ContentBlock::Text`. This brings Feishu to feature parity with Discord's attachment handling.

```
Feishu user sends image
  │
  ├─ Gateway receives event (msg_type: image/post)
  │   parse_message_event extracts image_key → MediaRef
  │
  ├─ Gateway downloads image
  │   GET /im/v1/messages/{id}/resources/{key}?type=image
  │   → resize (max 1200px) → JPEG compress → base64
  │
  ├─ GatewayEvent.content.attachments = [{type:"image", data:"base64..."}]
  │   → sent over WebSocket to OAB core
  │
  └─ Core decodes attachment → ContentBlock::Image → extra_blocks
      → forwarded to AI agent (vision-capable models see the image)
```

## Changes

| File | Layer | Description |
|------|-------|-------------|
| `gateway/src/schema.rs` | Gateway | `Content` gains `attachments: Vec<Attachment>`. New `Attachment` struct with type/filename/mime_type/data/size. Backward compatible via `#[serde(default)]`. |
| `gateway/Cargo.toml` | Gateway | Add `image` crate for resize/compress |
| `gateway/src/adapters/feishu.rs` | Gateway | `resize_and_compress()`: 1200px max, JPEG quality 75. `download_feishu_image()`: resources API + compress + base64. `download_feishu_file()`: text files only (512KB cap). `parse_message_event()` returns `(GatewayEvent, Vec<MediaRef>)`, accepts `text/image/file/post` types. Callers (WS + webhook) do async download after parse. Empty text + empty attachments → event not sent. |
| `gateway/src/main.rs` | Gateway | Updated test fixture for new `Content.attachments` field |
| `src/gateway.rs` ⚠️ **OAB core** | Core | Deserialize `attachments` from GatewayEvent. Convert `image` → `ContentBlock::Image`, `text_file` → base64 decode → `ContentBlock::Text` wrapped in code fence. Pass as `extra_blocks` to `handle_message()`. |
| `docs/feishu.md` | Docs | New "Image & File Attachments" section |

> **⚠️ Core change note:** ~20 lines in `src/gateway.rs` — adds `GwAttachment` struct + attachment→ContentBlock conversion loop before `handle_message()`. No changes to handle_message itself.

## Design decisions

1. **Gateway-side download** — Feishu attachments require `tenant_access_token` (gateway has it, core doesn't). Gateway downloads, compresses, and base64 encodes. Core just decodes. Same principle as Discord/Slack (whoever holds the auth token does the download).

2. **Compress before transmit** — `resize_and_compress` (1200px, JPEG 75) reduces typical images from 2-5MB to 200-400KB. Base64 overhead (~33%) is negligible at this size. No WebSocket pressure.

3. **`post` type support** — Feishu sends @mention + pasted image as `msg_type: "post"` (rich text). Parser extracts text nodes as prompt and `img` nodes as image attachments. This is the only way to send @mention + image in a group chat.

4. **Text files only for `file` type** — Only known text extensions (`.txt`, `.py`, `.rs`, `.md`, `.json`, etc.) are downloaded, capped at 512KB. Binary files (`.pdf`, `.zip`) are silently ignored to avoid sending garbage to the model.

5. **Graceful degradation** — If image download fails, text portion is still forwarded. If both text and attachments are empty (e.g. unsupported file type), event is not sent.

6. **Schema backward compatible** — `attachments` uses `#[serde(default)]`. Old gateway (no attachments) works with new core. New gateway works with old core (attachments ignored).

## Known limitations

- **Group chat: image upload cannot include @mention.** Feishu's image upload UI does not allow simultaneous @mention. Workaround: @mention first, then paste (Ctrl+V) the image — Feishu sends this as a `post` message containing both.
- **Binary files ignored.** PDF, ZIP, DOCX etc. are silently dropped. Future work could add PDF text extraction.
- **No outbound image support.** Bot cannot send images back to Feishu yet (text/post only).

## Testing

| Scenario | Result |
|----------|--------|
| Private chat: send image → agent describes image | PASS |
| Private chat: send .txt file → agent reads content | PASS |
| Private chat: send .pdf → silently ignored | PASS |
| Private chat: text + image separately → both work | PASS |
| Group: @Bot + paste image (post format) → agent sees image | PASS |
| Group: upload image (no @mention possible) → known limitation | PASS (documented) |
| Private chat: image again → stable | PASS |
| `cargo test` gateway — 96 passed | PASS |
| `cargo test` core — 197 passed | PASS |

End-to-end tested on Feishu with vision-capable model.

## Breaking Changes

None. `attachments` field is additive with `#[serde(default)]`. Existing text-only messages are unaffected.

## Prior Art

| | OpenClaw | Hermes Agent | OAB Discord | OAB Gateway (this PR) |
|---|---|---|---|---|
| Inbound image | Outbound only (skills) | ✅ Gateway-level download | ✅ download + resize + base64 | ✅ download + resize + base64 |
| Inbound text file | Not documented | ✅ Gateway-level download | ✅ download + inline (5 files, 1MB cap) | ✅ download + inline (512KB cap) |
| Image compression | N/A | Not documented | resize 1200px, JPEG 75 | resize 1200px, JPEG 75 (same) |
| Download API | `/im/v1/messages/{id}/resources/{key}` | `/im/v1/messages/{id}/resources/{key}` | Direct URL + Bearer token | `/im/v1/messages/{id}/resources/{key}` |
| Mixed @mention + image | Not documented | Not documented | N/A (Discord allows both) | ✅ Handled via `post` msg_type parsing |
| Binary files (.pdf, .zip) | Not documented | Not documented | Skipped | Skipped |

## Discord Discussion URL

https://discord.com/channels/1491295327620169908/1500160821567684660