### PR TITLE
feat: add receiver_id to SenderContext

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -195,6 +195,10 @@ pub struct SenderContext {
     /// via the `[[reply_to:<message_id>]]` output directive.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<String>,
+    /// The platform user ID of the receiving bot/agent.
+    /// Enables agents to identify themselves when multiple agents share the same backend.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receiver_id: Option<String>,
 }
 
 // --- ChatAdapter trait ---

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -602,6 +602,7 @@ async fn fire_cronjob(
         is_bot: true,
         timestamp: Some(Utc::now().to_rfc3339()),
         message_id: None, // cron jobs don't originate from a message
+        receiver_id: None, // cron jobs are self-triggered, no external receiver
     };
     let sender_json = match serde_json::to_string(&sender) {
         Ok(j) => j,

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -630,6 +630,7 @@ impl EventHandler for Handler {
             msg.author.bot,
             &msg.timestamp.to_rfc3339().unwrap_or_default(),
             &msg.id.to_string(),
+            &bot_id.to_string(),
         );
 
         // Build extra content blocks from attachments (audio -> STT, text -> inline,
@@ -1370,6 +1371,7 @@ fn build_sender_context(
     is_bot: bool,
     timestamp: &str,
     message_id: &str,
+    receiver_id: &str,
 ) -> SenderContext {
     SenderContext {
         schema: "openab.sender.v1".into(),
@@ -1382,6 +1384,7 @@ fn build_sender_context(
         is_bot,
         timestamp: Some(timestamp.to_string()),
         message_id: Some(message_id.to_string()),
+        receiver_id: Some(receiver_id.to_string()),
     }
 }
 
@@ -1758,12 +1761,14 @@ mod tests {
             false,
             "2026-05-01T00:00:00Z",
             "msg123",
+            "bot99",
         );
         assert_eq!(ctx.channel_id, "parent_ch");
         assert_eq!(ctx.thread_id, Some("thread_ch".to_string()));
         assert_eq!(ctx.channel, "discord");
         assert_eq!(ctx.sender_id, "user1");
         assert!(!ctx.is_bot);
+        assert_eq!(ctx.receiver_id, Some("bot99".to_string()));
     }
 
     /// Non-thread message: channel_id = message channel, thread_id = None.
@@ -1778,6 +1783,7 @@ mod tests {
             false,
             "2026-05-01T00:00:00Z",
             "msg456",
+            "bot99",
         );
         assert_eq!(ctx.channel_id, "main_ch");
         assert_eq!(ctx.thread_id, None);
@@ -1795,6 +1801,7 @@ mod tests {
             true,
             "2026-05-01T00:00:00Z",
             "msg789",
+            "bot99",
         );
         assert!(ctx.is_bot);
         assert_eq!(ctx.channel_id, "parent");

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -643,6 +643,7 @@ pub async fn run_gateway_adapter(
                                             event.timestamp.clone()
                                         }),
                                         message_id: if event.message_id.is_empty() { None } else { Some(event.message_id.clone()) },
+                                        receiver_id: None, // gateway does not yet resolve receiver identity
                                     };
                                     let sender_json = serde_json::to_string(&sender_ctx)
                                         .unwrap_or_default();

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1064,6 +1064,7 @@ async fn handle_message(
         is_bot: is_bot_msg,
         timestamp: Some(crate::timestamp::slack_ts_to_iso8601(&ts)),
         message_id: Some(ts.clone()),
+        receiver_id: bot_id.map(|id| id.to_string()),
     };
 
     let trigger_msg = MessageRef {


### PR DESCRIPTION
## What

Add optional `receiver_id` field to `SenderContext` so agents can identify themselves when multiple agents share the same backend runtime.

## Why

Currently agents infer their identity by matching their backend type (Kiro, Claude, etc.) against the ID mapping. This breaks if two agents share the same backend. With `receiver_id`, the bot injects its own platform UID into the message context, giving the agent an explicit identity signal.

## Changes

- **`src/adapter.rs`**: Add `receiver_id: Option<String>` to `SenderContext` struct (skip_serializing_if None)
- **`src/discord.rs`**: Inject `bot_id` (from `ctx.cache.current_user().id`) as `receiver_id`
- **`src/slack.rs`**: Inject `bot_user_id` (from `get_bot_user_id()`) as `receiver_id`
- **`src/gateway.rs`**: Set to `None` (gateway doesn't yet resolve receiver identity)
- **`src/cron.rs`**: Set to `None` (cron is self-triggered)

## Schema Impact

Non-breaking additive change — `openab.sender.v1` stays the same version. Field is optional and omitted from JSON when None.

## Example Output

```json
{
  "schema": "openab.sender.v1",
  "sender_id": "845835116920307722",
  "sender_name": "pahud.hsieh",
  "receiver_id": "1490365068863606784",
  "channel": "discord",
  ...
}
```

Closes #786