### PR TITLE
feat: add HTTP trigger server (axum 0.8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ config.toml
 .env
 .kiro/
 CLAUDE.md
+.claude.local.md
+.claude/
 gateway/target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +248,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -624,6 +677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +695,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -956,6 +1016,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1116,7 @@ version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "base64",
  "chrono",
  "chrono-tz",
@@ -1066,6 +1133,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serenity",
+ "subtle",
  "tempfile",
  "tokio",
  "tokio-tungstenite",
@@ -1667,6 +1735,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,6 +2166,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "model", "rustls_backend", "cache"] }
+axum = "0.8"
+subtle = "2"
 uuid = { version = "1", features = ["v4"] }
 regex = "1"
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 
 - **Multi-platform** — supports Discord and Slack, run one or both simultaneously
 - **Custom Gateway** — extend to Telegram, LINE, Feishu/Lark, Google Chat, MS Teams via standalone [gateway](gateway/)
+- **HTTP trigger** — call `POST /prompt` for local automation and service-to-service prompts ([docs/http-trigger.md](docs/http-trigger.md))
 - **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI via config
 - **@mention trigger** — mention the bot in an allowed channel to start a conversation
 - **Thread-based multi-turn** — auto-creates threads; no @mention needed for follow-ups

--- a/charts/openab/README.md
+++ b/charts/openab/README.md
@@ -30,6 +30,11 @@ Each agent lives under `agents.<name>`.
 | `slack.appToken` | Slack App-Level token for Socket Mode. | `""` |
 | `slack.allowedChannels` | Slack channel allowlist. Empty means allow all channels by default. | `[]` |
 | `slack.allowedUsers` | Slack user allowlist. Empty means allow all users by default. | `[]` |
+| `http.enabled` | Enable `POST /prompt` HTTP trigger for this agent. | `false` |
+| `http.bind` | HTTP listen address. Defaults to loopback for pod-local access. | `"127.0.0.1"` |
+| `http.port` | HTTP listen port. | `7865` |
+| `http.token` | Bearer token for `POST /prompt`; required when HTTP is enabled. | `""` |
+| `http.timeoutMs` | Prompt timeout in milliseconds. | `300000` |
 | `nameOverride` | Override this agent's generated resource name. | `""` |
 | `workingDir` | Working directory and HOME inside the container. | `"/home/agent"` |
 | `env` | Inline environment variables passed to the agent process. | `{}` |
@@ -81,6 +86,17 @@ agents:
 ```
 
 This is useful for credentials such as `GH_TOKEN` without storing them directly in Helm values.
+
+### Enable the HTTP trigger
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.discord.enabled=false \
+  --set agents.kiro.http.enabled=true \
+  --set-literal agents.kiro.http.token="$HTTP_TRIGGER_TOKEN"
+```
+
+The default HTTP bind address is `127.0.0.1`, so the endpoint is pod-local. Use a sidecar, ingress, or network policy before exposing it beyond the pod.
 
 ### Provide `AGENTS.md` with `--set-file`
 

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -224,6 +224,18 @@ data:
     max_batch_tokens = {{ ($cfg.gateway).maxBatchTokens | int }}
     {{- end }}
     {{- end }}
+    {{- if ($cfg.http).enabled }}
+    {{- if not ($cfg.http).token }}
+    {{ fail (printf "agents.%s.http.token is required when http.enabled=true" $name) }}
+    {{- end }}
+
+    [http]
+    enabled = true
+    bind = {{ ($cfg.http).bind | default "127.0.0.1" | toJson }}
+    port = {{ ($cfg.http).port | default 7865 | int }}
+    token = "${HTTP_TRIGGER_TOKEN}"
+    timeout_ms = {{ ($cfg.http).timeoutMs | default 300000 | int }}
+    {{- end }}
     {{- if or ($cfg.cronjobs) (($cfg.cron).usercronEnabled) (($cfg.cron).usercronPath) }}
 
     [cron]

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -37,6 +37,12 @@ spec:
         - name: openab
           image: {{ include "openab.agentImage" $d | quote }}
           imagePullPolicy: {{ include "openab.agentImagePullPolicy" $d }}
+          {{- if ($cfg.http).enabled }}
+          ports:
+            - name: http
+              containerPort: {{ ($cfg.http).port | default 7865 | int }}
+              protocol: TCP
+          {{- end }}
           {{- with $.Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -76,6 +82,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "openab.agentFullname" $d }}
                   key: gateway-ws-token
+            {{- end }}
+            {{- if and ($cfg.http).enabled ($cfg.http).token }}
+            - name: HTTP_TRIGGER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $d }}
+                  key: http-trigger-token
             {{- end }}
             - name: HOME
               value: {{ $cfg.workingDir | default "/home/agent" }}

