### PR TITLE
feat(chart): add gateway.colocated single-pod mode

### DIFF
--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -126,6 +126,162 @@ spec:
       {{- with $cfg.extraContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if eq (($cfg.gateway).colocated | toString) "true" }}
+      {{- $gwCfg := omit $cfg "nameOverride" }}
+      {{- $gwD := dict "ctx" $ "agent" (printf "%s-gateway" $name) "cfg" $gwCfg }}
+      {{- $hasTelegram := (($cfg.gateway).telegram).botToken }}
+      {{- $hasLine := (($cfg.gateway).line).channelSecret }}
+      {{- $hasTeams := and (($cfg.gateway).teams).appId (($cfg.gateway).teams).appSecret }}
+      {{- $hasFeishu := and (($cfg.gateway).feishu).appId (($cfg.gateway).feishu).appSecret }}
+      {{- $hasGoogleChat := or (($cfg.gateway).googleChat).saKeyJson (($cfg.gateway).googleChat).accessToken (($cfg.gateway).googleChat).audience }}
+      {{- $hasWecom := and (($cfg.gateway).wecom).corpId (($cfg.gateway).wecom).agentId (($cfg.gateway).wecom).secret (($cfg.gateway).wecom).token (($cfg.gateway).wecom).encodingAesKey }}
+        - name: gateway
+          image: {{ printf "%s:%s" (($cfg.gateway).image | default "ghcr.io/openabdev/openab-gateway") (($cfg.gateway).tag | default $.Chart.AppVersion) }}
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          {{- with $.Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            {{- if ($cfg.gateway).token }}
+            - name: GATEWAY_WS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $d }}
+                  key: gateway-ws-token
+            {{- end }}
+            {{- if $hasTelegram }}
+            - name: TELEGRAM_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $gwD }}
+                  key: telegram-bot-token
+            {{- if (($cfg.gateway).telegram).secretToken }}
+            - name: TELEGRAM_SECRET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $gwD }}
+                  key: telegram-secret-token
+            {{- end }}
+            {{- if (($cfg.gateway).telegram).webhookPath }}
+            - name: TELEGRAM_WEBHOOK_PATH
+              value: {{ (($cfg.gateway).telegram).webhookPath | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if $hasLine }}
+            - name: LINE_CHANNEL_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $gwD }}
+                  key: line-channel-secret
+            {{- if (($cfg.gateway).line).channelAccessToken }}
+            - name: LINE_CHANNEL_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $gwD }}
+                  key: line-channel-access-token
+            {{- end }}
+            {{- end }}
+            {{- if $hasTeams }}
+            - name: TEAMS_APP_ID
+              value: {{ ($cfg.gateway).teams.appId | quote }}
+            - name: TEAMS_APP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $gwD }}
+                  key: teams-app-secret
+            {{- if ($cfg.gateway).teams.oauthEndpoint }}
+            - name: TEAMS_OAUTH_ENDPOINT
+              value: {{ ($cfg.gateway).teams.oauthEndpoint | quote }}
+            {{- end }}
+            {{- if ($cfg.gateway).teams.allowedTenants }}
+            - name: TEAMS_ALLOWED_TENANTS
+              value: {{ ($cfg.gateway).teams.allowedTenants | join "," | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if $hasFeishu }}
+            - name: FEISHU_APP_ID
+              value: {{ ($cfg.gateway).feishu.appId | quote }}
+            - name: FEISHU_APP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $gwD }}
+                  key: feishu-app-secret
+            {{- if ($cfg.gateway).feishu.domain }}
+            - name: FEISHU_DOMAIN
+              value: {{ ($cfg.gateway).feishu.domain | quote }}
+            {{- end }}
+            {{- if ($cfg.gateway).feishu.connectionMode }}
+            - name: FEISHU_CONNECTION_MODE
+              value: {{ ($cfg.gateway).feishu.connectionMode | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if $hasGoogleChat }}
+            - name: GOOGLE_CHAT_ENABLED
+              value: "true"
+            {{- if (($cfg.gateway).googleChat).audience }}
+            - name: GOOGLE_CHAT_AUDIENCE
+              value: {{ ($cfg.gateway).googleChat.audience | quote }}
+            {{- end }}
+            {{- if (($cfg.gateway).googleChat).saKeyJson }}
+            - name: GOOGLE_CHAT_SA_KEY_JSON
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $gwD }}
+                  key: google-chat-sa-key-json
+            {{- end }}
+            {{- end }}
+            {{- if $hasWecom }}
+            - name: WECOM_CORP_ID
+              value: {{ ($cfg.gateway).wecom.corpId | quote }}
+            - name: WECOM_AGENT_ID
+              value: {{ ($cfg.gateway).wecom.agentId | quote }}
+            - name: WECOM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $gwD }}
+                  key: wecom-secret
+            - name: WECOM_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $gwD }}
+                  key: wecom-token
+            - name: WECOM_ENCODING_AES_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab.agentFullname" $gwD }}
+                  key: wecom-encoding-aes-key
+            {{- end }}
+            - name: RUST_LOG
+              value: {{ ($cfg.gateway).rustLog | default "info" | quote }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          {{- with ($cfg.gateway).resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with ($cfg.gateway).extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with ($cfg.gateway).extraContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
       {{- with $cfg.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -151,6 +307,11 @@ spec:
           emptyDir: {}
         {{- with $cfg.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if eq (($cfg.gateway).colocated | toString) "true" }}
+        {{- with ($cfg.gateway).extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openab/templates/gateway-secret.yaml
+++ b/charts/openab/templates/gateway-secret.yaml
@@ -1,6 +1,6 @@
 {{- range $name, $cfg := .Values.agents }}
 {{- if and (ne (include "openab.agentEnabled" $cfg) "false") (($cfg.gateway).enabled) }}
-{{- if ne (($cfg.gateway).deploy | toString) "false" }}
+{{- if or (ne (($cfg.gateway).deploy | toString) "false") (eq (($cfg.gateway).colocated | toString) "true") }}
 {{- $gwCfg := omit $cfg "nameOverride" }}
 {{- $d := dict "ctx" $ "agent" (printf "%s-gateway" $name) "cfg" $gwCfg }}
 {{- $hasTeams := and (($cfg.gateway).teams).appId (($cfg.gateway).teams).appSecret }}

--- a/charts/openab/templates/gateway.yaml
+++ b/charts/openab/templates/gateway.yaml
@@ -1,6 +1,6 @@
 {{- range $name, $cfg := .Values.agents }}
 {{- if and (ne (include "openab.agentEnabled" $cfg) "false") ($cfg.gateway).enabled }}
-{{- if ne (($cfg.gateway).deploy | toString) "false" }}
+{{- if and (ne (($cfg.gateway).deploy | toString) "false") (ne (($cfg.gateway).colocated | toString) "true") }}
 {{- $gwCfg := omit $cfg "nameOverride" }}
 {{- $d := dict "ctx" $ "agent" (printf "%s-gateway" $name) "cfg" $gwCfg }}
 {{- $agentD := dict "ctx" $ "agent" $name "cfg" $cfg }}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -293,6 +293,7 @@ agents:
     gateway:
       enabled: false    # set to true + provide url to enable the [gateway] config block
       deploy: true      # set to false to skip Gateway Deployment/Service (config-only mode)
+      colocated: false  # set to true to run gateway as a sidecar in the agent pod (single-pod mode)
       url: ""           # e.g. ws://openab-gateway:8080/ws
       platform: "telegram"  # default platform when gateway is enabled
       token: ""         # optional shared secret (injected via GATEWAY_WS_TOKEN env var)


### PR DESCRIPTION
## Summary

Adds `gateway.colocated: true` option that runs the gateway container and its `extraContainers` (e.g. cloudflared) as sidecars in the agent pod, instead of creating a separate Deployment + Service.

Discord Discussion URL: https://discord.com/channels/1490282656913559673/1506041401740103774

## Motivation

For simple single-agent setups (e.g. one Telegram bot on K3s), running everything in one pod is simpler:
- 1 pod instead of 2
- No Service needed — OAB connects to gateway via `ws://localhost:8080/ws`
- Shared lifecycle for all components

See: `docs/refarch/telegram-cloudflare-tunnel.md`

## Usage

```yaml
agents:
  kiro:
    gateway:
      enabled: true
      colocated: true
      url: "ws://localhost:8080/ws"
      platform: "telegram"
      telegram:
        botToken: "..."
      extraContainers:
        - name: cloudflared
          image: cloudflare/cloudflared:2024.12.2
          args: ["tunnel", "--no-autoupdate", "run"]
          env:
            - name: TUNNEL_TOKEN
              value: "..."
```

## What changed

- `deployment.yaml`: when `colocated=true`, injects gateway container + gateway.extraContainers into the agent pod
- `gateway.yaml`: skips Deployment + Service when `colocated=true`
- `gateway-secret.yaml`: still renders the Secret for colocated mode
- `values.yaml`: documents the new `colocated: false` default

## Backward compatible

- Default is `colocated: false` — existing deployments are unaffected
- Non-colocated mode verified to render identically

Closes #847