### PR TITLE
fix(docker): pre-create agent hidden directories with correct ownership

### DIFF
--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -31,6 +31,8 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
+RUN mkdir -p /home/node/.claude && chown -R node:node /home/node/.claude
+
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -28,6 +28,8 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
+RUN mkdir -p /home/node/.codex && chown -R node:node /home/node/.codex
+
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -27,6 +27,8 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
+RUN mkdir -p /home/node/.copilot && chown -R node:node /home/node/.copilot
+
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -39,6 +39,8 @@ WORKDIR /home/agent
 
 COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
 
+RUN mkdir -p /home/agent/.cursor && chown -R agent:agent /home/agent/.cursor
+
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -42,6 +42,8 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
+RUN mkdir -p /home/node/.opencode && chown -R node:node /home/node/.opencode
+
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1


### PR DESCRIPTION
## What problem does this solve?

This PR fixes a common "Permission Denied" (EACCES) issue in Docker environments when agents (Claude, Copilot, Gemini, etc.) attempt to create their internal hidden configuration/cache directories (e.g., `.claude`, `.copilot`) at runtime while running as a non-root user.

As reported in **Issue #767**, when bind-mounting volumes that don't yet exist, Docker automatically creates the missing directories on the host as `root`. Even without mounts, if the base image's home directory has restrictive permissions, the runtime agent cannot initialize its state, leading to silent failures or crashes.

Closes #767

## Discord Discussion URL

https://discord.com/channels/1491295327620169908/1491365158868619404

## At a Glance

**Current Fix Flow:**
```
Runtime Stage (Dockerfile):
1. [root]  mkdir -p /home/node/.agent
2. [root]  chown -R node:node /home/node/.agent  <-- Fix: Ensure ownership
3. [root]  USER node
4. [node]  ENTRYPOINT ["openab", "run"]
           (Agent writes to .agent folder -> SUCCESS)
```

**Problematic Flow (Previous):**
```
Runtime Stage (Dockerfile):
1. [root]  USER node
2. [node]  ENTRYPOINT ["openab", "run"]
           (Agent tries to mkdir .agent)
           -> If parent is root-owned or bind-mount created as root:
           -> EACCES: Permission Denied
```

## Prior Art & Industry Research

**OpenClaw:**
OpenClaw typically recommends users manually run `chown` on the host machine (`sudo chown -R 1000:1000 ~/.openclaw`) or specify `user: \"${UID}:${GID}\"` in `docker-compose.yml`. While effective, it places the burden of permission management on the user's infrastructure setup.

**Hermes Agent:**
Hermes Agent uses environment variables like `HERMES_UID` and `HERMES_GID` to coordinate ownership, or maps volumes to `/opt/data` with specific UID requirements.

**OpenAB Approach:**
We chose a \"battery-included\" approach by pre-provisioning the necessary hidden directories inside the Dockerfile. This ensures that even if a user starts the container without advanced UID/GID mapping, the default internal storage paths are already owned by the runtime user, significantly reducing \"out of the box\" permission errors.

## Proposed Solution

Modified the following Dockerfiles:
- `Dockerfile.claude`
- `Dockerfile.codex`
- `Dockerfile.copilot`
- `Dockerfile.cursor`
- `Dockerfile.gemini` (already on main, no change needed)
- `Dockerfile.opencode`

Added specific `mkdir -p` and `chown` commands for each agent's respective hidden directory (`.claude`, `.codex`, `.copilot`, `.cursor`, `.opencode`) in the runtime stage before switching to the non-root user.

## Why this approach?

It provides the most seamless user experience. By pre-creating the directories with correct ownership, we avoid the race condition where Docker or the application creates them as root. It aligns with best practices for \"slim\" and \"distroless-like\" execution where the runtime user is strictly non-privileged.

## Alternatives Considered

1. **Host-side fix documentation**: Rejected because it's error-prone for beginners.
2. **Entrypoint script with `chown`**: Rejected because `chown` requires root privileges, and we want the container to start as a non-root user immediately for better security (avoiding `sudo` or `gosu` inside the container if possible).

## Validation

- [x] Verified that built images contain the directories with correct ownership (`ls -la /home/node`).
- [x] Verified that agents can start and write to these directories without `EACCES` errors.
- [x] Confirmed images still run as non-root (UID 1000).

