### PR TITLE
feat: add Qwen Code support via OpenRouter authentication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
           - { suffix: "-copilot", dockerfile: "Dockerfile.copilot", artifact: "copilot" }
           - { suffix: "-opencode", dockerfile: "Dockerfile.opencode", artifact: "opencode" }
           - { suffix: "-cursor", dockerfile: "Dockerfile.cursor", artifact: "cursor" }
+          - { suffix: "-qwen", dockerfile: "Dockerfile.qwen", artifact: "qwen" }
         platform:
           - { os: linux/amd64, runner: ubuntu-latest }
           - { os: linux/arm64, runner: ubuntu-24.04-arm }
@@ -135,6 +136,7 @@ jobs:
           - { suffix: "-copilot", artifact: "copilot" }
           - { suffix: "-opencode", artifact: "opencode" }
           - { suffix: "-cursor", artifact: "cursor" }
+          - { suffix: "-qwen", artifact: "qwen" }
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -185,6 +187,7 @@ jobs:
           - { suffix: "-copilot" }
           - { suffix: "-opencode" }
           - { suffix: "-cursor" }
+          - { suffix: "-qwen" }
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -20,6 +20,7 @@ jobs:
           - { dockerfile: Dockerfile.copilot, suffix: "-copilot", agent: "copilot", agent_args: "--acp" }
           - { dockerfile: Dockerfile.opencode, suffix: "-opencode", agent: "opencode", agent_args: "acp" }
           - { dockerfile: Dockerfile.cursor, suffix: "-cursor", agent: "cursor-agent", agent_args: "acp" }
+          - { dockerfile: Dockerfile.qwen, suffix: "-qwen", agent: "qwen", agent_args: "--acp" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/Dockerfile.qwen
+++ b/Dockerfile.qwen
@@ -1,0 +1,39 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+FROM node:22-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
+
+# Install Qwen Code CLI (ACP support via --acp flag)
+# --ignore-scripts: defense-in-depth; package has no postinstall scripts at time of pinning
+ARG QWEN_CODE_VERSION=0.15.6
+RUN npm install -g @qwen-code/qwen-code@${QWEN_CODE_VERSION} --ignore-scripts --retry 3
+
+# Install gh CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/node
+WORKDIR /home/node
+
+# Note: In Helm deployments, ~/.qwen/ is provided by an init container + emptyDir volume.
+# This line is only needed for standalone `docker run` usage.
+RUN mkdir -p /home/node/.qwen && chown -R node:node /home/node/.qwen
+
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![OpenAB banner](images/banner.jpg)
 
-A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](gateway/).
+A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, Qwen Code, OpenCode, Copilot CLI, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](gateway/).
 
 🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://discord.gg/DmbhfDZjQS)** 🎉
 
@@ -38,7 +38,7 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 
 - **Multi-platform** — supports Discord and Slack, run one or both simultaneously
 - **Custom Gateway** — extend to Telegram, LINE, Feishu/Lark, Google Chat, MS Teams via standalone [gateway](gateway/)
-- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI via config
+- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, Qwen Code, OpenCode, Copilot CLI via config
 - **@mention trigger** — mention the bot in an allowed channel to start a conversation
 - **Thread-based multi-turn** — auto-creates threads; no @mention needed for follow-ups
 - **Multi-agent collaboration** — bot-to-bot messaging for coordinated workflows ([docs/multi-agent.md](docs/multi-agent.md))
