### PR TITLE
[codex] Pass Discord video attachments to agents

### DIFF
--- a/docs/discord.md
+++ b/docs/discord.md
@@ -206,6 +206,37 @@ Each thread gets its own agent session. Sessions are cleaned up after `session_t
 
 ---
 
+## Attachment Handling
+
+OpenAB processes Discord file attachments and converts them into content blocks
+for the agent. Supported types (checked in order):
+
+| Type | Detection | Agent receives |
+|------|-----------|----------------|
+| Audio | MIME `audio/*` | Transcribed text via STT (if enabled) |
+| Text files | Extension list (`.txt`, `.md`, `.json`, etc.) | File content inlined (up to 5 files, 1 MB total) |
+| Images | MIME `image/*` or image extensions | Base64-encoded image block |
+| Video | MIME `video/*` or extensions (`.mp4`, `.mov`, `.webm`, `.mkv`, `.m4v`, `.avi`) | Text block with filename, content type, size, and Discord CDN URL |
+
+Unsupported attachment types are silently ignored.
+
+### Video attachments
+
+Video files are not downloaded or transcoded. The agent receives metadata and the
+Discord CDN URL so it can fetch or inspect the file using tools like `ffprobe`.
+
+```
+[Video attachment]
+filename: demo.mp4
+content_type: video/mp4
+size_bytes: 8421376
+url: https://cdn.discordapp.com/attachments/.../demo.mp4
+```
+
+No configuration is needed — video forwarding is always enabled.
+
+---
+
 ## Streaming
 
 OpenAB uses **edit-streaming** on Discord — the bot sends a placeholder message and updates it every 1.5 seconds as tokens arrive, giving a live typing effect.

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -596,7 +596,8 @@ impl EventHandler for Handler {
             &msg.timestamp.to_rfc3339().unwrap_or_default(),
         );
 
-        // Build extra content blocks from attachments (audio → STT, text → inline, image → encode)
+        // Build extra content blocks from attachments (audio -> STT, text -> inline,
+        // image -> encode, video -> URL for agent-side inspection).
         let mut extra_blocks = Vec::new();
         let mut echo_entries: Vec<crate::stt::EchoEntry> = Vec::new();
         let mut text_file_bytes: u64 = 0;
@@ -675,6 +676,14 @@ impl EventHandler for Handler {
             {
                 debug!(url = %attachment.url, filename = %attachment.filename, "adding image attachment");
                 extra_blocks.push(block);
+            } else if media::is_video_file(&attachment.filename, attachment.content_type.as_deref()) {
+                debug!(url = %attachment.url, filename = %attachment.filename, "adding video attachment link");
+                extra_blocks.push(video_attachment_block(
+                    &attachment.filename,
+                    attachment.content_type.as_deref(),
+                    u64::from(attachment.size),
+                    &attachment.url,
+                ));
             }
         }
 
@@ -1285,6 +1294,23 @@ fn resolve_mentions(content: &str, bot_id: UserId, allowed_role_ids: &HashSet<u6
     out.trim().to_string()
 }
 
+fn video_attachment_block(
+    filename: &str,
+    content_type: Option<&str>,
+    size: u64,
+    url: &str,
+) -> ContentBlock {
+    ContentBlock::Text {
+        text: format!(
+            "[Video attachment]\nfilename: {}\ncontent_type: {}\nsize_bytes: {}\nurl: {}",
+            filename,
+            content_type.unwrap_or("unknown"),
+            size,
+            url
+        ),
+    }
+}
+
 /// Build a `SenderContext` for Discord messages.
 ///
 /// Pure function extracted from `EventHandler::message` for testability.
@@ -1478,6 +1504,26 @@ mod tests {
         let roles: HashSet<u64> = [999].into_iter().collect();
         let result = resolve_mentions("<@&999> check <@&888>", bot_id, &roles);
         assert_eq!(result, "check @(role)");
+    }
+
+    #[test]
+    fn video_attachment_block_includes_actionable_metadata() {
+        let block = video_attachment_block(
+            "demo.mp4",
+            Some("video/mp4"),
+            12345,
+            "https://cdn.discordapp.com/attachments/demo.mp4",
+        );
+
+        let ContentBlock::Text { text } = block else {
+            panic!("video attachments must be forwarded as text metadata");
+        };
+
+        assert!(text.contains("[Video attachment]"));
+        assert!(text.contains("filename: demo.mp4"));
+        assert!(text.contains("content_type: video/mp4"));
+        assert!(text.contains("size_bytes: 12345"));
+        assert!(text.contains("url: https://cdn.discordapp.com/attachments/demo.mp4"));
     }
 
     // --- thread-race error detection ---

--- a/src/media.rs
+++ b/src/media.rs
@@ -198,6 +198,26 @@ pub fn is_audio_mime(mime: &str) -> bool {
     mime.starts_with("audio/")
 }
 
+/// Check if an attachment is a video file.
+pub fn is_video_file(filename: &str, content_type: Option<&str>) -> bool {
+    let mime = content_type.unwrap_or("");
+    let mime_base = mime.split(';').next().unwrap_or(mime).trim();
+    if mime_base.starts_with("video/") {
+        return true;
+    }
+
+    filename
+        .rsplit('.')
+        .next()
+        .map(|ext| {
+            matches!(
+                ext.to_lowercase().as_str(),
+                "mp4" | "mov" | "m4v" | "webm" | "mkv" | "avi"
+            )
+        })
+        .unwrap_or(false)
+}
+
 /// Extensions recognised as text-based files that can be inlined into the prompt.
 const TEXT_EXTENSIONS: &[&str] = &[
     "txt", "csv", "log", "md", "json", "jsonl", "yaml", "yml", "toml", "xml", "rs", "py", "js",
@@ -400,5 +420,13 @@ mod tests {
     fn invalid_data_returns_error() {
         let garbage = vec![0x00, 0x01, 0x02, 0x03];
         assert!(resize_and_compress(&garbage).is_err());
+    }
+
+    #[test]
+    fn video_file_detects_mime_and_common_extensions() {
+        assert!(is_video_file("clip.bin", Some("video/mp4")));
+        assert!(is_video_file("clip.mp4", None));
+        assert!(is_video_file("clip.MOV", None));
+        assert!(!is_video_file("notes.txt", Some("text/plain")));
     }
 }


### PR DESCRIPTION
## Summary

Discord video attachments were being accepted as messages with attachments, but they were not converted into any ACP content block. When a user sent an MP4 without text, the agent only saw an empty prompt and replied that no media was available.

This change adds a video attachment fallback:

- detects video/* attachments and common video filename extensions
- forwards video metadata as a text content block with filename, content type, byte size, and Discord CDN URL
- keeps existing audio STT, text file, and image handling unchanged

Agents can then download the URL and inspect or transform the media with tools such as ffprobe or ffmpeg.

## Validation

- git diff --check -- src/discord.rs src/media.rs
- Built test image successfully with Dockerfile.codex using CODEX_VERSION=0.128.0 and CODEX_ACP_VERSION=0.10.0; release compile completed.
- Deployed the test image to the first local bot for manual MP4 testing.

Note: host does not have cargo, so cargo fmt --check and cargo test were not run directly outside Docker.

## Discussion

Discord Discussion UR:  https://discord.com/channels/1491295327620169908/1491365157010542652