### PR TITLE
feat: agent-controlled reply-to via [[reply_to:message_id]] directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 - **@mention trigger** — mention the bot in an allowed channel to start a conversation
 - **Thread-based multi-turn** — auto-creates threads; no @mention needed for follow-ups
 - **Multi-agent collaboration** — bot-to-bot messaging for coordinated workflows ([docs/multi-agent.md](docs/multi-agent.md))
+- **Agent-controlled reply-to** — agents choose which message to reply to via `[[reply_to:id]]` directive, enabling clear conversation threads in multi-bot channels ([docs/output-directives.md](docs/output-directives.md))
 - **Edit-streaming** — live-updates the Discord message every 1.5s as tokens arrive
 - **Emoji status reactions** — 👀→🤔→🔥/👨‍💻/⚡→👍+random mood face
 - **Image & file support** — send images and files through chat ([docs/sendimages.md](docs/sendimages.md), [docs/sendfiles.md](docs/sendfiles.md))

--- a/docs/output-directives.md
+++ b/docs/output-directives.md
@@ -14,9 +14,11 @@ Actual message content starts here...
 
 Rules:
 - Consecutive `[[key:value]]` lines at the start of output = directive header block
-- First line that doesn't match `[[...]]` = content begins
+- First line that doesn't match `[[key:value]]` (with colon) = content begins
+- `[[X]]` without colon is NOT a directive — stops parsing, preserved as content
 - Directives are stripped from the final message (never visible to users)
-- Unknown keys are silently ignored (forward compatible)
+- Unknown keys are silently ignored (forward compatible, logged at debug level)
+- If the same key appears multiple times, the last value wins
 
 ## Available Directives
 
@@ -29,7 +31,7 @@ Reply to a specific message by ID (Discord: `message_reference`).
 Here is my reply to that specific message.
 ```
 
-**Value**: Platform message ID (Discord snowflake — numeric only)
+**Value**: Platform message ID. Format depends on the target adapter — Discord requires a numeric snowflake; Slack accepts `ts` (e.g. `1234567890.123456`). The directive parser validates only that the value is non-empty, ≤64 chars, and contains no whitespace; per-platform format validation happens in each adapter.
 
 **Behavior**:
 - Discord: sends with `message_reference`, showing the native "replying to..." UI

--- a/docs/output-directives.md
+++ b/docs/output-directives.md
@@ -71,6 +71,8 @@ This creates clear visual conversation threads within a Discord thread — essen
 | Hermes Agent | `DISCORD_REPLY_TO_MODE` env var | ❌ Platform decides, always to trigger msg |
 | **OAB** | `[[reply_to:message_id]]` directive | ✅ Agent chooses any message |
 
+> **Note:** `reply_to` is currently implemented for Discord only. Slack message IDs (ts format like `1234567890.123456`) are accepted by the parser but the Slack adapter does not yet send threaded replies via this directive — it falls back to plain send. Slack support can be added in a future PR.
+
 ## Future Directives
 
 The `[[key:value]]` format is extensible. Planned:

--- a/docs/output-directives.md
+++ b/docs/output-directives.md
@@ -72,10 +72,3 @@ This creates clear visual conversation threads within a Discord thread — essen
 | **OAB** | `[[reply_to:message_id]]` directive | ✅ Agent chooses any message |
 
 > **Note:** `reply_to` is currently implemented for Discord only. Slack message IDs (ts format like `1234567890.123456`) are accepted by the parser but the Slack adapter does not yet send threaded replies via this directive — it falls back to plain send. Slack support can be added in a future PR.
-
-## Future Directives
-
-The `[[key:value]]` format is extensible. Planned:
-- `[[ephemeral:true]]` — send as ephemeral message (only visible to trigger user)
-- `[[suppress_embeds:true]]` — prevent URL embeds
-- `[[thread_name:New Title]]` — rename thread on send

--- a/docs/output-directives.md
+++ b/docs/output-directives.md
@@ -1,0 +1,79 @@
+# Output Directives
+
+## Overview
+
+Agents can control platform-specific message delivery by prefixing their output with `[[key:value]]` directives. OAB parses and strips these before sending to the platform.
+
+## Format
+
+```
+[[reply_to:1502606076451885136]]
+[[ephemeral:true]]              ← future
+Actual message content starts here...
+```
+
+Rules:
+- Consecutive `[[key:value]]` lines at the start of output = directive header block
+- First line that doesn't match `[[...]]` = content begins
+- Directives are stripped from the final message (never visible to users)
+- Unknown keys are silently ignored (forward compatible)
+
+## Available Directives
+
+### `reply_to`
+
+Reply to a specific message by ID (Discord: `message_reference`).
+
+```
+[[reply_to:1502606076451885136]]
+Here is my reply to that specific message.
+```
+
+**Value**: Platform message ID (Discord snowflake — numeric only)
+
+**Behavior**:
+- Discord: sends with `message_reference`, showing the native "replying to..." UI
+- Invalid/non-existent message ID: silently falls back to plain send
+- Works in both streaming and send-once modes
+
+**How agents get message IDs**: Every incoming message includes `message_id` in `SenderContext`:
+
+```json
+{
+  "schema": "openab.sender.v1",
+  "sender_id": "845835116920307722",
+  "sender_name": "pahud.hsieh",
+  "message_id": "1502606076451885136",
+  "channel": "discord",
+  ...
+}
+```
+
+## Multi-Agent Use Case
+
+In a thread with multiple bots, agents can reply to each other's messages:
+
+```
+Human: "Review this PR" (message_id: 100)
+Bot A: "Found 3 issues" (message_id: 101)
+Bot B output:
+  [[reply_to:101]]
+  I agree with Bot A on F1, but F2 is actually fine because...
+```
+
+This creates clear visual conversation threads within a Discord thread — essential for multi-agent collaboration.
+
+## Comparison with Other Platforms
+
+| Platform | Reply Mechanism | Agent Control |
+|----------|----------------|---------------|
+| OpenClaw | `replyToMode` config (`off`/`first`/`all`) | ❌ Platform decides, always to trigger msg |
+| Hermes Agent | `DISCORD_REPLY_TO_MODE` env var | ❌ Platform decides, always to trigger msg |
+| **OAB** | `[[reply_to:message_id]]` directive | ✅ Agent chooses any message |
+
+## Future Directives
+
+The `[[key:value]]` format is extensible. Planned:
+- `[[ephemeral:true]]` — send as ephemeral message (only visible to trigger user)
+- `[[suppress_embeds:true]]` — prevent URL embeds
+- `[[thread_name:New Title]]` — rename thread on send

--- a/docs/output-directives.md
+++ b/docs/output-directives.md
@@ -31,7 +31,7 @@ Reply to a specific message by ID (Discord: `message_reference`).
 Here is my reply to that specific message.
 ```
 
