### PR TITLE
docs: add steering design guide for AI agent hot/cold memory

### DIFF
--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -105,7 +105,7 @@ MEMORY.md index (CC auto-memory) Individual memory files (.claude/projects/*/mem
 | Claude Code | `CLAUDE.md` (project) + `~/.claude/CLAUDE.md` (global) + `MEMORY.md` index | Hierarchical loading (global → project → subdir). Auto-memory index is hot (200-line cap); individual memory files are cold. `settings.json` is config, not instructions |
 | Codex | `AGENTS.md` hierarchical (global → project root → subdir) | Each directory loads at most one file. 32KB cap (`project_doc_max_bytes`). Use nested `AGENTS.md` for per-directory responsibility split. No multi-file topic split within same dir |
 | Gemini | `GEMINI.md` hierarchical (`~/.gemini/GEMINI.md` global → `./GEMINI.md` project → subdir) + `MEMORY.md` index | Same hierarchical pattern as CC/Codex. Private project memory index is hot; individual memory files are cold |
-| Copilot | `.github/copilot-instructions.md` (repo-wide) + `.github/instructions/**/*.instructions.md` (path-specific) + `AGENTS.md` (nearest-in-tree) | Layered: Personal > Path-specific > Repo-wide > Agent > Organization. No hard size cap for Chat/Agent (code review reads first 4K chars only). Keep short (~2 pages recommended) |
+| Copilot | `.github/copilot-instructions.md` (repo-wide) + `.github/instructions/**/*.instructions.md` (path-specific) + `AGENTS.md` (nearest-in-tree, where supported: cloud agent / CLI) | Layered: Personal > Path-specific > Repo-wide > Agent > Organization. No documented hard size cap for Chat/Agent (code review reads first 4K chars only). Keep short (~2 pages recommended) |
 | OpenCode | `AGENTS.md` or equivalent | Follows repo convention |
 
 ---

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -81,16 +81,39 @@ Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent th
 ## Architecture Pattern
 
 ```
-🔥 Hot (always loaded)               ☕ Warm (triggered)                    ❄️ Cold (search on demand)
-─────────────────────────            ──────────────────────────            ──────────────────────────
-AGENTS.md / CLAUDE.md / GEMINI.md    Codex Skills (SKILL.md body)          Knowledge bases
-.kiro/steering/*.md                  Copilot path-specific instructions    docs/*.md
-.github/copilot-instructions.md      CC/Gemini individual memory files     Project wikis, ADRs, RFCs
-MEMORY.md index (CC/Gemini)          Subdir instruction files              Historical records
-Skill/trigger metadata               Domain-specific SOPs                  Lessons learned
+┌─────────────────────────────────────────────────────────────────┐
+│                    🔥 HOT — Always Loaded                        │
+│                                                                 │
+│  Identity, hard rules, collaboration protocol, trigger index    │
+│  AGENTS.md / CLAUDE.md / GEMINI.md / .kiro/steering/*           │
+│  .github/copilot-instructions.md / MEMORY.md index              │
+│                         < 15KB                                  │
+├─────────────────────────────────────────────────────────────────┤
+│                 ☕ WARM — Progressive Exposure                    │
+│                                                                 │
+│  Auto-loaded when trigger condition matches                     │
+│  Skills (SKILL.md body), path-specific instructions,            │
+│  subdir instruction files, individual memory files,             │
+│  domain SOPs, deployment playbooks                              │
+│                                                                 │
+│  Triggers:  Rule-based (applyTo glob)                           │
+│             Semantic (agent reads index, decides to load)        │
+│             Explicit (activate_skill / read_file)               │
+├─────────────────────────────────────────────────────────────────┤
+│                 ❄️ COLD — Search on Demand                       │
+│                                                                 │
+│  No automatic trigger; requires explicit search/retrieval       │
+│  Knowledge bases, docs/*.md, wikis, ADRs, RFCs,                 │
+│  historical records, lessons learned, team trivia               │
+│                       Unlimited                                  │
+└─────────────────────────────────────────────────────────────────┘
+
+         ▲ Smaller, precise, behavioral
+         │
+         ▼ Larger, reference, historical
 ```
 
-**Key insight:** The warm layer's *trigger metadata* lives in hot memory (skill names, index entries, applyTo globs). Only the *body* loads on demand. This is the pattern: **put the table of contents in hot, put the chapters in warm.**
+**Key insight:** The warm layer's *trigger metadata* lives in hot memory (skill names, index entries, applyTo globs). Only the *body* loads on demand. Pattern: **put the table of contents in hot, put the chapters in warm.**
 
 > **Trigger mechanisms vary by agent:**
 > - **Rule-based:** Copilot `applyTo` glob match, Codex skill metadata match

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -46,6 +46,8 @@ Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent th
 4. **Testable** — Each rule should be verifiable with a single prompt from a fresh session.
 5. **One file per responsibility** — Separate concerns: identity, review process, workflow triggers. Avoid monolithic instruction files.
 6. **Hot/cold separation** — If the agent can find it via search when needed, it doesn't need to be always-loaded.
+7. **Structure over prose** — Use lists, tables, or key-value pairs in hot memory. LLMs follow structured constraints more reliably than natural language paragraphs.
+8. **WHAT and HOW only** — Hot memory defines what to do and how. Put the WHY (historical context, incident backstory) in cold storage (ADRs, lessons learned).
 
 ---
 

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -197,7 +197,7 @@ If the agent doesn't follow the rule → it's either not loaded, too buried in o
 Use this prompt from a fresh session to audit memory allocation against this guide:
 
 ```
-Per the steering design guide, audit my current memory allocation:
+Per the steering design guide in docs/steering-design-guide.md from OpenAB GitHub repo, review your current memory allocation:
 
 1. INVENTORY — List all loaded/discoverable instruction sources:
    - File path

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -40,7 +40,7 @@ Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent th
 
 ## Design Principles
 
-1. **Small and precise** — Keep hot memory under ~15KB total. Larger context dilutes attention on critical rules.
+1. **Small and precise** — Keep hot memory concise. Practical caps vary by agent (CC: ~200 lines for MEMORY.md, Codex: 32KB, Kiro: ~15KB recommended). Regardless of hard limits, attention dilution is the real constraint — less is more.
 2. **Behavior-oriented** — Every line should change "what the agent does next." Remove anything that's just "nice to know."
 3. **Single source of truth** — Define each rule in exactly one place. Duplication across files creates contradiction risk.
 4. **Testable** — Each rule should be verifiable with a single prompt from a fresh session.
@@ -77,6 +77,8 @@ MEMORY.md index (CC auto-memory) Individual memory files (.claude/projects/*/mem
 
 > **Real-world example:** Claude Code's auto-memory system is a natural implementation of hot/cold separation — `MEMORY.md` index (hot, 200-line cap) points to individual `.md` memory files (cold, loaded on demand). This pattern validates the guide's core principle.
 
+> **Common pattern:** CC, Codex, and Gemini all use hierarchical loading (global → project → subdir). This naturally supports "one file per responsibility" by placing topic-specific rules in the relevant subdirectory's instruction file.
+
 ---
 
 ## Agent-Specific File Mapping
@@ -85,9 +87,9 @@ MEMORY.md index (CC auto-memory) Individual memory files (.claude/projects/*/mem
 |-------|-------------------|-------|
 | Kiro | `AGENTS.md` + `.kiro/steering/*.md` | Multiple files, one per topic |
 | Claude Code | `CLAUDE.md` (project) + `~/.claude/CLAUDE.md` (global) + `MEMORY.md` index | Hierarchical loading (global → project → subdir). Auto-memory index is hot (200-line cap); individual memory files are cold. `settings.json` is config, not instructions |
-| Codex | `.codex/instructions.md` | Single file |
-| Gemini | `GEMINI.md` or context window | Varies by integration |
-| Copilot | `.github/copilot-instructions.md` | Single file |
+| Codex | `AGENTS.md` hierarchical (global → project root → subdir) | Each directory loads at most one file. 32KB cap (`project_doc_max_bytes`). Use nested `AGENTS.md` for per-directory responsibility split. No multi-file topic split within same dir |
+| Gemini | `GEMINI.md` hierarchical (`~/.gemini/GEMINI.md` global → `./GEMINI.md` project → subdir) + `MEMORY.md` index | Same hierarchical pattern as CC/Codex. Private project memory index is hot; individual memory files are cold |
+| Copilot | `.github/copilot-instructions.md` | Single file (pending confirmation) |
 | OpenCode | `AGENTS.md` or equivalent | Follows repo convention |
 
 ---

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -1,5 +1,17 @@
 # Steering Design Guide
 
+## Problem
+
+AI coding agents load persistent instructions every session, but without deliberate organization:
+- **Bloated instructions** dilute attention — critical rules get buried in noise
+- **Duplicated rules** across files inevitably contradict each other when one is updated
+- **Missing triggers** mean mandatory behaviors live in docs the agent never reads
+- **No shared standard** across agents leads to each team reinventing the wheel
+
+This guide establishes a universal framework for organizing agent memory into layers, so rules are reliably followed, context budgets are respected, and teams can onboard new agents without starting from scratch.
+
+---
+
 How to organize AI agent memory across three tiers: hot (always loaded), warm (triggered on demand), and cold (searched when needed).
 
 Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent that supports persistent instruction files.

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -1,6 +1,6 @@
 # Steering Design Guide
 
-How to decide what goes into hot memory (always loaded) vs cold storage (searched on demand) for AI coding agents.
+How to organize AI agent memory across three tiers: hot (always loaded), warm (triggered on demand), and cold (searched when needed).
 
 Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent that supports persistent instruction files.
 
@@ -11,7 +11,7 @@ Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent th
 | Term | Meaning | Examples |
 |------|---------|---------|
 | 🔥 **Hot memory** | Loaded every session, always in context | `AGENTS.md`, `.kiro/steering/`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md` |
-| ☕ **Warm context** | Not always loaded, but auto-triggered when conditions match | Codex Skills, Copilot path-specific instructions, CC/Gemini memory index entries, subdir instruction files |
+| ☕ **Warm context** | Not always loaded, but auto-triggered when conditions match | Codex Skills (body), Copilot path-specific instructions, CC/Gemini individual memory files (pointed to by hot index), subdir instruction files |
 | ❄️ **Cold storage** | Searched or retrieved on demand, no automatic trigger | Knowledge bases, `docs/`, project wikis, ADRs, historical records |
 
 ---
@@ -120,7 +120,7 @@ Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent th
 > - **Semantic:** CC/Gemini memory index — agent reads description and decides to load
 > - **Explicit:** Agent calls `activate_skill` or `read_file` when task matches
 
-> **Real-world example:** Claude Code's auto-memory system is a natural implementation of hot/cold separation — `MEMORY.md` index (hot, 200-line cap) points to individual `.md` memory files (cold, loaded on demand). This pattern validates the guide's core principle.
+> **Real-world example:** Claude Code's auto-memory system is a natural implementation of hot/warm separation — `MEMORY.md` index (hot, 200-line cap) points to individual `.md` memory files (warm, loaded when agent determines relevance from index description).
 
 > **Common pattern:** CC, Codex, and Gemini all use hierarchical loading (global → project → subdir). This naturally supports "one file per responsibility" by placing topic-specific rules in the relevant subdirectory's instruction file.
 

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -133,6 +133,7 @@ If the agent doesn't follow the rule → it's either not loaded, too buried in o
 | Putting case studies in hot memory | Wastes context budget on history | Move to docs, reference by lesson only |
 | Vague rules ("be helpful") | Untestable, no behavioral change | Make specific and testable |
 | Hot memory > 20KB | Diminishing returns, attention dilution | Audit and move cold items out |
+| Task-scoped rules in file/directory-scoped locations | Review SOP, response format, collaboration protocol only load when certain files are touched — missing when needed most | Put task-agnostic workflow rules in always-loaded layer, not path-specific |
 
 ---
 

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -73,8 +73,6 @@ AGENTS.md / CLAUDE.md / GEMINI.md  Knowledge bases (semantic search)
 .github/copilot-instructions.md  Project wikis, ADRs, RFCs
 MEMORY.md index (CC/Gemini)      Individual memory files
 ```
-MEMORY.md index (CC auto-memory) Individual memory files (.claude/projects/*/memory/*.md)
-```
 
 > **Real-world example:** Claude Code's auto-memory system is a natural implementation of hot/cold separation — `MEMORY.md` index (hot, 200-line cap) points to individual `.md` memory files (cold, loaded on demand). This pattern validates the guide's core principle.
 
@@ -134,6 +132,7 @@ If the agent doesn't follow the rule → it's either not loaded, too buried in o
 | Vague rules ("be helpful") | Untestable, no behavioral change | Make specific and testable |
 | Hot memory > 20KB | Diminishing returns, attention dilution | Audit and move cold items out |
 | Task-scoped rules in file/directory-scoped locations | Review SOP, response format, collaboration protocol only load when certain files are touched — missing when needed most | Put task-agnostic workflow rules in always-loaded layer, not path-specific |
+| Stale links in hot memory | Index points to missing files; fresh session gets dead references | Audit links quarterly; remove or create the target |
 
 ---
 
@@ -142,3 +141,4 @@ If the agent doesn't follow the rule → it's either not loaded, too buried in o
 - **Quarterly audit**: Review hot memory files. Remove rules that are no longer relevant or have become default behavior.
 - **After contradictions**: When agent behavior contradicts a rule, check if it's a loading issue or a conflict with another rule.
 - **After new capabilities**: When adding new workflows, decide hot vs cold before writing the doc.
+- **Adding a new agent**: Document its loading model and precedence before adding file mappings. Don't assume it works like existing agents.

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -83,6 +83,21 @@ MEMORY.md index (CC auto-memory) Individual memory files (.claude/projects/*/mem
 
 ## Agent-Specific File Mapping
 
+> **Note:** Most agents are hybrid — they combine multiple loading models. The table below shows the primary mechanisms.
+
+### Loading Models
+
+| Model | Trigger | Examples |
+|-------|---------|---------|
+| **Always loaded** | Every session/interaction in repo context | Kiro `.kiro/steering/*`, CC/Codex/Gemini root instruction file, Copilot `.github/copilot-instructions.md` |
+| **Directory-scoped** | Processing files within that directory tree | CC/Codex/Gemini subdir instruction files, Copilot `AGENTS.md` (nearest-in-tree) |
+| **File-scoped** | Matching an `applyTo` glob pattern | Copilot `.github/instructions/**/*.instructions.md` |
+
+**Implication for hot memory design:**
+- "Always loaded" = put task-agnostic rules here (identity, verdict logic, workflow triggers)
+- "Directory-scoped" = put domain-specific rules here (gateway checklist, docs standards)
+- "File-scoped" = put file-type-specific review expectations here (only Copilot supports this natively)
+
 | Agent | Hot Memory Location | Notes |
 |-------|-------------------|-------|
 | Kiro | `AGENTS.md` + `.kiro/steering/*.md` | Multiple files, one per topic |

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -10,7 +10,7 @@ Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent th
 
 | Term | Meaning | Examples |
 |------|---------|---------|
-| **Hot memory** | Loaded every session, always in context | `AGENTS.md`, `.kiro/steering/`, `CLAUDE.md`, `.codex/instructions.md`, `.github/copilot-instructions.md` |
+| **Hot memory** | Loaded every session, always in context | `AGENTS.md`, `.kiro/steering/`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md` |
 | **Cold storage** | Indexed/searchable, loaded on demand | Knowledge bases, `docs/`, project wikis |
 
 ---
@@ -68,10 +68,11 @@ Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent th
 ```
 Hot (always loaded)              Cold (search on demand)
 ───────────────────────          ──────────────────────────
-AGENTS.md / CLAUDE.md            Knowledge bases (semantic search)
+AGENTS.md / CLAUDE.md / GEMINI.md  Knowledge bases (semantic search)
 .kiro/steering/*.md              docs/*.md
-.codex/instructions.md           Project wikis
-.github/copilot-instructions.md  ADRs, RFCs, lessons learned
+.github/copilot-instructions.md  Project wikis, ADRs, RFCs
+MEMORY.md index (CC/Gemini)      Individual memory files
+```
 MEMORY.md index (CC auto-memory) Individual memory files (.claude/projects/*/memory/*.md)
 ```
 

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -10,6 +10,8 @@ AI coding agents load persistent instructions every session, but without deliber
 
 This guide establishes a universal framework for organizing agent memory into layers, so rules are reliably followed, context budgets are respected, and teams can onboard new agents without starting from scratch.
 
+OpenAB is designed to be agent-agnostic — it supports Kiro, Claude Code, Codex, Gemini, Copilot, and OpenCode running side by side. This guide provides a shared memory architecture standard that allows all supported coding agents to maintain consistent behavior, collaborate effectively, and operate from a single source of truth regardless of their underlying platform differences.
+
 ---
 
 How to organize AI agent memory across three tiers: hot (always loaded), warm (triggered on demand), and cold (searched when needed).

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -10,8 +10,9 @@ Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent th
 
 | Term | Meaning | Examples |
 |------|---------|---------|
-| **Hot memory** | Loaded every session, always in context | `AGENTS.md`, `.kiro/steering/`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md` |
-| **Cold storage** | Indexed/searchable, loaded on demand | Knowledge bases, `docs/`, project wikis |
+| 🔥 **Hot memory** | Loaded every session, always in context | `AGENTS.md`, `.kiro/steering/`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md` |
+| ☕ **Warm context** | Not always loaded, but auto-triggered when conditions match | Codex Skills, Copilot path-specific instructions, CC/Gemini memory index entries, subdir instruction files |
+| ❄️ **Cold storage** | Searched or retrieved on demand, no automatic trigger | Knowledge bases, `docs/`, project wikis, ADRs, historical records |
 
 ---
 
@@ -36,6 +37,17 @@ Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent th
 | Design proposals / RFCs | Architecture decisions, feature specs |
 | Lookup tables | Feature flags, config reference, changelogs |
 
+## What Goes in Warm Context
+
+| Criteria | Example |
+|----------|---------|
+| Too large for hot, but has a reliable trigger | Deployment SOP, release checklist |
+| Only relevant for specific file types or paths | Gateway adapter checklist, Helm wiring rules |
+| Domain-specific expert knowledge | Platform auth spec details, crypto implementation patterns |
+| Complex workflows with steps and scripts | Incident triage playbook, skill bodies |
+
+**Rule of thumb:** If it has a clear trigger condition and is > 1KB, make it warm. Keep only the trigger (name + one-line description + path) in hot.
+
 ---
 
 ## Design Principles
@@ -56,11 +68,12 @@ Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent th
 ```
 "If this rule is NOT loaded, will the next response be wrong?"
 │
-├─ Yes → Hot memory
+├─ Yes → 🔥 Hot memory
 │
-├─ Sometimes, depends on task → Hot memory (if small) or cold with reliable trigger
+├─ Only when doing a specific task/touching specific files
+│  → ☕ Warm context (put trigger in hot, body in warm)
 │
-└─ No, it's reference → Cold storage
+└─ No, it's reference → ❄️ Cold storage
 ```
 
 ---
@@ -68,13 +81,21 @@ Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent th
 ## Architecture Pattern
 
 ```
-Hot (always loaded)              Cold (search on demand)
-───────────────────────          ──────────────────────────
-AGENTS.md / CLAUDE.md / GEMINI.md  Knowledge bases (semantic search)
-.kiro/steering/*.md              docs/*.md
-.github/copilot-instructions.md  Project wikis, ADRs, RFCs
-MEMORY.md index (CC/Gemini)      Individual memory files
+🔥 Hot (always loaded)               ☕ Warm (triggered)                    ❄️ Cold (search on demand)
+─────────────────────────            ──────────────────────────            ──────────────────────────
+AGENTS.md / CLAUDE.md / GEMINI.md    Codex Skills (SKILL.md body)          Knowledge bases
+.kiro/steering/*.md                  Copilot path-specific instructions    docs/*.md
+.github/copilot-instructions.md      CC/Gemini individual memory files     Project wikis, ADRs, RFCs
+MEMORY.md index (CC/Gemini)          Subdir instruction files              Historical records
+Skill/trigger metadata               Domain-specific SOPs                  Lessons learned
 ```
+
+**Key insight:** The warm layer's *trigger metadata* lives in hot memory (skill names, index entries, applyTo globs). Only the *body* loads on demand. This is the pattern: **put the table of contents in hot, put the chapters in warm.**
+
+> **Trigger mechanisms vary by agent:**
+> - **Rule-based:** Copilot `applyTo` glob match, Codex skill metadata match
+> - **Semantic:** CC/Gemini memory index — agent reads description and decides to load
+> - **Explicit:** Agent calls `activate_skill` or `read_file` when task matches
 
 > **Real-world example:** Claude Code's auto-memory system is a natural implementation of hot/cold separation — `MEMORY.md` index (hot, 200-line cap) points to individual `.md` memory files (cold, loaded on demand). This pattern validates the guide's core principle.
 
@@ -135,6 +156,7 @@ If the agent doesn't follow the rule → it's either not loaded, too buried in o
 | Hot memory > 20KB | Diminishing returns, attention dilution | Audit and move cold items out |
 | Task-scoped rules in file/directory-scoped locations | Review SOP, response format, collaboration protocol only load when certain files are touched — missing when needed most | Put task-agnostic workflow rules in always-loaded layer, not path-specific |
 | Stale links in hot memory | Index points to missing files; fresh session gets dead references | Audit links quarterly; remove or create the target |
+| Mandatory behavior hidden in cold without trigger | Agent must follow it but has no path to discover it | Add trigger metadata to hot, or promote to warm with clear activation condition |
 
 ---
 

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -189,3 +189,29 @@ If the agent doesn't follow the rule → it's either not loaded, too buried in o
 - **After contradictions**: When agent behavior contradicts a rule, check if it's a loading issue or a conflict with another rule.
 - **After new capabilities**: When adding new workflows, decide hot vs cold before writing the doc.
 - **Adding a new agent**: Document its loading model and precedence before adding file mappings. Don't assume it works like existing agents.
+
+---
+
+## Self-Reflection Prompt
+
+Any agent can use this prompt to audit its own memory allocation against this guide:
+
+```
+Per the steering design guide, review your current memory allocation:
+
+1. List everything in your hot memory (always loaded). How many lines/KB?
+2. Identify items that violate the guide's principles:
+   - Not behavior-oriented (nice-to-know, not need-to-know)
+   - Duplicated across files (contradiction risk)
+   - Too large (should be warm or cold)
+   - Stale (references missing files or outdated info)
+   - Contains WHY instead of WHAT/HOW
+3. Identify mandatory behaviors currently in cold storage with no trigger path.
+4. Propose an optimization plan:
+   - What to remove from hot
+   - What to promote from cold to warm (with trigger)
+   - What to demote from hot to warm or cold
+   - What's missing from hot that should be there
+```
+
+Expected output: a concrete before/after with line counts and rationale for each move.

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -72,7 +72,10 @@ AGENTS.md / CLAUDE.md            Knowledge bases (semantic search)
 .kiro/steering/*.md              docs/*.md
 .codex/instructions.md           Project wikis
 .github/copilot-instructions.md  ADRs, RFCs, lessons learned
+MEMORY.md index (CC auto-memory) Individual memory files (.claude/projects/*/memory/*.md)
 ```
+
+> **Real-world example:** Claude Code's auto-memory system is a natural implementation of hot/cold separation — `MEMORY.md` index (hot, 200-line cap) points to individual `.md` memory files (cold, loaded on demand). This pattern validates the guide's core principle.
 
 ---
 
@@ -81,7 +84,7 @@ AGENTS.md / CLAUDE.md            Knowledge bases (semantic search)
 | Agent | Hot Memory Location | Notes |
 |-------|-------------------|-------|
 | Kiro | `AGENTS.md` + `.kiro/steering/*.md` | Multiple files, one per topic |
-| Claude Code | `CLAUDE.md` + `.claude/settings.json` | Single file + config |
+| Claude Code | `CLAUDE.md` (project) + `~/.claude/CLAUDE.md` (global) + `MEMORY.md` index | Hierarchical loading (global → project → subdir). Auto-memory index is hot (200-line cap); individual memory files are cold. `settings.json` is config, not instructions |
 | Codex | `.codex/instructions.md` | Single file |
 | Gemini | `GEMINI.md` or context window | Varies by integration |
 | Copilot | `.github/copilot-instructions.md` | Single file |

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -1,0 +1,122 @@
+# Steering Design Guide
+
+How to decide what goes into hot memory (always loaded) vs cold storage (searched on demand) for AI coding agents.
+
+Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode — any agent that supports persistent instruction files.
+
+---
+
+## Terminology
+
+| Term | Meaning | Examples |
+|------|---------|---------|
+| **Hot memory** | Loaded every session, always in context | `AGENTS.md`, `.kiro/steering/`, `CLAUDE.md`, `.codex/instructions.md`, `.github/copilot-instructions.md` |
+| **Cold storage** | Indexed/searchable, loaded on demand | Knowledge bases, `docs/`, project wikis |
+
+---
+
+## What Goes in Hot Memory
+
+| Criteria | Example |
+|----------|---------|
+| Every interaction might trigger it | Output format spec, verdict logic |
+| Identity & relationships | Agent name, team members, contact IDs |
+| SOP trigger words | "review PRs" → auto-execute workflow |
+| Hard rules that are easy to get wrong | "NITs are blocking", "never merge", "English only on GitHub" |
+| Tool usage patterns | Login flows, API call patterns |
+| Constraints that override defaults | "Don't ask for confirmation on X", "Always do Y before Z" |
+
+## What Stays in Cold Storage
+
+| Criteria | Example |
+|----------|---------|
+| Historical records / case studies | Past incident lessons, collaboration logs |
+| One-time reference | Installation steps, migration guides |
+| Large data | User profiles, conversation history |
+| Design proposals / RFCs | Architecture decisions, feature specs |
+| Lookup tables | Feature flags, config reference, changelogs |
+
+---
+
+## Design Principles
+
+1. **Small and precise** — Keep hot memory under ~15KB total. Larger context dilutes attention on critical rules.
+2. **Behavior-oriented** — Every line should change "what the agent does next." Remove anything that's just "nice to know."
+3. **Single source of truth** — Define each rule in exactly one place. Duplication across files creates contradiction risk.
+4. **Testable** — Each rule should be verifiable with a single prompt from a fresh session.
+5. **One file per responsibility** — Separate concerns: identity, review process, workflow triggers. Avoid monolithic instruction files.
+6. **Hot/cold separation** — If the agent can find it via search when needed, it doesn't need to be always-loaded.
+
+---
+
+## Decision Flowchart
+
+```
+"If this rule is NOT loaded, will the next response be wrong?"
+│
+├─ Yes → Hot memory
+│
+├─ Sometimes, depends on task → Hot memory (if small) or cold with reliable trigger
+│
+└─ No, it's reference → Cold storage
+```
+
+---
+
+## Architecture Pattern
+
+```
+Hot (always loaded)              Cold (search on demand)
+───────────────────────          ──────────────────────────
+AGENTS.md / CLAUDE.md            Knowledge bases (semantic search)
+.kiro/steering/*.md              docs/*.md
+.codex/instructions.md           Project wikis
+.github/copilot-instructions.md  ADRs, RFCs, lessons learned
+```
+
+---
+
+## Agent-Specific File Mapping
+
+| Agent | Hot Memory Location | Notes |
+|-------|-------------------|-------|
+| Kiro | `AGENTS.md` + `.kiro/steering/*.md` | Multiple files, one per topic |
+| Claude Code | `CLAUDE.md` + `.claude/settings.json` | Single file + config |
+| Codex | `.codex/instructions.md` | Single file |
+| Gemini | `GEMINI.md` or context window | Varies by integration |
+| Copilot | `.github/copilot-instructions.md` | Single file |
+| OpenCode | `AGENTS.md` or equivalent | Follows repo convention |
+
+---
+
+## Validation Checklist
+
+After adding or changing hot memory:
+
+1. **Start a fresh session** (no prior context)
+2. **Ask a question that triggers the rule** — e.g., "what format should a review comment use?"
+3. **Verify the response follows the rule exactly**
+4. **Test edge cases** — e.g., "what if there's only one 🟡 finding?"
+5. **Check for contradictions** — does the new rule conflict with anything else in hot memory?
+
+If the agent doesn't follow the rule → it's either not loaded, too buried in other content, or ambiguously worded.
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It's Bad | Fix |
+|--------------|-------------|-----|
+| Dumping everything into one file | Critical rules get lost in noise | Split by responsibility |
+| Duplicating rules across files | Inevitable contradictions when one is updated | Single source + pointer |
+| Putting case studies in hot memory | Wastes context budget on history | Move to docs, reference by lesson only |
+| Vague rules ("be helpful") | Untestable, no behavioral change | Make specific and testable |
+| Hot memory > 20KB | Diminishing returns, attention dilution | Audit and move cold items out |
+
+---
+
+## Maintenance
+
+- **Quarterly audit**: Review hot memory files. Remove rules that are no longer relevant or have become default behavior.
+- **After contradictions**: When agent behavior contradicts a rule, check if it's a loading issue or a conflict with another rule.
+- **After new capabilities**: When adding new workflows, decide hot vs cold before writing the doc.

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -194,24 +194,44 @@ If the agent doesn't follow the rule → it's either not loaded, too buried in o
 
 ## Self-Reflection Prompt
 
-Any agent can use this prompt to audit its own memory allocation against this guide:
+Use this prompt from a fresh session to audit memory allocation against this guide:
 
 ```
-Per the steering design guide, review your current memory allocation:
+Per the steering design guide, audit my current memory allocation:
 
-1. List everything in your hot memory (always loaded). How many lines/KB?
-2. Identify items that violate the guide's principles:
-   - Not behavior-oriented (nice-to-know, not need-to-know)
-   - Duplicated across files (contradiction risk)
-   - Too large (should be warm or cold)
-   - Stale (references missing files or outdated info)
-   - Contains WHY instead of WHAT/HOW
-3. Identify mandatory behaviors currently in cold storage with no trigger path.
-4. Propose an optimization plan:
-   - What to remove from hot
-   - What to promote from cold to warm (with trigger)
-   - What to demote from hot to warm or cold
-   - What's missing from hot that should be there
+1. INVENTORY — List all loaded/discoverable instruction sources:
+   - File path
+   - Layer (Hot / Warm / Cold)
+   - Trigger model (always / directory / file-glob / semantic / explicit)
+   - Approximate size (lines or KB)
+
+2. CLASSIFY — For each item, what type of content is it?
+   - WHAT/HOW (behavior rule) vs WHY (history/rationale)
+   - Identity / hard rule / workflow / reference / trivia
+
+3. VIOLATIONS — Identify items that break the guide's principles:
+   - Not behavior-oriented (nice-to-know in hot)
+   - Duplicated or conflicting across files
+   - Stale links pointing to missing files
+   - Too large for its layer
+   - WHY/history in hot instead of cold
+   - Mandatory behavior in cold with no trigger path
+
+4. TRIGGER QUALITY — Review warm layer triggers:
+   - Are index descriptions precise enough to fire correctly?
+   - Where is the canonical source for each rule?
+   - Will the agent reliably see it when needed?
+
+5. OPTIMIZATION PLAN — Propose concrete moves:
+   - Remove (stale, duplicate, irrelevant)
+   - Keep in hot (behavioral, high-frequency)
+   - Promote cold → warm (add trigger)
+   - Demote hot → warm or cold (too large, low-frequency)
+   - Split (one file doing too many jobs)
+   - Add missing trigger/index entry
+
+6. VERIFY — Name one fresh-session test prompt that would confirm
+   the highest-risk rule still loads correctly.
 ```
 
-Expected output: a concrete before/after with line counts and rationale for each move.
+Expected output: a before/after table with file paths, layer assignments, sizes, and rationale for each move.

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -89,7 +89,7 @@ MEMORY.md index (CC auto-memory) Individual memory files (.claude/projects/*/mem
 | Claude Code | `CLAUDE.md` (project) + `~/.claude/CLAUDE.md` (global) + `MEMORY.md` index | Hierarchical loading (global → project → subdir). Auto-memory index is hot (200-line cap); individual memory files are cold. `settings.json` is config, not instructions |
 | Codex | `AGENTS.md` hierarchical (global → project root → subdir) | Each directory loads at most one file. 32KB cap (`project_doc_max_bytes`). Use nested `AGENTS.md` for per-directory responsibility split. No multi-file topic split within same dir |
 | Gemini | `GEMINI.md` hierarchical (`~/.gemini/GEMINI.md` global → `./GEMINI.md` project → subdir) + `MEMORY.md` index | Same hierarchical pattern as CC/Codex. Private project memory index is hot; individual memory files are cold |
-| Copilot | `.github/copilot-instructions.md` | Single file (pending confirmation) |
+| Copilot | `.github/copilot-instructions.md` (repo-wide) + `.github/instructions/**/*.instructions.md` (path-specific) + `AGENTS.md` (nearest-in-tree) | Layered: Personal > Path-specific > Repo-wide > Agent > Organization. No hard size cap for Chat/Agent (code review reads first 4K chars only). Keep short (~2 pages recommended) |
 | OpenCode | `AGENTS.md` or equivalent | Follows repo convention |
 
 ---


### PR DESCRIPTION
## What problem does this solve?

AI agents (Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode) all have some form of persistent instructions that load every session. Without a clear guide on what belongs in hot memory vs cold storage, teams end up with:

- Bloated instruction files that dilute critical rules
- Duplicated rules across files that contradict each other
- Important behaviors that get lost because they're buried in noise

## Proposed Solution

A design guide that establishes principles for hot/cold memory separation:

- **Hot memory** (~15KB max): behavior rules, identity, SOP triggers, hard constraints
- **Cold storage** (unlimited): case studies, RFCs, reference docs, large data

Includes:
- Decision criteria for hot vs cold
- Agent-specific file mapping (Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode)
- Validation checklist for testing rules from fresh sessions
- Anti-patterns to avoid

## Why This Approach

Derived from hands-on experience reorganizing steering files. The principles generalize across all agents that support persistent instructions.

## Test Plan

- [x] Validated principles by testing rule loading from fresh Kiro sessions
- [x] Confirmed hot memory stays under 15KB after applying the guide

## Discord Discussion URL

https://discord.com/channels/1491295327620169908/1502381535343411411