### PR TITLE
feat: add Grok Build (xAI) as agent provider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
           - { suffix: "-opencode", dockerfile: "Dockerfile.opencode", artifact: "opencode" }
           - { suffix: "-cursor", dockerfile: "Dockerfile.cursor", artifact: "cursor" }
           - { suffix: "-hermes", dockerfile: "Dockerfile.hermes", artifact: "hermes" }
+          - { suffix: "-grok", dockerfile: "Dockerfile.grok", artifact: "grok" }
         platform:
           - { os: linux/amd64, runner: ubuntu-latest }
           - { os: linux/arm64, runner: ubuntu-24.04-arm }
@@ -137,6 +138,7 @@ jobs:
           - { suffix: "-opencode", artifact: "opencode" }
           - { suffix: "-cursor", artifact: "cursor" }
           - { suffix: "-hermes", artifact: "hermes" }
+          - { suffix: "-grok", artifact: "grok" }
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -188,6 +190,7 @@ jobs:
           - { suffix: "-opencode" }
           - { suffix: "-cursor" }
           - { suffix: "-hermes" }
+          - { suffix: "-grok" }
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -1,0 +1,59 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+FROM debian:bookworm-slim
+
+# Create agent user first so WORKDIR gets correct ownership
+RUN useradd -m -u 1000 agent
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl procps ripgrep tini git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Grok Build CLI — pinned version with SHA256 checksum verification.
+# Binary sourced from xAI's public artifacts bucket (same source the official
+# `https://x.ai/cli/install.sh` resolves to) so the build is reproducible.
+ARG GROK_VERSION=0.1.211
+ARG GROK_SHA256_AMD64=9245f9c921b1f91bfb34ee2ee27715000b65e947723541ff1a612eaece468bd0
+ARG GROK_SHA256_ARM64=b283cb72fdc3143365e044fd7f8630e14845640d4d81404bb36905cc7209abc6
+ARG TARGETPLATFORM
+RUN set -eux; \
+    case "${TARGETPLATFORM:-linux/amd64}" in \
+      "linux/amd64") arch=x86_64; sha="${GROK_SHA256_AMD64}" ;; \
+      "linux/arm64") arch=aarch64; sha="${GROK_SHA256_ARM64}" ;; \
+      *) echo "Unsupported platform: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-${GROK_VERSION}-linux-${arch}" \
+      -o /tmp/grok && \
+    echo "${sha}  /tmp/grok" | sha256sum -c - && \
+    install -m 0755 /tmp/grok /usr/local/bin/grok && \
+    ln -sf /usr/local/bin/grok /usr/local/bin/agent && \
+    rm /tmp/grok
+
+# Install gh CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/agent
+WORKDIR /home/agent
+
+COPY --from=builder --chown=1000:1000 /build/target/release/openab /usr/local/bin/openab
+
+# Pre-create credential dir so a PVC mounted at ~/.grok inherits correct ownership
+RUN mkdir -p /home/agent/.grok && chown -R agent:agent /home/agent
+
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/config.toml.example
+++ b/config.toml.example
@@ -110,6 +110,16 @@ working_dir = "/home/agent"
 # # Supports 30+ providers (xAI Grok OAuth, Anthropic, OpenAI Codex, Gemini, etc.)
 # # Provider switching: kubectl exec -it <pod> -- hermes model
 
