### PR TITLE
fix(ci): add gateway/Cargo.lock to path triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "src/**"
       - "gateway/**"
+      - "gateway/Cargo.lock"
       - "Cargo.toml"
       - "Cargo.lock"
       - "Dockerfile*"


### PR DESCRIPTION
## Summary

Add `gateway/Cargo.lock` explicitly to the CI pull_request paths filter so dependency-only gateway PRs are clearly covered.

## What This Fixes

Issue #805 identified that `gateway/Cargo.lock` was not explicitly listed in the CI path triggers added by #769. While `gateway/**` already matches it, listing it explicitly:
- Makes the intent clear (lockfile-only changes should trigger gateway CI)
- Prevents accidental coverage loss if the glob is later narrowed

## Changes

- `.github/workflows/ci.yml`: Add `gateway/Cargo.lock` to `pull_request.paths`

Closes #805