### PR TITLE
feat(gateway): feishu voice message STT via gateway audio attachment

### DIFF
--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -167,6 +167,7 @@ The gateway downloads and forwards image and text file attachments to the AI age
 | `text` | Text extracted, forwarded as prompt |
 | `image` | Image downloaded, resized (max 1200px), JPEG compressed, base64 encoded → `ContentBlock::Image` |
 | `file` | Text files only (`.txt`, `.py`, `.rs`, `.md`, `.json`, etc., max 512KB). Non-text files (`.pdf`, `.zip`, etc.) are silently ignored. |
+| `audio` | Voice message downloaded (opus/ogg, max 25MB), base64 encoded, forwarded to core. If `[stt]` is enabled, core transcribes via Whisper API and injects `[Voice message transcript]: ...` into the prompt. If STT is disabled or fails, the message is silently skipped. |
 | `post` | Rich text: text nodes extracted as prompt, `img` nodes downloaded as image attachments. This is the format Feishu uses when @mention + paste image in a group. |
 
 **Group chat limitation:** Feishu does not allow @mention and image upload in the same message. However, @mention + paste (Ctrl+V) an image works — Feishu sends this as a `post` message containing both the mention and the image. Direct image upload (via the attachment button) cannot include @mention, so the bot will not respond in groups.

--- a/docs/stt.md
+++ b/docs/stt.md
@@ -1,6 +1,6 @@
 # Speech-to-Text (STT) for Voice Messages
 
-openab can automatically transcribe Discord voice message attachments and forward the transcript to your ACP agent as text.
+openab can automatically transcribe voice message attachments (Discord, Feishu, and other gateway platforms) and forward the transcript to your ACP agent as text.
 
 ## Quick Start
 
