### PR TITLE
feat: add Grok Build CLI as supported agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
           - { suffix: "-opencode", dockerfile: "Dockerfile.opencode", artifact: "opencode" }
           - { suffix: "-cursor", dockerfile: "Dockerfile.cursor", artifact: "cursor" }
           - { suffix: "-hermes", dockerfile: "Dockerfile.hermes", artifact: "hermes" }
+          - { suffix: "-grok", dockerfile: "Dockerfile.grok", artifact: "grok" }
         platform:
           - { os: linux/amd64, runner: ubuntu-latest }
           - { os: linux/arm64, runner: ubuntu-24.04-arm }
@@ -137,6 +138,7 @@ jobs:
           - { suffix: "-opencode", artifact: "opencode" }
           - { suffix: "-cursor", artifact: "cursor" }
           - { suffix: "-hermes", artifact: "hermes" }
+          - { suffix: "-grok", artifact: "grok" }
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -188,6 +190,7 @@ jobs:
           - { suffix: "-opencode" }
           - { suffix: "-cursor" }
           - { suffix: "-hermes" }
+          - { suffix: "-grok" }
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -21,6 +21,7 @@ jobs:
           - { dockerfile: Dockerfile.opencode, suffix: "-opencode", agent: "opencode", agent_args: "acp" }
           - { dockerfile: Dockerfile.cursor, suffix: "-cursor", agent: "cursor-agent", agent_args: "acp" }
           - { dockerfile: Dockerfile.hermes, suffix: "-hermes", agent: "hermes-acp", agent_args: "" }
+          - { dockerfile: Dockerfile.grok, suffix: "-grok", agent: "grok", agent_args: "agent stdio" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -1,0 +1,59 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+FROM debian:bookworm-slim
+
+# Create agent user first so WORKDIR gets correct ownership
+RUN useradd -m -u 1000 agent
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl procps ripgrep tini git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Grok Build CLI — pinned version with SHA256 checksum verification.
+# Binary sourced from xAI's public artifacts bucket (same source the official
+# `https://x.ai/cli/install.sh` resolves to) so the build is reproducible.
+ARG GROK_VERSION=0.1.211
+ARG GROK_SHA256_AMD64=9245f9c921b1f91bfb34ee2ee27715000b65e947723541ff1a612eaece468bd0
+ARG GROK_SHA256_ARM64=b283cb72fdc3143365e044fd7f8630e14845640d4d81404bb36905cc7209abc6
+ARG TARGETPLATFORM
+RUN set -eux; \
+    case "${TARGETPLATFORM:-linux/amd64}" in \
+      "linux/amd64") arch=x86_64; sha="${GROK_SHA256_AMD64}" ;; \
+      "linux/arm64") arch=aarch64; sha="${GROK_SHA256_ARM64}" ;; \
+      *) echo "Unsupported platform: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-${GROK_VERSION}-linux-${arch}" \
+      -o /tmp/grok && \
+    echo "${sha}  /tmp/grok" | sha256sum -c - && \
+    install -m 0755 /tmp/grok /usr/local/bin/grok && \
+    ln -sf /usr/local/bin/grok /usr/local/bin/agent && \
+    rm /tmp/grok
+
+# Install gh CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/agent
+WORKDIR /home/agent
+
+COPY --from=builder --chown=1000:1000 /build/target/release/openab /usr/local/bin/openab
+
+# Pre-create credential dir so a PVC mounted at ~/.grok inherits correct ownership
+RUN mkdir -p /home/agent/.grok && chown -R agent:agent /home/agent
+
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -33,7 +33,6 @@ RUN set -eux; \
       -o /tmp/grok && \
     echo "${sha}  /tmp/grok" | sha256sum -c - && \
     install -m 0755 /tmp/grok /usr/local/bin/grok && \
-    ln -sf /usr/local/bin/grok /usr/local/bin/agent && \
     rm /tmp/grok
 
 # Install gh CLI

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![OpenAB banner](images/banner.jpg)
 
-A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, Hermes, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](gateway/).
+A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, Hermes, Grok Build, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](gateway/).
 
 🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://discord.gg/DmbhfDZjQS)** 🎉
 
@@ -20,8 +20,8 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 │   User       │            │         │                       │ copilot --acp    │
 ├──────────────┤            ▼         ▼                       │ hermes-acp       │
 │   LINE       │◄──webhook──┌──────────────────┐              │ opencode acp     │