--- a/charts/openab/templates/secret.yaml
+++ b/charts/openab/templates/secret.yaml
@@ -4,7 +4,8 @@
 {{- $hasSlack := and ($cfg.slack).enabled (or ($cfg.slack).botToken ($cfg.slack).appToken) }}
 {{- $hasStt := and ($cfg.stt).enabled ($cfg.stt).apiKey }}
 {{- $hasGateway := and ($cfg.gateway).enabled ($cfg.gateway).token }}
-{{- if or $hasDiscord $hasSlack $hasStt $hasGateway }}
+{{- $hasHttp := and ($cfg.http).enabled ($cfg.http).token }}
+{{- if or $hasDiscord $hasSlack $hasStt $hasGateway $hasHttp }}
 {{- $d := dict "ctx" $ "agent" $name "cfg" $cfg }}
 ---
 apiVersion: v1
@@ -31,6 +32,9 @@ data:
   {{- end }}
   {{- if $hasGateway }}
   gateway-ws-token: {{ $cfg.gateway.token | b64enc | quote }}
+  {{- end }}
+  {{- if $hasHttp }}
+  http-trigger-token: {{ $cfg.http.token | b64enc | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openab/tests/http_test.yaml
+++ b/charts/openab/tests/http_test.yaml
@@ -1,0 +1,98 @@
+suite: http trigger config rendering
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: does not render [http] when disabled
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: '\[http\]'
+
+  - it: renders [http] when enabled with token
+    set:
+      agents.kiro.http.enabled: true
+      agents.kiro.http.token: "secret"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[http\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'enabled = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'bind = "127.0.0.1"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'port = 7865'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'token = "\$\{HTTP_TRIGGER_TOKEN\}"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'timeout_ms = 300000'
+
+  - it: renders custom bind port and timeout
+    set:
+      agents.kiro.http.enabled: true
+      agents.kiro.http.bind: "0.0.0.0"
+      agents.kiro.http.port: 8080
+      agents.kiro.http.token: "secret"
+      agents.kiro.http.timeoutMs: 15000
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'bind = "0.0.0.0"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'port = 8080'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'timeout_ms = 15000'
+
+  - it: fails when enabled without token
+    set:
+      agents.kiro.http.enabled: true
+      agents.kiro.http.token: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "http.token is required when http.enabled=true"
+
+---
+suite: http trigger secret rendering
+templates:
+  - templates/secret.yaml
+tests:
+  - it: renders http token secret when enabled
+    set:
+      agents.kiro.http.enabled: true
+      agents.kiro.http.token: "secret"
+    asserts:
+      - equal:
+          path: data.http-trigger-token
+          value: "c2VjcmV0"
+
+---
+suite: http trigger deployment rendering
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: injects HTTP_TRIGGER_TOKEN and port when enabled
+    set:
+      agents.kiro.http.enabled: true
+      agents.kiro.http.token: "secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTP_TRIGGER_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-kiro
+                key: http-trigger-token
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 7865
+            protocol: TCP

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -320,6 +320,12 @@ agents:
         webhookPath: ""        # Gateway default: /webhook/wecom → WECOM_WEBHOOK_PATH
         streamingEnabled: ""   # Enable thinking-placeholder + recall streaming (causes brief client flicker) → WECOM_STREAMING_ENABLED. Default off.
         debounceSecs: ""       # Debounce quiet-period seconds before flushing streamed text → WECOM_DEBOUNCE_SECS. Default 3, minimum 1 (0 is treated as unset by Helm).
+    http:
+      enabled: false           # set to true to enable POST /prompt HTTP trigger
+      bind: "127.0.0.1"        # loopback by default; use 0.0.0.0 only with network controls
+      port: 7865
+      token: ""                # required when enabled; stored in Secret and injected as HTTP_TRIGGER_TOKEN
+      timeoutMs: 300000
     # Scheduled messages — config-driven cron (ADR: basic-cronjob)
     # Each entry sends a message to the agent at the specified schedule.
     # Example:

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -2,7 +2,7 @@
 
 OpenAB is configured via a TOML file (default: `config.toml`). Environment variables can be interpolated using `${VAR_NAME}` syntax.
 
-At least one adapter section (`[discord]` or `[slack]`) is required.
+At least one adapter section (`[discord]`, `[slack]`, `[gateway]`, or `[http]` with `enabled = true`) is required.
 
 ## Loading Config
 
@@ -77,6 +77,55 @@ Custom Gateway adapter for platforms like Telegram, LINE, Feishu/Lark, and Googl
 | `allowed_channels` | string[] | `[]` | Chat/group IDs to allow. Only checked when `allow_all_channels` resolves to false. |
 | `allow_all_users` | bool \| omit | auto-detect | `true` = any user; `false` = only `allowed_users`. Omitted = inferred from list. |
 | `allowed_users` | string[] | `[]` | User IDs to allow. Only checked when `allow_all_users` resolves to false. |
+
+---
+
+## `[http]`
+
+HTTP trigger adapter. Exposes a minimal JSON API for local automation and service-to-service prompts.
+
+```toml
+[http]
+enabled = true
+bind = "127.0.0.1"
+port = 7865
+token = "${HTTP_TRIGGER_TOKEN}"
+timeout_ms = 300000
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `false` | Enable `POST /prompt`. |
+| `bind` | string | `"127.0.0.1"` | Listen address. Keep loopback unless an ingress, sidecar, or network policy provides access control. |
+| `port` | u16 | `7865` | Listen port. |
+| `token` | string | `""` | Bearer token required by `Authorization: Bearer <token>`. Startup fails when HTTP is enabled and this is empty. |
+| `timeout_ms` | u64 | `300000` | Prompt timeout in milliseconds. A timeout returns HTTP 504 and resets that HTTP session. |
+
+Request:
+
+```bash
+curl -sS http://127.0.0.1:7865/prompt \
+  -H "Authorization: Bearer $HTTP_TRIGGER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"session_id":"build-123","prompt":"summarize the last CI failure"}'
+```
+
+Response:
+
+```json
+{"response":"...","session_reset":false}
+```
+
+Limits:
+
+| Field | Limit |
+|-------|-------|
+| `session_id` | 1-128 bytes |
+| `prompt` | 1-65536 bytes |
+
+HTTP sessions use `http:<session_id>` internally, so they do not collide with Discord, Slack, or Gateway session keys.
+
+See [HTTP trigger guide](http-trigger.md) for deployment examples and security notes.
 
 ---
 
@@ -310,6 +359,11 @@ Key mapping (`values.yaml` → `config.toml`):
 | `agents.<name>.discord.trustedBotIds` | `[discord] trusted_bot_ids` |
 | `agents.<name>.discord.allowUserMessages` | `[discord] allow_user_messages` |
 | `agents.<name>.slack.*` | `[slack] *` (same pattern) |
+| `agents.<name>.http.enabled` | `[http] enabled` |
+| `agents.<name>.http.bind` | `[http] bind` |
+| `agents.<name>.http.port` | `[http] port` |
+| `agents.<name>.http.token` | `[http] token` via `HTTP_TRIGGER_TOKEN` Secret |
+| `agents.<name>.http.timeoutMs` | `[http] timeout_ms` |
 | `agents.<name>.pool.maxSessions` | `[pool] max_sessions` |
 | `agents.<name>.pool.sessionTtlHours` | `[pool] session_ttl_hours` |
 | `agents.<name>.reactions.enabled` | `[reactions] enabled` |

--- a/docs/http-trigger.md
+++ b/docs/http-trigger.md
@@ -1,0 +1,78 @@
+# HTTP Trigger
+
+OpenAB can expose a small HTTP API for programmatic prompts without Discord, Slack, or a Custom Gateway.
+
+Use this for local automation, CI jobs, webhooks routed through a trusted sidecar, or internal services that need to run an ACP agent turn.
+
+## Config
+
+```toml
+[http]
+enabled = true
+bind = "127.0.0.1"
+port = 7865
+token = "${HTTP_TRIGGER_TOKEN}"
+timeout_ms = 300000
+
+[agent]
+command = "kiro-cli"
+args = ["acp", "--trust-all-tools"]
+working_dir = "/home/agent"
+```
+
+`token` is required when HTTP is enabled. Keep `bind = "127.0.0.1"` unless another layer provides authentication, TLS, and network access control.
+
+## Request
+
+```bash
+curl -sS http://127.0.0.1:7865/prompt \
+  -H "Authorization: Bearer $HTTP_TRIGGER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"session_id":"ci-main","prompt":"summarize the latest failed test"}'
+```
+
+Response:
+
+```json
+{
+  "response": "...",
+  "session_reset": false
+}
+```
+
+`session_id` controls conversational continuity. Reuse the same value to keep context, or use a unique value for one-shot automation. OpenAB stores HTTP sessions internally as `http:<session_id>`.
+
+## Limits And Errors
+
+| Condition | Status |
+|-----------|--------|
+| Missing or invalid bearer token | `401` |
+| Empty `session_id` or `prompt` | `400` |
+| `session_id` longer than 128 bytes | `400` |
+| `prompt` longer than 64 KiB | `413` |
+| Session pool unavailable | `503` |
+| Prompt timeout | `504` |
+| Agent/internal error | `500` |
+
+On timeout, OpenAB resets that HTTP session before returning `504`, so late ACP notifications do not leak into the next request for the same `session_id`.
+
+## Helm
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.discord.enabled=false \
+  --set agents.kiro.http.enabled=true \
+  --set-literal agents.kiro.http.token="$HTTP_TRIGGER_TOKEN"
+```
+
+Default Helm values bind the HTTP listener to `127.0.0.1`, which is reachable only inside the pod. For external access, prefer a sidecar or ingress that terminates TLS and enforces access control, then forward to `127.0.0.1:7865`.
+
+If you intentionally bind to all pod interfaces:
+
+```bash
+helm upgrade openab openab/openab \
+  --reuse-values \
+  --set agents.kiro.http.bind=0.0.0.0
+```
+
+Do this only with Kubernetes NetworkPolicy, an authenticated ingress, or equivalent controls.

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,6 +81,35 @@ pub struct Config {
     pub markdown: MarkdownConfig,
     #[serde(default)]
     pub cron: CronConfig,
+    #[serde(default)]
+    pub http: HttpConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HttpConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_http_port")]
+    pub port: u16,
+    #[serde(default = "default_http_bind")]
+    pub bind: String,
+    /// Empty string disables auth (not recommended for production).
+    #[serde(default)]
+    pub token: String,
+    #[serde(default = "default_http_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+impl Default for HttpConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            port: default_http_port(),
+            bind: default_http_bind(),
+            token: String::new(),
+            timeout_ms: default_http_timeout_ms(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -499,6 +528,16 @@ fn default_done_hold_ms() -> u64 {
 }
 fn default_error_hold_ms() -> u64 {
     2_500
+}
+
+fn default_http_port() -> u16 {
+    7865
+}
+fn default_http_bind() -> String {
+    "127.0.0.1".into()
+}
+fn default_http_timeout_ms() -> u64 {
+    300_000
 }
 
 impl Default for PoolConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -938,6 +938,37 @@ command = "echo"
     }
 
     #[test]
+    fn http_config_defaults_when_omitted() {
+        let cfg = parse_config(MINIMAL_TOML, "test").unwrap();
+        assert!(!cfg.http.enabled);
+        assert_eq!(cfg.http.bind, "127.0.0.1");
+        assert_eq!(cfg.http.port, 7865);
+        assert!(cfg.http.token.is_empty());
+        assert_eq!(cfg.http.timeout_ms, 300_000);
+    }
+
+    #[test]
+    fn parse_http_config() {
+        let toml = r#"
+[http]
+enabled = true
+bind = "0.0.0.0"
+port = 8080
+token = "secret"
+timeout_ms = 15000
+
+[agent]
+command = "echo"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        assert!(cfg.http.enabled);
+        assert_eq!(cfg.http.bind, "0.0.0.0");
+        assert_eq!(cfg.http.port, 8080);
+        assert_eq!(cfg.http.token, "secret");
+        assert_eq!(cfg.http.timeout_ms, 15_000);
+    }
+
+    #[test]
     fn stt_echo_transcript_defaults_to_false() {
         let cfg = SttConfig::default();
         assert!(

--- a/src/http.rs
+++ b/src/http.rs
@@ -60,7 +60,10 @@ async fn handle_prompt(
     }
 
     if req.session_id.is_empty() || req.prompt.is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "session_id and prompt are required".into()));
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "session_id and prompt are required".into(),
+        ));
     }
     if req.session_id.len() > MAX_SESSION_ID {
         return Err((StatusCode::BAD_REQUEST, "session_id too long".into()));
@@ -72,27 +75,29 @@ async fn handle_prompt(
     // Namespace HTTP sessions so they cannot collide with Discord thread IDs.
     let pool_key = format!("http:{}", req.session_id);
 
-    state
-        .pool
-        .get_or_create(&pool_key)
-        .await
-        .map_err(|e| {
-            tracing::warn!(session_id = %req.session_id, err = %e, "pool unavailable");
-            (StatusCode::SERVICE_UNAVAILABLE, "service unavailable".into())
-        })?;
+    state.pool.get_or_create(&pool_key).await.map_err(|e| {
+        tracing::warn!(session_id = %req.session_id, err = %e, "pool unavailable");
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "service unavailable".into(),
+        )
+    })?;
 
     let timeout = std::time::Duration::from_millis(state.timeout_ms);
-    tokio::time::timeout(
-        timeout,
-        run_prompt(&state.pool, &pool_key, &req.prompt),
-    )
-    .await
-    .map_err(|_| (StatusCode::GATEWAY_TIMEOUT, "prompt timeout".into()))?
-    .map(Json)
-    .map_err(|e| {
-        tracing::error!(session_id = %req.session_id, err = %e, "prompt failed");
-        (StatusCode::INTERNAL_SERVER_ERROR, "internal error".into())
-    })
+    match tokio::time::timeout(timeout, run_prompt(&state.pool, &pool_key, &req.prompt)).await {
+        Ok(Ok(resp)) => Ok(Json(resp)),
+        Ok(Err(e)) => {
+            tracing::error!(session_id = %req.session_id, err = %e, "prompt failed");
+            Err((StatusCode::INTERNAL_SERVER_ERROR, "internal error".into()))
+        }
+        Err(_) => {
+            tracing::warn!(session_id = %req.session_id, "prompt timeout; resetting http session");
+            if let Err(e) = state.pool.reset_session(&pool_key).await {
+                tracing::warn!(session_id = %req.session_id, err = %e, "failed to reset timed-out http session");
+            }
+            Err((StatusCode::GATEWAY_TIMEOUT, "prompt timeout".into()))
+        }
+    }
 }
 
 async fn run_prompt(
@@ -106,8 +111,10 @@ async fn run_prompt(
             let reset = conn.session_reset;
             conn.session_reset = false;
 
-            let blocks = vec![ContentBlock::Text { text: prompt.clone() }];
-            let (mut rx, _) = match conn.session_prompt(blocks).await {
+            let blocks = vec![ContentBlock::Text {
+                text: prompt.clone(),
+            }];
+            let (mut rx, request_id) = match conn.session_prompt(blocks).await {
                 Ok(r) => r,
                 Err(e) => {
                     // Always clear the subscriber slot even on failure.
@@ -118,7 +125,13 @@ async fn run_prompt(
 
             let mut text_buf = String::new();
             while let Some(notification) = rx.recv().await {
-                if notification.id.is_some() {
+                if let Some(notification_id) = notification.id {
+                    if notification_id != request_id {
+                        continue;
+                    }
+                    if let Some(err) = notification.error {
+                        return Err(anyhow::anyhow!("agent returned {err}"));
+                    }
                     break;
                 }
                 if let Some(AcpEvent::Text(t)) = classify_notification(&notification) {
@@ -148,7 +161,8 @@ pub async fn run_server(pool: Arc<SessionPool>, cfg: HttpConfig) -> anyhow::Resu
 
     let addr = format!("{}:{}", cfg.bind, cfg.port);
     info!(addr = %addr, "http trigger server starting");
-    let listener = tokio::net::TcpListener::bind(&addr).await
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
         .map_err(|e| anyhow::anyhow!("failed to bind {addr}: {e}"))?;
     axum::serve(listener, app).await?;
     Ok(())

--- a/src/http.rs
+++ b/src/http.rs
@@ -34,31 +34,29 @@ struct PromptResponse {
     session_reset: bool,
 }
 
-async fn handle_prompt(
-    State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
-    Json(req): Json<PromptRequest>,
-) -> Result<Json<PromptResponse>, (StatusCode, String)> {
-    if !state.token.is_empty() {
-        // Extract Bearer token; scheme comparison is case-insensitive per RFC 7235.
-        let provided = headers
-            .get("authorization")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| {
-                let mut parts = v.splitn(2, ' ');
-                let scheme = parts.next()?;
-                if !scheme.eq_ignore_ascii_case("bearer") {
-                    return None;
-                }
-                parts.next()
-            })
-            .unwrap_or("");
-        let ok: bool = provided.as_bytes().ct_eq(state.token.as_bytes()).into();
-        if !ok {
-            return Err((StatusCode::UNAUTHORIZED, "invalid token".into()));
-        }
+fn bearer_authorized(headers: &HeaderMap, token: &str) -> bool {
+    if token.is_empty() {
+        return true;
     }
 
+    // Extract Bearer token; scheme comparison is case-insensitive per RFC 7235.
+    let provided = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| {
+            let mut parts = v.splitn(2, ' ');
+            let scheme = parts.next()?;
+            if !scheme.eq_ignore_ascii_case("bearer") {
+                return None;
+            }
+            parts.next()
+        })
+        .unwrap_or("");
+
+    provided.as_bytes().ct_eq(token.as_bytes()).into()
+}
+
+fn validate_prompt_request(req: &PromptRequest) -> Result<(), (StatusCode, String)> {
     if req.session_id.is_empty() || req.prompt.is_empty() {
         return Err((
             StatusCode::BAD_REQUEST,
@@ -71,6 +69,19 @@ async fn handle_prompt(
     if req.prompt.len() > MAX_PROMPT {
         return Err((StatusCode::PAYLOAD_TOO_LARGE, "prompt too long".into()));
     }
+    Ok(())
+}
+
+async fn handle_prompt(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<PromptRequest>,
+) -> Result<Json<PromptResponse>, (StatusCode, String)> {
+    if !bearer_authorized(&headers, &state.token) {
+        return Err((StatusCode::UNAUTHORIZED, "invalid token".into()));
+    }
+
+    validate_prompt_request(&req)?;
 
     // Namespace HTTP sessions so they cannot collide with Discord thread IDs.
     let pool_key = format!("http:{}", req.session_id);
@@ -166,4 +177,68 @@ pub async fn run_server(pool: Arc<SessionPool>, cfg: HttpConfig) -> anyhow::Resu
         .map_err(|e| anyhow::anyhow!("failed to bind {addr}: {e}"))?;
     axum::serve(listener, app).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::header::AUTHORIZATION;
+
+    fn prompt_request(session_id: &str, prompt: &str) -> PromptRequest {
+        PromptRequest {
+            session_id: session_id.to_string(),
+            prompt: prompt.to_string(),
+        }
+    }
+
+    #[test]
+    fn bearer_authorized_accepts_valid_token_case_insensitive_scheme() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, "bEaReR secret".parse().unwrap());
+
+        assert!(bearer_authorized(&headers, "secret"));
+    }
+
+    #[test]
+    fn bearer_authorized_rejects_missing_wrong_or_wrong_scheme() {
+        assert!(!bearer_authorized(&HeaderMap::new(), "secret"));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, "Bearer nope".parse().unwrap());
+        assert!(!bearer_authorized(&headers, "secret"));
+
+        headers.insert(AUTHORIZATION, "Basic secret".parse().unwrap());
+        assert!(!bearer_authorized(&headers, "secret"));
+    }
+
+    #[test]
+    fn bearer_authorized_allows_empty_token_for_internal_tests_only() {
+        assert!(bearer_authorized(&HeaderMap::new(), ""));
+    }
+
+    #[test]
+    fn validate_prompt_request_accepts_valid_payload() {
+        assert!(validate_prompt_request(&prompt_request("session", "hello")).is_ok());
+    }
+
+    #[test]
+    fn validate_prompt_request_rejects_empty_fields() {
+        let err = validate_prompt_request(&prompt_request("", "hello")).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+
+        let err = validate_prompt_request(&prompt_request("session", "")).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn validate_prompt_request_rejects_large_payloads() {
+        let err =
+            validate_prompt_request(&prompt_request(&"s".repeat(MAX_SESSION_ID + 1), "hello"))
+                .unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+
+        let err = validate_prompt_request(&prompt_request("session", &"p".repeat(MAX_PROMPT + 1)))
+            .unwrap_err();
+        assert_eq!(err.0, StatusCode::PAYLOAD_TOO_LARGE);
+    }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,155 @@
+use crate::acp::{classify_notification, AcpEvent, ContentBlock, SessionPool};
+use crate::config::HttpConfig;
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::Json,
+    routing::post,
+    Router,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use subtle::ConstantTimeEq;
+use tracing::info;
+
+const MAX_SESSION_ID: usize = 128;
+const MAX_PROMPT: usize = 64 * 1024;
+
+#[derive(Clone)]
+struct AppState {
+    pool: Arc<SessionPool>,
+    token: String,
+    timeout_ms: u64,
+}
+
+#[derive(Deserialize)]
+struct PromptRequest {
+    session_id: String,
+    prompt: String,
+}
+
+#[derive(Serialize)]
+struct PromptResponse {
+    response: String,
+    session_reset: bool,
+}
+
+async fn handle_prompt(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<PromptRequest>,
+) -> Result<Json<PromptResponse>, (StatusCode, String)> {
+    if !state.token.is_empty() {
+        // Extract Bearer token; scheme comparison is case-insensitive per RFC 7235.
+        let provided = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| {
+                let mut parts = v.splitn(2, ' ');
+                let scheme = parts.next()?;
+                if !scheme.eq_ignore_ascii_case("bearer") {
+                    return None;
+                }
+                parts.next()
+            })
+            .unwrap_or("");
+        let ok: bool = provided.as_bytes().ct_eq(state.token.as_bytes()).into();
+        if !ok {
+            return Err((StatusCode::UNAUTHORIZED, "invalid token".into()));
+        }
+    }
+
+    if req.session_id.is_empty() || req.prompt.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "session_id and prompt are required".into()));
+    }
+    if req.session_id.len() > MAX_SESSION_ID {
+        return Err((StatusCode::BAD_REQUEST, "session_id too long".into()));
+    }
+    if req.prompt.len() > MAX_PROMPT {
+        return Err((StatusCode::PAYLOAD_TOO_LARGE, "prompt too long".into()));
+    }
+
+    // Namespace HTTP sessions so they cannot collide with Discord thread IDs.
+    let pool_key = format!("http:{}", req.session_id);
+
+    state
+        .pool
+        .get_or_create(&pool_key)
+        .await
+        .map_err(|e| {
+            tracing::warn!(session_id = %req.session_id, err = %e, "pool unavailable");
+            (StatusCode::SERVICE_UNAVAILABLE, "service unavailable".into())
+        })?;
+
+    let timeout = std::time::Duration::from_millis(state.timeout_ms);
+    tokio::time::timeout(
+        timeout,
+        run_prompt(&state.pool, &pool_key, &req.prompt),
+    )
+    .await
+    .map_err(|_| (StatusCode::GATEWAY_TIMEOUT, "prompt timeout".into()))?
+    .map(Json)
+    .map_err(|e| {
+        tracing::error!(session_id = %req.session_id, err = %e, "prompt failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "internal error".into())
+    })
+}
+
+async fn run_prompt(
+    pool: &SessionPool,
+    pool_key: &str,
+    prompt: &str,
+) -> anyhow::Result<PromptResponse> {
+    pool.with_connection(pool_key, |conn| {
+        let prompt = prompt.to_string();
+        Box::pin(async move {
+            let reset = conn.session_reset;
+            conn.session_reset = false;
+
+            let blocks = vec![ContentBlock::Text { text: prompt.clone() }];
+            let (mut rx, _) = match conn.session_prompt(blocks).await {
+                Ok(r) => r,
+                Err(e) => {
+                    // Always clear the subscriber slot even on failure.
+                    conn.prompt_done().await;
+                    return Err(e);
+                }
+            };
+
+            let mut text_buf = String::new();
+            while let Some(notification) = rx.recv().await {
+                if notification.id.is_some() {
+                    break;
+                }
+                if let Some(AcpEvent::Text(t)) = classify_notification(&notification) {
+                    text_buf.push_str(&t);
+                }
+            }
+
+            conn.prompt_done().await;
+            Ok(PromptResponse {
+                response: text_buf,
+                session_reset: reset,
+            })
+        })
+    })
+    .await
+}
+
+pub async fn run_server(pool: Arc<SessionPool>, cfg: HttpConfig) -> anyhow::Result<()> {
+    let state = Arc::new(AppState {
+        pool,
+        token: cfg.token,
+        timeout_ms: cfg.timeout_ms,
+    });
+    let app = Router::new()
+        .route("/prompt", post(handle_prompt))
+        .with_state(state);
+
+    let addr = format!("{}:{}", cfg.bind, cfg.port);
+    info!(addr = %addr, "http trigger server starting");
+    let listener = tokio::net::TcpListener::bind(&addr).await
+        .map_err(|e| anyhow::anyhow!("failed to bind {addr}: {e}"))?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod dispatch;
 mod error_display;
 mod format;
 mod gateway;
+mod http;
 mod markdown;
 mod media;
 mod reactions;
@@ -119,9 +120,17 @@ async fn main() -> anyhow::Result<()> {
         "config loaded"
     );
 
-    if cfg.discord.is_none() && cfg.slack.is_none() && cfg.gateway.is_none() {
+    if cfg.discord.is_none() && cfg.slack.is_none() && cfg.gateway.is_none() && !cfg.http.enabled {
         anyhow::bail!(
-            "no adapter configured — add [discord], [slack], and/or [gateway] to config.toml"
+            "no adapter configured — add [discord], [slack], [gateway], or [http] to config.toml"
+        );
+    }
+
+    if cfg.http.enabled && cfg.http.token.is_empty() {
+        anyhow::bail!(
+            "http trigger is enabled without a token -- set http.token in config. \
+             If running without auth is intentional (e.g. local development), \
+             set http.token = \"none\" and handle access control at the network layer."
         );
     }
 
@@ -313,6 +322,22 @@ async fn main() -> anyhow::Result<()> {
         None
     };
 
+    // Spawn HTTP trigger if enabled; signal shutdown if server exits unexpectedly.
+    let http_handle = if cfg.http.enabled {
+        let pool = pool.clone();
+        let http_cfg = cfg.http.clone();
+        let http_shutdown_tx = shutdown_tx.clone();
+        info!(port = http_cfg.port, bind = %http_cfg.bind, "starting http trigger");
+        Some(tokio::spawn(async move {
+            if let Err(e) = http::run_server(pool, http_cfg).await {
+                tracing::error!("http server error: {e}");
+                let _ = http_shutdown_tx.send(true);
+            }
+        }))
+    } else {
+        None
+    };
+
     // Spawn cron scheduler (background task) — reuses shared adapters
     let usercron_path = if cfg.cron.usercron_enabled {
         cfg.cron.usercron_path.as_ref().map(|p| {
@@ -484,6 +509,12 @@ async fn main() -> anyhow::Result<()> {
 
     // Cleanup
     cleanup_handle.abort();
+    if let Some(h) = http_handle {
+        h.abort();
+        match h.await {
+            Ok(()) | Err(_) => {}
+        }
+    }
     // Signal Slack adapter to shut down gracefully
     let _ = shutdown_tx.send(true);
     if let Some(handle) = slack_handle {

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,7 +403,8 @@ async fn main() -> anyhow::Result<()> {
         let allowed_users = parse_id_set(&discord_cfg.allowed_users, "discord.allowed_users")?;
         let trusted_bot_ids =
             parse_id_set(&discord_cfg.trusted_bot_ids, "discord.trusted_bot_ids")?;
-        let allowed_role_ids = parse_id_set(&discord_cfg.allowed_role_ids, "discord.allowed_role_ids")?;
+        let allowed_role_ids =
+            parse_id_set(&discord_cfg.allowed_role_ids, "discord.allowed_role_ids")?;
         info!(
             allow_all_channels,
             allow_all_users,
@@ -474,8 +475,16 @@ async fn main() -> anyhow::Result<()> {
 
         // Graceful Discord shutdown on ctrl_c
         let shard_manager = client.shard_manager.clone();
+        let mut discord_shutdown_rx = shutdown_rx.clone();
         tokio::spawn(async move {
-            shutdown_signal().await;
+            tokio::select! {
+                _ = shutdown_signal() => {}
+                changed = discord_shutdown_rx.changed() => {
+                    if changed.is_ok() {
+                        info!("shutdown requested");
+                    }
+                }
+            }
             info!("shutdown signal received");
             shard_manager.shutdown_all().await;
         });
@@ -501,9 +510,17 @@ async fn main() -> anyhow::Result<()> {
             Ok(_) => {}
         }
     } else {
-        // No Discord — wait for SIGINT or SIGTERM
+        // No Discord — wait for SIGINT/SIGTERM or another adapter requesting shutdown.
         info!("running without discord, press ctrl+c to stop");
-        shutdown_signal().await;
+        let mut shutdown_rx = shutdown_rx.clone();
+        tokio::select! {
+            _ = shutdown_signal() => {}
+            changed = shutdown_rx.changed() => {
+                if changed.is_ok() {
+                    info!("shutdown requested");
+                }
+            }
+        }
         info!("shutdown signal received");
     }
 


### PR DESCRIPTION
## Summary

- Adds `POST /prompt` HTTP trigger endpoint alongside existing Discord, Slack, and Gateway adapters
- Adds `[http]` config block: `enabled`, `port` (default 7865), `bind` (default `127.0.0.1`), `token`, `timeout_ms`
- Sessions are namespaced with `http:` prefix to prevent collision with other adapter keys
- Follow-up commits harden HTTP timeout handling, locked dependency resolution, adapter-triggered shutdown, docs, Helm values, and focused tests

Closes #801

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404/1503936506581090464

## Security

- Bearer token comparison uses `subtle::ConstantTimeEq` (timing-safe, prevents timing oracle)
- Bearer scheme matching is case-insensitive per RFC 7235
- Startup fails closed if `http.token` is empty (`bail!` not `warn!`)
- Input limits: `session_id <= 128` bytes, `prompt <= 64 KiB`
- Internal error details are logged server-side; generic messages returned to caller
- Bind defaults to `127.0.0.1` (loopback-only hardening default)

## Correctness

- `prompt_done()` called on `session_prompt` error path (prevents `notify_tx` subscriber leak)
- HTTP prompt loop filters completion messages by request id, so stale id-bearing responses are ignored
- HTTP prompt timeout resets the HTTP session before returning 504, preventing late ACP notifications from contaminating the next request on the same `session_id`
- HTTP bind/server failure signals global shutdown; HTTP-only mode exits cleanly instead of hanging
- Discord foreground mode observes adapter-requested shutdown and shuts down the shard manager
- `h.abort()` is awaited before `pool.shutdown()` to prevent write-lock deadlock on shutdown
- Helm values render `[http]`, store `http.token` in a Secret, and inject it as `HTTP_TRIGGER_TOKEN`
- HTTP config, auth, and request validation have focused unit coverage

## Known Limitations (follow-up PRs)

- Write lock is held for entire prompt duration (pre-existing pool design, affects all adapters)

## Test Plan

- [x] `cargo metadata --locked --format-version 1`
- [x] `cargo check --locked`
- [x] `cargo test --locked` (351 passed)
- [x] `cargo build --locked`
- [x] `helm lint charts/openab`
- [x] `helm unittest charts/openab` (103 passed)
- [x] `helm template test charts/openab`
- [x] `helm template test charts/openab --set agents.kiro.enabled=false`
- [x] `helm template test charts/openab --set agents.kiro.discord.enabled=false --set agents.kiro.http.enabled=true --set-literal agents.kiro.http.token=secret`
- [x] HTTP-only bind failure exits cleanly instead of hanging
- [x] Missing Helm `http.token` with `http.enabled=true` fails template rendering
- [x] Invalid Bearer token: unit-covered 401 path
- [x] `session_id` > 128 bytes: unit-covered 400 path
- [x] `prompt` > 64 KiB: unit-covered 413 path

---

*Rebased on upstream/main*