+# [agent]
+# command = "grok"
+# args = ["agent", "stdio"]
+# working_dir = "/home/agent"
+# # Auth options:
+# #   1. API key:        env = { GROK_CODE_XAI_API_KEY = "${XAI_API_KEY}" }
+# #   2. Device-code:    kubectl exec -it <pod> -- grok login --device-auth
+# #   3. Deployment key: env = { GROK_DEPLOYMENT_KEY = "${GROK_DEPLOYMENT_KEY}" }
+# # See docs/grok.md for details.
+
 [pool]
 max_sessions = 10
 session_ttl_hours = 24

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -1,0 +1,134 @@
+# Grok Build (xAI)
+
+[Grok Build](https://x.ai/news/grok-build-cli) is xAI's official coding agent CLI. It speaks ACP natively via `grok agent stdio` — no wrapper required.
+
+## Docker Image
+
+```bash
+docker build -f Dockerfile.grok -t openab-grok:latest .
+```
+
+The image pulls a pinned `grok` binary from xAI's public artifacts bucket and verifies its SHA256 checksum. Bump `GROK_VERSION`, `GROK_SHA256_AMD64`, and `GROK_SHA256_ARM64` in `Dockerfile.grok` to upgrade.
+
+## Helm Install
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.grok.discord.enabled=true \
+  --set agents.grok.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.grok.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.grok.image=ghcr.io/openabdev/openab-grok:latest \
+  --set agents.grok.command=grok \
+  --set-string 'agents.grok.args[0]=agent' \
+  --set-string 'agents.grok.args[1]=stdio' \
+  --set agents.grok.workingDir=/home/agent
+```
+
+> Set `agents.kiro.enabled=false` to disable the default Kiro agent.
+
+## Manual config.toml
+
+```toml
+[agent]
+command = "grok"
+args = ["agent", "stdio"]
+working_dir = "/home/agent"
+```
+
+## Authentication
+
+Grok Build supports three credential sources. Pick whichever fits your deployment.
+
+### Option A: API key (simplest, recommended for CI / bot deployments)
+
+Set the environment variable in the pod / task definition:
+
+```bash
+export GROK_CODE_XAI_API_KEY="xai-..."
+```
+
+Get a key from <https://console.x.ai/>. No interactive login needed.
+
+> ⚠️ **Security**: env vars listed under `[agent].env` are visible to the agent and can be leaked via prompt injection. Prefer mounting them via the platform's secret manager.
+
+### Option B: Device-code OAuth (for SuperGrok subscriptions)
+
+If you want to use a SuperGrok subscription instead of pay-per-token API billing:
+
+```bash
+kubectl exec -it <pod> -- grok login --device-auth
+```
+
+The CLI prints a short code and URL — open the URL on any device, enter the code, approve. The token is stored at `~/.grok/auth.json` inside the container.
+
+This works in any headless environment (K8s exec, ECS exec, plain SSH) **without port-forwarding** — unlike loopback OAuth flows.
+
+### Option C: Enterprise deployment key
+
+```bash
+export GROK_DEPLOYMENT_KEY="..."
+```
+
+A deployment key takes precedence over `auth.json`. The CLI fetches managed config from `cli-chat-proxy.grok.com/v1/deployment/config` on startup. Available to xAI enterprise customers; contact xAI sales for details.
+
+## Credential Persistence
+
+`grok login` stores OAuth credentials at `~/.grok/auth.json` and runtime config at `~/.grok/config.toml`. The OpenAB Helm chart's default persistence covers `workingDir` automatically (PVC mounted at `/home/agent`).
+
+If deploying manually, mount persistent storage at `/home/agent/.grok`:
+
+```yaml
+volumes:
+  - name: grok-credentials
+    persistentVolumeClaim:
+      claimName: grok-credentials-pvc
+volumeMounts:
+  - name: grok-credentials
+    mountPath: /home/agent/.grok
+```
+
+API-key-only deployments don't need persistence.
+
+## Model Selection
+
+The default model is whichever Grok Build CLI selects (currently `grok-code-fast-1` for the free tier; `grok-4.3` family for SuperGrok). To override:
+
+```toml
+[agent]
+command = "grok"
+args = ["agent", "stdio", "--model", "grok-4.3"]
+working_dir = "/home/agent"
+```
+
+List available models inside the pod:
+
+```bash
+kubectl exec -it <pod> -- grok models
+```
+
+## Updating
+
+```bash
+# Inside the container (one-shot upgrade):
+kubectl exec -it <pod> -- grok update
+
+# Or rebuild the image with a new pinned version:
+docker build -f Dockerfile.grok \
+  --build-arg GROK_VERSION=0.1.220 \
+  --build-arg GROK_SHA256_AMD64=... \
+  --build-arg GROK_SHA256_ARM64=... \
+  -t openab-grok:latest .
+```
+
+## Comparison with Hermes
+
+| Property | `Dockerfile.grok` | `Dockerfile.hermes` |
+|----------|-------------------|---------------------|
+| Provider | xAI Grok only | xAI + 30 others via Nous gateway |
+| ACP | Native (`grok agent stdio`) | Via `hermes-acp` wrapper |
+| Headless auth | API key env or device-code | Loopback OAuth (needs port-forward / ECS curl trick) |
+| Supply chain | xAI only | xAI + Nous Research install script |
+| Image size | Smaller (single static binary, no Python venv) | Larger (Python + uv + ffmpeg) |
+
+Pick `Dockerfile.grok` if Grok is the only model you need. Pick `Dockerfile.hermes` if you want multi-provider switching or fallback chains.


### PR DESCRIPTION
## Discord Discussion URL

Internal thread on the openab-testing Discord (channel `1495121978007228466`, thread `1505232450471596096`) — discussed *"should OpenAB ship a pure xAI variant alongside Hermes"* on 2026-05-16. Summary: Hermes already supports xAI Grok OAuth, but it pulls in the entire Nous gateway, requires loopback OAuth (kubectl port-forward / ECS curl-the-callback), and adds a second supply-chain dependency. Now that xAI's official `grok` CLI (Grok Build, GA 2026-05-14) ships native ACP and supports headless API-key / device-code auth, a dedicated Dockerfile is simpler for users who only want Grok.

## 1. What problem does this solve?

OAB users who want to run xAI Grok currently have to deploy `Dockerfile.hermes` and complete the loopback-OAuth flow (`hermes auth add xai-oauth`). That flow needs port-forwarding into the pod or an ECS curl-the-callback workaround, both of which are documented in `docs/hermes.md` but are non-obvious operations and pull in 30+ unused providers.

xAI released [Grok Build](https://x.ai/news/grok-build-cli) on 2026-05-14 — an official coding-agent CLI distributed as a single static binary with **native ACP** (`grok agent stdio`). It supports three headless auth modes:

1. `GROK_CODE_XAI_API_KEY` env var (pay-per-token API)
2. Device-code OAuth (SuperGrok subscription) — no port-forward
3. `GROK_DEPLOYMENT_KEY` env var (enterprise managed config)

This PR adds `Dockerfile.grok` so users who only need Grok can deploy it without the Nous gateway layer.

No issue filed yet — happy to open one if maintainers prefer.

## 2. At a Glance

```
Hermes path (existing):
  OAB ──ACP──> hermes-acp ──HTTPS──> Nous gateway ──HTTPS──> xAI

Grok path (this PR):
  OAB ──ACP──> grok agent stdio ──HTTPS──> xAI
```

## 3. Prior Art & Industry Research

- **OpenClaw**: gateway-style aggregator; same model-routing pattern as Hermes. Doesn't ship a per-provider native-ACP variant.
- **Hermes Agent** (`Dockerfile.hermes`, PR #824): existing OAB integration. This PR coexists with it — see the comparison table in `docs/grok.md`. Hermes wins on multi-provider switching and fallback chains; Grok wins on supply-chain surface and headless auth simplicity.
- **Codex CLI** (`Dockerfile.codex`): closest analog inside the repo — also an official-vendor CLI with ACP support (via `@zed-industries/codex-acp` wrapper). Grok Build ships ACP in-binary so no wrapper is needed.

## 4. Proposed Solution

Mirror the existing per-agent Dockerfile pattern. Four touchpoints:

1. **`Dockerfile.grok`** — `debian:bookworm-slim` base. Pinned `GROK_VERSION=0.1.211` with separate SHA256s for amd64 and arm64. Binary pulled directly from `https://storage.googleapis.com/grok-build-public-artifacts/cli/` (the same source `https://x.ai/cli/install.sh` resolves to) so the install script's PATH/shell-config side-effects are skipped in the container.
2. **`docs/grok.md`** — Docker build / Helm install / three auth flows / credential persistence / model selection / comparison with `Dockerfile.hermes`.
3. **`config.toml.example`** — agent block placed immediately after the hermes one.
4. **`.github/workflows/build.yml`** — `grok` variant added to `build-image`, `merge-manifests`, and `promote-stable` matrices.

ACP invocation `grok agent stdio` was verified against the 0.1.211 binary's `--help` output (subcommand tree includes `agent → stdio | headless | serve | leader`).

## 5. Why This Approach

- **Pinning the binary, not the installer**: `Dockerfile.hermes` pins NousResearch's `install.sh` by commit + SHA256. The xAI install script doesn't expose a versioned URL, but the GCS-hosted binary itself does. Pinning the binary directly is one fewer indirection and verifies what actually runs.
- **No wrapper**: Grok Build implements ACP natively, so unlike `Dockerfile.codex` we don't need a separate `*-acp` package on top.
- **Three auth options up front**: covers the three deployment shapes maintainers have asked about — pure-API-key CI bots, SuperGrok subscription via device-code, and enterprise deployment keys.

Known limitations:
- Helm chart values for `agents.grok.*` not added yet — `docs/grok.md` documents `--set` flags so users can deploy today, but a chart-side first-class entry is a follow-up PR.
- Image size: full grok binary is ~110 MB (amd64). Comparable to other agent variants.

## 6. Alternatives Considered

- **Extend `Dockerfile.hermes` instead of new file**: rejected. Hermes provides value as a multi-provider gateway; conflating it with a single-provider variant erases the distinction users currently rely on.
- **Use `https://x.ai/cli/install.sh` directly in the Dockerfile** (à la Hermes): rejected. The script modifies `~/.bashrc`, writes `~/.grok/config.toml`, and fetches managed config from a proxy URL — useful for interactive installs, noise in a container.
- **`@superagent-ai/grok-cli` community wrapper**: rejected. It's a third-party project on top of the xAI API; defeats the point of preferring the official surface.

## 7. Validation

- [x] **Build script reasoning**: `grok agent stdio` confirmed against 0.1.211 `--help`.
- [x] **SHA256s computed locally**: `9245f9c9...` (amd64), `b283cb72...` (arm64) — both downloaded from the GCS bucket and `sha256sum`'d.
- [x] **Install URL probed**: `https://x.ai/cli/install.sh` returns HTTP 200 (cross-checked the install script's own GCS fallback URL to derive the artifact path).
- [x] **Channel pointer verified**: `https://x.ai/cli/stable` → `0.1.211`.
- [ ] **`docker build -f Dockerfile.grok`**: not yet run — opening as Draft for this reason; will run before marking ready.
- [ ] **End-to-end ACP smoke**: planned via openab-testing once the image is on GHCR.
- [ ] **Helm chart values**: deferred to follow-up PR.

## 8. Follow-ups

- Helm chart `agents.grok.*` values + templates (follow-up PR).
- Smoke-test image in openab-testing project once GHCR publishes.
- Add `grok` to `docker-smoke-test.yml` once the basic ACP handshake is validated.