### PR TITLE
docs: fix claude authentication command

### DIFF
--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -32,7 +32,7 @@ Agents deployed:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- codex login --device-auth
 {{- else if eq (toString $cfg.command) "claude-agent-acp" }}
     Authenticate:
-    kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- claude setup-token
+    kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- claude auth login
 {{- else if eq (toString $cfg.command) "gemini" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- gemini

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -35,6 +35,16 @@ working_dir = "/home/node"
 
 ## Authentication
 
+Sign in interactively using the OAuth device flow. Credentials are stored on disk (persisted via PVC across pod restarts):
+
 ```bash
-kubectl exec -it deployment/openab-claude -- claude setup-token
+kubectl exec -it deployment/openab-claude -- claude auth login
 ```
+
+After authenticating, restart the pod to pick up the new credentials:
+
+```bash
+kubectl rollout restart deployment/openab-claude
+```
+
+> **Note:** `claude setup-token` is a different command — it generates a long-lived token for CI/scripts and prints it without saving locally. For container-based deployments, `claude auth login` is the correct approach as it persists credentials to the filesystem.

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -41,7 +41,7 @@ Sign in interactively using the OAuth device flow. Credentials are stored on dis
 kubectl exec -it deployment/openab-claude -- claude auth login
 ```
 
-After authenticating, restart the pod to pick up the new credentials:
+After authenticating, restart the pod so the bot process loads the new credentials:
 
 ```bash
 kubectl rollout restart deployment/openab-claude

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -525,7 +525,7 @@ fn print_next_steps(agent: &str, output_path: &Path, is_local: bool) {
                 cprintln!(C.cyan, "  1. Install Claude Code + ACP adapter:");
                 println!("       npm install -g @anthropic-ai/claude-code @agentclientprotocol/claude-agent-acp");
                 cprintln!(C.cyan, "  2. Authenticate:");
-                println!("       claude setup-token");
+                println!("       claude auth login");
             }
             "codex" => {
                 cprintln!(C.cyan, "  1. Install Codex CLI + ACP adapter:");
@@ -560,7 +560,7 @@ fn print_next_steps(agent: &str, output_path: &Path, is_local: bool) {
                 "       kubectl exec -it deployment/openab-kiro -- kiro-cli login --use-device-flow"
             ),
             "claude" => println!(
-                "       kubectl exec -it deployment/openab-claude -- claude setup-token"
+                "       kubectl exec -it deployment/openab-claude -- claude auth login"
             ),
             "codex" => println!(
                 "       kubectl exec -it deployment/openab-codex -- codex login --device-auth"


### PR DESCRIPTION
## Summary

Replace `claude setup-token` with `claude auth login` in `docs/claude-code.md`.

## Problem

The doc previously instructed users to run `claude setup-token` for authentication. This command generates a long-lived token and prints it to stdout **without saving it locally** — it is intended for CI/scripts where you set `CLAUDE_CODE_OAUTH_TOKEN` as an env var.

For container deployments with PVC persistence, `claude auth login` is the correct command. It authenticates via OAuth device flow and stores credentials on disk, surviving pod restarts.

## Reference

From the official [Claude Code CLI reference](https://docs.anthropic.com/en/docs/claude-code/cli-usage):

- **`claude setup-token`** — "Generate a long-lived OAuth token for CI and scripts. Prints the token to the terminal without saving it."
- **`claude auth login`** — "Sign in to your Anthropic account." (stores credentials locally)

For container deployments with PVC persistence, `claude auth login` is the correct command.