### PR TITLE
docs(copilot): document auto model default via settings.json

### DIFF
--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -140,13 +140,20 @@ helm install openab-copilot openab/openab \
 
 ## Model Selection
 
-Copilot CLI defaults to Claude Sonnet 4.6. Other available models include:
+The default model is defined in `~/.copilot/settings.json`.
 
-- Claude Opus 4.6, Claude Haiku 4.5 (Anthropic)
-- GPT-5.3-Codex (OpenAI)
-- Gemini 3 Pro (Google)
+To set `auto` as the default model, exec into the container and create the file:
 
-Model selection is controlled by Copilot CLI itself (via `/model` in interactive mode). In ACP mode, the default model is used.
+```bash
+kubectl exec -it deployment/openab-copilot-copilot -- bash -c '
+cat << EOF > ~/.copilot/settings.json
+{
+  "model": "auto"
+}
+EOF'
+```
+
+The `auto` setting lets Copilot automatically select the best model for each request. This persists across pod restarts when `persistence.enabled=true` (the home directory is on a PVC).
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary

Document how to set `auto` as the default model for Copilot CLI by creating `~/.copilot/settings.json`.

## Changes

- Added a subsection under **Model Selection** in `docs/copilot.md` showing how to create `~/.copilot/settings.json` with `"model": "auto"`

## Context

Per <@845835116920307722>'s request — this lets Copilot automatically route requests to the best model for each task instead of defaulting to a fixed model.

Discord: https://discord.com/channels/1490282656913559673/1503524608278532107