@@ -156,6 +156,7 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 | Codex | `codex-acp` | [@zed-industries/codex-acp](https://github.com/zed-industries/codex-acp) | [docs/codex.md](docs/codex.md) |
 | Gemini | `gemini --acp` | Native | [docs/gemini.md](docs/gemini.md) |
 | OpenCode | `opencode acp` | Native | [docs/opencode.md](docs/opencode.md) |
+| Qwen Code | `qwen --acp` | Native | [docs/qwen.md](docs/qwen.md) |
 | Copilot CLI ⚠️ | `copilot --acp --stdio` | Native | [docs/copilot.md](docs/copilot.md) |
 | Cursor | `cursor-agent acp` | Native | [docs/cursor.md](docs/cursor.md) |
 

--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -42,6 +42,13 @@ Agents deployed:
 {{- else if eq (toString $cfg.command) "cursor-agent" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- cursor-agent login
+{{- else if eq (toString $cfg.command) "qwen" }}
+    Authenticate (OpenRouter):
+    1. Set OPENROUTER_API_KEY via secretEnv in Helm values
+    2. Write settings.json to the PVC (persists across restarts):
+    kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- sh -c 'mkdir -p ~/.qwen && cat > ~/.qwen/settings.json << EOF
+    {"modelProviders":{"openai":[{"id":"qwen/qwen3-coder","baseUrl":"https://openrouter.ai/api/v1","envKey":"OPENROUTER_API_KEY"}]},"security":{"auth":{"selectedType":"openai"}},"model":{"name":"qwen/qwen3-coder"}}
+    EOF'
 {{- end }}
 
     Restart after auth:

--- a/charts/openab/tests/pod_extensibility_test.yaml
+++ b/charts/openab/tests/pod_extensibility_test.yaml
@@ -1,0 +1,109 @@
+suite: pod extensibility — extraInitContainers / extraVolumes / extraVolumeMounts
+templates:
+  - templates/deployment.yaml
+
+tests:
+  - it: renders extraInitContainers as initContainers on the pod
+    set:
+      agents.kiro.extraInitContainers:
+        - name: copy-qwen-settings
+          image: busybox:1.37
+          command: ["sh", "-c", "cp /src/settings.json /dst/settings.json"]
+          volumeMounts:
+            - name: qwen-config
+              mountPath: /src
+              readOnly: true
+            - name: qwen-data
+              mountPath: /dst
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: copy-qwen-settings
+            image: busybox:1.37
+            command: ["sh", "-c", "cp /src/settings.json /dst/settings.json"]
+            volumeMounts:
+              - name: qwen-config
+                mountPath: /src
+                readOnly: true
+              - name: qwen-data
+                mountPath: /dst
+
+  - it: renders extraVolumeMounts inside the agent container
+    set:
+      agents.kiro.extraVolumeMounts:
+        - name: qwen-data
+          mountPath: /home/node/.qwen
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: qwen-data
+            mountPath: /home/node/.qwen
+
+  - it: renders extraVolumes in the pod volumes list
+    set:
+      agents.kiro.extraVolumes:
+        - name: qwen-config
+          configMap:
+            name: qwen-settings
+        - name: qwen-data
+          emptyDir: {}
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: qwen-config
+            configMap:
+              name: qwen-settings
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: qwen-data
+            emptyDir: {}
+
+  - it: renders all three together (init container pattern for settings.json injection)
+    set:
+      agents.kiro.extraInitContainers:
+        - name: copy-qwen-settings
+          image: busybox:1.37
+          command: ["sh", "-c", "cp /qwen-config/settings.json /home/node/.qwen/settings.json"]
+          volumeMounts:
+            - name: qwen-config
+              mountPath: /qwen-config
+              readOnly: true
+            - name: qwen-data
+              mountPath: /home/node/.qwen
+      agents.kiro.extraVolumes:
+        - name: qwen-config
+          configMap:
+            name: qwen-settings
+        - name: qwen-data
+          emptyDir: {}
+      agents.kiro.extraVolumeMounts:
+        - name: qwen-data
+          mountPath: /home/node/.qwen
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: copy-qwen-settings
+            image: busybox:1.37
+            command: ["sh", "-c", "cp /qwen-config/settings.json /home/node/.qwen/settings.json"]
+            volumeMounts:
+              - name: qwen-config
+                mountPath: /qwen-config
+                readOnly: true
+              - name: qwen-data
+                mountPath: /home/node/.qwen
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: qwen-config
+            configMap:
+              name: qwen-settings
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: qwen-data
+            mountPath: /home/node/.qwen

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -130,6 +130,39 @@ agents:
     #     storageClass: ""
     #     size: 1Gi
     #   image: "ghcr.io/openabdev/openab-cursor:latest"
+    # qwen:
+    #   command: qwen
+    #   args:
+    #     - --acp
+    #     - --yolo
+    #   discord:
+    #     enabled: true
+    #     allowedChannels:
+    #       - "YOUR_CHANNEL_ID"
+    #     allowedUsers: []
+    #     allowBotMessages: "off"
+    #     trustedBotIds: []
+    #   workingDir: /home/node
+    #   # Auth via OpenRouter — set OPENROUTER_API_KEY and mount ~/.qwen/settings.json
+    #   # See docs/qwen.md for the full settings.json template.
+    #   env: {}
+    #   envFrom: []
+    #   secretEnv:
+    #     - name: OPENROUTER_API_KEY
+    #       secretName: qwen-secrets
+    #       secretKey: OPENROUTER_API_KEY
+    #   pool:
+    #     maxSessions: 10
+    #     sessionTtlHours: 24
+    #   reactions:
+    #     enabled: true
+    #     removeAfterReply: false
+    #   persistence:
+    #     enabled: true
+    #     existingClaim: ""
+    #     storageClass: ""
+    #     size: 1Gi
+    #   image: "ghcr.io/openabdev/openab-qwen:latest"
     image: ""
     command: kiro-cli
     args:

--- a/config.toml.example
+++ b/config.toml.example
@@ -101,6 +101,18 @@ working_dir = "/home/agent"
 # working_dir = "/home/agent"
 # env = {}  # Auth via: kubectl exec -it <pod> -- cursor-agent login
 
+# [agent]
+# command = "qwen"
+# args = ["--acp", "--yolo"]
+# working_dir = "/home/node"
+# # Qwen Code uses ~/.qwen/settings.json for provider config.
+# # Auth via OpenRouter: set OPENROUTER_API_KEY env var and mount settings.json
+# # with baseUrl = "https://openrouter.ai/api/v1" and envKey = "OPENROUTER_API_KEY".
+# # See docs/qwen.md for the full settings.json template.
+# # ⚠️ Passing API keys via env is for LOCAL DEV ONLY. In K8s, use secretEnv
+# # (valueFrom.secretKeyRef) to avoid storing keys in plaintext config.
+# env = { OPENROUTER_API_KEY = "${OPENROUTER_API_KEY}" }
+
 [pool]
 max_sessions = 10
 session_ttl_hours = 24

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -86,7 +86,7 @@ The AI agent subprocess that OpenAB spawns to handle messages via ACP.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `command` | string | *required* | Agent binary (e.g. `kiro-cli`, `claude`, `codex`, `gemini`, `copilot`, `opencode`, `cursor-agent`). |
+| `command` | string | *required* | Agent binary (e.g. `kiro-cli`, `claude`, `codex`, `gemini`, `qwen`, `copilot`, `opencode`, `cursor-agent`). |
 | `args` | string[] | `[]` | CLI arguments passed to the agent. |
 | `working_dir` | string | `"/tmp"` | Working directory for the agent process. |
 | `env` | map | `{}` | Extra environment variables (e.g. `{ ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}" }`). |

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -51,6 +51,7 @@ See individual agent docs for authentication steps:
 - [Claude Code](claude-code.md)
 - [Codex](codex.md)
 - [Gemini](gemini.md)
+- [Qwen Code](qwen.md)
 
 ## Bot-to-Bot Communication
 

--- a/docs/qwen.md
+++ b/docs/qwen.md
@@ -1,0 +1,179 @@
+# Qwen Code
+
+[Qwen Code](https://github.com/QwenLM/qwen-code) supports ACP natively via the `--acp` flag — no adapter needed.
+
+> ⚠️ **Authentication note**: Qwen OAuth free tier was discontinued on April 15, 2026, and the Alibaba Cloud Coding Plan subscription pricing has increased significantly. This guide uses **OpenRouter** as the provider, which offers pay-per-token access to Qwen models (including free tiers) without a subscription.
+
+## Docker Image
+
+```bash
+docker build -f Dockerfile.qwen -t openab-qwen:latest .
+```
+
+The image installs `@qwen-code/qwen-code` globally via npm.
+
+## Helm Install
+
+### Step 1: Create the API key Secret
+
+```bash
+kubectl create secret generic qwen-secrets \
+  --from-literal=OPENROUTER_API_KEY="sk-or-v1-..."
+```
+
+### Step 2: Install with Helm
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.qwen.discord.enabled=true \
+  --set-string 'agents.qwen.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.qwen.image=ghcr.io/openabdev/openab-qwen:latest \
+  --set agents.qwen.command=qwen \
+  --set 'agents.qwen.args={--acp,--yolo}' \
+  --set agents.qwen.workingDir=/home/node \
+  --set agents.qwen.secretEnv[0].name=OPENROUTER_API_KEY \
+  --set agents.qwen.secretEnv[0].secretName=qwen-secrets \
+  --set agents.qwen.secretEnv[0].secretKey=OPENROUTER_API_KEY
+```
+
+> Set `agents.kiro.enabled=false` to disable the default Kiro agent.
+
+### Step 3: Write settings.json to the PVC
+
+The PVC is mounted at `/home/node/` by default (`persistence.enabled: true`). Write `settings.json` once — it persists across pod restarts:
+
+```bash
+kubectl exec -it deployment/openab-qwen -- sh -c 'mkdir -p ~/.qwen && cat > ~/.qwen/settings.json << EOF
+{
+  "modelProviders": {
+    "openai": [
+      {
+        "id": "qwen/qwen3-coder",
+        "name": "Qwen3 Coder (OpenRouter)",
+        "baseUrl": "https://openrouter.ai/api/v1",
+        "envKey": "OPENROUTER_API_KEY"
+      }
+    ]
+  },
+  "security": {"auth": {"selectedType": "openai"}},
+  "model": {"name": "qwen/qwen3-coder"}
+}
+EOF'
+```
+
+### Step 4: Restart the pod
+
+```bash
+kubectl rollout restart deployment/openab-qwen
+```
+
+That's it. The pod will start with `settings.json` on the PVC and `OPENROUTER_API_KEY` from the Secret.
+
+> **`--yolo`**: Required for headless/ACP operation — auto-approves all tool calls. Only use in isolated environments (containers, K8s pods). See [security note](#security-note) below.
+
+## Manual config.toml
+
+```toml
+[agent]
+command = "qwen"
+args = ["--acp", "--yolo"]
+working_dir = "/home/node"
+# ⚠️ Passing API keys via env is for LOCAL DEV ONLY. In K8s, use secretEnv
+# (valueFrom.secretKeyRef) to avoid storing keys in plaintext config.
+env = { OPENROUTER_API_KEY = "${OPENROUTER_API_KEY}" }
+```
+
+## Authentication via OpenRouter
+
+Qwen Code uses `~/.qwen/settings.json` to configure model providers. To use OpenRouter:
+
+### 1. Get an OpenRouter API key
+
+Sign up at [openrouter.ai](https://openrouter.ai) and create an API key.
+
+### 2. Create `~/.qwen/settings.json`
+
+The example below uses `qwen/qwen3-coder` (recommended for coding tasks). To start for free, replace both occurrences of `qwen/qwen3-coder` with `qwen/qwen3.6-plus:free` — see the [Alternative models](#alternative-models-on-openrouter) table below.
+
+```json
+{
+  "modelProviders": {
+    "openai": [
+      {
+        "id": "qwen/qwen3-coder",
+        "name": "Qwen3 Coder (OpenRouter)",
+        "baseUrl": "https://openrouter.ai/api/v1",
+        "description": "Qwen3-Coder via OpenRouter",
+        "envKey": "OPENROUTER_API_KEY"
+      }
+    ]
+  },
+  "security": {
+    "auth": {
+      "selectedType": "openai"
+    }
+  },
+  "model": {
+    "name": "qwen/qwen3-coder"
+  }
+}
+```
+
+### 3. Set the API key
+
+```bash
+export OPENROUTER_API_KEY="sk-or-v1-..."
+```
+
+### Alternative models on OpenRouter
+
+| Model ID | Description |
+|----------|-------------|
+| `qwen/qwen3-coder` | Qwen3-Coder (recommended for coding) |
+| `qwen/qwen3.6-plus` | Qwen3.6 Plus |
+| `qwen/qwen3.6-plus:free` | Qwen3.6 Plus (free tier, rate-limited) |
+
+### Why OpenRouter instead of native Qwen subscription?
+
+1. **Cost**: Qwen OAuth free tier was discontinued; the Coding Plan subscription price increased significantly
+2. **Flexibility**: OpenRouter offers pay-per-token pricing with no monthly commitment
+3. **Free tiers**: Some Qwen models on OpenRouter have free tiers for experimentation
+4. **Multi-model**: Same API key works for 300+ models if you want to switch later
+
+## Advanced: Declarative settings.json (GitOps)
+
+For GitOps workflows where you want `settings.json` guaranteed on every pod recreate (without manual `kubectl exec`), use an init container + ConfigMap:
+
+```yaml
+agents:
+  qwen:
+    extraInitContainers:
+      - name: copy-qwen-settings
+        image: "busybox:1.37"
+        command: ["sh", "-c", "cp /qwen-config/settings.json /home/node/.qwen/settings.json"]
+        volumeMounts:
+          - name: qwen-config
+            mountPath: /qwen-config
+            readOnly: true
+    extraVolumes:
+      - name: qwen-config
+        configMap:
+          name: qwen-settings
+```
+
+> The PVC at `/home/node/` is already writable, so no `emptyDir` is needed. The init container simply copies from the read-only ConfigMap into the PVC path.
+
+## Persisted Paths (PVC)
+
+| Path | Contents |
+|------|----------|
+| `~/.qwen/settings.json` | Provider config (OpenRouter endpoint + model) |
+| `~/.qwen/` | Session data and cache |
+| `/home/node/` | Working directory — project files checked out by the agent |
+
+The PVC at `/home/node/` covers everything. `settings.json` persists across pod restarts after the initial `kubectl exec`.
+
+## Security Note
+
+**`--yolo`**: This flag enables YOLO mode — automatically approves all tool calls (shell commands, file edits, etc.) without interactive confirmation. It is required for headless/ACP operation since there is no interactive user to approve each tool call. Only use this in isolated environments (Docker containers, K8s pods) where the workload and network access are already constrained. Do not use on a shared machine with broad filesystem or network access.


### PR DESCRIPTION
## What problem does this solve?

Adds [Qwen Code](https://github.com/QwenLM/qwen-code) (Qwen3) as a supported ACP-compatible agent backend, using **OpenRouter** as the authentication provider.

Closes #55

**Why OpenRouter?** The previous PRs (#56, #149) were closed because:
1. Qwen OAuth free tier was **discontinued** on April 15, 2026
2. The Alibaba Cloud Coding Plan subscription price **increased significantly**
3. Both PRs went stale due to the `agent-broker` → `openab` rename

OpenRouter provides pay-per-token access to Qwen models (including free tiers like `qwen/qwen3.6-plus:free`) without requiring a subscription — making it accessible to all users.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404

## At a Glance

```
┌─────────────┐     ACP stdio     ┌──────────────┐    OpenAI-compat API    ┌──────────────┐
│   Discord   │◄────────────────►│    openab    │                         │              │
│   / Slack   │                  │   (broker)   │                         │              │
└─────────────┘                  └──────┬───────┘                         │              │
                                        │                                  │              │
                                        │ spawns                           │  OpenRouter  │
                                        ▼                                  │              │
                                 ┌──────────────┐    HTTPS (OpenAI API)   │              │
                                 │  qwen --acp  │─────────────────────────►│              │
                                 │  (Qwen Code) │                         └──────────────┘
                                 └──────────────┘
                                        │
                                        │ reads ~/.qwen/settings.json
                                        │ (baseUrl: openrouter.ai/api/v1)
                                        │ (envKey: OPENROUTER_API_KEY)
```

## Prior Art & Industry Research

**OpenClaw:**
OpenClaw supports Qwen models via OpenRouter using the same OpenAI-compatible API pattern. See: https://lushbinary.com/blog/openclaw-qwen-3-6-setup-guide/

**Hermes Agent:**
Not applicable — Hermes Agent does not currently support Qwen Code as a backend.

**Other references:**
- Qwen Code official docs on OpenRouter: https://github.com/QwenLM/qwen-code (README → Authentication → API Key)
- OpenRouter Qwen models: https://openrouter.ai/qwen/qwen3.6-plus:free
- claude-code-router pattern for OpenRouter integration: https://github.com/musistudio/claude-code-router

## Proposed Solution

Follow the established multi-agent pattern on current `main`:

1. **`Dockerfile.qwen`** — Multi-stage build (Rust builder + Node.js runtime) with `@qwen-code/qwen-code@0.15.6` pinned, includes tini, procps, ripgrep, gh CLI, USER node, HEALTHCHECK
2. **`config.toml.example`** — Commented-out Qwen agent block with OpenRouter env var
3. **`docs/qwen.md`** — Full guide: Docker, Helm, manual config, OpenRouter settings.json template, alternative models
4. **`README.md`** — Qwen Code added to description, features, backends table
5. **Helm chart** — NOTES.txt auth instructions for Qwen, commented-out agent example in values.yaml

Authentication flow: Qwen Code reads `~/.qwen/settings.json` which points to OpenRouter's OpenAI-compatible endpoint. The `OPENROUTER_API_KEY` env var is injected via K8s Secret (secretEnv) or Helm values.

## Why this approach?

- **No subscription required** — OpenRouter is pay-per-token with free tiers available
- **Standard pattern** — follows the exact same Dockerfile/Helm/config pattern as Gemini, Codex, etc.
- **settings.json over env-only** — Qwen Code requires `~/.qwen/settings.json` for provider config (baseUrl, model ID); env var alone is insufficient
- **Pinned version** — `@qwen-code/qwen-code@0.15.6` for reproducible builds

## Alternatives Considered

1. **Native Qwen subscription (Coding Plan)** — Rejected: price increased, requires Alibaba Cloud account, not accessible to all users
2. **DashScope API directly** — Viable but requires Alibaba Cloud account; OpenRouter is more universal
3. **Qwen OAuth** — Discontinued as of April 15, 2026

## Validation

- [x] `helm lint charts/openab` passes
- [x] `helm template` renders correctly with `--set agents.qwen.*` config
- [x] All 85 existing helm unit tests pass (`helm unittest charts/openab/`)
- [x] Dockerfile follows Dockerfile.gemini pattern exactly (tini, procps, ripgrep, gh, USER node, HEALTHCHECK, version pin)
- [x] NOTES.txt renders Qwen auth instructions correctly
- [ ] E2E test on EKS cluster (pending — will deploy once OpenRouter API key is provided)