### PR TITLE
fix(discord): register slash commands globally only

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -839,20 +839,25 @@ impl EventHandler for Handler {
                 ).required(true)),
         ];
 
-        // Register global commands (works in DMs + all guilds after propagation).
+        // Register global commands only. Registering the same commands per-guild
+        // makes Discord show duplicate slash commands in guild command pickers.
         if let Err(e) = Command::set_global_commands(&ctx.http, commands.clone()).await {
             tracing::warn!(error = %e, "failed to register global slash commands");
         } else {
             info!("registered global slash commands");
         }
 
-        // Also register per-guild for instant availability (global can take up to 1h).
+        // One-time migration cleanup: older versions registered the same
+        // slash commands per-guild, and Discord persists those server-side.
+        // Keep guild command sets empty so only global commands are shown.
         for guild in &ready.guilds {
             let guild_id = guild.id;
-            if let Err(e) = guild_id.set_commands(&ctx.http, commands.clone()).await {
-                tracing::warn!(%guild_id, error = %e, "failed to register guild slash commands");
-            } else {
-                info!(%guild_id, "registered guild slash commands");
+            if let Err(e) = guild_id.set_commands(&ctx.http, Vec::new()).await {
+                tracing::warn!(
+                    %guild_id,
+                    error = %e,
+                    "failed to clear stale guild slash commands"
+                );
             }
         }
 


### PR DESCRIPTION
## What problem does this solve?

Discord slash commands were registered twice for guild users: once as global commands and once again as guild-specific commands during `ready()`. Discord shows both command scopes in guild command pickers, so users can see duplicate `/models`, `/agents`, `/cancel`, `/cancel-all`, `/reset`, and `/remind` entries.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365157010542652/1503874520128295072

## At a Glance

```
Before:
Discord ready()
  -> set_global_commands(commands)
  -> for each guild: guild.set_commands(commands)
  -> duplicate slash command entries in guilds

After:
Discord ready()
  -> set_global_commands(commands)
  -> for each guild: guild.set_commands([])
  -> global commands remain, stale guild commands are cleared
```

## Prior Art & Industry Research

Not applicable — this is a narrow Discord adapter bug fix. It removes duplicate registration of the same slash commands and adds a migration cleanup for stale Discord guild commands. It does not introduce architectural, runtime, agent, scheduling, delivery, or persistence design changes.

**OpenClaw:** Not researched because prior-art research is not required for this trivial bug fix.

**Hermes Agent:** Not researched because prior-art research is not required for this trivial bug fix.

## Proposed Solution

Register Discord slash commands with `Command::set_global_commands()` so commands remain available in DMs and all guilds.

During `ready()`, overwrite each guild's command set with an empty list using `guild_id.set_commands(&ctx.http, Vec::new())`. This clears guild-specific commands left behind by older OpenAB versions, because Discord persists guild commands server-side after registration.

The source-grep regression test from the initial PR revision was removed because the cleanup path legitimately calls `set_commands()` to delete stale guild commands.

## Why this approach?

Global command registration matches the desired behavior because OpenAB supports Discord DMs. Guild-specific registration would make commands appear faster in guilds, but it cannot support DMs and causes duplicates when used alongside global registration.

Clearing guild command sets in `ready()` handles deployments that already ran the old version. Without this migration cleanup, removing the old registration loop would stop creating new duplicates but would not remove guild commands already persisted by Discord.

Tradeoff: global command updates can take time to propagate through Discord. That is preferable to duplicate user-facing commands and keeps DM support intact.

## Alternatives Considered

- Use guild-only commands: rejected because slash commands would not work in DMs.
- Keep both global and guild registrations: rejected because Discord displays both scopes, causing duplicate slash commands.
- Remove the guild registration loop without cleanup: rejected because existing guild-level commands are persisted server-side and would remain visible.
- Add config to choose registration scope: rejected because this bug has a clear desired default and extra config would add operational complexity.

## Validation

- [x] `git diff --check` passes
- [ ] `cargo check` passes — not run because this environment does not have `cargo` installed
- [ ] `cargo test` passes — not run because this environment does not have `cargo` installed
- [ ] `cargo clippy` clean — not run because this environment does not have `cargo` installed
- [ ] Manual testing — not performed against a live Discord bot in this environment
