### PR TITLE
fix(docker): pre-create /home/node/.gemini with correct ownership

### DIFF
--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -27,6 +27,8 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
+RUN mkdir -p /home/node/.gemini && chown -R node:node /home/node/.gemini
+
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1


### PR DESCRIPTION
## Summary

Pre-create `/home/node/.gemini` with `node:node` ownership in `Dockerfile.gemini` before `USER node`.

## Problem

Docker bind-mounts auto-create missing parent directories as **root**. When `docker-compose.multi-agent.yml` mounts files into `/home/node/.gemini/`, the directory ends up root-owned. The gemini CLI then crashes with `EACCES` when trying to write `projects.json`.

## Fix

```diff
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab

+RUN mkdir -p /home/node/.gemini && chown -R node:node /home/node/.gemini

 USER node
```

Closes #740