### PR TITLE
docs: move Local Development to docs/local-dev.md with disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,29 +187,6 @@ enabled = true                        # enable emoji status reactions
 remove_after_reply = false            # remove reactions after reply
 ```
 
-<details>
-<summary>Full reactions config</summary>
-
-```toml
-[reactions.emojis]
-queued = "👀"
-thinking = "🤔"
-tool = "🔥"
-coding = "👨‍💻"
-web = "⚡"
-done = "🆗"
-error = "😱"
-
-[reactions.timing]
-debounce_ms = 700
-stall_soft_ms = 10000
-stall_hard_ms = 30000
-done_hold_ms = 1500
-error_hold_ms = 2500
-```
-
-</details>
-
 ## Kubernetes Deployment
 
 The Docker image bundles both `openab` and `kiro-cli` in a single container.

--- a/README.md
+++ b/README.md
@@ -156,10 +156,6 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 
 > 🔧 Running multiple agents? See [docs/multi-agent.md](docs/multi-agent.md)
 
-## Local Development
-
-> 🛠️ See [docs/local-dev.md](docs/local-dev.md) for setup instructions, remote config, and security considerations.
-
 ## Configuration Reference
 
 > 📖 Full reference with all options, defaults, and Helm mapping: [docs/config-reference.md](docs/config-reference.md)

--- a/README.md
+++ b/README.md
@@ -37,11 +37,16 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 ## Features
 
 - **Multi-platform** — supports Discord and Slack, run one or both simultaneously
+- **Custom Gateway** — extend to Telegram, LINE, Feishu/Lark, Google Chat, MS Teams via standalone [gateway](gateway/)
 - **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI via config
 - **@mention trigger** — mention the bot in an allowed channel to start a conversation
 - **Thread-based multi-turn** — auto-creates threads; no @mention needed for follow-ups
+- **Multi-agent collaboration** — bot-to-bot messaging for coordinated workflows ([docs/multi-agent.md](docs/multi-agent.md))
 - **Edit-streaming** — live-updates the Discord message every 1.5s as tokens arrive
 - **Emoji status reactions** — 👀→🤔→🔥/👨‍💻/⚡→👍+random mood face
+- **Image & file support** — send images and files through chat ([docs/sendimages.md](docs/sendimages.md), [docs/sendfiles.md](docs/sendfiles.md))
+- **Scheduled messages** — config-driven cron jobs for automated agent prompts ([docs/cronjob.md](docs/cronjob.md))
+- **Slash commands** — built-in slash command support ([docs/slash-commands.md](docs/slash-commands.md))
 - **Session pool** — one CLI process per thread, auto-managed lifecycle
 - **ACP protocol** — JSON-RPC over stdio with tool call, thinking, and permission auto-reply support
 - **Kubernetes-ready** — Dockerfile + k8s manifests with PVC for auth persistence

--- a/README.md
+++ b/README.md
@@ -158,34 +158,7 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 
 ## Local Development
 
-```bash
-cp config.toml.example config.toml
-# Edit config.toml with your bot token and channel ID
-
-export DISCORD_BOT_TOKEN="your-token"
-cargo run
-```
-
-### Remote Config
-
-Config can be loaded from a local file or a remote URL via the `--config` / `-c` flag:
-
-```bash
-# Local file
-openab run --config config.toml
-openab run -c config.toml
-
-# Remote URL (http:// or https://)
-openab run --config https://example.com/config.toml
-openab run -c https://example.com/config.toml
-
-# Default (no flag → config.toml)
-openab run
-```
-
-This is useful for containerized or multi-node deployments where config is hosted on a central server (e.g. S3, Git raw URL, internal HTTP service).
-
-> **Security best practice:** Never hardcode secrets in remote config files. Use environment variable references like `bot_token = "${DISCORD_BOT_TOKEN}"` and inject the actual values via local environment variables or Kubernetes Secrets. OpenAB expands `${VAR}` identically for both local and remote config.
+> 🛠️ See [docs/local-dev.md](docs/local-dev.md) for setup instructions, remote config, and security considerations.
 
 ## Configuration Reference
 

--- a/README.md
+++ b/README.md
@@ -222,27 +222,6 @@ kubectl apply -f k8s/deployment.yaml
 | `k8s/secret.yaml` | `DISCORD_BOT_TOKEN` injected as env var |
 | `k8s/pvc.yaml` | Persistent storage for auth + settings |
 
-## Project Structure
-
-```
-├── Dockerfile          # multi-stage: rust build + debian-slim runtime with kiro-cli
-├── config.toml.example # example config with all agent backends
-├── k8s/                # Kubernetes manifests
-└── src/
-    ├── main.rs         # entrypoint: multi-adapter startup, cleanup, shutdown
-    ├── adapter.rs      # ChatAdapter trait, AdapterRouter (platform-agnostic)
-    ├── config.rs       # TOML config + ${ENV_VAR} expansion
-    ├── discord.rs      # DiscordAdapter: serenity EventHandler + ChatAdapter impl
-    ├── slack.rs        # SlackAdapter: Socket Mode + ChatAdapter impl
-    ├── media.rs        # shared image resize/compress + STT download
-    ├── format.rs       # message splitting, thread name shortening
-    ├── reactions.rs    # status reaction controller (debounce, stall detection)
-    └── acp/
-        ├── protocol.rs # JSON-RPC types + ACP event classification
-        ├── connection.rs # spawn CLI, stdio JSON-RPC communication
-        └── pool.rs     # session key → AcpConnection map
-```
-
 ## Inspired By
 
 - [sample-acp-bridge](https://github.com/aws-samples/sample-acp-bridge) — ACP protocol + process pool architecture

--- a/README.md
+++ b/README.md
@@ -227,14 +227,6 @@ The Docker image bundles both `openab` and `kiro-cli` in a single container.
 └───────────────────────────────────────────────────────┘
 ```
 