-**Value**: Platform message ID. Format depends on the target adapter — Discord requires a numeric snowflake; Slack accepts `ts` (e.g. `1234567890.123456`). The directive parser validates only that the value is non-empty, ≤64 chars, and contains no whitespace; per-platform format validation happens in each adapter.
+**Value**: Platform message ID. Format depends on the target adapter — Discord requires a numeric snowflake; Slack accepts `ts` (e.g. `1234567890.123456`). The directive parser validates that the value is non-empty, ≤64 chars, and contains only ASCII alphanumeric characters plus `.`, `-`, `_`; per-platform format validation happens in each adapter.
 
 **Behavior**:
 - Discord: sends with `message_reference`, showing the native "replying to..." UI

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -638,7 +638,7 @@ impl AdapterRouter {
                     };
                     let chunks = format::split_message(&final_content, message_limit);
                     if let Some(msg) = placeholder_msg {
-                        if directives.reply_to.is_some() {
+                        if let Some(ref reply_id) = directives.reply_to {
                             // reply_to directive present: delete placeholder and re-send as reply
                             let _ = adapter.delete_message(&msg).await;
                             let mut first = true;
@@ -647,7 +647,7 @@ impl AdapterRouter {
                                     let _ = adapter.send_message_with_reply(
                                         &thread_channel,
                                         chunk,
-                                        directives.reply_to.as_ref().unwrap(),
+                                        reply_id,
                                     ).await;
                                 } else {
                                     let _ = adapter.send_message(&thread_channel, chunk).await;

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -42,7 +42,14 @@ pub fn parse_output_directives(content: &str) -> (OutputDirectives, String) {
                     _ => {} // Unknown directives silently ignored (forward compatible)
                 }
             }
-            content_start += line.len() + 1; // +1 for newline
+            // Advance past this line + its line ending (handles both \n and \r\n)
+            content_start += line.len();
+            if content.as_bytes().get(content_start) == Some(&b'\r') {
+                content_start += 1;
+            }
+            if content.as_bytes().get(content_start) == Some(&b'\n') {
+                content_start += 1;
+            }
         } else {
             break;
         }
@@ -613,7 +620,11 @@ impl AdapterRouter {
                     };
 
                     let final_content = markdown::convert_tables(&final_content, table_mode);
-                    // Parse output directives (e.g. [[reply_to:msg_id]]) from content header
+                    // Parse output directives (e.g. [[reply_to:msg_id]]) from content header.
+                    // Note: reply_to only takes effect in send-once mode (placeholder_msg == None).
+                    // In streaming mode, the placeholder is already sent before we know the directive.
+                    // This is acceptable: streaming is disabled in multi-bot threads (where reply-to
+                    // matters most), so the common multi-agent case always uses send-once.
                     let (directives, stripped_content) = parse_output_directives(&final_content);
                     let final_content = stripped_content;
                     let chunks = format::split_message(&final_content, message_limit);

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1047,4 +1047,21 @@ mod directive_tests {
         assert_eq!(directives.reply_to, None);
         assert_eq!(content, input);
     }
+
+    #[test]
+    fn parse_duplicate_reply_to_last_wins() {
+        let input = "[[reply_to:111]]\n[[reply_to:222]]\nContent";
+        let (directives, content) = parse_output_directives(input);
+        // Last value wins
+        assert_eq!(directives.reply_to, Some("222".to_string()));
+        assert_eq!(content, "Content");
+    }
+
+    #[test]
+    fn parse_crlf_multiple_directives() {
+        let input = "[[reply_to:456]]\r\n[[unknown:x]]\r\nContent after CRLF";
+        let (directives, content) = parse_output_directives(input);
+        assert_eq!(directives.reply_to, Some("456".to_string()));
+        assert_eq!(content, "Content after CRLF");
+    }
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -34,8 +34,8 @@ pub fn parse_output_directives(content: &str) -> (OutputDirectives, String) {
                 match key.trim() {
                     "reply_to" => {
                         let v = value.trim();
-                        // Validate: must be numeric snowflake
-                        if v.chars().all(|c| c.is_ascii_digit()) && !v.is_empty() {
+                        // Validate: non-empty, reasonable length, no whitespace/control chars
+                        if !v.is_empty() && v.len() <= 64 && v.chars().all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_') {
                             directives.reply_to = Some(v.to_string());
                         }
                     }
@@ -1009,10 +1009,18 @@ mod directive_tests {
     }
 
     #[test]
-    fn parse_invalid_reply_to_non_numeric() {
-        let input = "[[reply_to:not-a-number]]\nContent";
+    fn parse_invalid_reply_to_rejects_whitespace() {
+        let input = "[[reply_to:has spaces]]\nContent";
         let (directives, content) = parse_output_directives(input);
         assert_eq!(directives.reply_to, None);
+        assert_eq!(content, "Content");
+    }
+
+    #[test]
+    fn parse_slack_ts_format_accepted() {
+        let input = "[[reply_to:1234567890.123456]]\nContent";
+        let (directives, content) = parse_output_directives(input);
+        assert_eq!(directives.reply_to, Some("1234567890.123456".to_string()));
         assert_eq!(content, "Content");
     }
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -666,12 +666,16 @@ impl AdapterRouter {
                         // First chunk uses reply_to directive if present
                         let mut first = true;
                         for chunk in &chunks {
-                            if first && directives.reply_to.is_some() {
-                                let _ = adapter.send_message_with_reply(
-                                    &thread_channel,
-                                    chunk,
-                                    directives.reply_to.as_ref().unwrap(),
-                                ).await;
+                            if first {
+                                if let Some(ref reply_id) = directives.reply_to {
+                                    let _ = adapter.send_message_with_reply(
+                                        &thread_channel,
+                                        chunk,
+                                        reply_id,
+                                    ).await;
+                                } else {
+                                    let _ = adapter.send_message(&thread_channel, chunk).await;
+                                }
                             } else {
                                 let _ = adapter.send_message(&thread_channel, chunk).await;
                             }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -622,7 +622,12 @@ impl AdapterRouter {
                     let final_content = markdown::convert_tables(&final_content, table_mode);
                     // Parse output directives (e.g. [[reply_to:msg_id]]) from content header.
                     let (directives, stripped_content) = parse_output_directives(&final_content);
-                    let final_content = stripped_content;
+                    // Guard: if content is empty after stripping directives, use fallback
+                    let final_content = if stripped_content.trim().is_empty() {
+                        "_(no response)_".to_string()
+                    } else {
+                        stripped_content
+                    };
                     let chunks = format::split_message(&final_content, message_limit);
                     if let Some(msg) = placeholder_msg {
                         if directives.reply_to.is_some() {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -621,20 +621,39 @@ impl AdapterRouter {
 
                     let final_content = markdown::convert_tables(&final_content, table_mode);
                     // Parse output directives (e.g. [[reply_to:msg_id]]) from content header.
-                    // Note: reply_to only takes effect in send-once mode (placeholder_msg == None).
-                    // In streaming mode, the placeholder is already sent before we know the directive.
-                    // This is acceptable: streaming is disabled in multi-bot threads (where reply-to
-                    // matters most), so the common multi-agent case always uses send-once.
                     let (directives, stripped_content) = parse_output_directives(&final_content);
                     let final_content = stripped_content;
                     let chunks = format::split_message(&final_content, message_limit);
                     if let Some(msg) = placeholder_msg {
-                        // Streaming: edit first chunk into placeholder, send rest as new messages
-                        if let Some(first) = chunks.first() {
-                            let _ = adapter.edit_message(&msg, first).await;
-                        }
-                        for chunk in chunks.iter().skip(1) {
-                            let _ = adapter.send_message(&thread_channel, chunk).await;
+                        if directives.reply_to.is_some() {
+                            // reply_to directive present: clear placeholder and re-send as reply
+                            // so the directive has consistent semantics regardless of streaming mode.
+                            let _ = adapter.edit_message(&msg, "…").await;
+                            let _ = adapter.edit_message(&msg, &chunks.first().cloned().unwrap_or_default()).await;
+                            // Note: we can't make the placeholder a reply retroactively,
+                            // so send the real content as a new reply message and blank the placeholder.
+                            let _ = adapter.edit_message(&msg, "\u{200b}").await; // zero-width space (effectively hidden)
+                            let mut first = true;
+                            for chunk in &chunks {
+                                if first {
+                                    let _ = adapter.send_message_with_reply(
+                                        &thread_channel,
+                                        chunk,
+                                        directives.reply_to.as_ref().unwrap(),
+                                    ).await;
+                                } else {
+                                    let _ = adapter.send_message(&thread_channel, chunk).await;
+                                }
+                                first = false;
+                            }
+                        } else {
+                            // Normal streaming: edit first chunk into placeholder, send rest
+                            if let Some(first) = chunks.first() {
+                                let _ = adapter.edit_message(&msg, first).await;
+                            }
+                            for chunk in chunks.iter().skip(1) {
+                                let _ = adapter.send_message(&thread_channel, chunk).await;
+                            }
                         }
                     } else {
                         // Send-once: all chunks as new messages

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -39,7 +39,9 @@ pub fn parse_output_directives(content: &str) -> (OutputDirectives, String) {
                             directives.reply_to = Some(v.to_string());
                         }
                     }
-                    _ => {} // Unknown directives silently ignored (forward compatible)
+                    _ => {
+                        tracing::debug!(key = key.trim(), "unknown output directive ignored");
+                    }
                 }
             }
             // Advance past this line + its line ending (handles both \n and \r\n)

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -11,6 +11,51 @@ use crate::format;
 use crate::markdown::{self, TableMode};
 use crate::reactions::StatusReactionController;
 
+// --- Output directive parsing ---
+
+/// Parsed directives from agent output header block.
+/// Consecutive `[[key:value]]` lines at the start of output are directives.
+#[derive(Default, Debug)]
+pub struct OutputDirectives {
+    /// Message ID to reply to (Discord: message_reference)
+    pub reply_to: Option<String>,
+}
+
+/// Parse `[[key:value]]` directives from the beginning of agent output.
+/// Returns parsed directives and the remaining content (directives stripped).
+pub fn parse_output_directives(content: &str) -> (OutputDirectives, String) {
+    let mut directives = OutputDirectives::default();
+    let mut content_start = 0;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(inner) = trimmed.strip_prefix("[[").and_then(|s| s.strip_suffix("]]")) {
+            if let Some((key, value)) = inner.split_once(':') {
+                match key.trim() {
+                    "reply_to" => {
+                        let v = value.trim();
+                        // Validate: must be numeric snowflake
+                        if v.chars().all(|c| c.is_ascii_digit()) && !v.is_empty() {
+                            directives.reply_to = Some(v.to_string());
+                        }
+                    }
+                    _ => {} // Unknown directives silently ignored (forward compatible)
+                }
+            }
+            content_start += line.len() + 1; // +1 for newline
+        } else {
+            break;
+        }
+    }
+
+    let remaining = if content_start < content.len() {
+        &content[content_start..]
+    } else {
+        ""
+    };
+    (directives, remaining.to_string())
+}
+
 // --- Platform-agnostic types ---
 
 /// Identifies a channel or thread across platforms.
@@ -106,6 +151,10 @@ pub struct SenderContext {
     /// breakage). If future additions require breaking changes, bump to v1.1+.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
+    /// Platform message ID. Agents can use this to reply to a specific message
+    /// via the `[[reply_to:<message_id>]]` output directive.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
 }
 
 // --- ChatAdapter trait ---
@@ -139,6 +188,18 @@ pub trait ChatAdapter: Send + Sync + 'static {
     /// Default: unsupported (send-once only).
     async fn edit_message(&self, _msg: &MessageRef, _content: &str) -> Result<()> {
         Err(anyhow::anyhow!("edit_message not supported"))
+    }
+
+    /// Send a message as a reply to a specific message (Discord: message_reference).
+    /// Default: falls back to plain send_message (ignores reply_to).
+    async fn send_message_with_reply(
+        &self,
+        channel: &ChannelRef,
+        content: &str,
+        reply_to_message_id: &str,
+    ) -> Result<MessageRef> {
+        let _ = reply_to_message_id; // unused in default impl
+        self.send_message(channel, content).await
     }
 
     /// Whether this adapter should use streaming edit (true) or send-once (false).
@@ -552,6 +613,9 @@ impl AdapterRouter {
                     };
 
                     let final_content = markdown::convert_tables(&final_content, table_mode);
+                    // Parse output directives (e.g. [[reply_to:msg_id]]) from content header
+                    let (directives, stripped_content) = parse_output_directives(&final_content);
+                    let final_content = stripped_content;
                     let chunks = format::split_message(&final_content, message_limit);
                     if let Some(msg) = placeholder_msg {
                         // Streaming: edit first chunk into placeholder, send rest as new messages
@@ -563,8 +627,19 @@ impl AdapterRouter {
                         }
                     } else {
                         // Send-once: all chunks as new messages
+                        // First chunk uses reply_to directive if present
+                        let mut first = true;
                         for chunk in &chunks {
-                            let _ = adapter.send_message(&thread_channel, chunk).await;
+                            if first && directives.reply_to.is_some() {
+                                let _ = adapter.send_message_with_reply(
+                                    &thread_channel,
+                                    chunk,
+                                    directives.reply_to.as_ref().unwrap(),
+                                ).await;
+                            } else {
+                                let _ = adapter.send_message(&thread_channel, chunk).await;
+                            }
+                            first = false;
                         }
                     }
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -627,8 +627,7 @@ impl AdapterRouter {
                         final_content
                     };
 
-                    let final_content = markdown::convert_tables(&final_content, table_mode);
-                    // Parse output directives (e.g. [[reply_to:msg_id]]) from content header.
+                    // Parse output directives BEFORE markdown conversion (meta-layer first)
                     let (directives, stripped_content) = parse_output_directives(&final_content);
                     // Guard: if content is empty after stripping directives, use fallback
                     let final_content = if stripped_content.trim().is_empty() {
@@ -636,11 +635,12 @@ impl AdapterRouter {
                     } else {
                         stripped_content
                     };
+                    let final_content = markdown::convert_tables(&final_content, table_mode);
                     let chunks = format::split_message(&final_content, message_limit);
                     if let Some(msg) = placeholder_msg {
                         if let Some(ref reply_id) = directives.reply_to {
-                            // reply_to directive present: delete placeholder and re-send as reply
-                            let _ = adapter.delete_message(&msg).await;
+                            // reply_to directive: send reply first, then delete placeholder.
+                            // Order matters: if send fails, placeholder remains (no message loss).
                             let mut first = true;
                             for chunk in &chunks {
                                 if first {
@@ -654,6 +654,7 @@ impl AdapterRouter {
                                 }
                                 first = false;
                             }
+                            let _ = adapter.delete_message(&msg).await;
                         } else {
                             // Normal streaming: edit first chunk into placeholder, send rest
                             if let Some(first) = chunks.first() {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -626,13 +626,8 @@ impl AdapterRouter {
                     let chunks = format::split_message(&final_content, message_limit);
                     if let Some(msg) = placeholder_msg {
                         if directives.reply_to.is_some() {
-                            // reply_to directive present: clear placeholder and re-send as reply
-                            // so the directive has consistent semantics regardless of streaming mode.
-                            let _ = adapter.edit_message(&msg, "…").await;
-                            let _ = adapter.edit_message(&msg, &chunks.first().cloned().unwrap_or_default()).await;
-                            // Note: we can't make the placeholder a reply retroactively,
-                            // so send the real content as a new reply message and blank the placeholder.
-                            let _ = adapter.edit_message(&msg, "\u{200b}").await; // zero-width space (effectively hidden)
+                            // reply_to directive present: hide placeholder and re-send as reply
+                            let _ = adapter.edit_message(&msg, "\u{200b}").await;
                             let mut first = true;
                             for chunk in &chunks {
                                 if first {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -209,6 +209,12 @@ pub trait ChatAdapter: Send + Sync + 'static {
         self.send_message(channel, content).await
     }
 
+    /// Delete a message. Used to remove streaming placeholders when reply_to is set.
+    /// Default: no-op (platforms that don't support delete just ignore).
+    async fn delete_message(&self, _msg: &MessageRef) -> Result<()> {
+        Ok(())
+    }
+
     /// Whether this adapter should use streaming edit (true) or send-once (false).
     /// `other_bot_present` indicates if another bot has posted in the current thread.
     /// Streaming should be disabled in multi-bot threads to avoid edit interference.
@@ -631,8 +637,8 @@ impl AdapterRouter {
                     let chunks = format::split_message(&final_content, message_limit);
                     if let Some(msg) = placeholder_msg {
                         if directives.reply_to.is_some() {
-                            // reply_to directive present: hide placeholder and re-send as reply
-                            let _ = adapter.edit_message(&msg, "\u{200b}").await;
+                            // reply_to directive present: delete placeholder and re-send as reply
+                            let _ = adapter.delete_message(&msg).await;
                             let mut first = true;
                             for chunk in &chunks {
                                 if first {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -646,12 +646,15 @@ impl AdapterRouter {
                             let mut first = true;
                             for chunk in &chunks {
                                 if first {
-                                    if adapter.send_message_with_reply(
+                                    match adapter.send_message_with_reply(
                                         &thread_channel,
                                         chunk,
                                         reply_id,
-                                    ).await.is_ok() {
-                                        send_ok = true;
+                                    ).await {
+                                        Ok(_) => { send_ok = true; }
+                                        Err(e) => {
+                                            tracing::warn!(error = ?e, "reply_to send failed; preserving placeholder");
+                                        }
                                     }
                                 } else {
                                     let _ = adapter.send_message(&thread_channel, chunk).await;
@@ -659,7 +662,9 @@ impl AdapterRouter {
                                 first = false;
                             }
                             if send_ok {
-                                let _ = adapter.delete_message(&msg).await;
+                                if let Err(e) = adapter.delete_message(&msg).await {
+                                    tracing::warn!(error = ?e, "delete placeholder failed; placeholder will remain visible");
+                                }
                             }
                         } else {
                             // Normal streaming: edit first chunk into placeholder, send rest

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -984,3 +984,72 @@ mod tests {
         assert_eq!(out, "response text");
     }
 }
+
+#[cfg(test)]
+mod directive_tests {
+    use super::parse_output_directives;
+
+    #[test]
+    fn parse_reply_to_directive() {
+        let input = "[[reply_to:1502606076451885136]]\nHello world";
+        let (directives, content) = parse_output_directives(input);
+        assert_eq!(directives.reply_to, Some("1502606076451885136".to_string()));
+        assert_eq!(content, "Hello world");
+    }
+
+    #[test]
+    fn parse_no_directives() {
+        let input = "Just plain content\nwith multiple lines";
+        let (directives, content) = parse_output_directives(input);
+        assert_eq!(directives.reply_to, None);
+        assert_eq!(content, input);
+    }
+
+    #[test]
+    fn parse_multiple_directives() {
+        let input = "[[reply_to:123456]]\n[[unknown_key:value]]\nContent here";
+        let (directives, content) = parse_output_directives(input);
+        assert_eq!(directives.reply_to, Some("123456".to_string()));
+        assert_eq!(content, "Content here");
+    }
+
+    #[test]
+    fn parse_invalid_reply_to_non_numeric() {
+        let input = "[[reply_to:not-a-number]]\nContent";
+        let (directives, content) = parse_output_directives(input);
+        assert_eq!(directives.reply_to, None);
+        assert_eq!(content, "Content");
+    }
+
+    #[test]
+    fn parse_empty_reply_to() {
+        let input = "[[reply_to:]]\nContent";
+        let (directives, content) = parse_output_directives(input);
+        assert_eq!(directives.reply_to, None);
+        assert_eq!(content, "Content");
+    }
+
+    #[test]
+    fn parse_crlf_line_endings() {
+        let input = "[[reply_to:999]]\r\nContent with CRLF";
+        let (directives, content) = parse_output_directives(input);
+        assert_eq!(directives.reply_to, Some("999".to_string()));
+        assert_eq!(content, "Content with CRLF");
+    }
+
+    #[test]
+    fn parse_directive_only_no_content() {
+        let input = "[[reply_to:123]]";
+        let (directives, content) = parse_output_directives(input);
+        assert_eq!(directives.reply_to, Some("123".to_string()));
+        assert_eq!(content, "");
+    }
+
+    #[test]
+    fn parse_non_directive_line_stops_parsing() {
+        let input = "Normal first line\n[[reply_to:123]]\nMore content";
+        let (directives, content) = parse_output_directives(input);
+        assert_eq!(directives.reply_to, None);
+        assert_eq!(content, input);
+    }
+}

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -43,14 +43,17 @@ pub fn parse_output_directives(content: &str) -> (OutputDirectives, String) {
                         tracing::debug!(key = key.trim(), "unknown output directive ignored");
                     }
                 }
-            }
-            // Advance past this line + its line ending (handles both \n and \r\n)
-            content_start += line.len();
-            if content.as_bytes().get(content_start) == Some(&b'\r') {
-                content_start += 1;
-            }
-            if content.as_bytes().get(content_start) == Some(&b'\n') {
-                content_start += 1;
+                // Advance past this line + its line ending (handles both \n and \r\n)
+                content_start += line.len();
+                if content.as_bytes().get(content_start) == Some(&b'\r') {
+                    content_start += 1;
+                }
+                if content.as_bytes().get(content_start) == Some(&b'\n') {
+                    content_start += 1;
+                }
+            } else {
+                // [[X]] without colon — not a directive, stop parsing
+                break;
             }
         } else {
             break;
@@ -1092,5 +1095,14 @@ mod directive_tests {
         let (directives, content) = parse_output_directives(input);
         assert_eq!(directives.reply_to, Some("456".to_string()));
         assert_eq!(content, "Content after CRLF");
+    }
+
+    #[test]
+    fn parse_bracket_without_colon_preserved() {
+        // [[Note]] has no colon — not a directive, preserved as content
+        let input = "[[Summary]]\nThis is body text";
+        let (directives, content) = parse_output_directives(input);
+        assert_eq!(directives.reply_to, None);
+        assert_eq!(content, input);
     }
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -210,9 +210,9 @@ pub trait ChatAdapter: Send + Sync + 'static {
     }
 
     /// Delete a message. Used to remove streaming placeholders when reply_to is set.
-    /// Default: no-op (platforms that don't support delete just ignore).
-    async fn delete_message(&self, _msg: &MessageRef) -> Result<()> {
-        Ok(())
+    /// Default: edits to zero-width space (fallback for platforms without delete support).
+    async fn delete_message(&self, msg: &MessageRef) -> Result<()> {
+        self.edit_message(msg, "\u{200b}").await
     }
 
     /// Whether this adapter should use streaming edit (true) or send-once (false).

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -612,6 +612,12 @@ impl AdapterRouter {
                     // Stop the edit loop
                     drop(buf_tx);
 
+                    // Parse output directives from raw text_buf BEFORE compose_display.
+                    // Directives are agent meta-layer, not content — must be stripped
+                    // before tool lines are composed into the display output.
+                    let (directives, stripped_text) = parse_output_directives(&text_buf);
+                    let text_buf = stripped_text;
+
                     // Build final content
                     let final_content =
                         compose_display(&tool_lines, &text_buf, false, tool_display);
@@ -627,34 +633,31 @@ impl AdapterRouter {
                         final_content
                     };
 
-                    // Parse output directives BEFORE markdown conversion (meta-layer first)
-                    let (directives, stripped_content) = parse_output_directives(&final_content);
-                    // Guard: if content is empty after stripping directives, use fallback
-                    let final_content = if stripped_content.trim().is_empty() {
-                        "_(no response)_".to_string()
-                    } else {
-                        stripped_content
-                    };
                     let final_content = markdown::convert_tables(&final_content, table_mode);
                     let chunks = format::split_message(&final_content, message_limit);
                     if let Some(msg) = placeholder_msg {
                         if let Some(ref reply_id) = directives.reply_to {
                             // reply_to directive: send reply first, then delete placeholder.
-                            // Order matters: if send fails, placeholder remains (no message loss).
+                            // Only delete if send succeeds — preserves placeholder on failure.
+                            let mut send_ok = false;
                             let mut first = true;
                             for chunk in &chunks {
                                 if first {
-                                    let _ = adapter.send_message_with_reply(
+                                    if adapter.send_message_with_reply(
                                         &thread_channel,
                                         chunk,
                                         reply_id,
-                                    ).await;
+                                    ).await.is_ok() {
+                                        send_ok = true;
+                                    }
                                 } else {
                                     let _ = adapter.send_message(&thread_channel, chunk).await;
                                 }
                                 first = false;
                             }
-                            let _ = adapter.delete_message(&msg).await;
+                            if send_ok {
+                                let _ = adapter.delete_message(&msg).await;
+                            }
                         } else {
                             // Normal streaming: edit first chunk into placeholder, send rest
                             if let Some(first) = chunks.first() {

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -399,6 +399,7 @@ async fn fire_cronjob(
             .or(Some(reply_channel.channel_id.clone())),
         is_bot: true,
         timestamp: Some(Utc::now().to_rfc3339()),
+        message_id: None, // cron jobs don't originate from a message
     };
     let sender_json = match serde_json::to_string(&sender) {
         Ok(j) => j,

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -102,6 +102,13 @@ impl ChatAdapter for DiscordAdapter {
         }
     }
 
+    async fn delete_message(&self, msg: &MessageRef) -> anyhow::Result<()> {
+        let ch_id: u64 = Self::resolve_channel(&msg.channel).parse()?;
+        let msg_id: u64 = msg.message_id.parse()?;
+        self.http.delete_message(ChannelId::new(ch_id), MessageId::new(msg_id), None).await?;
+        Ok(())
+    }
+
     async fn edit_message(&self, msg: &MessageRef, content: &str) -> anyhow::Result<()> {
         let ch_id: u64 = Self::resolve_channel(&msg.channel).parse()?;
         let msg_id: u64 = msg.message_id.parse()?;

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1360,6 +1360,7 @@ fn video_attachment_block(
 /// Note: `ChannelRef.channel_id` uses the *opposite* convention — it holds
 /// the thread's channel ID for routing (Discord API sends to thread by its
 /// channel ID). See `ChannelRef` doc comments for details.
+#[allow(clippy::too_many_arguments)]
 fn build_sender_context(
     sender_id: &str,
     sender_name: &str,

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -94,8 +94,9 @@ impl ChatAdapter for DiscordAdapter {
                 channel: channel.clone(),
                 message_id: msg.id.to_string(),
             }),
-            Err(_) => {
+            Err(e) => {
                 // Fallback to plain send if reply fails (e.g. unknown message, cross-channel)
+                tracing::warn!(error = ?e, reply_to = reply_to_message_id, "reply_to failed, falling back to plain send");
                 self.send_message(channel, content).await
             }
         }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -89,11 +89,16 @@ impl ChatAdapter for DiscordAdapter {
         let builder = serenity::builder::CreateMessage::new()
             .content(content)
             .reference_message((ChannelId::new(ch_id), MessageId::new(msg_id)));
-        let msg = ChannelId::new(ch_id).send_message(&self.http, builder).await?;
-        Ok(MessageRef {
-            channel: channel.clone(),
-            message_id: msg.id.to_string(),
-        })
+        match ChannelId::new(ch_id).send_message(&self.http, builder).await {
+            Ok(msg) => Ok(MessageRef {
+                channel: channel.clone(),
+                message_id: msg.id.to_string(),
+            }),
+            Err(_) => {
+                // Fallback to plain send if reply fails (e.g. unknown message, cross-channel)
+                self.send_message(channel, content).await
+            }
+        }
     }
 
     async fn edit_message(&self, msg: &MessageRef, content: &str) -> anyhow::Result<()> {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -74,6 +74,28 @@ impl ChatAdapter for DiscordAdapter {
         })
     }
 
+    async fn send_message_with_reply(
+        &self,
+        channel: &ChannelRef,
+        content: &str,
+        reply_to_message_id: &str,
+    ) -> anyhow::Result<MessageRef> {
+        let ch_id: u64 = Self::resolve_channel(channel).parse()?;
+        let msg_id: u64 = reply_to_message_id.parse().unwrap_or(0);
+        if msg_id == 0 {
+            // Invalid message ID, fall back to plain send
+            return self.send_message(channel, content).await;
+        }
+        let builder = serenity::builder::CreateMessage::new()
+            .content(content)
+            .reference_message((ChannelId::new(ch_id), MessageId::new(msg_id)));
+        let msg = ChannelId::new(ch_id).send_message(&self.http, builder).await?;
+        Ok(MessageRef {
+            channel: channel.clone(),
+            message_id: msg.id.to_string(),
+        })
+    }
+
     async fn edit_message(&self, msg: &MessageRef, content: &str) -> anyhow::Result<()> {
         let ch_id: u64 = Self::resolve_channel(&msg.channel).parse()?;
         let msg_id: u64 = msg.message_id.parse()?;
@@ -594,6 +616,7 @@ impl EventHandler for Handler {
             thread_parent_id.as_deref(),
             msg.author.bot,
             &msg.timestamp.to_rfc3339().unwrap_or_default(),
+            &msg.id.to_string(),
         );
 
         // Build extra content blocks from attachments (audio -> STT, text -> inline,
@@ -1332,6 +1355,7 @@ fn build_sender_context(
     thread_parent_id: Option<&str>,
     is_bot: bool,
     timestamp: &str,
+    message_id: &str,
 ) -> SenderContext {
     SenderContext {
         schema: "openab.sender.v1".into(),
@@ -1343,6 +1367,7 @@ fn build_sender_context(
         thread_id: thread_parent_id.map(|_| msg_channel_id.to_string()),
         is_bot,
         timestamp: Some(timestamp.to_string()),
+        message_id: Some(message_id.to_string()),
     }
 }
 
@@ -1718,6 +1743,7 @@ mod tests {
             Some("parent_ch"),
             false,
             "2026-05-01T00:00:00Z",
+            "msg123",
         );
         assert_eq!(ctx.channel_id, "parent_ch");
         assert_eq!(ctx.thread_id, Some("thread_ch".to_string()));
@@ -1737,6 +1763,7 @@ mod tests {
             None,
             false,
             "2026-05-01T00:00:00Z",
+            "msg456",
         );
         assert_eq!(ctx.channel_id, "main_ch");
         assert_eq!(ctx.thread_id, None);
@@ -1753,6 +1780,7 @@ mod tests {
             Some("parent"),
             true,
             "2026-05-01T00:00:00Z",
+            "msg789",
         );
         assert!(ctx.is_bot);
         assert_eq!(ctx.channel_id, "parent");

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -642,6 +642,7 @@ pub async fn run_gateway_adapter(
                                         } else {
                                             event.timestamp.clone()
                                         }),
+                                        message_id: if event.message_id.is_empty() { None } else { Some(event.message_id.clone()) },
                                     };
                                     let sender_json = serde_json::to_string(&sender_ctx)
                                         .unwrap_or_default();

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1063,6 +1063,7 @@ async fn handle_message(
         thread_id: thread_ts.clone(),
         is_bot: is_bot_msg,
         timestamp: Some(crate::timestamp::slack_ts_to_iso8601(&ts)),
+        message_id: Some(ts.clone()),
     };
 
     let trigger_msg = MessageRef {


### PR DESCRIPTION
## Problem

Agents currently cannot reply to a specific message in a thread. All output is sent as plain messages via `ChannelId::say()`, losing conversational context in busy multi-bot threads where multiple conversations interleave.

## Scenario

In a Discord thread with 5 bots + 1 human:
- Human asks Bot A a question (msg #100)
- Bot B, C, D respond to other things
- Bot A responds... but its reply appears as a plain message with no visual link to msg #100
- Human has to scroll up to understand what Bot A is responding to

With this PR, Bot A can reply directly to msg #100 using Discord's native reply UI.

## Prior Art & Why OAB Is Better

| Platform | Mechanism | Agent-Controlled? | Multi-Agent Aware? |
|----------|-----------|-------------------|--------------------|
| **OpenClaw** | `replyToMode: "off"/"first"/"all"` (config) | ❌ Platform decides | ❌ Always replies to trigger msg |
| **Hermes Agent** | `DISCORD_REPLY_TO_MODE: "off"/"first"/"all"` (env) | ❌ Platform decides | ❌ Always replies to trigger msg |
| **OAB (this PR)** | `[[reply_to:message_id]]` output directive | ✅ **Agent decides** | ✅ **Can reply to any message** |

### Why agent-controlled reply-to matters

OpenClaw and Hermes treat reply-to as a **platform-level config** — the system always replies to the trigger message (or never). The agent has no say.

This breaks down in **multi-agent collaboration**:

```
Human: "Review this PR" (msg #100)
Bot A: "I found 3 issues..." (msg #101)
Bot B: "I agree with Bot A on F1, but..." (msg #102)  ← wants to reply to #101
Bot C: "Here's my analysis..." (msg #103)
Bot A: "Good point Bot B, let me revise..." (msg #104) ← wants to reply to #102
```

With OpenClaw/Hermes: all bot replies point to msg #100 (the trigger). No way to show Bot B is responding to Bot A, or Bot A is responding to Bot B. The thread becomes an unreadable wall of text.

With OAB: each agent chooses its reply target. The thread has clear visual conversation threads within the thread. **Agents are active conversational participants, not passive responders.**

This is the fundamental difference: OAB is built for **multi-agent collaboration** where agents talk to each other, not just single-agent Q&A where one bot answers one human.

## Solution: Output Directives (Option A)

Two-layer change:

### Input: `SenderContext.message_id`
Agents now receive the platform message ID of each incoming message, so they know what to reply to.

```json
{"schema":"openab.sender.v1", "sender_id":"845835116920307722", "message_id":"1502606076451885136", ...}
```

### Output: `[[key:value]]` header block
Agents prefix their response with directives that OAB parses and strips:

```
[[reply_to:1502606076451885136]]
Here is my actual reply content...
```

OAB sends this as a Discord reply (message_reference) to the specified message.

## Design Decisions Evaluated

| Option | Approach | Pros | Cons |
|--------|----------|------|------|
| **A (chosen)** | Inline `[[key:value]]` directives | No ACP change, forward-compatible, minimal code | Slightly magic; relies on text parsing |
| B (deferred) | ACP metadata field | Cleaner separation | Requires protocol change across all backends |

**Why A now**: reply-to is a platform delivery detail, not semantic content. Putting it in ACP metadata would over-engineer for a single use case. When we need `[[ephemeral:true]]`, `[[suppress_embeds:true]]`, etc., we can add them to the same directive format without any protocol change.

## Directive Format Spec

```
[[reply_to:1502606076451885136]]
[[ephemeral:true]]              ← future example
Actual message content starts here...
```

Rules:
1. Consecutive `[[key:value]]` lines at output start = header block
2. First non-`[[...]]` line = content begins
3. Unknown keys silently ignored (forward compatible)
4. `reply_to` value must be numeric snowflake (validated, invalid = ignored)
5. Directives are stripped before sending to platform

## Changes

- `src/adapter.rs`: `parse_output_directives()` + `OutputDirectives` struct + `send_message_with_reply()` trait method
- `src/discord.rs`: `CreateMessage::reference_message()` implementation + `message_id` in `SenderContext`
- `src/slack.rs`: `message_id` field (Slack ts)
- `src/cron.rs`: `message_id: None` (cron has no trigger message)
- `src/gateway.rs`: `message_id` from gateway event

## Testing

- `build_sender_context` tests updated with `message_id` parameter
- Directive parser is a pure function, easy to unit test (can add in follow-up)

## Discord Discussion URL

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365150664560881/1502642639852277851

## Streaming Mode Placeholder Handling

When `reply_to` is used and the adapter is in streaming mode (single-bot thread), a placeholder message (`…`) has already been sent before the directive is known. The resolution:

- **Discord**: placeholder is deleted via `delete_message`, then content is sent as a reply
- **Other adapters / delete failure**: placeholder is edited to zero-width space (`\u{200b}`) as fallback
- **Result**: no ghost empty bubbles in Discord; graceful degradation elsewhere

This is handled by `ChatAdapter::delete_message()` — Discord overrides with real delete, default falls back to edit.