### PR TITLE
docs: add message dispatch config fields to config-reference

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -41,6 +41,9 @@ Discord adapter. Requires a Discord bot token.
 | `allow_user_messages` | string | `"involved"` | `"involved"` — reply in threads bot has participated in without @mention; channel messages require @mention; DMs always process. `"mentions"` — always require @mention. `"multibot-mentions"` — like `"involved"`, but require @mention once another bot has posted in the thread. |
 | `allow_dm` | bool | `false` | `true` = respond to Discord DMs; `false` = ignore DMs. `allowed_users` still applies in DMs. Each DM user consumes one session slot. |
 | `max_bot_turns` | u32 | `100` | Max consecutive bot turns per thread before throttling (soft limit). Human message resets the counter. A compiled-in hard cap of 1000 consecutive bot messages is always enforced. |
+| `message_processing_mode` | string | `"per-message"` | Message dispatch mode: `"per-message"` (each message = own turn), `"per-thread"` (all messages in thread share one buffer), or `"per-lane"` (each sender gets own buffer). See [Message Dispatch Modes](message-dispatch-modes.md). |
+| `max_buffered_messages` | u32 | `10` | Per-thread/lane mpsc channel capacity. Only applies to `per-thread` / `per-lane` modes. |
+| `max_batch_tokens` | u32 | `24000` | Soft token cap per ACP turn. Only applies to `per-thread` / `per-lane` modes. |
 
 ---
 
@@ -60,6 +63,9 @@ Slack adapter using Socket Mode. Requires both a Bot User OAuth Token and an App
 | `trusted_bot_ids` | string[] | `[]` | Slack Bot User IDs (`U...`) or Bot IDs (`B...`). `U...` matching resolves event Bot IDs via Slack `bots.info`, so the bot token needs `users:read`. |
 | `allow_user_messages` | string | `"involved"` | Same as Discord. |
 | `max_bot_turns` | u32 | `100` | Same as Discord. |
+| `message_processing_mode` | string | `"per-message"` | Same as Discord. See [Message Dispatch Modes](message-dispatch-modes.md). |
+| `max_buffered_messages` | u32 | `10` | Same as Discord. |
+| `max_batch_tokens` | u32 | `24000` | Same as Discord. |
 
 ---
 
@@ -77,6 +83,9 @@ Custom Gateway adapter for platforms like Telegram, LINE, Feishu/Lark, and Googl
 | `allowed_channels` | string[] | `[]` | Chat/group IDs to allow. Only checked when `allow_all_channels` resolves to false. |
 | `allow_all_users` | bool \| omit | auto-detect | `true` = any user; `false` = only `allowed_users`. Omitted = inferred from list. |
 | `allowed_users` | string[] | `[]` | User IDs to allow. Only checked when `allow_all_users` resolves to false. |
+| `message_processing_mode` | string | `"per-message"` | Same as Discord. See [Message Dispatch Modes](message-dispatch-modes.md). |
+| `max_buffered_messages` | u32 | `10` | Same as Discord. |
+| `max_batch_tokens` | u32 | `24000` | Same as Discord. |
 
 ---
 
@@ -314,6 +323,9 @@ Key mapping (`values.yaml` → `config.toml`):
 | `agents.<name>.discord.allowBotMessages` | `[discord] allow_bot_messages` |
 | `agents.<name>.discord.trustedBotIds` | `[discord] trusted_bot_ids` |
 | `agents.<name>.discord.allowUserMessages` | `[discord] allow_user_messages` |
+| `agents.<name>.discord.messageProcessingMode` | `[discord] message_processing_mode` |
+| `agents.<name>.discord.maxBufferedMessages` | `[discord] max_buffered_messages` |
+| `agents.<name>.discord.maxBatchTokens` | `[discord] max_batch_tokens` |
 | `agents.<name>.slack.*` | `[slack] *` (same pattern) |
 | `agents.<name>.pool.maxSessions` | `[pool] max_sessions` |
 | `agents.<name>.pool.sessionTtlHours` | `[pool] session_ttl_hours` |


### PR DESCRIPTION
## Summary

Adds the following fields to `docs/config-reference.md` under `[discord]`, `[slack]`, and `[gateway]` sections:

- `message_processing_mode` — `"per-message"" | "per-thread" | "per-lane"`
- `max_buffered_messages` — default 10
- `max_batch_tokens` — default 24000

Also adds the corresponding Helm value mappings (`messageProcessingMode`, `maxBufferedMessages`, `maxBatchTokens`).

These fields are already documented in `docs/message-dispatch-modes.md` and implemented in `src/config.rs`, but were missing from the single-page config reference.

## What was tested

- Verified fields exist in source code (`src/config.rs`) and Helm templates (`charts/openab/templates/configmap.yaml`)
- Cross-referenced defaults with `docs/message-dispatch-modes.md`