-### Build & Push
-
-```bash
-docker build -t openab:latest .
-docker tag openab:latest <your-registry>/openab:latest
-docker push <your-registry>/openab:latest
-```
-
 ### Deploy without Helm
 
 ```bash

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,6 +1,6 @@
 # Local Development
 
-> ⚠️ **Security disclaimer:** OpenAB is designed to run in Kubernetes with Pod-level isolation (NetworkPolicy, resource limits, read-only root filesystem). Running directly on a host without container isolation is **not recommended for production** — the agent subprocess inherits full host permissions, which is a meaningful attack surface for a bot accepting messages from arbitrary users.
+> ⚠️ **Security disclaimer:** OpenAB is designed to run in Kubernetes with Pod-level isolation (NetworkPolicy, resource limits, read-only root filesystem). Native binaries — including Windows builds — are provided for **temporary local development and debugging only**, not for daily use. Running directly on a host without container isolation is **not recommended for production** — the agent subprocess inherits full host permissions and is not protected by any sandbox, which is a meaningful attack surface for a bot accepting messages from arbitrary users.
 
 ```bash
 cp config.toml.example config.toml

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -38,3 +38,24 @@ docker build -t openab:latest .
 docker tag openab:latest <your-registry>/openab:latest
 docker push <your-registry>/openab:latest
 ```
+
+## Project Structure
+
+```
+├── Dockerfile          # multi-stage: rust build + debian-slim runtime with kiro-cli
+├── config.toml.example # example config with all agent backends
+├── k8s/                # Kubernetes manifests
+└── src/
+    ├── main.rs         # entrypoint: multi-adapter startup, cleanup, shutdown
+    ├── adapter.rs      # ChatAdapter trait, AdapterRouter (platform-agnostic)
+    ├── config.rs       # TOML config + ${ENV_VAR} expansion
+    ├── discord.rs      # DiscordAdapter: serenity EventHandler + ChatAdapter impl
+    ├── slack.rs        # SlackAdapter: Socket Mode + ChatAdapter impl
+    ├── media.rs        # shared image resize/compress + STT download
+    ├── format.rs       # message splitting, thread name shortening
+    ├── reactions.rs    # status reaction controller (debounce, stall detection)
+    └── acp/
+        ├── protocol.rs # JSON-RPC types + ACP event classification
+        ├── connection.rs # spawn CLI, stdio JSON-RPC communication
+        └── pool.rs     # session key → AcpConnection map
+```

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,32 @@
+# Local Development
+
+> ⚠️ **Security disclaimer:** OpenAB is designed to run in Kubernetes with Pod-level isolation (NetworkPolicy, resource limits, read-only root filesystem). Running directly on a host without container isolation is **not recommended for production** — the agent subprocess inherits full host permissions, which is a meaningful attack surface for a bot accepting messages from arbitrary users.
+
+```bash
+cp config.toml.example config.toml
+# Edit config.toml with your bot token and channel ID
+
+export DISCORD_BOT_TOKEN="your-token"
+cargo run
+```
+
+## Remote Config
+
+Config can be loaded from a local file or a remote URL via the `--config` / `-c` flag:
+
+```bash
+# Local file
+openab run --config config.toml
+openab run -c config.toml
+
+# Remote URL (http:// or https://)
+openab run --config https://example.com/config.toml
+openab run -c https://example.com/config.toml
+
+# Default (no flag → config.toml)
+openab run
+```
+
+This is useful for containerized or multi-node deployments where config is hosted on a central server (e.g. S3, Git raw URL, internal HTTP service).
+
+> **Security best practice:** Never hardcode secrets in remote config files. Use environment variable references like `bot_token = "${DISCORD_BOT_TOKEN}"` and inject the actual values via local environment variables or Kubernetes Secrets. OpenAB expands `${VAR}` identically for both local and remote config.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -30,3 +30,11 @@ openab run
 This is useful for containerized or multi-node deployments where config is hosted on a central server (e.g. S3, Git raw URL, internal HTTP service).
 
 > **Security best practice:** Never hardcode secrets in remote config files. Use environment variable references like `bot_token = "${DISCORD_BOT_TOKEN}"` and inject the actual values via local environment variables or Kubernetes Secrets. OpenAB expands `${VAR}` identically for both local and remote config.
+
+## Build & Push
+
+```bash
+docker build -t openab:latest .
+docker tag openab:latest <your-registry>/openab:latest
+docker push <your-registry>/openab:latest
+```


### PR DESCRIPTION
## Summary

- Move the entire Local Development section (quick start + remote config) from README to `docs/local-dev.md`
- Add security disclaimer: OpenAB is designed for K8s with Pod-level isolation; running on bare host is not recommended for production
- README keeps a one-line link to the new doc

## Context

Follows the decision to close PR #155 and issue #104 — OpenAB's security model relies on Kubernetes Pod isolation.