### PR TITLE
feat: add HTTP trigger server (axum 0.8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 config.toml
 *.swp
 .DS_Store
+.claude.local.md
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# openab
+
+## Repository Structure
+
+- `origin` = `howie/openab` (personal fork); `upstream` = `openabdev/openab` (main repo)
+- Local `main` is often far behind upstream — always `git fetch upstream` before checking upstream state
+- To work on upstream changes without touching local working tree: `git worktree add ../openab-fix-XXX -b fix/XXX upstream/main`
+- PRs target `openabdev/openab main`; push branch to `origin` then use `--head "howie:branch-name"` in `gh pr create`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serenity",
+ "subtle",
  "tokio",
  "toml",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,23 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "openab"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "rand 0.8.5",
- "regex",
- "serde",
- "serde_json",
- "serenity",
- "tokio",
- "toml",
- "tracing",
- "tracing-subscriber",
- "uuid",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +48,58 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -446,6 +481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +499,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -713,6 +755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +823,24 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openab"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "serenity",
+ "tokio",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1242,6 +1308,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1714,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "model", "rustls_backend", "cache"] }
 axum = "0.8"
+subtle = "2"
 uuid = { version = "1", features = ["v4"] }
 regex = "1"
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "model", "rustls_backend", "cache"] }
+axum = "0.8"
 uuid = { version = "1", features = ["v4"] }
 regex = "1"
 anyhow = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,14 +5,12 @@ use std::path::Path;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
-    /// Discord gateway config. Optional — omit to run in HTTP-only mode.
     pub discord: Option<DiscordConfig>,
     pub agent: AgentConfig,
     #[serde(default)]
     pub pool: PoolConfig,
     #[serde(default)]
     pub reactions: ReactionsConfig,
-    /// HTTP trigger server. Disabled by default.
     #[serde(default)]
     pub http: HttpConfig,
 }
