### PR TITLE
feat(gateway): feishu multibot-mentions mode

### DIFF
--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -81,6 +81,7 @@ https://your-gateway-host/webhook/feishu
 | — | `FEISHU_TRUSTED_BOT_IDS` | — | Comma-separated open_id list of known bots |
 | — | `FEISHU_MAX_BOT_TURNS` | `20` | Max consecutive bot replies per channel before suppression |
 | — | `FEISHU_SESSION_TTL_HOURS` | `24` | How long the bot remembers thread participation (hours). After expiry, @mention is required again. |
+| — | `FEISHU_ALLOW_USER_MESSAGES` | `involved` | Thread response mode: `involved` / `mentions` / `multibot-mentions`. See below. |
 | `gateway.botUsername` | — | — | Set to bot's `open_id` for @mention gating |
 | `gateway.streaming` | — | `false` | Enable streaming (typewriter) mode |
 
@@ -103,6 +104,24 @@ Once the bot replies in a thread (topic), it remembers that thread and responds 
 - Only applies to threads (messages with `root_id`). Main channel messages always require @mention.
 - Participation is stored in memory. Gateway restart clears the cache; users need to @mention once to re-engage.
 - TTL controlled by `FEISHU_SESSION_TTL_HOURS` (default 24h). After expiry, @mention is required again.
+
+### Multi-Bot Threads (multibot-mentions Mode)
+
+When `FEISHU_ALLOW_USER_MESSAGES=multibot-mentions`, the bot detects when another bot is @mentioned in a participated thread and reverts to requiring @mention — preventing all bots from responding simultaneously.
+
+| Mode | Behavior |
+|------|----------|
+| `involved` (default) | Bot responds in participated threads without @mention. All participated bots respond. |
+| `multibot-mentions` | Same as `involved`, but once another bot is @mentioned in the thread, require @mention for all bots. |
+| `mentions` | Always require @mention, even in participated threads. |
+
+**Multi-bot detection** (how the gateway identifies "another bot"):
+
+1. If `FEISHU_TRUSTED_BOT_IDS` is set → exact match against configured IDs
+2. If only `FEISHU_ALLOWED_USERS` is set → any @mention that is not self and not in allowed_users is inferred as another bot (recommended, zero-config)
+3. If neither is set → no multibot detection
+
+Note: Detection only triggers in threads where the bot has already participated. This prevents premature marking of threads the bot hasn't joined.
 
 ## Security Notes
 

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -104,6 +104,7 @@ pub struct FeishuConfig {
     /// this are forgotten and require a fresh @mention to re-engage.
     /// Set to 0 (via FEISHU_SESSION_TTL_HOURS=0) to disable participation
     /// tracking entirely — all messages will require @mention.
+    /// Converted from `FEISHU_SESSION_TTL_HOURS` (user-facing, in hours) to seconds internally.
     pub session_ttl_secs: u64,
 }
 