@@ -24,7 +24,7 @@ api_key = "${GROQ_API_KEY}"
 ## How It Works
 
 ```
-Discord voice message (.ogg)
+Voice message (Discord .ogg, Feishu opus/ogg, etc.)
        │
        ▼
   openab downloads the audio file
@@ -170,6 +170,6 @@ When disabled, audio attachments are silently skipped with no impact on existing
 ## Technical Notes
 
 - openab sends `response_format=json` in the transcription request to ensure the response is always parseable JSON. Some local whisper servers default to plain text output without this parameter.
-- The actual MIME type from the Discord attachment is passed through to the STT API (e.g. `audio/ogg`, `audio/mp4`, `audio/wav`).
+- The actual MIME type from the platform attachment is passed through to the STT API (e.g. `audio/ogg` for Discord and Feishu voice messages, `audio/mp4`, `audio/wav`).
 - Environment variables in config values are expanded via `${VAR}` syntax (e.g. `api_key = "${GROQ_API_KEY}"`).
 - The `api_key` field is auto-detected from the `GROQ_API_KEY` environment variable when using the default Groq endpoint. If you set a custom `base_url` (e.g. local server), auto-detect is disabled to avoid leaking the Groq key to unrelated endpoints — you must set `api_key` explicitly.

--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -1112,7 +1112,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openab-gateway"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -1134,6 +1134,7 @@ dependencies = [
  "tokio-tungstenite 0.21.0",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
  "wiremock",
 ]
@@ -2166,6 +2167,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -25,6 +25,7 @@ cbc = "0.1"
 prost = "0.13"
 subtle = "2"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
+urlencoding = "2"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -1522,9 +1522,10 @@ pub async fn download_feishu_audio(
     message_id: &str,
     file_key: &str,
 ) -> Option<crate::schema::Attachment> {
+    use urlencoding::encode;
     let url = format!(
         "{}/open-apis/im/v1/messages/{}/resources/{}?type=file",
-        api_base, message_id, file_key
+        api_base, encode(message_id), encode(file_key)
     );
     let resp = match client.get(&url).bearer_auth(token).send().await {
         Ok(r) => r,
@@ -1537,6 +1538,12 @@ pub async fn download_feishu_audio(
         tracing::warn!(file_key, status = %resp.status(), "feishu audio download failed");
         return None;
     }
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("audio/ogg")
+        .to_string();
     if let Some(cl) = resp.headers().get(reqwest::header::CONTENT_LENGTH) {
         if let Ok(size) = cl.to_str().unwrap_or("0").parse::<u64>() {
             if size > AUDIO_MAX_DOWNLOAD {
@@ -1556,7 +1563,7 @@ pub async fn download_feishu_audio(
     Some(crate::schema::Attachment {
         attachment_type: "audio".into(),
         filename: format!("{}.ogg", file_key),
-        mime_type: "audio/ogg".into(),
+        mime_type: content_type,
         data,
         size: bytes.len() as u64,
     })

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -297,7 +297,7 @@ mod event_types {
         let sender = event.sender.as_ref()?;
 
         let msg_type = msg.message_type.as_deref().unwrap_or("text");
-        if !matches!(msg_type, "text" | "image" | "file" | "post") {
+        if !matches!(msg_type, "text" | "image" | "file" | "post" | "audio") {
             return None;
         }
         // Skip bot messages with explicit sender_type
@@ -382,6 +382,17 @@ mod event_types {
                     message_id: message_id.to_string(),
                     file_key: file_key.to_string(),
                     file_name: file_name.to_string(),
+                }];
+                (String::new(), mentions.1, refs)
+            }
+            "audio" => {
+                let file_key = content_json.get("file_key")?.as_str()?;
+                let mentions = extract_mentions(
+                    "", msg.mentions.as_deref().unwrap_or(&[]), bot_open_id,
+                );
+                let refs = vec![MediaRef::Audio {
+                    message_id: message_id.to_string(),
+                    file_key: file_key.to_string(),
                 }];
                 (String::new(), mentions.1, refs)
             }
@@ -1038,6 +1049,9 @@ async fn handle_ws_message(
                         MediaRef::File { message_id, file_key, file_name } => {
                             download_feishu_file(client, &api_base, &token, message_id, file_key, file_name).await
                         }
+                        MediaRef::Audio { message_id, file_key } => {
+                            download_feishu_audio(client, &api_base, &token, message_id, file_key).await
+                        }
                     };
                     if let Some(att) = attachment {
                         gateway_event.content.attachments.push(att);
@@ -1343,6 +1357,7 @@ fn try_parse_link(chars: &[char], start: usize) -> Option<(String, String, usize
 pub enum MediaRef {
     Image { message_id: String, image_key: String },
     File { message_id: String, file_key: String, file_name: String },
+    Audio { message_id: String, file_key: String },
 }
 
 const IMAGE_MAX_DIMENSION_PX: u32 = 1200;
@@ -1492,6 +1507,56 @@ pub async fn download_feishu_file(
         attachment_type: "text_file".into(),
         filename: file_name.to_string(),
         mime_type: "text/plain".into(),
+        data,
+        size: bytes.len() as u64,
+    })
+}
+
+const AUDIO_MAX_DOWNLOAD: u64 = 25 * 1024 * 1024; // 25 MB (Whisper API limit)
+
+/// Download a Feishu audio message by message_id + file_key → base64 Attachment.
+pub async fn download_feishu_audio(
+    client: &reqwest::Client,
+    api_base: &str,
+    token: &str,
+    message_id: &str,
+    file_key: &str,
+) -> Option<crate::schema::Attachment> {
+    let url = format!(
+        "{}/open-apis/im/v1/messages/{}/resources/{}?type=file",
+        api_base, message_id, file_key
+    );
+    let resp = match client.get(&url).bearer_auth(token).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(file_key, error = %e, "feishu audio download failed");
+            return None;
+        }
+    };
+    if !resp.status().is_success() {
+        tracing::warn!(file_key, status = %resp.status(), "feishu audio download failed");
+        return None;
+    }
+    if let Some(cl) = resp.headers().get(reqwest::header::CONTENT_LENGTH) {
+        if let Ok(size) = cl.to_str().unwrap_or("0").parse::<u64>() {
+            if size > AUDIO_MAX_DOWNLOAD {
+                tracing::warn!(file_key, size, "feishu audio exceeds 25MB limit");
+                return None;
+            }
+        }
+    }
+    let bytes = resp.bytes().await.ok()?;
+    if bytes.len() as u64 > AUDIO_MAX_DOWNLOAD {
+        tracing::warn!(file_key, size = bytes.len(), "feishu audio exceeds 25MB limit");
+        return None;
+    }
+    tracing::debug!(file_key, size = bytes.len(), "feishu audio downloaded");
+    use base64::Engine;
+    let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    Some(crate::schema::Attachment {
+        attachment_type: "audio".into(),
+        filename: format!("{}.ogg", file_key),
+        mime_type: "audio/ogg".into(),
         data,
         size: bytes.len() as u64,
     })
@@ -2262,6 +2327,9 @@ pub async fn webhook(
                             }
                             MediaRef::File { message_id, file_key, file_name } => {
                                 download_feishu_file(&feishu.client, &api_base, &token, message_id, file_key, file_name).await
+                            }
+                            MediaRef::Audio { message_id, file_key } => {
+                                download_feishu_audio(&feishu.client, &api_base, &token, message_id, file_key).await
                             }
                         };
                         if let Some(att) = attachment {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -488,6 +488,7 @@ pub struct GatewayParams {
     pub allow_all_users: bool,
     pub allowed_users: Vec<String>,
     pub streaming: bool,
+    pub stt: crate::config::SttConfig,
 }
 
 pub async fn run_gateway_adapter(
@@ -506,6 +507,7 @@ pub async fn run_gateway_adapter(
     let allow_all_users = params.allow_all_users;
     let allowed_users = params.allowed_users;
     let streaming = params.streaming;
+    let stt_config = params.stt;
 
     let connect_url = match &params.token {
         Some(token) => {
@@ -674,6 +676,24 @@ pub async fn run_gateway_adapter(
                                                     extra_blocks.push(ContentBlock::Text {
                                                         text: format!("```{}\n{}\n```", att.filename, text),
                                                     });
+                                                }
+                                            }
+                                            "audio" if stt_config.enabled => {
+                                                use base64::Engine;
+                                                if let Ok(audio_bytes) = base64::engine::general_purpose::STANDARD.decode(&att.data) {
+                                                    if let Some(transcript) = crate::stt::transcribe(
+                                                        &crate::media::HTTP_CLIENT,
+                                                        &stt_config,
+                                                        audio_bytes,
+                                                        att.filename.clone(),
+                                                        &att.mime_type,
+                                                    ).await {
+                                                        extra_blocks.push(ContentBlock::Text {
+                                                            text: format!("[Voice message transcript]: {transcript}"),
+                                                        });
+                                                    }
+                                                } else {
+                                                    warn!(filename = %att.filename, "audio attachment base64 decode failed");
                                                 }
                                             }
                                             _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,6 +298,7 @@ async fn main() -> anyhow::Result<()> {
             ),
             allowed_users: gw_cfg.allowed_users,
             streaming: gw_cfg.streaming,
+            stt: cfg.stt.clone(),
         };
         let gw_router = router.clone();
         Some(tokio::spawn(async move {


### PR DESCRIPTION
## Summary

Adds voice message (speech-to-text) support for the Feishu gateway adapter. When a user sends a voice message, the gateway downloads the opus/ogg audio, passes it to core as a base64-encoded `"audio"` attachment, and core transcribes it via the existing `[stt]` infrastructure before injecting the transcript into the LLM prompt.

This also introduces the `"audio"` attachment type to the gateway protocol — making it trivial for LINE/Telegram adapters to add voice support in the future (only the download logic differs per platform).

```
Feishu user sends voice message
    │
    ▼
