### PR TITLE
fix(config): correct working_dir for non-Kiro agents

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -53,7 +53,7 @@ working_dir = "/home/agent"
 # [agent]
 # command = "claude"
 # args = ["--acp"]
-# working_dir = "/home/agent"
+# working_dir = "/home/node"
 # ⚠️ SECURITY WARNING: Any env var listed here is accessible to the agent.
 # A user could trick the agent into leaking these values via prompt injection.
 # All supported backends support OAuth login — prefer that over env var API keys.
@@ -71,19 +71,19 @@ working_dir = "/home/agent"
 # [agent]
 # command = "codex"
 # args = ["--acp"]
-# working_dir = "/home/agent"
+# working_dir = "/home/node"
 # env = { OPENAI_API_KEY = "${OPENAI_API_KEY}" }
 
 # [agent]
 # command = "gemini"
 # args = ["--acp"]
-# working_dir = "/home/agent"
+# working_dir = "/home/node"
 # env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 
 # [agent]
 # command = "copilot"
 # args = ["--acp", "--stdio"]
-# working_dir = "/home/agent"
+# working_dir = "/home/node"
 # env = {}  # Auth via: kubectl exec -it <pod> -- gh auth login -p https -w
 
 # [agent]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -107,28 +107,28 @@ working_dir = "/home/agent"
 [agent]
 command = "claude"
 args = ["--acp"]
-working_dir = "/home/agent"
+working_dir = "/home/node"
 env = { ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}" }
 
 # Codex
 [agent]
 command = "codex"
 args = ["--acp"]
-working_dir = "/home/agent"
+working_dir = "/home/node"
 env = { OPENAI_API_KEY = "${OPENAI_API_KEY}" }
 
 # Gemini CLI
 [agent]
 command = "gemini"
 args = ["--acp"]
-working_dir = "/home/agent"
+working_dir = "/home/node"
 env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 
 # GitHub Copilot
 [agent]
 command = "copilot"
 args = ["--acp", "--stdio"]
-working_dir = "/home/agent"
+working_dir = "/home/node"
 
 # opencode
 [agent]


### PR DESCRIPTION
## Summary

Fix `working_dir` in `config.toml.example` to match each agent's actual Dockerfile.

## Changes

- `codex`: `/home/agent` → `/home/node`
- `gemini`: `/home/agent` → `/home/node`
- `copilot`: `/home/agent` → `/home/node`
- `claude`: `/home/agent` → `/home/node`

## Unchanged (correct as-is)

- `kiro-cli`: `/home/agent` (Rust image, creates agent user)
- `cursor-agent`: `/home/agent` (Dockerfile.cursor creates agent user)
- `opencode`: `/home/node` (already correct)

## Context

Raised in Discord — the example file incorrectly showed `/home/agent` for Node.js-based backends.