-│   User       │            │  Custom Gateway  │              └──────────────────┘
-├──────────────┤            │  (standalone)    │
+│   User       │            │  Custom Gateway  │              │ grok agent stdio │
+├──────────────┤            │  (standalone)    │              └──────────────────┘
 │  Feishu/Lark │◄───WS──────│                  │
 │   User       │            │                  │
 ├──────────────┤            │                  │
@@ -38,7 +38,7 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 
 - **Multi-platform** — supports Discord and Slack, run one or both simultaneously
 - **Custom Gateway** — extend to Telegram, LINE, Feishu/Lark, Google Chat, MS Teams via standalone [gateway](gateway/)
-- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, Hermes via config
+- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, Hermes, Grok Build via config
 - **@mention trigger** — mention the bot in an allowed channel to start a conversation
 - **Thread-based multi-turn** — auto-creates threads; no @mention needed for follow-ups
 - **Multi-agent collaboration** — bot-to-bot messaging for coordinated workflows ([docs/multi-agent.md](docs/multi-agent.md))
@@ -169,6 +169,7 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 | Copilot CLI ⚠️ | `copilot --acp --stdio` | Native | [docs/copilot.md](docs/copilot.md) |
 | Cursor | `cursor-agent acp` | Native | [docs/cursor.md](docs/cursor.md) |
 | Hermes Agent | `hermes-acp` | Native | [docs/hermes.md](docs/hermes.md) |
+| Grok Build | `grok agent stdio` | Native | [docs/grok.md](docs/grok.md) |
 
 > 🔧 Running multiple agents? See [docs/multi-agent.md](docs/multi-agent.md)
 

