### PR TITLE
fix: reconnect Discord gateway on silent WS disconnect

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -497,6 +497,7 @@ async fn main() -> anyhow::Result<()> {
                          Enable MESSAGE CONTENT INTENT at: \
                          https://discord.com/developers/applications → Bot → Privileged Gateway Intents"
                     );
+                    // Fatal config error — exit immediately; no active sessions to drain.
                     std::process::exit(1);
                 }
                 Err(serenity::Error::Gateway(GatewayError::InvalidAuthentication)) => {
@@ -504,6 +505,7 @@ async fn main() -> anyhow::Result<()> {
                         "Discord rejected bot token. \
                          Verify your bot_token in config.toml is correct and has not been reset."
                     );
+                    // Fatal config error — exit immediately; no active sessions to drain.
                     std::process::exit(1);
                 }
                 Err(e) => {
@@ -518,7 +520,7 @@ async fn main() -> anyhow::Result<()> {
                 Ok(_) => {
                     // Gateway ran successfully then disconnected — reset backoff and retry quickly.
                     reconnect_delay = std::time::Duration::from_secs(1);
-                    warn!("discord gateway exited, reconnecting in 1s");
+                    warn!(delay_secs = reconnect_delay.as_secs(), "discord gateway exited, reconnecting");
                     tokio::select! {
                         _ = tokio::time::sleep(reconnect_delay) => {}
                         _ = shutdown_rx_discord.changed() => { break; }

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,19 +454,36 @@ async fn main() -> anyhow::Result<()> {
                 scheduled_ids: tokio::sync::Mutex::new(std::collections::HashSet::new()),
             };
 
-            let mut client = Client::builder(&discord_cfg.bot_token, intents)
+            // F1 fix: handle builder errors within the loop instead of propagating with ?
+            let mut client = match Client::builder(&discord_cfg.bot_token, intents)
                 .event_handler(handler)
-                .await?;
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!(error = %e, delay_secs = reconnect_delay.as_secs(), "failed to build discord client, retrying");
+                    tokio::select! {
+                        _ = tokio::time::sleep(reconnect_delay) => {}
+                        _ = shutdown_rx_discord.changed() => { break; }
+                    }
+                    reconnect_delay = (reconnect_delay * 2).min(MAX_RECONNECT_DELAY);
+                    continue;
+                }
+            };
 
+            // F2 fix: use an abort handle so the shutdown listener is cleaned up each iteration
             let shard_manager = client.shard_manager.clone();
             let mut shutdown_rx_inner = shutdown_rx.clone();
-            tokio::spawn(async move {
+            let shutdown_task = tokio::spawn(async move {
                 let _ = shutdown_rx_inner.changed().await;
                 shard_manager.shutdown_all().await;
             });
 
             info!("discord bot running");
             let result = client.start().await;
+
+            // Abort the shutdown listener for this iteration to avoid accumulation.
+            shutdown_task.abort();
 
             // Check if we're shutting down — if so, don't reconnect.
             if *shutdown_rx_discord.borrow() {
@@ -491,20 +508,23 @@ async fn main() -> anyhow::Result<()> {
                 }
                 Err(e) => {
                     warn!(error = %e, delay_secs = reconnect_delay.as_secs(), "discord gateway error, reconnecting");
+                    // F3 fix: escalate backoff only on errors
+                    tokio::select! {
+                        _ = tokio::time::sleep(reconnect_delay) => {}
+                        _ = shutdown_rx_discord.changed() => { break; }
+                    }
+                    reconnect_delay = (reconnect_delay * 2).min(MAX_RECONNECT_DELAY);
                 }
                 Ok(_) => {
-                    // Gateway ran successfully then disconnected — reset backoff.
+                    // Gateway ran successfully then disconnected — reset backoff and retry quickly.
                     reconnect_delay = std::time::Duration::from_secs(1);
                     warn!("discord gateway exited, reconnecting in 1s");
+                    tokio::select! {
+                        _ = tokio::time::sleep(reconnect_delay) => {}
+                        _ = shutdown_rx_discord.changed() => { break; }
+                    }
                 }
             }
-
-            tokio::select! {
-                _ = tokio::time::sleep(reconnect_delay) => {}
-                _ = shutdown_rx_discord.changed() => { break; }
-            }
-            // Escalate delay only for errors (Ok resets above).
-            reconnect_delay = (reconnect_delay * 2).min(MAX_RECONNECT_DELAY);
         }
     } else {
         // No Discord — wait for SIGINT or SIGTERM

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,6 +361,14 @@ async fn main() -> anyhow::Result<()> {
         None
     };
 
+    // Spawn shutdown signal listener that notifies all adapters via shutdown_tx.
+    let shutdown_tx_signal = shutdown_tx.clone();
+    tokio::spawn(async move {
+        shutdown_signal().await;
+        info!("shutdown signal received");
+        let _ = shutdown_tx_signal.send(true);
+    });
+
     // Run Discord adapter (foreground, blocking) or wait for ctrl_c
     if let Some(discord_cfg) = cfg.discord {
         let allow_all_channels = config::resolve_allow_all(
@@ -411,74 +419,98 @@ async fn main() -> anyhow::Result<()> {
             .join(".openab")
             .join("reminders.json");
         let reminder_store = remind::ReminderStore::load(reminder_path);
-
-        let handler = discord::Handler {
-            router,
-            allow_all_channels,
-            allow_all_users,
-            allowed_channels,
-            allowed_users,
-            stt_config: cfg.stt.clone(),
-            adapter: std::sync::OnceLock::new(),
-            allow_bot_messages: discord_cfg.allow_bot_messages,
-            trusted_bot_ids,
-            allow_user_messages: discord_cfg.allow_user_messages,
-            allowed_role_ids,
-            participated_threads: tokio::sync::Mutex::new(std::collections::HashMap::new()),
-            multibot_threads: tokio::sync::Mutex::new(std::collections::HashMap::new()),
-            session_ttl: std::time::Duration::from_secs(ttl_secs),
-            max_bot_turns: discord_cfg.max_bot_turns,
-            bot_turns: tokio::sync::Mutex::new(bot_turns::BotTurnTracker::new(
-                discord_cfg.max_bot_turns,
-            )),
-            allow_dm: discord_cfg.allow_dm,
-            dispatcher: discord_dispatcher,
-            reminder_store: reminder_store.clone(),
-            scheduled_ids: tokio::sync::Mutex::new(std::collections::HashSet::new()),
-        };
-
         let intents = GatewayIntents::GUILD_MESSAGES
             | GatewayIntents::MESSAGE_CONTENT
             | GatewayIntents::GUILDS
             | GatewayIntents::DIRECT_MESSAGES;
 
-        let mut client = Client::builder(&discord_cfg.bot_token, intents)
-            .event_handler(handler)
-            .await?;
+        let mut reconnect_delay = std::time::Duration::from_secs(1);
+        const MAX_RECONNECT_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
+        let mut shutdown_rx_discord = shutdown_rx.clone();
 
-        // Graceful Discord shutdown on ctrl_c
-        let shard_manager = client.shard_manager.clone();
-        tokio::spawn(async move {
-            shutdown_signal().await;
-            info!("shutdown signal received");
-            shard_manager.shutdown_all().await;
-        });
+        loop {
+            let handler = discord::Handler {
+                router: router.clone(),
+                allow_all_channels,
+                allow_all_users,
+                allowed_channels: allowed_channels.clone(),
+                allowed_users: allowed_users.clone(),
+                stt_config: cfg.stt.clone(),
+                adapter: std::sync::OnceLock::new(),
+                allow_bot_messages: discord_cfg.allow_bot_messages,
+                trusted_bot_ids: trusted_bot_ids.clone(),
+                allow_user_messages: discord_cfg.allow_user_messages,
+                allowed_role_ids: allowed_role_ids.clone(),
+                participated_threads: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+                multibot_threads: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+                session_ttl: std::time::Duration::from_secs(ttl_secs),
+                max_bot_turns: discord_cfg.max_bot_turns,
+                bot_turns: tokio::sync::Mutex::new(bot_turns::BotTurnTracker::new(
+                    discord_cfg.max_bot_turns,
+                )),
+                allow_dm: discord_cfg.allow_dm,
+                dispatcher: discord_dispatcher.clone(),
+                reminder_store: reminder_store.clone(),
+                scheduled_ids: tokio::sync::Mutex::new(std::collections::HashSet::new()),
+            };
 
-        info!("discord bot running");
-        match client.start().await {
-            Err(serenity::Error::Gateway(GatewayError::DisallowedGatewayIntents)) => {
-                error!(
-                    "Discord rejected privileged intents. \
-                     Enable MESSAGE CONTENT INTENT at: \
-                     https://discord.com/developers/applications → Bot → Privileged Gateway Intents"
-                );
-                std::process::exit(1);
+            let mut client = Client::builder(&discord_cfg.bot_token, intents)
+                .event_handler(handler)
+                .await?;
+
+            let shard_manager = client.shard_manager.clone();
+            let mut shutdown_rx_inner = shutdown_rx.clone();
+            tokio::spawn(async move {
+                let _ = shutdown_rx_inner.changed().await;
+                shard_manager.shutdown_all().await;
+            });
+
+            info!("discord bot running");
+            let result = client.start().await;
+
+            // Check if we're shutting down — if so, don't reconnect.
+            if *shutdown_rx_discord.borrow() {
+                break;
             }
-            Err(serenity::Error::Gateway(GatewayError::InvalidAuthentication)) => {
-                error!(
-                    "Discord rejected bot token. \
-                     Verify your bot_token in config.toml is correct and has not been reset."
-                );
-                std::process::exit(1);
+
+            match result {
+                Err(serenity::Error::Gateway(GatewayError::DisallowedGatewayIntents)) => {
+                    error!(
+                        "Discord rejected privileged intents. \
+                         Enable MESSAGE CONTENT INTENT at: \
+                         https://discord.com/developers/applications → Bot → Privileged Gateway Intents"
+                    );
+                    std::process::exit(1);
+                }
+                Err(serenity::Error::Gateway(GatewayError::InvalidAuthentication)) => {
+                    error!(
+                        "Discord rejected bot token. \
+                         Verify your bot_token in config.toml is correct and has not been reset."
+                    );
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    warn!(error = %e, delay_secs = reconnect_delay.as_secs(), "discord gateway error, reconnecting");
+                }
+                Ok(_) => {
+                    // Gateway ran successfully then disconnected — reset backoff.
+                    reconnect_delay = std::time::Duration::from_secs(1);
+                    warn!("discord gateway exited, reconnecting in 1s");
+                }
             }
-            Err(e) => return Err(e.into()),
-            Ok(_) => {}
+
+            tokio::select! {
+                _ = tokio::time::sleep(reconnect_delay) => {}
+                _ = shutdown_rx_discord.changed() => { break; }
+            }
+            // Escalate delay only for errors (Ok resets above).
+            reconnect_delay = (reconnect_delay * 2).min(MAX_RECONNECT_DELAY);
         }
     } else {
         // No Discord — wait for SIGINT or SIGTERM
         info!("running without discord, press ctrl+c to stop");
-        shutdown_signal().await;
-        info!("shutdown signal received");
+        let mut shutdown_rx_wait = shutdown_rx.clone();
+        let _ = shutdown_rx_wait.changed().await;
     }
 
     // Cleanup


### PR DESCRIPTION
## Summary

Fixes #790 — Discord gateway silently dies after WS disconnect with no reconnect.

## Problem

When serenity's `client.start()` returns `Ok(())` (internal reconnect exhausted), the Discord adapter permanently stops receiving events while the container remains "healthy".

## Changes

Wraps the Discord client lifecycle in a reconnect loop with exponential backoff:

- **Retry on disconnect**: `client.start()` returning `Ok(())` or transient errors triggers a reconnect attempt
- **Exponential backoff**: 1s → 2s → 4s → ... → 60s max on consecutive errors; resets to 1s after a successful session
- **Fatal errors exit immediately**: `DisallowedGatewayIntents` and `InvalidAuthentication` still call `process::exit(1)`
- **Graceful shutdown**: loop breaks on `shutdown_rx` signal (SIGINT/SIGTERM)
- **Observability**: WARN-level logs on every reconnect attempt with delay info

## How it works

```
loop {
    build handler + client
    client.start().await
    if shutdown → break
    if fatal error → exit
    if transient error → backoff, retry
    if Ok (clean disconnect) → reset backoff, retry immediately (1s)
}
```

Handler is rebuilt each iteration — all shared state (`router`, `dispatcher`) is `Arc`-wrapped so cloning is cheap. Thread-local caches (`participated_threads`, `multibot_threads`) are fresh per reconnect, which is correct since Discord will re-dispatch the `READY` event.

## Testing

- No Rust toolchain available in this environment; verified code structure and borrow semantics manually
- Recommend CI build + integration test with simulated WS drop

## Not included (future work)

- Healthcheck endpoint checking WS gateway state (separate PR)
- INFO-level heartbeat logging

https://discord.com/channels/1491295327620169908/1491365157010542652/1503355477612957696