### PR TITLE
feat(gateway): feishu thread participation tracking (involved mode)

### DIFF
--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -80,6 +80,7 @@ https://your-gateway-host/webhook/feishu
 | — | `FEISHU_ALLOW_BOTS` | `off` | Bot message handling: `off` / `mentions` / `all` |
 | — | `FEISHU_TRUSTED_BOT_IDS` | — | Comma-separated open_id list of known bots |
 | — | `FEISHU_MAX_BOT_TURNS` | `20` | Max consecutive bot replies per channel before suppression |
+| — | `FEISHU_SESSION_TTL_HOURS` | `24` | How long the bot remembers thread participation (hours). After expiry, @mention is required again. |
 | `gateway.botUsername` | — | — | Set to bot's `open_id` for @mention gating |
 | `gateway.streaming` | — | `false` | Enable streaming (typewriter) mode |
 
@@ -94,6 +95,14 @@ In group chats, the bot only responds when @mentioned (default). To find your bo
 2. Set `gateway.botUsername` to this value.
 
 To disable mention gating: `feishu.requireMention: false`.
+
+### Thread Participation (Involved Mode)
+
+Once the bot replies in a thread (topic), it remembers that thread and responds to subsequent messages **without requiring @mention** — similar to Discord's `allow_user_messages: "involved"` mode.
+
+- Only applies to threads (messages with `root_id`). Main channel messages always require @mention.
+- Participation is stored in memory. Gateway restart clears the cache; users need to @mention once to re-engage.
+- TTL controlled by `FEISHU_SESSION_TTL_HOURS` (default 24h). After expiry, @mention is required again.
 
 ## Security Notes
 

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -939,18 +939,9 @@ async fn handle_ws_message(
     let bot_id_ref = bot_id.as_deref();
 
     // Check if the message is in a thread where bot has previously replied
-    let is_thread_participated = envelope
-        .event
-        .as_ref()
-        .and_then(|e| e.message.as_ref())
-        .and_then(|m| m.root_id.as_deref().or(m.parent_id.as_deref()))
-        .map(|tid| {
-            let cache = participated_threads.lock().unwrap_or_else(|e| e.into_inner());
-            cache
-                .get(tid)
-                .is_some_and(|ts| ts.elapsed().as_secs() < config.session_ttl_secs)
-        })
-        .unwrap_or(false);
+    let is_thread_participated = check_thread_participated(
+        &envelope, participated_threads, config.session_ttl_secs,
+    );
 
     if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, config, is_thread_participated) {
         // Also dedupe by message_id
@@ -1677,6 +1668,28 @@ async fn remove_reaction(adapter: &FeishuAdapter, message_id: &str, emoji: &str)
 // Reply handler
 // ---------------------------------------------------------------------------
 
+/// Check if the bot has participated in the thread referenced by this envelope.
+/// Returns `true` if the message is in a thread and that thread has a valid
+/// (non-expired) participation entry in the cache.
+fn check_thread_participated(
+    envelope: &FeishuEventEnvelope,
+    cache: &Arc<std::sync::Mutex<HashMap<String, Instant>>>,
+    session_ttl_secs: u64,
+) -> bool {
+    envelope
+        .event
+        .as_ref()
+        .and_then(|e| e.message.as_ref())
+        .and_then(|m| m.root_id.as_deref().or(m.parent_id.as_deref()))
+        .map(|tid| {
+            // Intentionally recover from poisoned mutex — cache data loss is acceptable
+            // and preferable to panicking the gateway.
+            let c = cache.lock().unwrap_or_else(|e| e.into_inner());
+            c.get(tid).is_some_and(|ts| ts.elapsed().as_secs() < session_ttl_secs)
+        })
+        .unwrap_or(false)
+}
+
 /// Max entries in the participated_threads cache before eviction.
 const PARTICIPATION_CACHE_MAX: usize = 1000;
 
@@ -1685,16 +1698,22 @@ const PARTICIPATION_CACHE_MAX: usize = 1000;
 fn record_participation(
     cache: &Arc<std::sync::Mutex<HashMap<String, Instant>>>,
     thread_id: &str,
+    session_ttl_secs: u64,
 ) {
+    // Intentionally recover from poisoned mutex — cache data loss is acceptable
+    // and preferable to panicking the gateway.
     let mut map = cache.lock().unwrap_or_else(|e| e.into_inner());
     map.insert(thread_id.to_string(), Instant::now());
-    // Evict if over capacity: remove oldest half
+    // Evict if over capacity: first drop expired entries, then oldest half if still over
     if map.len() > PARTICIPATION_CACHE_MAX {
-        let mut entries: Vec<_> = map.iter().map(|(k, v)| (k.clone(), *v)).collect();
-        entries.sort_by_key(|(_, ts)| *ts);
-        let evict_count = entries.len() / 2;
-        for (k, _) in entries.into_iter().take(evict_count) {
-            map.remove(&k);
+        map.retain(|_, ts| ts.elapsed().as_secs() < session_ttl_secs);
+        if map.len() > PARTICIPATION_CACHE_MAX {
+            let mut entries: Vec<_> = map.iter().map(|(k, v)| (k.clone(), *v)).collect();
+            entries.sort_by_key(|(_, ts)| *ts);
+            let evict_count = entries.len() / 2;
+            for (k, _) in entries.into_iter().take(evict_count) {
+                map.remove(&k);
+            }
         }
     }
 }
@@ -1763,7 +1782,7 @@ pub async fn handle_reply(
                 adapter.dedupe.is_duplicate(&msg_id);
                 // Record thread participation for mention bypass
                 if let Some(tid) = thread_id {
-                    record_participation(&adapter.participated_threads, tid);
+                    record_participation(&adapter.participated_threads, tid, adapter.config.session_ttl_secs);
                 }
                 // Send response with message_id back to OAB core (for streaming edit)
                 if let Some(ref req_id) = reply.request_id {
@@ -1807,7 +1826,7 @@ pub async fn handle_reply(
         }
         if sent_any {
             if let Some(tid) = thread_id {
-                record_participation(&adapter.participated_threads, tid);
+                record_participation(&adapter.participated_threads, tid, adapter.config.session_ttl_secs);
             }
         }
     }
@@ -2084,18 +2103,9 @@ pub async fn webhook(
     let bot_id_ref = bot_id.as_deref();
 
     // Check participated threads for mention bypass
-    let is_thread_participated = envelope
-        .event
-        .as_ref()
-        .and_then(|e| e.message.as_ref())
-        .and_then(|m| m.root_id.as_deref().or(m.parent_id.as_deref()))
-        .map(|tid| {
-            let cache = feishu.participated_threads.lock().unwrap_or_else(|e| e.into_inner());
-            cache
-                .get(tid)
-                .is_some_and(|ts| ts.elapsed().as_secs() < feishu.config.session_ttl_secs)
-        })
-        .unwrap_or(false);
+    let is_thread_participated = check_thread_participated(
+        &envelope, &feishu.participated_threads, feishu.config.session_ttl_secs,
+    );
 
     if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, &feishu.config, is_thread_participated) {
         if !feishu.dedupe.is_duplicate(&gateway_event.message_id) {
@@ -2753,11 +2763,11 @@ mod tests {
     fn record_participation_and_eviction() {
         let cache = Arc::new(std::sync::Mutex::new(HashMap::new()));
         // Record a thread
-        record_participation(&cache, "thread_1");
+        record_participation(&cache, "thread_1", 86400);
         assert_eq!(cache.lock().unwrap().len(), 1);
         // Fill beyond PARTICIPATION_CACHE_MAX
         for i in 0..PARTICIPATION_CACHE_MAX + 10 {
-            record_participation(&cache, &format!("thread_{i}"));
+            record_participation(&cache, &format!("thread_{i}"), 86400);
         }
         // After eviction, should be roughly half
         assert!(cache.lock().unwrap().len() <= PARTICIPATION_CACHE_MAX);

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -87,6 +87,8 @@ pub struct FeishuConfig {
     pub message_limit: usize,
     /// TTL for participated-thread cache entries (seconds). Threads older than
     /// this are forgotten and require a fresh @mention to re-engage.
+    /// Set to 0 (via FEISHU_SESSION_TTL_HOURS=0) to disable participation
+    /// tracking entirely — all messages will require @mention.
     pub session_ttl_secs: u64,
 }
 
@@ -642,7 +644,7 @@ pub struct FeishuAdapter {
     pub name_cache: Arc<std::sync::Mutex<HashMap<String, String>>>,
     /// Per-channel bot turn counter. Key = chat_id, Value = (count, last_reset).
     /// Human message resets count to 0. Prevents runaway bot-to-bot loops.
-    pub bot_turns: Arc<std::sync::Mutex<HashMap<String, u32>>>, // TODO: add TTL eviction for long-running deploys
+    pub bot_turns: Arc<std::sync::Mutex<HashMap<String, u32>>>, // eviction: human msg resets; follow-up can add TTL like participated_threads
     /// Positive-only cache: thread_id (root_id) → last_replied_at.
     /// When bot has replied in a thread, subsequent messages in that thread
     /// bypass @mention gating (like Discord's "involved" mode).

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -85,6 +85,9 @@ pub struct FeishuConfig {
     pub max_bot_turns: u32,
     pub dedupe_ttl_secs: u64,
     pub message_limit: usize,
+    /// TTL for participated-thread cache entries (seconds). Threads older than
+    /// this are forgotten and require a fresh @mention to re-engage.
+    pub session_ttl_secs: u64,
 }
 
 impl FeishuConfig {
@@ -137,6 +140,11 @@ impl FeishuConfig {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(4000);
+        let session_ttl_secs = std::env::var("FEISHU_SESSION_TTL_HOURS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(24)
+            * 3600;
 
         Some(Self {
             app_id,
@@ -154,6 +162,7 @@ impl FeishuConfig {
             max_bot_turns,
             dedupe_ttl_secs,
             message_limit,
+            session_ttl_secs,
         })
     }
 
@@ -246,6 +255,7 @@ mod event_types {
         envelope: &FeishuEventEnvelope,
         bot_open_id: Option<&str>,
         config: &FeishuConfig,
+        is_thread_participated: bool,
     ) -> Option<(GatewayEvent, Vec<MediaRef>)> {
         let _header = envelope.header.as_ref()?;
         let event = envelope.event.as_ref()?;
@@ -412,11 +422,16 @@ mod event_types {
 
         // Gateway-side mention gating: in groups, skip if require_mention
         // is true and bot is not mentioned (for human senders).
+        // Bypass: if bot has previously replied in this thread (participated),
+        // no @mention needed (like Discord's "involved" mode).
+        let in_thread = thread_id.is_some();
         if channel_type == "group" && !is_bot_sender && config.require_mention {
-            if let Some(bot_id) = bot_open_id {
-                let bot_mentioned = mention_ids.iter().any(|id| id == bot_id);
-                if !bot_mentioned {
-                    return None;
+            if !(in_thread && is_thread_participated) {
+                if let Some(bot_id) = bot_open_id {
+                    let bot_mentioned = mention_ids.iter().any(|id| id == bot_id);
+                    if !bot_mentioned {
+                        return None;
+                    }
                 }
             }
         }
@@ -628,6 +643,10 @@ pub struct FeishuAdapter {
     /// Per-channel bot turn counter. Key = chat_id, Value = (count, last_reset).
     /// Human message resets count to 0. Prevents runaway bot-to-bot loops.
     pub bot_turns: Arc<std::sync::Mutex<HashMap<String, u32>>>, // TODO: add TTL eviction for long-running deploys
+    /// Positive-only cache: thread_id (root_id) → last_replied_at.
+    /// When bot has replied in a thread, subsequent messages in that thread
+    /// bypass @mention gating (like Discord's "involved" mode).
+    pub participated_threads: Arc<std::sync::Mutex<HashMap<String, Instant>>>,
     pub client: reqwest::Client,
 }
 
@@ -644,6 +663,7 @@ impl FeishuAdapter {
             bot_open_id: Arc::new(RwLock::new(None)),
             name_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             bot_turns: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            participated_threads: Arc::new(std::sync::Mutex::new(HashMap::new())),
             client: reqwest::Client::new(),
         }
     }
@@ -737,6 +757,7 @@ pub async fn start_websocket(
     let client = adapter.client.clone();
     let name_cache = adapter.name_cache.clone();
     let bot_turns = adapter.bot_turns.clone();
+    let participated_threads = adapter.participated_threads.clone();
 
     let handle = tokio::spawn(async move {
         let mut backoff_secs = 1u64;
@@ -751,6 +772,7 @@ pub async fn start_websocket(
                 &mut shutdown_rx,
                 &name_cache,
                 &bot_turns,
+                &participated_threads,
             )
             .await;
 
@@ -791,6 +813,7 @@ async fn ws_connect_loop(
     shutdown_rx: &mut watch::Receiver<bool>,
     name_cache: &Arc<std::sync::Mutex<HashMap<String, String>>>,
     bot_turns: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
+    participated_threads: &Arc<std::sync::Mutex<HashMap<String, Instant>>>,
 ) -> anyhow::Result<()> {
     let api_base = config.api_base();
 
@@ -818,7 +841,7 @@ async fn ws_connect_loop(
                     Some(Ok(tokio_tungstenite::tungstenite::Message::Text(text))) => {
                         handle_ws_message(
                             &text, bot_open_id_store, dedupe, config, event_tx,
-                            name_cache, token_cache, client, bot_turns,
+                            name_cache, token_cache, client, bot_turns, participated_threads,
                         ).await;
                     }
                     Some(Ok(tokio_tungstenite::tungstenite::Message::Ping(data))) => {
@@ -839,7 +862,7 @@ async fn ws_connect_loop(
                                         if let Ok(text) = String::from_utf8(payload.clone()) {
                                             handle_ws_message(
                                                 &text, bot_open_id_store, dedupe, config, event_tx,
-                                                name_cache, token_cache, client, bot_turns,
+                                                name_cache, token_cache, client, bot_turns, participated_threads,
                                             ).await;
                                         }
                                     }
@@ -879,6 +902,7 @@ async fn handle_ws_message(
     token_cache: &Arc<FeishuTokenCache>,
     client: &reqwest::Client,
     bot_turns: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
+    participated_threads: &Arc<std::sync::Mutex<HashMap<String, Instant>>>,
 ) {
     let envelope: FeishuEventEnvelope = match serde_json::from_str(text) {
         Ok(e) => e,
@@ -914,7 +938,21 @@ async fn handle_ws_message(
     let bot_id = bot_open_id_store.read().await;
     let bot_id_ref = bot_id.as_deref();
 
-    if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, config) {
+    // Check if the message is in a thread where bot has previously replied
+    let is_thread_participated = envelope
+        .event
+        .as_ref()
+        .and_then(|e| e.message.as_ref())
+        .and_then(|m| m.root_id.as_deref().or(m.parent_id.as_deref()))
+        .map(|tid| {
+            let cache = participated_threads.lock().unwrap_or_else(|e| e.into_inner());
+            cache
+                .get(tid)
+                .is_some_and(|ts| ts.elapsed().as_secs() < config.session_ttl_secs)
+        })
+        .unwrap_or(false);
+
+    if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, config, is_thread_participated) {
         // Also dedupe by message_id
         if dedupe.is_duplicate(&gateway_event.message_id) {
             return;
@@ -1639,6 +1677,28 @@ async fn remove_reaction(adapter: &FeishuAdapter, message_id: &str, emoji: &str)
 // Reply handler
 // ---------------------------------------------------------------------------
 
+/// Max entries in the participated_threads cache before eviction.
+const PARTICIPATION_CACHE_MAX: usize = 1000;
+
+/// Record that the bot has participated in a thread. Evicts oldest entries
+/// when the cache exceeds PARTICIPATION_CACHE_MAX.
+fn record_participation(
+    cache: &Arc<std::sync::Mutex<HashMap<String, Instant>>>,
+    thread_id: &str,
+) {
+    let mut map = cache.lock().unwrap_or_else(|e| e.into_inner());
+    map.insert(thread_id.to_string(), Instant::now());
+    // Evict if over capacity: remove oldest half
+    if map.len() > PARTICIPATION_CACHE_MAX {
+        let mut entries: Vec<_> = map.iter().map(|(k, v)| (k.clone(), *v)).collect();
+        entries.sort_by_key(|(_, ts)| *ts);
+        let evict_count = entries.len() / 2;
+        for (k, _) in entries.into_iter().take(evict_count) {
+            map.remove(&k);
+        }
+    }
+}
+
 pub async fn handle_reply(
     reply: &GatewayReply,
     adapter: &FeishuAdapter,
@@ -1701,6 +1761,10 @@ pub async fn handle_reply(
         match send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, thread_id, text).await {
             Some(msg_id) => {
                 adapter.dedupe.is_duplicate(&msg_id);
+                // Record thread participation for mention bypass
+                if let Some(tid) = thread_id {
+                    record_participation(&adapter.participated_threads, tid);
+                }
                 // Send response with message_id back to OAB core (for streaming edit)
                 if let Some(ref req_id) = reply.request_id {
                     let resp = crate::schema::GatewayResponse {
@@ -1734,9 +1798,16 @@ pub async fn handle_reply(
             }
         }
     } else {
+        let mut sent_any = false;
         for chunk in split_text(text, limit) {
             if let Some(msg_id) = send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, thread_id, chunk).await {
                 adapter.dedupe.is_duplicate(&msg_id);
+                sent_any = true;
+            }
+        }
+        if sent_any {
+            if let Some(tid) = thread_id {
+                record_participation(&adapter.participated_threads, tid);
             }
         }
     }
@@ -2012,7 +2083,21 @@ pub async fn webhook(
     let bot_id = feishu.bot_open_id.read().await;
     let bot_id_ref = bot_id.as_deref();
 
-    if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, &feishu.config) {
+    // Check participated threads for mention bypass
+    let is_thread_participated = envelope
+        .event
+        .as_ref()
+        .and_then(|e| e.message.as_ref())
+        .and_then(|m| m.root_id.as_deref().or(m.parent_id.as_deref()))
+        .map(|tid| {
+            let cache = feishu.participated_threads.lock().unwrap_or_else(|e| e.into_inner());
+            cache
+                .get(tid)
+                .is_some_and(|ts| ts.elapsed().as_secs() < feishu.config.session_ttl_secs)
+        })
+        .unwrap_or(false);
+
+    if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, &feishu.config, is_thread_participated) {
         if !feishu.dedupe.is_duplicate(&gateway_event.message_id) {
             let name = resolve_user_name(
                 &gateway_event.sender.id, &feishu.name_cache, &feishu.token_cache,
@@ -2086,6 +2171,7 @@ mod tests {
             max_bot_turns: 20,
             dedupe_ttl_secs: 300,
             message_limit: 4000,
+            session_ttl_secs: 86400,
         }
     }
 
@@ -2304,7 +2390,7 @@ mod tests {
     fn parse_dm_text() {
         let env = make_envelope("p2p", "hello", "ou_user1", None);
         let cfg = test_config();
-        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
+        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg, false).unwrap();
         assert_eq!(evt.platform, "feishu");
         assert_eq!(evt.channel.channel_type, "direct");
         assert_eq!(evt.channel.id, "oc_chat1");
@@ -2324,7 +2410,7 @@ mod tests {
         }];
         let env = make_envelope("group", "@_user_1 explain VPC", "ou_user1", Some(mentions));
         let cfg = test_config();
-        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
+        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg, false).unwrap();
         assert_eq!(evt.channel.channel_type, "group");
         assert_eq!(evt.content.text, "explain VPC");
         assert_eq!(evt.mentions, vec!["ou_bot"]);
@@ -2335,7 +2421,7 @@ mod tests {
         let env = make_envelope("group", "just chatting", "ou_user1", None);
         let cfg = test_config(); // require_mention = true
         // Gateway-side mention gating: group message without bot mention is filtered
-        assert!(parse_message_event(&env, Some("ou_bot"), &cfg).is_none());
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
     }
 
     #[test]
@@ -2343,7 +2429,7 @@ mod tests {
         let env = make_envelope("group", "just chatting", "ou_user1", None);
         let mut cfg = test_config();
         cfg.require_mention = false;
-        let evt = parse_message_event(&env, Some("ou_bot"), &cfg);
+        let evt = parse_message_event(&env, Some("ou_bot"), &cfg, false);
         assert!(evt.is_some());
     }
 
@@ -2352,14 +2438,14 @@ mod tests {
         let mut env = make_envelope("p2p", "hello", "ou_bot", None);
         env.event.as_mut().unwrap().sender.as_mut().unwrap().sender_type = Some("bot".into());
         let cfg = test_config();
-        assert!(parse_message_event(&env, Some("ou_bot"), &cfg).is_none());
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
     }
 
     #[test]
     fn parse_skips_empty_text() {
         let env = make_envelope("p2p", "  ", "ou_user1", None);
         let cfg = test_config();
-        assert!(parse_message_event(&env, Some("ou_bot"), &cfg).is_none());
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
     }
 
     #[test]
@@ -2367,14 +2453,14 @@ mod tests {
         let mut env = make_envelope("p2p", "hello", "ou_user1", None);
         env.event.as_mut().unwrap().message.as_mut().unwrap().message_type = Some("sticker".into());
         let cfg = test_config();
-        assert!(parse_message_event(&env, Some("ou_bot"), &cfg).is_none());
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
     }
 
     #[test]
     fn parse_skips_self_message() {
         let env = make_envelope("p2p", "hello", "ou_bot", None);
         let cfg = test_config();
-        assert!(parse_message_event(&env, Some("ou_bot"), &cfg).is_none());
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
     }
 
     // --- Dedupe tests ---
@@ -2506,7 +2592,7 @@ mod tests {
         }];
         let env = make_envelope("group", "@_user_1 tell me about @_user_1 patterns", "ou_user1", Some(mentions));
         let cfg = test_config();
-        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
+        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg, false).unwrap();
         // Only first @_user_1 removed, second preserved
         assert!(evt.content.text.contains("@_user_1"));
     }
@@ -2518,7 +2604,7 @@ mod tests {
         let env = make_envelope("p2p", "hello", "ou_stranger", None);
         let mut cfg = test_config();
         cfg.allowed_users = vec!["ou_vip".into()];
-        assert!(parse_message_event(&env, Some("ou_bot"), &cfg).is_none());
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
     }
 
     #[test]
@@ -2526,7 +2612,7 @@ mod tests {
         let env = make_envelope("p2p", "hello", "ou_vip", None);
         let mut cfg = test_config();
         cfg.allowed_users = vec!["ou_vip".into()];
-        assert!(parse_message_event(&env, Some("ou_bot"), &cfg).is_some());
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_some());
     }
 
     // --- allowed_groups filtering ---
@@ -2541,7 +2627,7 @@ mod tests {
         let env = make_envelope("group", "@_user_1 hello", "ou_user1", Some(mentions));
         let mut cfg = test_config();
         cfg.allowed_groups = vec!["oc_other".into()]; // oc_chat1 not in list
-        assert!(parse_message_event(&env, Some("ou_bot"), &cfg).is_none());
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
     }
 
     #[test]
@@ -2554,7 +2640,7 @@ mod tests {
         let env = make_envelope("group", "@_user_1 hello", "ou_user1", Some(mentions));
         let mut cfg = test_config();
         cfg.allowed_groups = vec!["oc_chat1".into()];
-        assert!(parse_message_event(&env, Some("ou_bot"), &cfg).is_some());
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_some());
     }
 
     // --- Token TTL from API response ---
@@ -2611,7 +2697,7 @@ mod tests {
         let mut env = make_envelope("p2p", "reply", "ou_user1", None);
         env.event.as_mut().unwrap().message.as_mut().unwrap().root_id = Some("om_root".into());
         let cfg = test_config();
-        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
+        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg, false).unwrap();
         assert_eq!(evt.channel.thread_id, Some("om_root".into()));
     }
 
@@ -2620,7 +2706,7 @@ mod tests {
         let mut env = make_envelope("p2p", "reply", "ou_user1", None);
         env.event.as_mut().unwrap().message.as_mut().unwrap().parent_id = Some("om_parent".into());
         let cfg = test_config();
-        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg).unwrap();
+        let (evt, _media) = parse_message_event(&env, Some("ou_bot"), &cfg, false).unwrap();
         assert_eq!(evt.channel.thread_id, Some("om_parent".into()));
     }
 
@@ -2636,5 +2722,44 @@ mod tests {
     #[test]
     fn emoji_mapping_unknown() {
         assert_eq!(emoji_to_feishu_reaction("🎉"), None);
+    }
+
+    // --- Participated thread tests ---
+
+    #[test]
+    fn participated_thread_bypasses_mention_gating() {
+        let cfg = test_config(); // require_mention = true
+        // Build envelope with root_id (in a thread)
+        let mut env = make_envelope("group", "Hello", "ou_user1", None);
+        env.event.as_mut().unwrap().message.as_mut().unwrap().root_id = Some("root_123".into());
+        // Without participation: no @mention → None
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
+        // With participation: no @mention → Some (bypass)
+        let result = parse_message_event(&env, Some("ou_bot"), &cfg, true);
+        assert!(result.is_some());
+        let (evt, _) = result.unwrap();
+        assert_eq!(evt.channel.thread_id.as_deref(), Some("root_123"));
+    }
+
+    #[test]
+    fn participated_no_effect_without_thread() {
+        let cfg = test_config(); // require_mention = true
+        // Message in main channel (no thread_id) — participated flag doesn't help
+        let env = make_envelope("group", "Hello", "ou_user1", None);
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, true).is_none());
+    }
+
+    #[test]
+    fn record_participation_and_eviction() {
+        let cache = Arc::new(std::sync::Mutex::new(HashMap::new()));
+        // Record a thread
+        record_participation(&cache, "thread_1");
+        assert_eq!(cache.lock().unwrap().len(), 1);
+        // Fill beyond PARTICIPATION_CACHE_MAX
+        for i in 0..PARTICIPATION_CACHE_MAX + 10 {
+            record_participation(&cache, &format!("thread_{i}"));
+        }
+        // After eviction, should be roughly half
+        assert!(cache.lock().unwrap().len() <= PARTICIPATION_CACHE_MAX);
     }
 }

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -1702,6 +1702,9 @@ fn record_participation(
     thread_id: &str,
     session_ttl_secs: u64,
 ) {
+    if session_ttl_secs == 0 {
+        return; // Participation tracking disabled
+    }
     // Intentionally recover from poisoned mutex — cache data loss is acceptable
     // and preferable to panicking the gateway.
     let mut map = cache.lock().unwrap_or_else(|e| e.into_inner());


### PR DESCRIPTION
## Summary

Adds thread participation tracking to the Feishu adapter. Once the bot replies in a thread (topic), subsequent messages in that thread no longer require @mention — matching Discord's default `allow_user_messages: "involved"` behavior.

```
                    Incoming message (group chat)
                              │
                              ▼
                     Has thread_id (root_id)?
                      /                \
                    No                  Yes
                    │                    │
                    ▼                    ▼
            Require @mention     Bot participated in
                    │            this thread?
                    │             /          \
                    │           No           Yes
                    │            │             │
                    │            ▼             ▼
                    │     Require @mention   BYPASS ─── respond
                    │            │                     without @
                    ▼            ▼
              Bot @mentioned?  Bot @mentioned?
               /       \        /       \
             No        Yes    No        Yes
              │         │      │         │
              ▼         ▼      ▼         ▼
           (drop)   respond  (drop)   respond
                                      + record
                                      participation
```

## Prior Art

| Project | Approach | Key Difference |
|---------|----------|----------------|
| **Discord (OAB)** | In-memory cache + API history rebuild on miss | Discord threads are channels → one API call rebuilds state seamlessly after restart |
| **OpenClaw** | Bot creates threads (topic-spawn) → always owner | No participation tracking needed |
| **Hermes Agent** | No tracking — strict @mention always | Different philosophy |

## Feishu API Fact-Check

Feishu's `GET /im/v1/messages` returns **all messages in a chat** with no per-thread filter (`root_id` must be matched client-side). Rebuilding participation state after restart would require scanning entire chat histories — impractical for active groups. This is why we use pure in-memory cache (same as Discord's data structure, minus the API rebuild path).

## Changes

| File | Change |
|------|--------|
| `gateway/src/adapters/feishu.rs` | Add `session_ttl_secs` config, `participated_threads` cache, participation check in mention gating, `record_participation` on reply |
| `docs/feishu.md` | Add `FEISHU_SESSION_TTL_HOURS` env var + Thread Participation docs |

## Testing

| Scenario | Result |
|----------|--------|
| @bot in thread → then message without @ | ✅ bot responds |
| Message without @ in main channel | ✅ bot silent |
| Restart → message without @ in same thread | ✅ bot silent (cache cleared) |
| Re-@bot → then message without @ | ✅ bot responds again |
| @bot2 in thread where bot1 participated | ⚠️ bot1 also responds (known, see below) |
| `cargo test` — 99 passed, 0 failed | ✅ |

## Known Limitations

1. **Multi-bot threads:** All participated bots respond to every message (matches Discord `involved` default). Follow-up: `multibot-mentions` mode.
2. **No persistence:** Restart clears cache. Users re-@ once to re-engage. Feishu API doesn't support efficient per-thread history queries.
3. **No `/leave`:** Bot stays involved until TTL expires.

## Follow-up Plan

| Priority | Item |
|----------|------|
| Next | `multibot-mentions` mode — require @mention when multiple bots are in a thread |
| Later | `/leave` command |
| Later | Persistence to PV (JSON file) |

## New Environment Variable

| Variable | Default | Description |
|----------|---------|-------------|
| `FEISHU_SESSION_TTL_HOURS` | `24` | Thread participation cache TTL. Set `0` to disable. |

### Discord Discussion URL

https://discord.com/channels/1491295327620169908/1500160821567684660