@@ -89,19 +87,15 @@ pub struct ReactionTiming {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct HttpConfig {
-    /// Enable HTTP trigger server (default: false).
     #[serde(default)]
     pub enabled: bool,
-    /// TCP port to listen on (default: 7865).
     #[serde(default = "default_http_port")]
     pub port: u16,
-    /// Bind address (default: "127.0.0.1").
     #[serde(default = "default_http_bind")]
     pub bind: String,
-    /// Bearer token for authentication. Empty string disables auth (not recommended).
+    /// Empty string disables auth (not recommended for production).
     #[serde(default)]
     pub token: String,
-    /// Default prompt timeout in milliseconds (default: 300000 = 5 min).
     #[serde(default = "default_http_timeout_ms")]
     pub timeout_ms: u64,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,12 +5,16 @@ use std::path::Path;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
-    pub discord: DiscordConfig,
+    /// Discord gateway config. Optional — omit to run in HTTP-only mode.
+    pub discord: Option<DiscordConfig>,
     pub agent: AgentConfig,
     #[serde(default)]
     pub pool: PoolConfig,
     #[serde(default)]
     pub reactions: ReactionsConfig,
+    /// HTTP trigger server. Disabled by default.
+    #[serde(default)]
+    pub http: HttpConfig,
 }
 
 #[derive(Debug, Deserialize)]
@@ -83,12 +87,34 @@ pub struct ReactionTiming {
     pub error_hold_ms: u64,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct HttpConfig {
+    /// Enable HTTP trigger server (default: false).
+    #[serde(default)]
+    pub enabled: bool,
+    /// TCP port to listen on (default: 7865).
+    #[serde(default = "default_http_port")]
+    pub port: u16,
+    /// Bind address (default: "127.0.0.1").
+    #[serde(default = "default_http_bind")]
+    pub bind: String,
+    /// Bearer token for authentication. Empty string disables auth (not recommended).
+    #[serde(default)]
+    pub token: String,
+    /// Default prompt timeout in milliseconds (default: 300000 = 5 min).
+    #[serde(default = "default_http_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
 // --- defaults ---
 
 fn default_working_dir() -> String { "/tmp".into() }
 fn default_max_sessions() -> usize { 10 }
 fn default_ttl_hours() -> u64 { 24 }
 fn default_true() -> bool { true }
+fn default_http_port() -> u16 { 7865 }
+fn default_http_bind() -> String { "127.0.0.1".into() }
+fn default_http_timeout_ms() -> u64 { 300_000 }
 
 fn emoji_queued() -> String { "👀".into() }
 fn emoji_thinking() -> String { "🤔".into() }
@@ -107,6 +133,18 @@ fn default_error_hold_ms() -> u64 { 2_500 }
 impl Default for PoolConfig {
     fn default() -> Self {
         Self { max_sessions: default_max_sessions(), session_ttl_hours: default_ttl_hours() }
+    }
+}
+
+impl Default for HttpConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            port: default_http_port(),
+            bind: default_http_bind(),
+            token: String::new(),
+            timeout_ms: default_http_timeout_ms(),
+        }
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -12,6 +12,9 @@ use std::sync::Arc;
 use subtle::ConstantTimeEq;
 use tracing::info;
 
+const MAX_SESSION_ID: usize = 128;
+const MAX_PROMPT: usize = 64 * 1024;
+
 #[derive(Clone)]
 struct AppState {
     pool: Arc<SessionPool>,
@@ -37,10 +40,18 @@ async fn handle_prompt(
     Json(req): Json<PromptRequest>,
 ) -> Result<Json<PromptResponse>, (StatusCode, String)> {
     if !state.token.is_empty() {
+        // Extract Bearer token; scheme comparison is case-insensitive per RFC 7235.
         let provided = headers
             .get("authorization")
             .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.strip_prefix("Bearer "))
+            .and_then(|v| {
+                let mut parts = v.splitn(2, ' ');
+                let scheme = parts.next()?;
+                if !scheme.eq_ignore_ascii_case("bearer") {
+                    return None;
+                }
+                parts.next()
+            })
             .unwrap_or("");
         let ok: bool = provided.as_bytes().ct_eq(state.token.as_bytes()).into();
         if !ok {
@@ -51,38 +62,60 @@ async fn handle_prompt(
     if req.session_id.is_empty() || req.prompt.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "session_id and prompt are required".into()));
     }
+    if req.session_id.len() > MAX_SESSION_ID {
+        return Err((StatusCode::BAD_REQUEST, "session_id too long".into()));
+    }
+    if req.prompt.len() > MAX_PROMPT {
+        return Err((StatusCode::PAYLOAD_TOO_LARGE, "prompt too long".into()));
+    }
+
+    // Namespace HTTP sessions so they cannot collide with Discord thread IDs.
+    let pool_key = format!("http:{}", req.session_id);
 
     state
         .pool
-        .get_or_create(&req.session_id)
+        .get_or_create(&pool_key)
         .await
-        .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e.to_string()))?;
+        .map_err(|e| {
+            tracing::warn!(session_id = %req.session_id, err = %e, "pool unavailable");
+            (StatusCode::SERVICE_UNAVAILABLE, "service unavailable".into())
+        })?;
 
     let timeout = std::time::Duration::from_millis(state.timeout_ms);
     tokio::time::timeout(
         timeout,
-        run_prompt(&state.pool, &req.session_id, &req.prompt),
+        run_prompt(&state.pool, &pool_key, &req.prompt),
     )
     .await
     .map_err(|_| (StatusCode::GATEWAY_TIMEOUT, "prompt timeout".into()))?
     .map(Json)
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+    .map_err(|e| {
+        tracing::error!(session_id = %req.session_id, err = %e, "prompt failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "internal error".into())
+    })
 }
 
 async fn run_prompt(
     pool: &SessionPool,
-    session_id: &str,
+    pool_key: &str,
     prompt: &str,
 ) -> anyhow::Result<PromptResponse> {
-    pool.with_connection(session_id, |conn| {
+    pool.with_connection(pool_key, |conn| {
         let prompt = prompt.to_string();
         Box::pin(async move {
             let reset = conn.session_reset;
             conn.session_reset = false;
 
-            let (mut rx, _) = conn.session_prompt(&prompt).await?;
-            let mut text_buf = String::new();
+            let (mut rx, _) = match conn.session_prompt(&prompt).await {
+                Ok(r) => r,
+                Err(e) => {
+                    // Always clear the subscriber slot even on failure.
+                    conn.prompt_done().await;
+                    return Err(e);
+                }
+            };
 
+            let mut text_buf = String::new();
             while let Some(notification) = rx.recv().await {
                 if notification.id.is_some() {
                     break;
@@ -114,7 +147,8 @@ pub async fn run_server(pool: Arc<SessionPool>, cfg: HttpConfig) -> anyhow::Resu
 
     let addr = format!("{}:{}", cfg.bind, cfg.port);
     info!(addr = %addr, "http trigger server starting");
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    let listener = tokio::net::TcpListener::bind(&addr).await
+        .map_err(|e| anyhow::anyhow!("failed to bind {addr}: {e}"))?;
     axum::serve(listener, app).await?;
     Ok(())
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,118 @@
+use crate::acp::{classify_notification, AcpEvent, SessionPool};
+use crate::config::HttpConfig;
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::Json,
+    routing::post,
+    Router,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::info;
+
+#[derive(Clone)]
+struct AppState {
+    pool: Arc<SessionPool>,
+    token: String,
+    timeout_ms: u64,
+}
+
+#[derive(Deserialize)]
+struct PromptRequest {
+    session_id: String,
+    prompt: String,
+}
+
+#[derive(Serialize)]
+struct PromptResponse {
+    response: String,
+    session_reset: bool,
+}
+
+async fn handle_prompt(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<PromptRequest>,
+) -> Result<Json<PromptResponse>, (StatusCode, String)> {
+    if !state.token.is_empty() {
+        let provided = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .unwrap_or("");
+        if provided != state.token {
+            return Err((StatusCode::UNAUTHORIZED, "invalid token".into()));
+        }
+    }
+
+    if req.session_id.is_empty() || req.prompt.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "session_id and prompt are required".into()));
+    }
+
+    state
+        .pool
+        .get_or_create(&req.session_id)
+        .await
+        .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e.to_string()))?;
+
+    let timeout = std::time::Duration::from_millis(state.timeout_ms);
+    tokio::time::timeout(
+        timeout,
+        run_prompt(&state.pool, &req.session_id, &req.prompt),
+    )
+    .await
+    .map_err(|_| (StatusCode::GATEWAY_TIMEOUT, "prompt timeout".into()))?
+    .map(Json)
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+}
+
+async fn run_prompt(
+    pool: &SessionPool,
+    session_id: &str,
+    prompt: &str,
+) -> anyhow::Result<PromptResponse> {
+    pool.with_connection(session_id, |conn| {
+        let prompt = prompt.to_string();
+        Box::pin(async move {
+            let reset = conn.session_reset;
+            conn.session_reset = false;
+
+            let (mut rx, _) = conn.session_prompt(&prompt).await?;
+            let mut text_buf = String::new();
+
+            while let Some(notification) = rx.recv().await {
+                if notification.id.is_some() {
+                    break;
+                }
+                if let Some(AcpEvent::Text(t)) = classify_notification(&notification) {
+                    text_buf.push_str(&t);
+                }
+            }
+
+            conn.prompt_done().await;
+            Ok(PromptResponse {
+                response: text_buf,
+                session_reset: reset,
+            })
+        })
+    })
+    .await
+}
+
+pub async fn run_server(pool: Arc<SessionPool>, cfg: HttpConfig) -> anyhow::Result<()> {
+    let state = Arc::new(AppState {
+        pool,
+        token: cfg.token,
+        timeout_ms: cfg.timeout_ms,
+    });
+    let app = Router::new()
+        .route("/prompt", post(handle_prompt))
+        .with_state(state);
+
+    let addr = format!("{}:{}", cfg.bind, cfg.port);
+    info!(addr = %addr, "http trigger server starting");
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -9,6 +9,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use subtle::ConstantTimeEq;
 use tracing::info;
 
 #[derive(Clone)]
@@ -41,7 +42,8 @@ async fn handle_prompt(
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.strip_prefix("Bearer "))
             .unwrap_or("");
-        if provided != state.token {
+        let ok: bool = provided.as_bytes().ct_eq(state.token.as_bytes()).into();
+        if !ok {
             return Err((StatusCode::UNAUTHORIZED, "invalid token".into()));
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,14 +53,11 @@ async fn main() -> anyhow::Result<()> {
 
     // Graceful shutdown channel
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-    {
-        let shutdown_tx = shutdown_tx.clone();
-        tokio::spawn(async move {
-            tokio::signal::ctrl_c().await.ok();
-            info!("shutdown signal received");
-            let _ = shutdown_tx.send(true);
-        });
-    }
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        info!("shutdown signal received");
+        let _ = shutdown_tx.send(true);
+    });
 
     // Spawn HTTP trigger if enabled
     let http_handle = if cfg.http.enabled {
@@ -108,7 +105,7 @@ async fn main() -> anyhow::Result<()> {
         client.start().await?;
     } else {
         // HTTP-only mode: block until SIGINT
-        let mut sr = shutdown_rx.clone();
+        let mut sr = shutdown_rx;
         sr.changed().await.ok();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod acp;
 mod config;
 mod discord;
 mod format;
+mod http;
 mod reactions;
 
 use serenity::prelude::*;
@@ -25,39 +26,23 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| PathBuf::from("config.toml"));
 
     let cfg = config::load_config(&config_path)?;
+
+    if cfg.discord.is_none() && !cfg.http.enabled {
+        anyhow::bail!("no trigger configured — set [discord] bot_token or [http] enabled = true");
+    }
+
     info!(
         agent_cmd = %cfg.agent.command,
         pool_max = cfg.pool.max_sessions,
-        channels = ?cfg.discord.allowed_channels,
-        reactions = cfg.reactions.enabled,
+        discord = cfg.discord.is_some(),
+        http = cfg.http.enabled,
         "config loaded"
     );
 
     let pool = Arc::new(acp::SessionPool::new(cfg.agent, cfg.pool.max_sessions));
     let ttl_secs = cfg.pool.session_ttl_hours * 3600;
 
-    let allowed_channels: HashSet<u64> = cfg
-        .discord
-        .allowed_channels
-        .iter()
-        .filter_map(|s| s.parse().ok())
-        .collect();
-
-    let handler = discord::Handler {
-        pool: pool.clone(),
-        allowed_channels,
-        reactions_config: cfg.reactions,
-    };
-
-    let intents = GatewayIntents::GUILD_MESSAGES
-        | GatewayIntents::MESSAGE_CONTENT
-        | GatewayIntents::GUILDS;
-
-    let mut client = Client::builder(&cfg.discord.bot_token, intents)
-        .event_handler(handler)
-        .await?;
-
-    // Spawn cleanup task
+    // Cleanup task
     let cleanup_pool = pool.clone();
     let cleanup_handle = tokio::spawn(async move {
         loop {
@@ -66,21 +51,72 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
-    // Run bot until SIGINT/SIGTERM
-    let shard_manager = client.shard_manager.clone();
-    let shutdown_pool = pool.clone();
-    tokio::spawn(async move {
-        tokio::signal::ctrl_c().await.ok();
-        info!("shutdown signal received");
-        shard_manager.shutdown_all().await;
-    });
+    // Graceful shutdown channel
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    {
+        let shutdown_tx = shutdown_tx.clone();
+        tokio::spawn(async move {
+            tokio::signal::ctrl_c().await.ok();
+            info!("shutdown signal received");
+            let _ = shutdown_tx.send(true);
+        });
+    }
 
-    info!("starting discord bot");
-    client.start().await?;
+    // Spawn HTTP trigger if enabled
+    let http_handle = if cfg.http.enabled {
+        let pool = pool.clone();
+        let http_cfg = cfg.http.clone();
+        Some(tokio::spawn(async move {
+            if let Err(e) = http::run_server(pool, http_cfg).await {
+                tracing::error!("http server error: {e}");
+            }
+        }))
+    } else {
+        None
+    };
 
-    // Cleanup
+    // Start Discord bot or wait for shutdown signal
+    if let Some(discord_cfg) = cfg.discord {
+        let allowed_channels: HashSet<u64> = discord_cfg
+            .allowed_channels
+            .iter()
+            .filter_map(|s| s.parse().ok())
+            .collect();
+
+        let handler = discord::Handler {
+            pool: pool.clone(),
+            allowed_channels,
+            reactions_config: cfg.reactions,
+        };
+
+        let intents = GatewayIntents::GUILD_MESSAGES
+            | GatewayIntents::MESSAGE_CONTENT
+            | GatewayIntents::GUILDS;
+
+        let mut client = Client::builder(&discord_cfg.bot_token, intents)
+            .event_handler(handler)
+            .await?;
+
+        let shard_manager = client.shard_manager.clone();
+        let mut sr = shutdown_rx.clone();
+        tokio::spawn(async move {
+            sr.changed().await.ok();
+            shard_manager.shutdown_all().await;
+        });
+
+        info!("starting discord bot");
+        client.start().await?;
+    } else {
+        // HTTP-only mode: block until SIGINT
+        let mut sr = shutdown_rx.clone();
+        sr.changed().await.ok();
+    }
+
     cleanup_handle.abort();
-    shutdown_pool.shutdown().await;
+    if let Some(h) = http_handle {
+        h.abort();
+    }
+    pool.shutdown().await;
     info!("openab shut down");
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     if cfg.http.enabled && cfg.http.token.is_empty() {
-        tracing::warn!("http trigger running without authentication -- set http.token in config");
+        anyhow::bail!(
+            "http trigger is enabled without a token -- set http.token in config. \
+             If running without auth is intentional (e.g. local development), \
+             set http.token = \"none\" and handle access control at the network layer."
+        );
     }
 
     info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,11 @@ async fn main() -> anyhow::Result<()> {
     let cfg = config::load_config(&config_path)?;
 
     if cfg.discord.is_none() && !cfg.http.enabled {
-        anyhow::bail!("no trigger configured — set [discord] bot_token or [http] enabled = true");
+        anyhow::bail!("no trigger configured -- set [discord] bot_token or [http] enabled = true");
+    }
+
+    if cfg.http.enabled && cfg.http.token.is_empty() {
+        tracing::warn!("http trigger running without authentication -- set http.token in config");
     }
 
     info!(
@@ -51,28 +55,31 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
-    // Graceful shutdown channel
+    // Graceful shutdown channel; cloned for both Ctrl+C and HTTP error path.
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let http_shutdown_tx = shutdown_tx.clone();
     tokio::spawn(async move {
         tokio::signal::ctrl_c().await.ok();
         info!("shutdown signal received");
         let _ = shutdown_tx.send(true);
     });
 
-    // Spawn HTTP trigger if enabled
+    // Spawn HTTP trigger if enabled; signal shutdown if server exits unexpectedly.
     let http_handle = if cfg.http.enabled {
         let pool = pool.clone();
         let http_cfg = cfg.http.clone();
         Some(tokio::spawn(async move {
             if let Err(e) = http::run_server(pool, http_cfg).await {
                 tracing::error!("http server error: {e}");
+                let _ = http_shutdown_tx.send(true);
             }
         }))
     } else {
+        drop(http_shutdown_tx);
         None
     };
 
-    // Start Discord bot or wait for shutdown signal
+    // Start Discord bot or wait for shutdown signal.
     if let Some(discord_cfg) = cfg.discord {
         let allowed_channels: HashSet<u64> = discord_cfg
             .allowed_channels
@@ -104,7 +111,7 @@ async fn main() -> anyhow::Result<()> {
         info!("starting discord bot");
         client.start().await?;
     } else {
-        // HTTP-only mode: block until SIGINT
+        // HTTP-only mode: block until SIGINT or HTTP server exits with error.
         let mut sr = shutdown_rx;
         sr.changed().await.ok();
     }
@@ -112,6 +119,10 @@ async fn main() -> anyhow::Result<()> {
     cleanup_handle.abort();
     if let Some(h) = http_handle {
         h.abort();
+        // Await cancellation so the task releases pool write locks before shutdown.
+        match h.await {
+            Ok(()) | Err(_) => {}
+        }
     }
     pool.shutdown().await;
     info!("openab shut down");


### PR DESCRIPTION
## Summary

- Adds `POST /prompt` HTTP trigger endpoint (axum 0.8) alongside the existing Discord gateway
- `discord` config is now optional -- omit `[discord]` to run in HTTP-only mode; at least one trigger must be configured
- Adds `[http]` config block with `enabled`, `port` (default 7865), `bind`, `token` (Bearer auth), `timeout_ms`
- HTTP responses return `{response, session_reset}` JSON -- callers get clean text output without Discord formatting

## Changes

- `Cargo.toml`: add `axum = "0.8"`
- `src/config.rs`: `discord: Option<DiscordConfig>`, new `HttpConfig` struct with `Default`
- `src/http.rs`: new -- axum server, Bearer token validation, ACP session pool reuse
- `src/main.rs`: conditional Discord + HTTP startup, shared graceful shutdown via `watch` channel
- `.gitignore`: ignore `.claude*` local files
- `CLAUDE.md`: document fork/upstream structure and PR workflow

## Test plan

- [ ] Config with `[discord]` only: Discord bot starts, HTTP server absent
- [ ] Config with `[http] enabled = true` only: HTTP-only mode, `POST /prompt` responds
- [ ] Config with both: both triggers run concurrently
- [ ] Missing both: process exits at startup with clear error
- [ ] Invalid Bearer token: 401
- [ ] Prompt timeout: 504

:robot: Generated with [Claude Code](https://claude.com/claude-code)