--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -42,6 +42,9 @@ Agents deployed:
 {{- else if eq (toString $cfg.command) "cursor-agent" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- cursor-agent login
+{{- else if eq (toString $cfg.command) "grok" }}
+    Authenticate:
+    kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- grok login --device-auth
 {{- end }}
 
     Restart after auth:

--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -45,6 +45,7 @@ Agents deployed:
 {{- else if eq (toString $cfg.command) "grok" }}
     Authenticate:
     kubectl exec -it deployment/{{ include "openab.agentFullname" (dict "ctx" $ "agent" $name) }} -- grok login --device-auth
+    For bot/CI deployments, prefer setting `GROK_CODE_XAI_API_KEY` via `secretEnv` instead of interactive device-auth login. See docs/grok.md for all authentication options.
 {{- end }}
 
     Restart after auth:

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -161,6 +161,34 @@ agents:
     #     storageClass: ""
     #     size: 1Gi
     #   image: "ghcr.io/openabdev/openab-hermes"
+    # grok:
+    #   command: grok
+    #   args:
+    #     - agent
+    #     - stdio
+    #   # See docs/grok.md for the three authentication methods:
+    #   # 1. API key (recommended for bots): set GROK_CODE_XAI_API_KEY via env or secretEnv
+    #   # 2. Device-code OAuth: kubectl exec + `grok login --device-auth` (requires persistence)
+    #   # 3. Enterprise deployment key: GROK_DEPLOYMENT_KEY
+    #   discord:
+    #     enabled: true
+    #     allowedChannels:
+    #       - "YOUR_CHANNEL_ID"
+    #     allowedUsers: []
+    #     allowBotMessages: "off"
+    #     trustedBotIds: []
+    #   workingDir: /home/agent
+    #   env: {}
+    #   envFrom: []
+    #   secretEnv: []
+    #   pool:
+    #     maxSessions: 10
+    #     sessionTtlHours: 24
+    #   persistence:
+    #     enabled: true
+    #     storageClass: ""
+    #     size: 1Gi
+    #   image: "ghcr.io/openabdev/openab-grok"
     image: ""
     command: kiro-cli
     args:

--- a/config.toml.example
+++ b/config.toml.example
@@ -110,6 +110,16 @@ working_dir = "/home/agent"
 # # Supports 30+ providers (xAI Grok OAuth, Anthropic, OpenAI Codex, Gemini, etc.)
 # # Provider switching: kubectl exec -it <pod> -- hermes model
 
+# [agent]
+# command = "grok"
+# args = ["agent", "stdio"]
+# working_dir = "/home/agent"
+# # Auth options:
+# #   1. API key:        env = { GROK_CODE_XAI_API_KEY = "${XAI_API_KEY}" }
+# #   2. Device-code:    kubectl exec -it <pod> -- grok login --device-auth
+# #   3. Deployment key: env = { GROK_DEPLOYMENT_KEY = "${GROK_DEPLOYMENT_KEY}" }
+# # See docs/grok.md for details.
+
 [pool]
 max_sessions = 10
 session_ttl_hours = 24

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -1,0 +1,134 @@
+# Grok Build (xAI)
+
+[Grok Build](https://x.ai/news/grok-build-cli) is xAI's official coding agent CLI. It speaks ACP natively via `grok agent stdio` — no wrapper required.
+
+## Docker Image
+
+```bash
+docker build -f Dockerfile.grok -t openab-grok:latest .
+```
+
+The image pulls a pinned `grok` binary from xAI's public artifacts bucket and verifies its SHA256 checksum. Bump `GROK_VERSION`, `GROK_SHA256_AMD64`, and `GROK_SHA256_ARM64` in `Dockerfile.grok` to upgrade.
+
+## Helm Install
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.grok.discord.enabled=true \
+  --set agents.grok.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.grok.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.grok.image=ghcr.io/openabdev/openab-grok:latest \
+  --set agents.grok.command=grok \
+  --set-string 'agents.grok.args[0]=agent' \
+  --set-string 'agents.grok.args[1]=stdio' \
+  --set agents.grok.workingDir=/home/agent
+```
+
+> Set `agents.kiro.enabled=false` to disable the default Kiro agent.
+
+## Manual config.toml
+
+```toml
+[agent]
+command = "grok"
+args = ["agent", "stdio"]
+working_dir = "/home/agent"
+```
+
+## Authentication
+
+Grok Build supports three credential sources. Pick whichever fits your deployment.
+
+### Option A: API key (simplest, recommended for CI / bot deployments)
+
+Set the environment variable in the pod / task definition:
+
+```bash
+export GROK_CODE_XAI_API_KEY="xai-..."
+```
+
+Get a key from <https://console.x.ai/>. No interactive login needed.
+
+> ⚠️ **Security**: env vars listed under `[agent].env` are visible to the agent and can be leaked via prompt injection. Prefer mounting them via the platform's secret manager.
+
+### Option B: Device-code OAuth (for SuperGrok subscriptions)
+
+If you want to use a SuperGrok subscription instead of pay-per-token API billing:
+
+```bash
+kubectl exec -it <pod> -- grok login --device-auth
+```
+
+The CLI prints a short code and URL — open the URL on any device, enter the code, approve. The token is stored at `~/.grok/auth.json` inside the container.
+
+This works in any headless environment (K8s exec, ECS exec, plain SSH) **without port-forwarding** — unlike loopback OAuth flows.
+
+### Option C: Enterprise deployment key
+
+```bash
+export GROK_DEPLOYMENT_KEY="..."
+```
+
+A deployment key takes precedence over `auth.json`. The CLI fetches managed config from `cli-chat-proxy.grok.com/v1/deployment/config` on startup. Available to xAI enterprise customers; contact xAI sales for details.
+
+## Credential Persistence
+
+`grok login` stores OAuth credentials at `~/.grok/auth.json` and runtime config at `~/.grok/config.toml`. The OpenAB Helm chart's default persistence covers `workingDir` automatically (PVC mounted at `/home/agent`).
+
+If deploying manually, mount persistent storage at `/home/agent/.grok`:
+
+```yaml
+volumes:
+  - name: grok-credentials
+    persistentVolumeClaim:
+      claimName: grok-credentials-pvc
+volumeMounts:
+  - name: grok-credentials
+    mountPath: /home/agent/.grok
+```
+
+API-key-only deployments don't need persistence.
+
+## Model Selection
+
+The default model is whichever Grok Build CLI selects (currently `grok-code-fast-1` for the free tier; `grok-4.3` family for SuperGrok). To override:
+
+```toml
+[agent]
+command = "grok"
+args = ["agent", "stdio", "--model", "grok-4.3"]
+working_dir = "/home/agent"
+```
+
+List available models inside the pod:
+
+```bash
+kubectl exec -it <pod> -- grok models
+```
+
+## Updating
+
+```bash
+# Inside the container (one-shot upgrade):
+kubectl exec -it <pod> -- grok update
+
+# Or rebuild the image with a new pinned version:
+docker build -f Dockerfile.grok \
+  --build-arg GROK_VERSION=0.1.220 \
+  --build-arg GROK_SHA256_AMD64=... \
+  --build-arg GROK_SHA256_ARM64=... \
+  -t openab-grok:latest .
+```
+
+## Comparison with Hermes
+
+| Property | `Dockerfile.grok` | `Dockerfile.hermes` |
+|----------|-------------------|---------------------|
+| Provider | xAI Grok only | xAI + 30 others via Nous gateway |
+| ACP | Native (`grok agent stdio`) | Via `hermes-acp` wrapper |
+| Headless auth | API key env or device-code | Loopback OAuth (needs port-forward / ECS curl trick) |
+| Supply chain | xAI only | xAI + Nous Research install script |
+| Image size | Smaller (single static binary, no Python venv) | Larger (Python + uv + ffmpeg) |
+
+Pick `Dockerfile.grok` if Grok is the only model you need. Pick `Dockerfile.hermes` if you want multi-provider switching or fallback chains.


### PR DESCRIPTION
## What problem does this solve?

OpenAB is adding Grok Build as one of its supported CLIs through the official `grok agent stdio` interface. However, for a new CLI to be truly usable in production environments, the Helm chart configuration must be complete and consistent with other supported agents.

Currently, agents such as hermes, cursor, claude, codex, gemini, and opencode all provide clear, ready-to-use configuration examples in `values.yaml`, along with authentication instructions in `NOTES.txt`. This allows users to easily enable them via Helm.

Grok was missing this piece. As a result, Helm users had to manually construct long and error-prone `--set` commands, making the experience inconsistent and incomplete.

This PR adds the necessary Helm configuration example for Grok, completing its support as a first-class CLI option in OpenAB.

## At a Glance

**User experience comparison when deploying Grok as a CLI:**

**Before (Missing Helm configuration example):**

```
Helm user wants to deploy Grok as an agent
    │
    └── must manually write long --set commands
        (no grok example in values.yaml)
```

**After (This PR):**

```
Helm user wants to deploy Grok as an agent
    │
    └── can directly copy the grok example from values.yaml
        + see login instructions in NOTES.txt
        (same experience as hermes, cursor, claude...)
```

**Actual connection after Helm deployment:**

```
OpenAB (deployed via Helm)
    │
    │ ACP (stdio JSON-RPC)
    ▼
grok agent stdio (running in the same pod)
    │
    │ HTTPS (device-auth or API Key)
    ▼
xAI (Grok models)
```

## Prior Art & Industry Research

**Hermes Agent (PR #824):**
The most relevant reference. Hermes was introduced with full documentation, including a detailed commented block in `values.yaml` and login instructions in `NOTES.txt`. This has become the standard approach when adding new CLI/agent support in OpenAB.

**Other agents:**
Cursor, Claude, Codex, Gemini, and OpenCode all follow the same pattern, providing clear Helm examples so users can adopt them easily.

**OpenClaw:**
Takes a different gateway-style approach and does not maintain per-CLI Helm examples in the same way, making it a less direct reference.

## Proposed Solution

- Add a complete, commented `# grok:` configuration block in `charts/openab/values.yaml`.
- Add the corresponding Grok authentication instruction in `charts/openab/templates/NOTES.txt`.

The Helm templates themselves did not require changes, as they already support arbitrary agents generically.

## Why this approach?

To establish Grok as a properly supported CLI in OpenAB, it must offer the same level of Helm usability as other agents. Providing a clear configuration example is the minimal and most consistent way to achieve this.

## Alternatives Considered

- Only documenting usage through `--set` flags in the documentation — Rejected. This would result in a significantly worse experience for Helm users compared to other CLIs.
- Enabling Grok by default in the chart — Rejected. Following the existing convention of keeping new agents commented out.

## Validation

**Helm chart validation:**
- `helm template test charts/openab` renders successfully.
- `helm template test charts/openab --set agents.kiro.enabled=false --set agents.grok.enabled=true` produces a valid Grok deployment.

**Manual testing:**
- Built `Dockerfile.grok` locally.
- Ran a full test with Discord + `grok agent stdio`.
- Completed `grok login --device-auth` inside the container using a real SuperGrok subscription.
- Verified through the Discord API that the bot could successfully interact with Grok.

## Follow-ups

None. This PR completes the Helm configuration support for Grok as a CLI in OpenAB.