### PR TITLE
chore: ignore .claude/ and .claude.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 /target
+gateway/target/
 config.toml
 *.swp
 .DS_Store
 .env
 .kiro/
+
+# Claude Code (https://claude.ai/code)
 CLAUDE.md
-gateway/target/
+.claude/
+.claude.local.md


### PR DESCRIPTION
## Summary
- Add `.claude/` and `.claude.local.md` to `.gitignore`

## Changes
- `.gitignore`: two new entries to exclude Claude Code session files

These paths are generated by Claude Code and contain personal session state, worktrees, and local settings. They are developer-specific and should not be committed to the repository.

## Test plan
- [ ] Verify `.claude/` and `.claude.local.md` no longer appear in `git status` output after this change


Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404/1505576771255533628

Generated with Claude Code