@@ -279,11 +280,16 @@ mod event_types {
     /// Parse a feishu im.message.receive_v1 event into a GatewayEvent.
     /// Returns None if the event should be skipped (unsupported type, bot message, etc).
     /// The Vec<MediaRef> contains references to media that need async download.
+    ///
+    /// `bypass_mention_gating`: whether the bot should skip @mention requirement for this message.
+    /// This is the final computed result from mode-specific logic (detect_and_mark_multibot),
+    /// already accounting for the configured `allow_user_messages` mode.
+    /// Do NOT pass raw participation status here.
     pub fn parse_message_event(
         envelope: &FeishuEventEnvelope,
         bot_open_id: Option<&str>,
         config: &FeishuConfig,
-        is_thread_participated: bool,
+        bypass_mention_gating: bool,
     ) -> Option<(GatewayEvent, Vec<MediaRef>)> {
         let _header = envelope.header.as_ref()?;
         let event = envelope.event.as_ref()?;
@@ -454,7 +460,7 @@ mod event_types {
         // no @mention needed (like Discord's "involved" mode).
         let in_thread = thread_id.is_some();
         if channel_type == "group" && !is_bot_sender && config.require_mention {
-            if !(in_thread && is_thread_participated) {
+            if !(in_thread && bypass_mention_gating) {
                 if let Some(bot_id) = bot_open_id {
                     let bot_mentioned = mention_ids.iter().any(|id| id == bot_id);
                     if !bot_mentioned {
@@ -2911,7 +2917,7 @@ mod tests {
         cfg.allow_user_messages = AllowUsers::MultibotMentions;
         let mut env = make_envelope("group", "Hello", "ou_user1", None);
         env.event.as_mut().unwrap().message.as_mut().unwrap().root_id = Some("root_456".into());
-        // participated + no other bot → bypass (is_thread_participated=true)
+        // participated + no other bot → bypass_mention_gating=true
         let result = parse_message_event(&env, Some("ou_bot"), &cfg, true);
         assert!(result.is_some());
     }
@@ -2922,7 +2928,7 @@ mod tests {
         cfg.allow_user_messages = AllowUsers::MultibotMentions;
         let mut env = make_envelope("group", "Hello", "ou_user1", None);
         env.event.as_mut().unwrap().message.as_mut().unwrap().root_id = Some("root_456".into());
-        // not participated → require @mention (is_thread_participated=false)
+        // not participated → bypass_mention_gating=false
         assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
     }
 
@@ -2932,7 +2938,7 @@ mod tests {
         cfg.allow_user_messages = AllowUsers::Mentions;
         let mut env = make_envelope("group", "Hello", "ou_user1", None);
         env.event.as_mut().unwrap().message.as_mut().unwrap().root_id = Some("root_789".into());
-        // Even with is_thread_participated=true, Mentions mode never bypasses
+        // Even with bypass_mention_gating=true, Mentions mode never bypasses
         // (caller would pass false because Mentions mode always returns false)
         assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
     }

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -979,81 +979,9 @@ async fn handle_ws_message(
     // - Involved (default): bypass @mention if participated
     // - MultibotMentions: bypass only if participated AND no other bot in thread
     // - Mentions: never bypass
-    let thread_id_for_check = envelope
-        .event
-        .as_ref()
-        .and_then(|e| e.message.as_ref())
-        .and_then(|m| m.root_id.as_deref().or(m.parent_id.as_deref()));
-
-    // Early multibot detection (before participation check): if a message in a
-    // thread @mentions another bot, mark the thread as multibot immediately.
-    // Only check threads where this bot has participated — no point marking
-    // threads we haven't joined yet (we wouldn't respond anyway).
-    // Detection strategy:
-    //   1. If FEISHU_TRUSTED_BOT_IDS is configured → exact match (explicit)
-    //   2. Otherwise → infer: any @mention that is not self and not in allowed_users
-    //      is assumed to be another bot. This works because in a controlled group,
-    //      allowed_users lists the humans; anything else is likely a bot.
-    // This avoids requiring users to discover per-app open_ids for other bots.
-    let self_participated = check_thread_participated(
-        &envelope, participated_threads, config.session_ttl_secs,
+    let is_thread_participated = detect_and_mark_multibot(
+        &envelope, bot_id_ref, config, participated_threads, multibot_threads,
     );
-    if let Some(tid) = thread_id_for_check {
-        if self_participated {
-            let mentions = envelope
-                .event
-                .as_ref()
-                .and_then(|e| e.message.as_ref())
-                .and_then(|m| m.mentions.as_ref());
-            if let Some(mention_list) = mentions {
-                let bot_self_id = bot_id_ref.unwrap_or("");
-                let mention_ids: Vec<_> = mention_list.iter().filter_map(|m| {
-                    m.id.as_ref().and_then(|id| id.open_id.as_deref())
-                }).collect();
-
-                let mentions_other_bot = if !config.trusted_bot_ids.is_empty() {
-                    mention_ids.iter().any(|oid| {
-                        config.trusted_bot_ids.iter().any(|bid| bid == oid)
-                    })
-                } else if !config.allowed_users.is_empty() {
-                    mention_ids.iter().any(|oid| {
-                        *oid != bot_self_id && !config.allowed_users.iter().any(|u| u == oid)
-                    })
-                } else {
-                    false
-                };
-
-                if mentions_other_bot {
-                    info!(thread_id = %tid, "multibot thread detected via @mention");
-                    // Intentionally recover from poisoned mutex
-                    let mut cache = multibot_threads.lock().unwrap_or_else(|e| e.into_inner());
-                    cache.entry(tid.to_string()).or_insert_with(Instant::now);
-                    // Evict expired entries if over capacity
-                    if cache.len() > PARTICIPATION_CACHE_MAX {
-                        cache.retain(|_, ts| ts.elapsed().as_secs() < config.session_ttl_secs);
-                    }
-                }
-            }
-        }
-    }
-
-    let is_thread_participated = match config.allow_user_messages {
-        AllowUsers::Mentions => false,
-        AllowUsers::Involved => self_participated,
-        AllowUsers::MultibotMentions => {
-            if !self_participated {
-                false
-            } else {
-                // Already participated; check if thread is multibot
-                thread_id_for_check
-                    .map(|tid| {
-                        let cache = multibot_threads.lock().unwrap_or_else(|e| e.into_inner());
-                        !cache.get(tid).is_some_and(|ts| ts.elapsed().as_secs() < config.session_ttl_secs)
-                    })
-                    .unwrap_or(true) // no thread_id → not multibot → allow
-            }
-        }
-    };
 
     if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, config, is_thread_participated) {
         // Also dedupe by message_id
@@ -1804,8 +1732,91 @@ fn check_thread_participated(
         .unwrap_or(false)
 }
 
-/// Max entries in the participated_threads cache before eviction.
+/// Max entries before eviction. Shared by both `participated_threads` and
+/// `multibot_threads` caches — they have the same cardinality (one entry per
+/// active thread) so a single limit is appropriate for both.
 const PARTICIPATION_CACHE_MAX: usize = 1000;
+
+/// Detect if a message @mentions another bot in a participated thread, and if
+/// so, mark the thread in the multibot cache. Returns the computed
+/// `is_thread_participated` value respecting the `allow_user_messages` mode.
+///
+/// This consolidates the duplicated multibot detection logic used by both the
+/// WebSocket and webhook paths.
+fn detect_and_mark_multibot(
+    envelope: &FeishuEventEnvelope,
+    bot_open_id: Option<&str>,
+    config: &FeishuConfig,
+    participated_threads: &Arc<std::sync::Mutex<HashMap<String, Instant>>>,
+    multibot_threads: &Arc<std::sync::Mutex<HashMap<String, Instant>>>,
+) -> bool {
+    let self_participated = check_thread_participated(
+        envelope, participated_threads, config.session_ttl_secs,
+    );
+
+    let thread_id_for_check = envelope
+        .event
+        .as_ref()
+        .and_then(|e| e.message.as_ref())
+        .and_then(|m| m.root_id.as_deref().or(m.parent_id.as_deref()));
+
+    // Early multibot detection: if a message in a participated thread @mentions
+    // another bot, mark the thread as multibot immediately.
+    if let Some(tid) = thread_id_for_check {
+        if self_participated {
+            let mentions = envelope
+                .event
+                .as_ref()
+                .and_then(|e| e.message.as_ref())
+                .and_then(|m| m.mentions.as_ref());
+            if let Some(mention_list) = mentions {
+                let bot_self_id = bot_open_id.unwrap_or("");
+                let mention_ids: Vec<_> = mention_list.iter().filter_map(|m| {
+                    m.id.as_ref().and_then(|id| id.open_id.as_deref())
+                }).collect();
+
+                let mentions_other_bot = if !config.trusted_bot_ids.is_empty() {
+                    mention_ids.iter().any(|oid| {
+                        config.trusted_bot_ids.iter().any(|bid| bid == oid)
+                    })
+                } else if !config.allowed_users.is_empty() {
+                    mention_ids.iter().any(|oid| {
+                        *oid != bot_self_id && !config.allowed_users.iter().any(|u| u == oid)
+                    })
+                } else {
+                    false
+                };
+
+                if mentions_other_bot {
+                    info!(thread_id = %tid, "multibot thread detected via @mention");
+                    let mut cache = multibot_threads.lock().unwrap_or_else(|e| e.into_inner());
+                    cache.entry(tid.to_string()).or_insert_with(Instant::now);
+                    if cache.len() > PARTICIPATION_CACHE_MAX {
+                        cache.retain(|_, ts| ts.elapsed().as_secs() < config.session_ttl_secs);
+                    }
+                }
+            }
+        }
+    }
+
+    // Compute is_thread_participated based on mode
+    match config.allow_user_messages {
+        AllowUsers::Mentions => false,
+        AllowUsers::Involved => self_participated,
+        AllowUsers::MultibotMentions => {
+            if !self_participated {
+                false
+            } else {
+                thread_id_for_check
+                    .map(|tid| {
+                        let cache = multibot_threads.lock().unwrap_or_else(|e| e.into_inner());
+                        !cache.get(tid).is_some_and(|ts| ts.elapsed().as_secs() < config.session_ttl_secs)
+                    })
+                    .unwrap_or(true)
+            }
+        }
+    }
+}
 
 /// Record that the bot has participated in a thread. Evicts oldest entries
 /// when the cache exceeds PARTICIPATION_CACHE_MAX.
@@ -2219,64 +2230,11 @@ pub async fn webhook(
     let bot_id = feishu.bot_open_id.read().await;
     let bot_id_ref = bot_id.as_deref();
 
-    // Check participated threads for mention bypass (respects allow_user_messages mode)
-    let self_participated = check_thread_participated(
-        &envelope, &feishu.participated_threads, feishu.config.session_ttl_secs,
+    // Check participated threads and multibot detection for mention bypass
+    let is_thread_participated = detect_and_mark_multibot(
+        &envelope, bot_id_ref, &feishu.config,
+        &feishu.participated_threads, &feishu.multibot_threads,
     );
-
-    // Early multibot detection (same logic as WebSocket path)
-    let thread_id_for_check = envelope
-        .event
-        .as_ref()
-        .and_then(|e| e.message.as_ref())
-        .and_then(|m| m.root_id.as_deref().or(m.parent_id.as_deref()));
-
-    if let Some(tid) = thread_id_for_check {
-        if self_participated {
-            let mentions = envelope
-                .event
-                .as_ref()
-                .and_then(|e| e.message.as_ref())
-                .and_then(|m| m.mentions.as_ref());
-            if let Some(mention_list) = mentions {
-                let bot_self_id = bot_id_ref.unwrap_or("");
-                let mention_ids: Vec<_> = mention_list.iter().filter_map(|m| {
-                    m.id.as_ref().and_then(|id| id.open_id.as_deref())
-                }).collect();
-                let mentions_other_bot = if !feishu.config.trusted_bot_ids.is_empty() {
-                    mention_ids.iter().any(|oid| feishu.config.trusted_bot_ids.iter().any(|bid| bid == oid))
-                } else if !feishu.config.allowed_users.is_empty() {
-                    mention_ids.iter().any(|oid| *oid != bot_self_id && !feishu.config.allowed_users.iter().any(|u| u == oid))
-                } else {
-                    false
-                };
-                if mentions_other_bot {
-                    let mut cache = feishu.multibot_threads.lock().unwrap_or_else(|e| e.into_inner());
-                    cache.entry(tid.to_string()).or_insert_with(Instant::now);
-                    if cache.len() > PARTICIPATION_CACHE_MAX {
-                        cache.retain(|_, ts| ts.elapsed().as_secs() < feishu.config.session_ttl_secs);
-                    }
-                }
-            }
-        }
-    }
-
-    let is_thread_participated = match feishu.config.allow_user_messages {
-        AllowUsers::Mentions => false,
-        AllowUsers::Involved => self_participated,
-        AllowUsers::MultibotMentions => {
-            if !self_participated {
-                false
-            } else {
-                thread_id_for_check
-                    .map(|tid| {
-                        let cache = feishu.multibot_threads.lock().unwrap_or_else(|e| e.into_inner());
-                        !cache.get(tid).is_some_and(|ts| ts.elapsed().as_secs() < feishu.config.session_ttl_secs)
-                    })
-                    .unwrap_or(true)
-            }
-        }
-    };
 
     if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, &feishu.config, is_thread_participated) {
         if !feishu.dedupe.is_duplicate(&gateway_event.message_id) {

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -68,6 +68,20 @@ pub enum AllowBots {
     All,
 }
 
+/// Controls when the bot responds without @mention in threads.
+/// Mirrors Discord's `allow_user_messages` setting.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum AllowUsers {
+    /// Bot responds in threads it has participated in without @mention.
+    #[default]
+    Involved,
+    /// Always require @mention, even in participated threads.
+    Mentions,
+    /// Like Involved, but if another bot has also posted in the thread,
+    /// require @mention to avoid all bots responding.
+    MultibotMentions,
+}
+
 #[derive(Debug, Clone)]
 pub struct FeishuConfig {
     pub app_id: String,
@@ -81,6 +95,7 @@ pub struct FeishuConfig {
     pub allowed_users: Vec<String>,
     pub require_mention: bool,
     pub allow_bots: AllowBots,
+    pub allow_user_messages: AllowUsers,
     pub trusted_bot_ids: Vec<String>,
     pub max_bot_turns: u32,
     pub dedupe_ttl_secs: u64,
@@ -130,6 +145,16 @@ impl FeishuConfig {
             _ => AllowBots::Off,
         };
         let trusted_bot_ids = parse_csv("FEISHU_TRUSTED_BOT_IDS");
+        let allow_user_messages = match std::env::var("FEISHU_ALLOW_USER_MESSAGES")
+            .unwrap_or_else(|_| "involved".into())
+            .to_lowercase()
+            .replace('-', "_")
+            .as_str()
+        {
+            "mentions" => AllowUsers::Mentions,
+            "multibot_mentions" => AllowUsers::MultibotMentions,
+            _ => AllowUsers::Involved,
+        };
         let max_bot_turns = std::env::var("FEISHU_MAX_BOT_TURNS")
             .ok()
             .and_then(|v| v.parse().ok())
@@ -160,6 +185,7 @@ impl FeishuConfig {
             allowed_users,
             require_mention,
             allow_bots,
+            allow_user_messages,
             trusted_bot_ids,
             max_bot_turns,
             dedupe_ttl_secs,
@@ -649,6 +675,9 @@ pub struct FeishuAdapter {
     /// When bot has replied in a thread, subsequent messages in that thread
     /// bypass @mention gating (like Discord's "involved" mode).
     pub participated_threads: Arc<std::sync::Mutex<HashMap<String, Instant>>>,
+    /// Positive-only cache: thread_id → first_seen for threads where other bots
+    /// have posted. Used by multibot-mentions mode to require @mention.
+    pub multibot_threads: Arc<std::sync::Mutex<HashMap<String, Instant>>>,
     pub client: reqwest::Client,
 }
 
@@ -666,6 +695,7 @@ impl FeishuAdapter {
             name_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             bot_turns: Arc::new(std::sync::Mutex::new(HashMap::new())),
             participated_threads: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            multibot_threads: Arc::new(std::sync::Mutex::new(HashMap::new())),
             client: reqwest::Client::new(),
         }
     }
@@ -760,6 +790,7 @@ pub async fn start_websocket(
     let name_cache = adapter.name_cache.clone();
     let bot_turns = adapter.bot_turns.clone();
     let participated_threads = adapter.participated_threads.clone();
+    let multibot_threads = adapter.multibot_threads.clone();
 
     let handle = tokio::spawn(async move {
         let mut backoff_secs = 1u64;
@@ -775,6 +806,7 @@ pub async fn start_websocket(
                 &name_cache,
                 &bot_turns,
                 &participated_threads,
+                &multibot_threads,
             )
             .await;
 
@@ -816,6 +848,7 @@ async fn ws_connect_loop(
     name_cache: &Arc<std::sync::Mutex<HashMap<String, String>>>,
     bot_turns: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
     participated_threads: &Arc<std::sync::Mutex<HashMap<String, Instant>>>,
+    multibot_threads: &Arc<std::sync::Mutex<HashMap<String, Instant>>>,
 ) -> anyhow::Result<()> {
     let api_base = config.api_base();
 
@@ -843,7 +876,7 @@ async fn ws_connect_loop(
                     Some(Ok(tokio_tungstenite::tungstenite::Message::Text(text))) => {
                         handle_ws_message(
                             &text, bot_open_id_store, dedupe, config, event_tx,
-                            name_cache, token_cache, client, bot_turns, participated_threads,
+                            name_cache, token_cache, client, bot_turns, participated_threads, multibot_threads,
                         ).await;
                     }
                     Some(Ok(tokio_tungstenite::tungstenite::Message::Ping(data))) => {
@@ -864,7 +897,7 @@ async fn ws_connect_loop(
                                         if let Ok(text) = String::from_utf8(payload.clone()) {
                                             handle_ws_message(
                                                 &text, bot_open_id_store, dedupe, config, event_tx,
-                                                name_cache, token_cache, client, bot_turns, participated_threads,
+                                                name_cache, token_cache, client, bot_turns, participated_threads, multibot_threads,
                                             ).await;
                                         }
                                     }
@@ -905,6 +938,7 @@ async fn handle_ws_message(
     client: &reqwest::Client,
     bot_turns: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
     participated_threads: &Arc<std::sync::Mutex<HashMap<String, Instant>>>,
+    multibot_threads: &Arc<std::sync::Mutex<HashMap<String, Instant>>>,
 ) {
     let envelope: FeishuEventEnvelope = match serde_json::from_str(text) {
         Ok(e) => e,
@@ -940,10 +974,86 @@ async fn handle_ws_message(
     let bot_id = bot_open_id_store.read().await;
     let bot_id_ref = bot_id.as_deref();
 
-    // Check if the message is in a thread where bot has previously replied
-    let is_thread_participated = check_thread_participated(
+    // Check if the message is in a thread where bot has previously replied,
+    // respecting the allow_user_messages mode:
+    // - Involved (default): bypass @mention if participated
+    // - MultibotMentions: bypass only if participated AND no other bot in thread
+    // - Mentions: never bypass
+    let thread_id_for_check = envelope
+        .event
+        .as_ref()
+        .and_then(|e| e.message.as_ref())
+        .and_then(|m| m.root_id.as_deref().or(m.parent_id.as_deref()));
+
+    // Early multibot detection (before participation check): if a message in a
+    // thread @mentions another bot, mark the thread as multibot immediately.
+    // Only check threads where this bot has participated — no point marking
+    // threads we haven't joined yet (we wouldn't respond anyway).
+    // Detection strategy:
+    //   1. If FEISHU_TRUSTED_BOT_IDS is configured → exact match (explicit)
+    //   2. Otherwise → infer: any @mention that is not self and not in allowed_users
+    //      is assumed to be another bot. This works because in a controlled group,
+    //      allowed_users lists the humans; anything else is likely a bot.
+    // This avoids requiring users to discover per-app open_ids for other bots.
+    let self_participated = check_thread_participated(
         &envelope, participated_threads, config.session_ttl_secs,
     );
+    if let Some(tid) = thread_id_for_check {
+        if self_participated {
+            let mentions = envelope
+                .event
+                .as_ref()
+                .and_then(|e| e.message.as_ref())
+                .and_then(|m| m.mentions.as_ref());
+            if let Some(mention_list) = mentions {
+                let bot_self_id = bot_id_ref.unwrap_or("");
+                let mention_ids: Vec<_> = mention_list.iter().filter_map(|m| {
+                    m.id.as_ref().and_then(|id| id.open_id.as_deref())
+                }).collect();
+
+                let mentions_other_bot = if !config.trusted_bot_ids.is_empty() {
+                    mention_ids.iter().any(|oid| {
+                        config.trusted_bot_ids.iter().any(|bid| bid == oid)
+                    })
+                } else if !config.allowed_users.is_empty() {
+                    mention_ids.iter().any(|oid| {
+                        *oid != bot_self_id && !config.allowed_users.iter().any(|u| u == oid)
+                    })
+                } else {
+                    false
+                };
+
+                if mentions_other_bot {
+                    info!(thread_id = %tid, "multibot thread detected via @mention");
+                    // Intentionally recover from poisoned mutex
+                    let mut cache = multibot_threads.lock().unwrap_or_else(|e| e.into_inner());
+                    cache.entry(tid.to_string()).or_insert_with(Instant::now);
+                    // Evict expired entries if over capacity
+                    if cache.len() > PARTICIPATION_CACHE_MAX {
+                        cache.retain(|_, ts| ts.elapsed().as_secs() < config.session_ttl_secs);
+                    }
+                }
+            }
+        }
+    }
+
+    let is_thread_participated = match config.allow_user_messages {
+        AllowUsers::Mentions => false,
+        AllowUsers::Involved => self_participated,
+        AllowUsers::MultibotMentions => {
+            if !self_participated {
+                false
+            } else {
+                // Already participated; check if thread is multibot
+                thread_id_for_check
+                    .map(|tid| {
+                        let cache = multibot_threads.lock().unwrap_or_else(|e| e.into_inner());
+                        !cache.get(tid).is_some_and(|ts| ts.elapsed().as_secs() < config.session_ttl_secs)
+                    })
+                    .unwrap_or(true) // no thread_id → not multibot → allow
+            }
+        }
+    };
 
     if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, config, is_thread_participated) {
         // Also dedupe by message_id
@@ -967,6 +1077,8 @@ async fn handle_ws_message(
                     );
                     return;
                 }
+                // (Feishu doesn't push bot messages to other bots' WebSocket,
+                // so multibot detection is done via mentions instead — see below.)
             } else {
                 // Human message resets bot turn counter
                 turns.remove(channel_id.as_str());
@@ -2107,10 +2219,64 @@ pub async fn webhook(
     let bot_id = feishu.bot_open_id.read().await;
     let bot_id_ref = bot_id.as_deref();
 
-    // Check participated threads for mention bypass
-    let is_thread_participated = check_thread_participated(
+    // Check participated threads for mention bypass (respects allow_user_messages mode)
+    let self_participated = check_thread_participated(
         &envelope, &feishu.participated_threads, feishu.config.session_ttl_secs,
     );
+
+    // Early multibot detection (same logic as WebSocket path)
+    let thread_id_for_check = envelope
+        .event
+        .as_ref()
+        .and_then(|e| e.message.as_ref())
+        .and_then(|m| m.root_id.as_deref().or(m.parent_id.as_deref()));
+
+    if let Some(tid) = thread_id_for_check {
+        if self_participated {
+            let mentions = envelope
+                .event
+                .as_ref()
+                .and_then(|e| e.message.as_ref())
+                .and_then(|m| m.mentions.as_ref());
+            if let Some(mention_list) = mentions {
+                let bot_self_id = bot_id_ref.unwrap_or("");
+                let mention_ids: Vec<_> = mention_list.iter().filter_map(|m| {
+                    m.id.as_ref().and_then(|id| id.open_id.as_deref())
+                }).collect();
+                let mentions_other_bot = if !feishu.config.trusted_bot_ids.is_empty() {
+                    mention_ids.iter().any(|oid| feishu.config.trusted_bot_ids.iter().any(|bid| bid == oid))
+                } else if !feishu.config.allowed_users.is_empty() {
+                    mention_ids.iter().any(|oid| *oid != bot_self_id && !feishu.config.allowed_users.iter().any(|u| u == oid))
+                } else {
+                    false
+                };
+                if mentions_other_bot {
+                    let mut cache = feishu.multibot_threads.lock().unwrap_or_else(|e| e.into_inner());
+                    cache.entry(tid.to_string()).or_insert_with(Instant::now);
+                    if cache.len() > PARTICIPATION_CACHE_MAX {
+                        cache.retain(|_, ts| ts.elapsed().as_secs() < feishu.config.session_ttl_secs);
+                    }
+                }
+            }
+        }
+    }
+
+    let is_thread_participated = match feishu.config.allow_user_messages {
+        AllowUsers::Mentions => false,
+        AllowUsers::Involved => self_participated,
+        AllowUsers::MultibotMentions => {
+            if !self_participated {
+                false
+            } else {
+                thread_id_for_check
+                    .map(|tid| {
+                        let cache = feishu.multibot_threads.lock().unwrap_or_else(|e| e.into_inner());
+                        !cache.get(tid).is_some_and(|ts| ts.elapsed().as_secs() < feishu.config.session_ttl_secs)
+                    })
+                    .unwrap_or(true)
+            }
+        }
+    };
 
     if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, &feishu.config, is_thread_participated) {
         if !feishu.dedupe.is_duplicate(&gateway_event.message_id) {
@@ -2182,6 +2348,7 @@ mod tests {
             allowed_users: vec![],
             require_mention: true,
             allow_bots: AllowBots::Off,
+            allow_user_messages: AllowUsers::Involved,
             trusted_bot_ids: vec![],
             max_bot_turns: 20,
             dedupe_ttl_secs: 300,
@@ -2776,5 +2943,39 @@ mod tests {
         }
         // After eviction, should be roughly half
         assert!(cache.lock().unwrap().len() <= PARTICIPATION_CACHE_MAX);
+    }
+
+    // --- Multibot-mentions mode tests ---
+
+    #[test]
+    fn multibot_mentions_mode_bypasses_when_single_bot() {
+        let mut cfg = test_config();
+        cfg.allow_user_messages = AllowUsers::MultibotMentions;
+        let mut env = make_envelope("group", "Hello", "ou_user1", None);
+        env.event.as_mut().unwrap().message.as_mut().unwrap().root_id = Some("root_456".into());
+        // participated + no other bot → bypass (is_thread_participated=true)
+        let result = parse_message_event(&env, Some("ou_bot"), &cfg, true);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn multibot_mentions_mode_requires_mention_when_not_participated() {
+        let mut cfg = test_config();
+        cfg.allow_user_messages = AllowUsers::MultibotMentions;
+        let mut env = make_envelope("group", "Hello", "ou_user1", None);
+        env.event.as_mut().unwrap().message.as_mut().unwrap().root_id = Some("root_456".into());
+        // not participated → require @mention (is_thread_participated=false)
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
+    }
+
+    #[test]
+    fn mentions_mode_never_bypasses() {
+        let mut cfg = test_config();
+        cfg.allow_user_messages = AllowUsers::Mentions;
+        let mut env = make_envelope("group", "Hello", "ou_user1", None);
+        env.event.as_mut().unwrap().message.as_mut().unwrap().root_id = Some("root_789".into());
+        // Even with is_thread_participated=true, Mentions mode never bypasses
+        // (caller would pass false because Mentions mode always returns false)
+        assert!(parse_message_event(&env, Some("ou_bot"), &cfg, false).is_none());
     }
 }

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -985,11 +985,11 @@ async fn handle_ws_message(
     // - Involved (default): bypass @mention if participated
     // - MultibotMentions: bypass only if participated AND no other bot in thread
     // - Mentions: never bypass
-    let is_thread_participated = detect_and_mark_multibot(
+    let bypass_mention = detect_and_mark_multibot(
         &envelope, bot_id_ref, config, participated_threads, multibot_threads,
     );
 
-    if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, config, is_thread_participated) {
+    if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, config, bypass_mention) {
         // Also dedupe by message_id
         if dedupe.is_duplicate(&gateway_event.message_id) {
             return;
@@ -1744,8 +1744,8 @@ fn check_thread_participated(
 const PARTICIPATION_CACHE_MAX: usize = 1000;
 
 /// Detect if a message @mentions another bot in a participated thread, and if
-/// so, mark the thread in the multibot cache. Returns the computed
-/// `is_thread_participated` value respecting the `allow_user_messages` mode.
+/// so, mark the thread in the multibot cache. Returns whether @mention gating
+/// should be bypassed, respecting the configured `allow_user_messages` mode.
 ///
 /// This consolidates the duplicated multibot detection logic used by both the
 /// WebSocket and webhook paths.
@@ -1805,7 +1805,7 @@ fn detect_and_mark_multibot(
         }
     }
 
-    // Compute is_thread_participated based on mode
+    // Compute bypass_mention_gating based on mode
     match config.allow_user_messages {
         AllowUsers::Mentions => false,
         AllowUsers::Involved => self_participated,
@@ -2237,12 +2237,12 @@ pub async fn webhook(
     let bot_id_ref = bot_id.as_deref();
 
     // Check participated threads and multibot detection for mention bypass
-    let is_thread_participated = detect_and_mark_multibot(
+    let bypass_mention = detect_and_mark_multibot(
         &envelope, bot_id_ref, &feishu.config,
         &feishu.participated_threads, &feishu.multibot_threads,
     );
 
-    if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, &feishu.config, is_thread_participated) {
+    if let Some((mut gateway_event, media_refs)) = parse_message_event(&envelope, bot_id_ref, &feishu.config, bypass_mention) {
         if !feishu.dedupe.is_duplicate(&gateway_event.message_id) {
             let name = resolve_user_name(
                 &gateway_event.sender.id, &feishu.name_cache, &feishu.token_cache,

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -1371,6 +1371,7 @@ mod tests {
             content: Content {
                 content_type: "text".into(),
                 text: "hello".into(),
+                attachments: vec![],
             },
             command: None,
             request_id: Some("req_123".into()),
@@ -1413,6 +1414,7 @@ mod tests {
             content: Content {
                 content_type: "text".into(),
                 text: "hello".into(),
+                attachments: vec![],
             },
             command: None,
             request_id: Some("req_fail".into()),
@@ -1459,6 +1461,7 @@ mod tests {
             content: Content {
                 content_type: "text".into(),
                 text: "".into(),
+                attachments: vec![],
             },
             command: None,
             request_id: Some("req_empty".into()),
@@ -1502,6 +1505,7 @@ mod tests {
             content: Content {
                 content_type: "text".into(),
                 text: long_text,
+                attachments: vec![],
             },
             command: None,
             request_id: Some("req_multi_fail".into()),
@@ -1535,6 +1539,7 @@ mod tests {
             content: Content {
                 content_type: "text".into(),
                 text: "hello".into(),
+                attachments: vec![],
             },
             command: None,
             request_id: Some("req_notoken".into()),
@@ -1579,6 +1584,7 @@ mod tests {
             content: Content {
                 content_type: "text".into(),
                 text: "updated text".into(),
+                attachments: vec![],
             },
             command: Some("edit_message".into()),
             request_id: None,
@@ -1620,6 +1626,7 @@ mod tests {
             content: Content {
                 content_type: "text".into(),
                 text: long_text,
+                attachments: vec![],
             },
             command: None,
             request_id: Some("req_multi".into()),
@@ -1676,6 +1683,7 @@ mod tests {
             content: Content {
                 content_type: "text".into(),
                 text: long_text,
+                attachments: vec![],
             },
             command: None,
             request_id: Some("req_partial".into()),


### PR DESCRIPTION
# PR Draft: feat(gateway): feishu multibot-mentions mode

## Title

```
feat(gateway): feishu multibot-mentions mode
```

## Summary

Follow-up to #744. Adds `multibot-mentions` mode: once another bot is @mentioned in a participated thread, all bots revert to requiring @mention — preventing multiple bots from responding simultaneously.

```
                Incoming message (participated thread)
                              │
                              ▼
                 allow_user_messages mode?
                /          |           \
          involved    multibot-mentions   mentions
              │              │               │
              ▼              ▼               ▼
          BYPASS        Is thread          REQUIRE
        (respond)       multibot?          @mention
                        /      \
                      No       Yes
                      │         │
                      ▼         ▼
                  BYPASS     REQUIRE
                (respond)    @mention
```

Multibot detection (how "is thread multibot?" is determined):

```
    Message arrives in participated thread
                    │
                    ▼
         Has @mentions in message?
          /                    \
        No                     Yes
        │                       │
        ▼                       ▼
    (no change)         Any mention is "other bot"?
                         /                \
                       No                 Yes
                       │                    │
                       ▼                    ▼
                  (no change)        Mark thread as multibot
                                     → require @mention
```

"Other bot" identification:

```
    FEISHU_TRUSTED_BOT_IDS configured?
           /              \
         Yes               No
          │                 │
          ▼                 ▼
    Exact match       FEISHU_ALLOWED_USERS configured?
    against list            /              \
                          Yes               No
                           │                 │
                           ▼                 ▼
                    Infer: mention        (disabled)
                    not self AND
                    not in allowed_users
                    → other bot
```

## Prior Art

| Project | Multi-bot handling | Detection method |
|---------|-------------------|-----------------|
| **Discord (OAB)** | `allow_user_messages: multibot-mentions` | `msg.author.bot` flag — Discord explicitly marks bot messages |
| **OpenClaw** | Multi-instance isolation | Each bot has own topic-spawn, no collision possible |
| **Hermes Agent** | No multi-bot support | Strict @mention always |

### Key difference from Discord

Discord can detect other bots trivially via `msg.author.bot` flag. Feishu has two problems:
1. Bot messages are **not pushed** to other bots' WebSocket (platform limitation)
2. Even if they were, `sender_type` is always `"user"` for other bots

So we cannot use Discord's approach. We detect via **@mentions in user messages** instead.

## Feishu API Fact-Check

### Per-App open_id problem

Feishu assigns **different open_ids** to the same entity depending on which app is observing:
- Bot2's open_id as seen by Bot1's app ≠ Bot2's own open_id
- This makes `FEISHU_TRUSTED_BOT_IDS` impractical — users would need to discover cross-app open_ids from debug logs

**Verified by testing:** Bot2's self-reported open_id is `ou_228fbf2af502d0ba3203778f16162cdd`, but Bot1 sees Bot2 as `ou_f15beb3b9d1af4e9dbf6983880325a2b` in @mention events.

### No new permissions needed

The feature is purely gateway-side logic operating on data already available in message events.

## Design Decisions

### Why inference mode (zero-config) as default

| Approach | Pros | Cons |
|----------|------|------|
| `FEISHU_TRUSTED_BOT_IDS` only | Precise | Users can't easily find cross-app open_ids |
| Infer from `allowed_users` | Zero-config, just works | Could false-positive if non-bot non-allowed users exist |
| Both (fallback chain) | Best of both worlds | Slightly more complex logic |

We chose the fallback chain: explicit IDs take priority, inference as fallback. In practice, most deployments have `FEISHU_ALLOWED_USERS` set (it's the standard access control), so inference works out of the box.

### Why only detect in participated threads

Without this guard, Bot2 would see `@bot1` in a thread it hasn't joined and prematurely mark it as multibot — blocking itself from ever responding when later @mentioned. The rule: **you can't have an opinion about a conversation you haven't joined.**

### Why detection happens before participation check

The @mention that triggers multibot detection must take effect **on the same message** — otherwise the bot would respond one extra time before going silent. We extract mentions from the raw envelope before `parse_message_event` runs.

## Changes

| File | Change |
|------|--------|
| `gateway/src/adapters/feishu.rs` | Add `AllowUsers` enum, `FEISHU_ALLOW_USER_MESSAGES` parsing, `multibot_threads` cache, inference-based detection, 3 new tests |
| `docs/feishu.md` | Add `FEISHU_ALLOW_USER_MESSAGES` env var, multibot-mentions behavior docs |

## Testing (two-bot setup, both running this code)

| # | Scenario | bot1 | bot2 |
|---|----------|------|------|
| 1 | @bot1 in new thread | ✅ replies | silent |
| 2 | No @ in same thread | ✅ replies (participated) | silent |
| 3 | @bot2 in same thread | silent (multibot) | ✅ replies |
| 4 | No @ in same thread | silent (multibot) | ✅ replies (participated) |
| 5 | @bot1 in same thread | ✅ replies (explicit) | silent (multibot) |
| — | `cargo test` — 102 passed | ✅ | ✅ |

## New Environment Variable

| Variable | Default | Description |
|----------|---------|-------------|
| `FEISHU_ALLOW_USER_MESSAGES` | `involved` | `involved` / `mentions` / `multibot-mentions` |

## Depends On

- #744 (thread participation tracking)

### Discord Discussion URL

https://discord.com/channels/1491295327620169908/1500160821567684660
