### PR TITLE
docs(cronjob): annotate breaking change with version (v0.8.2)

### DIFF
--- a/docs/cronjob.md
+++ b/docs/cronjob.md
@@ -179,7 +179,7 @@ The path is relative to `$HOME/.openab/` (e.g. `"cronjob.toml"` resolves to `$HO
 > **New installations**: If `~/.openab/` does not exist yet, the scheduler silently skips the file and continues running. Once you create the directory and place `cronjob.toml` inside, it will be picked up automatically on the next tick — no restart required.
 
 > [!CAUTION]
-> **Breaking Change** — `usercron_path` relative path base changed from `$HOME` to `$HOME/.openab/`.
+> **Breaking Change (v0.8.2)** — `usercron_path` relative path base changed from `$HOME` to `$HOME/.openab/`.
 > If you are upgrading from a previous version, move your existing file:
 > ```bash
 > mkdir -p ~/.openab


### PR DESCRIPTION
## What problem does this solve?

The CAUTION block in `docs/cronjob.md` warns about the `usercron_path` base directory change (`$HOME/` → `$HOME/.openab/`) but does not mention which version introduced it. Users upgrading across multiple versions cannot tell if this migration applies to them.

Closes # N/A

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1500698789986435212/1504112042666365201

## At a Glance

N/A (docs-only change)

## Prior Art & Industry Research

Not applicable — docs-only fix adding version annotation.

## Proposed Solution

Add `(v0.8.2)` to the breaking change CAUTION block so users know exactly which version requires the path migration.

## Why this approach?

The code change was introduced in v0.8.2 (confirmed by diffing `openab-0.8.1...openab-0.8.2` — `src/main.rs` resolves relative `usercron_path` from `$HOME/.openab/`). The upgrade guide (`docs/ai-install-upgrade.md`) already says `(v0.8.2+)` but the primary cronjob docs did not.

## Alternatives Considered

None — straightforward docs fix.

## Validation

- [x] Renders correctly in GitHub preview
- [x] Links are valid