Gateway: im.message.receive_v1 (msg_type=audio)
    │  parse content → extract file_key
    │  GET /im/v1/messages/{id}/resources/{key}?type=file
    │  base64 encode → Attachment{type:"audio", mime:"audio/ogg"}
    ▼
WebSocket → Core: GatewayEvent with audio attachment
    │
    ▼
Core: [stt] enabled?
    ├── Yes → decode base64 → stt::transcribe() → inject "[Voice message transcript]: ..."
    │         → LLM processes transcript as text
    └── No  → silently skip (graceful degradation)
```

## ⚠️ Dependency

**Stacks on #746 → #744.** Please merge in order: #744 → #746 → this PR. Will rebase onto main once dependencies land.

## Prior Art

| Feature | OpenAB (Discord) | OpenClaw | Hermes Agent | **This PR (Feishu)** |
|---------|------------------|----------|--------------|---------------------|
| Voice detection | `audio/*` MIME on attachment | Skill-based (plugin) | Built-in voice mode | `msg_type == "audio"` |
| STT engine | OpenAI-compatible (Groq default) | Extensible providers (Yandex, Whisper, Gemini) | Built-in (Whisper, configurable) | Same as Discord — reuses core `[stt]` |
| Audio format | ogg/opus | ogg, wav, mp3 | ogg/opus | opus/ogg (Feishu native) |
| Where STT runs | In adapter (direct core access) | In skill process | In gateway | In core (gateway passes raw audio) |
| Fallback on failure | Silent skip + 🎤 reaction | Error message to user | Configurable | Silent skip (matches Discord) |
| Config | `[stt]` section | Per-skill config | `voice:` YAML | Same `[stt]` — zero new config |

## Design Trade-offs

### Why STT in Core (not Gateway)?
- Gateway's `reqwest` doesn't have `multipart` feature (needed for Whisper API)
- Gateway would need to hold API keys, manage config, handle retries
- Core already has `stt.rs` + `media.rs` — reuse > rewrite
- **Verdict:** Keep gateway lightweight. STT is "understanding", belongs in core.

### Why base64 over WebSocket (not streaming/binary)?
- Feishu voice messages capped at 60s → ~1-2MB opus → ~2.7MB base64
- Whisper API requires complete file (no streaming input)
- Binary WS frames would save 33% bandwidth but require protocol changes
- **Verdict:** Not worth the complexity for <3MB payloads.

### Why no user feedback on STT failure?
- Discord adapter also silently skips (established pattern)
- Adding error feedback requires knowing user's language, platform-specific reply formatting
- **Verdict:** Match Discord behavior for v1. Can add feedback in follow-up.

## Changes

- **`gateway/src/adapters/feishu.rs`**: Allow `msg_type=audio`, add `MediaRef::Audio`, add `download_feishu_audio()`, handle in both WS and webhook paths
- **`src/gateway.rs`**: Add `stt: SttConfig` to `GatewayParams`, add `"audio"` attachment handler (decode → transcribe → inject), warn on decode failure
- **`src/main.rs`**: Pass `cfg.stt.clone()` to GatewayParams
- **`docs/feishu.md`**: Add `audio` row to message type table
- **`docs/stt.md`**: Update from Discord-only to multi-platform wording

## Configuration

Uses the existing `[stt]` section — **no new configuration**:

```toml
[stt]
enabled = true
# Default: Groq free tier (auto-detects GROQ_API_KEY env var)
# model = "whisper-large-v3-turbo"
# base_url = "https://api.groq.com/openai/v1"
```

See [docs/stt.md](docs/stt.md) for full setup guide.

## Testing

- Gateway: 102 tests pass
- Core: 197 tests pass
- E2E: Feishu private chat → voice message → download → STT → LLM responds ✅

## Feishu API Facts

- Event: `msg_type=audio`, content: `{"file_key":"...", "duration":N}`
- Download: same API as file (`/im/v1/messages/{id}/resources/{key}?type=file`)
- Format: opus/ogg — Whisper natively supports, no transcoding
- Permission: `im:message` (already required)
- Size: typical 0.5-2MB for 60s voice (test messages: 5-16KB for 2-7s)

## Known Limitations (v1)

1. STT failure → silent skip (no user feedback). Matches Discord behavior.
2. Base64 overhead (~33%) — negligible for actual voice messages (<2MB).
3. No duration-based filtering — very short voice messages (accidental taps) still get transcribed.

## Discussion

https://discord.com/channels/1491295327620169908/1500160821567684660