### PR TITLE
docs(adr): ECS Control Plane — CRD+Operator pattern

### DIFF
--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -114,34 +114,45 @@ spec:
 
 FARGATE_SPOT is suitable for stateless agents that can tolerate interruption (OAB reconnects automatically). For agents with long-running sessions or strict SLA requirements, use FARGATE.
 
-### Secrets (OAuth / API Keys)
+### Secrets & Bot Provisioning
 
-Each agent owns its own bot token and credentials — no shared secrets across services. Secrets are stored in SSM Parameter Store (or Secrets Manager) and referenced by path in the manifest:
+Each agent owns its own bot token. The controller **provisions** the Discord bot token automatically by calling the Discord API, then stores it in AWS Secrets Manager.
 
 ```yaml
 spec:
+  channel:
+    type: discord
+    applicationId: "1234567890"    # Discord Application ID (pre-created)
   secrets:
-    - name: DISCORD_TOKEN
-      valueFrom: /oab/prod/my-agent/discord-token
     - name: OPENAI_API_KEY
-      valueFrom: /oab/prod/my-agent/openai-key
+      valueFrom: /oab/prod/my-agent/openai-key   # operator-managed
 ```
 
-The controller maps these to ECS task definition `secrets` (injected at runtime, never stored in S3):
+**Controller-managed secrets (auto-provisioned):**
 
-```json
-{
-  "secrets": [
-    { "name": "DISCORD_TOKEN", "valueFrom": "arn:aws:ssm:us-east-1:123456789:parameter/oab/prod/my-agent/discord-token" }
-  ]
-}
+On first `oabctl apply`, the controller:
+1. Calls Discord API to generate/reset the bot token for the given `applicationId`
+2. Stores the token in Secrets Manager at `oab/{namespace}/{name}/discord-token`
+3. References it in the ECS task definition `secrets` field
+
 ```
+oabctl apply -f my-agent.yaml
+  → Controller detects new OABService
+  → POST https://discord.com/api/v10/applications/{id}/bot/reset
+  → secretsmanager:CreateSecret → oab/prod/my-agent/discord-token
+  → RegisterTaskDefinition (with secret reference)
+  → CreateService
+```
+
+**Operator-managed secrets (manual):**
+
+Non-bot secrets (API keys, model credentials) are managed by the operator via AWS console/CLI and referenced by path in `spec.secrets`.
 
 Design principles:
-- **One bot token per agent** — no shared credentials, no routing complexity
-- **Controller references only** — it never reads, creates, or rotates secrets
-- **Operator manages secret lifecycle** — via AWS console, CLI, or Terraform
-- **Naming convention**: `/oab/{namespace}/{service-name}/{secret-name}`
+- **Bot token = controller-managed** — provisioned via Discord API, stored in Secrets Manager, rotated by controller
+- **API keys = operator-managed** — stored in SSM/Secrets Manager by operator, referenced by path
+- **Naming convention**: `oab/{namespace}/{service-name}/{secret-name}`
+- **No secrets in S3** — manifests never contain secret values, only references or application IDs
 
 ---
 

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -328,7 +328,8 @@ spec:
 ### Rules
 
 - `platform:` is optional. If omitted, controller uses its own defaults.
-- Controller **ignores** unknown platform keys (ECS controller skips `platform.k8s`, and vice versa).
+- Controller **strict-validates** its own platform key (e.g., ECS controller rejects invalid `platform.ecs.*` fields with an error).
+- Controller **ignores** other platform keys entirely (ECS controller skips `platform.k8s`, and vice versa).
 - Core spec fields (`cpu`, `memory`, `config`, `secrets`) are mandatory and cross-platform.
 - `OABFleet` also supports `platform:` at both `defaults` and per-agent level.
 
@@ -347,27 +348,30 @@ The controller does **not** mount config into containers (ECS/Fargate has no sha
 
 ```
 oabctl apply -f agent.yaml
-  → writes manifest to S3 (manifests/{ns}/{name}.yaml)
+  → writes manifest to S3 (manifests/{ns}/{name}.yaml, generation incremented)
 
 Controller reconcile:
   → reads spec.config from manifest
   → renders config.toml
-  → writes to s3://oab-control-plane/artifacts/{ns}/{name}/config.toml
-  → registers new ECS TaskDefinition (or forces new deployment)
+  → writes to s3://oab-control-plane/artifacts/{ns}/{name}/{generation}/config.toml (immutable)
+  → registers new ECS TaskDefinition with env CONFIG_ARTIFACT_PATH pinned to this generation
+  → updates ECS Service (rolling deployment)
 
 ECS Task startup (entrypoint wrapper):
-  → s3:GetObject artifacts/{ns}/{name}/config.toml → /home/agent/config.toml
-  → s3:GetObject ${bootstrapFrom} → tar xzf → /home/agent/ (mutable state only)
+  → s3:GetObject ${CONFIG_ARTIFACT_PATH} → /home/agent/config.toml
+  → s3:GetObject ${BOOTSTRAP_FROM} → tar xzf → /home/agent/ (mutable state only)
   → exec openab
 ```
+
+Config artifacts are **immutable per generation** — once written, never overwritten. During rolling updates, old tasks keep fetching their pinned generation while new tasks use the new one.
 
 ### Entrypoint Wrapper
 
 ```bash
 #!/bin/bash
 set -e
-# Download controller-rendered config
-aws s3 cp "s3://oab-control-plane/artifacts/${NAMESPACE}/${NAME}/config.toml" /home/agent/config.toml
+# Download controller-rendered config (pinned to specific generation)
+aws s3 cp "$CONFIG_ARTIFACT_PATH" /home/agent/config.toml
 # Restore mutable state (memory, knowledge base) if bootstrapFrom is set
 if [ -n "$BOOTSTRAP_FROM" ]; then
   aws s3 cp "$BOOTSTRAP_FROM" /tmp/bootstrap.tar.gz
@@ -481,7 +485,8 @@ spec:
 s3://oab-control-plane/
   ├── manifests/{namespace}/{name}.yaml     ← desired state (oabctl writes)
   ├── status/{namespace}/{name}.json        ← observed state (controller writes)
-  └── artifacts/{namespace}/{name}/         ← rendered config.toml (controller writes)
+  └── artifacts/{namespace}/{name}/{generation}/  ← immutable config per generation
+        └── config.toml
 ```
 
 | Concern | Mechanism | Rationale |

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -150,6 +150,112 @@ spec:
       valueFrom: /oab/prod/my-agent/openai-key
 ```
 
+### Example: Multi-Agent Fleet (5 Kiro + 3 CC + 2 Codex)
+
+```
+agents/
+├── kiro-01.yaml ... kiro-05.yaml
+├── cc-01.yaml ... cc-03.yaml
+└── codex-01.yaml ... codex-02.yaml
+```
+
+```yaml
+# agents/kiro-01.yaml
+apiVersion: oab.dev/v1
+kind: OABService
+metadata:
+  name: kiro-01
+  namespace: prod
+spec:
+  replicas: 1
+  capacityProvider: FARGATE_SPOT
+  cpu: 256
+  memory: 512
+  taskDefinition:
+    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
+  bootstrapFrom: s3://oab-backups/agents/kiro-01/latest.tar.gz
+  networking:
+    subnets: [subnet-aaa, subnet-bbb]
+    securityGroups: [sg-oab]
+```
+
+```yaml
+# agents/cc-01.yaml
+apiVersion: oab.dev/v1
+kind: OABService
+metadata:
+  name: cc-01
+  namespace: prod
+spec:
+  replicas: 1
+  capacityProvider: FARGATE_SPOT
+  cpu: 512
+  memory: 1024
+  taskDefinition:
+    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
+  bootstrapFrom: s3://oab-backups/agents/cc-01/latest.tar.gz
+  networking:
+    subnets: [subnet-aaa, subnet-bbb]
+    securityGroups: [sg-oab]
+```
+
+```yaml
+# agents/codex-01.yaml
+apiVersion: oab.dev/v1
+kind: OABService
+metadata:
+  name: codex-01
+  namespace: prod
+spec:
+  replicas: 1
+  capacityProvider: FARGATE_SPOT
+  cpu: 1024
+  memory: 2048
+  taskDefinition:
+    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
+  bootstrapFrom: s3://oab-backups/agents/codex-01/latest.tar.gz
+  networking:
+    subnets: [subnet-aaa, subnet-bbb]
+    securityGroups: [sg-oab]
+```
+
+Deploy all 10 agents:
+
+```bash
+$ oabctl apply -f agents/
+
+✓ kiro-01  applied (FARGATE_SPOT, 256cpu/512mem)
+✓ kiro-02  applied (FARGATE_SPOT, 256cpu/512mem)
+✓ kiro-03  applied (FARGATE_SPOT, 256cpu/512mem)
+✓ kiro-04  applied (FARGATE_SPOT, 256cpu/512mem)
+✓ kiro-05  applied (FARGATE_SPOT, 256cpu/512mem)
+✓ cc-01    applied (FARGATE_SPOT, 512cpu/1024mem)
+✓ cc-02    applied (FARGATE_SPOT, 512cpu/1024mem)
+✓ cc-03    applied (FARGATE_SPOT, 512cpu/1024mem)
+✓ codex-01 applied (FARGATE_SPOT, 1024cpu/2048mem)
+✓ codex-02 applied (FARGATE_SPOT, 1024cpu/2048mem)
+
+10 services reconciled.
+```
+
+```bash
+$ oabctl get oabservice
+
+NAME       NAMESPACE  CPU   MEM   CAPACITY      STATUS   AGE
+kiro-01    prod       256   512   FARGATE_SPOT  Running  2m
+kiro-02    prod       256   512   FARGATE_SPOT  Running  2m
+kiro-03    prod       256   512   FARGATE_SPOT  Running  2m
+kiro-04    prod       256   512   FARGATE_SPOT  Running  2m
+kiro-05    prod       256   512   FARGATE_SPOT  Running  2m
+cc-01      prod       512   1024  FARGATE_SPOT  Running  2m
+cc-02      prod       512   1024  FARGATE_SPOT  Running  2m
+cc-03      prod       512   1024  FARGATE_SPOT  Running  2m
+codex-01   prod       1024  2048  FARGATE_SPOT  Running  1m
+codex-02   prod       1024  2048  FARGATE_SPOT  Running  1m
+```
+
+Each agent's identity (bot token, steering, backend config) lives in its own `bootstrapFrom` archive. The manifest only manages infrastructure.
+
 ---
 
 ## 4. State Store Design (S3-Only)

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -64,11 +64,10 @@ metadata:
 spec:
   replicas: 2
   capacityProvider: FARGATE        # FARGATE (default) or FARGATE_SPOT
-  size: small                      # small | medium | large | custom
+  cpu: 256                         # vCPU units (256 = 0.25 vCPU)
+  memory: 512                      # MB
   taskDefinition:
     image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
-    cpu: 256                       # override when size=custom
-    memory: 512                    # override when size=custom
   bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
   networking:
     subnets: [subnet-abc, subnet-def]
@@ -78,29 +77,17 @@ spec:
 
 Key fields:
 - `spec.capacityProvider` — `FARGATE` (default, on-demand) or `FARGATE_SPOT` (up to 70% cost savings, with interruption risk)
-- `spec.size` — predefined instance sizes (see table below); use `custom` to set cpu/memory directly
-- `spec.taskDefinition` — maps directly to ECS RegisterTaskDefinition
+- `spec.cpu` / `spec.memory` — maps directly to ECS task definition (must be a valid Fargate combination)
+- `spec.taskDefinition` — container image and optional overrides
 - `spec.bootstrapFrom` — S3 path to agent HOME archive (contains config, OAuth, steering, memory)
 - `spec.networking` — ECS awsvpc configuration
 
 The manifest only manages **infrastructure** (container, compute, networking). Agent-level config (backend, model, channels, steering) lives inside the bootstrap archive's `config.toml`.
 
-### Instance Sizes
-
-| Size | vCPU | Memory | Use Case |
-|------|------|--------|----------|
-| `small` | 256 (.25 vCPU) | 512 MB | Lightweight agents, low traffic |
-| `medium` | 512 (.5 vCPU) | 1024 MB | Standard workloads |
-| `large` | 1024 (1 vCPU) | 2048 MB | High-throughput or multi-backend |
-| `xlarge` | 2048 (2 vCPU) | 4096 MB | Heavy compute, large context |
-| `custom` | user-defined | user-defined | Full control via cpu/memory fields |
-
-When `size` is set to a named value, `cpu` and `memory` in `taskDefinition` are ignored. When `size=custom`, `cpu` and `memory` are required.
-
-### Capacity Provider Strategy
+### Capacity Provider
 
 ```yaml
-# Cost-optimized: prefer spot, fall back to on-demand
+# Cost-optimized: spot instances, tolerates interruption
 spec:
   capacityProvider: FARGATE_SPOT
 
@@ -109,7 +96,7 @@ spec:
   capacityProvider: FARGATE
 ```
 
-FARGATE_SPOT is suitable for stateless agents that can tolerate interruption (OAB reconnects automatically). For agents with long-running sessions or strict SLA requirements, use FARGATE.
+FARGATE_SPOT is suitable for stateless agents that can tolerate interruption (OAB reconnects automatically). For agents with strict SLA requirements, use FARGATE.
 
 ### Bootstrap & Agent HOME
 

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -46,14 +46,25 @@ This enables a "GitOps for ECS" workflow where pushing a YAML change triggers th
 
 1. Load all YAML manifests from S3 (desired state)
 2. Describe current ECS services/tasks (observed state)
-3. Compute diff
+3. Compute diff (compare `metadata.generation` vs `status.observedGeneration`)
 4. Apply changes: create, update, or delete ECS resources
-5. Write status back to S3 (separate prefix)
+5. Write status back to S3 (separate prefix), set `status.observedGeneration = metadata.generation`
 6. Sleep / wait for next event
 
 ---
 
 ## 3. Manifest Schema
+
+### API Identity (fixed)
+
+| Field | Value |
+|-------|-------|
+| `apiVersion` | `oab.dev/v1` |
+| `kind` | `OABService` |
+
+All examples in this ADR use this identity. No other combinations (`openab.dev/v1`, `AgentDeployment`) are valid.
+
+### Full Example
 
 ```yaml
 apiVersion: oab.dev/v1
@@ -61,450 +72,160 @@ kind: OABService
 metadata:
   name: my-agent
   namespace: prod
+  generation: 4                    # incremented by oabctl on each apply
 spec:
-  replicas: 2
+  replicas: 1
   capacityProvider: FARGATE        # FARGATE (default) or FARGATE_SPOT
   cpu: 256                         # vCPU units (256 = 0.25 vCPU)
   memory: 512                      # MB
   taskDefinition:
     image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
-  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
+  bootstrapFrom: s3://oab-state/agents/my-agent/latest.tar.gz
+  secrets:
+    - name: DISCORD_BOT_TOKEN
+      source: ssm
+      path: /oab/my-agent/discord-token
+    - name: LLM_API_KEY
+      source: secretsmanager
+      arn: arn:aws:secretsmanager:us-east-1:123:secret:oab/my-agent/llm-key
   networking:
     subnets: [subnet-abc, subnet-def]
     securityGroups: [sg-123]
     assignPublicIp: false
   config:
-    channels:
-      - type: discord
-        guild_id: "1490282656913559673"
-    backend:
-      type: bedrock
-      model_id: anthropic.claude-sonnet-4-20250514
-      region: us-east-1
-    steering:
-      system_prompt: "You are 超渡法師(Kiro), an OpenAB agent..."
-    features:
-      stt: true
-      cronjob: true
-```
-
-Key fields:
-- `spec.capacityProvider` — `FARGATE` (default, on-demand) or `FARGATE_SPOT` (up to 70% cost savings, with interruption risk)
-- `spec.cpu` / `spec.memory` — maps directly to ECS task definition (must be a valid Fargate combination)
-- `spec.taskDefinition` — container image and optional overrides
-- `spec.bootstrapFrom` — S3 path to agent HOME archive (contains OAuth tokens, memory, scripts)
-- `spec.networking` — ECS awsvpc configuration
-- `spec.config` — structured agent configuration (channels, backend, steering, features); controller validates and generates `config.toml`
-
-The manifest manages both **infrastructure** and **agent configuration**. On reconcile, the controller generates `config.toml` from `spec.config` and injects it into the running task.
-
-### Config Reconciliation
-
-| Change | Controller Action |
-|--------|-------------------|
-| `spec.config` changed | Generate new config.toml → write to agent's config volume → restart task |
-| `spec.cpu/memory/capacityProvider` changed | New task definition revision → UpdateService (rolling restart) |
-| `spec.bootstrapFrom` changed | Next task start uses new archive |
-| Infra + config changed together | Single rolling restart with both changes applied |
-
-`spec.config` takes precedence over any config.toml in the bootstrap archive. Bootstrap provides the initial HOME state; `spec.config` is the live desired state for configuration.
-
-### Capacity Provider
-
-```yaml
-# Cost-optimized: spot instances, tolerates interruption
-spec:
-  capacityProvider: FARGATE_SPOT
-
-# Production: guaranteed capacity
-spec:
-  capacityProvider: FARGATE
-```
-
-FARGATE_SPOT is suitable for stateless agents that can tolerate interruption (OAB reconnects automatically). For agents with strict SLA requirements, use FARGATE.
-
-### Bootstrap & Agent HOME
-
-Each agent's HOME directory (containing OAuth tokens, config, steering, memory) is restored from an S3 archive on startup via `bootstrapFrom`:
-
-```yaml
-spec:
-  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
-```
-
-**Startup flow:**
-
-```
-ECS Task starts
-  → init: s3:GetObject ${bootstrapFrom}
-  → init: tar xzf → $HOME/
-  → OAB process starts with fully populated HOME
-       ├── config.toml
-       ├── .oauth/discord-token
-       ├── steering/
-       └── memory/
-```
-
-**What's in the bootstrap archive:**
-- OAuth tokens (Discord bot token, Slack OAuth, etc.)
-- `config.toml` (channel bindings, backend config)
-- Steering files (personality, system prompts)
-- Memory / knowledge base snapshots
-- Any agent-specific tooling or scripts
-
-**Lifecycle:**
-
-| Event | Action |
-|-------|--------|
-| First deploy | Operator prepares bootstrap archive manually or via `oabctl snapshot` |
-| Redeploy / scale-out | New tasks restore from same `bootstrapFrom` path |
-| Agent state changes | Periodic `oabctl snapshot my-agent` → uploads new archive to S3 |
-| Disaster recovery | Point `bootstrapFrom` to any previous snapshot |
-
-**Secrets handling:**
-- OAuth tokens live inside the bootstrap archive (encrypted at rest via S3 SSE-KMS)
-- No need for controller to call Discord API or manage Secrets Manager
-- The S3 bucket + KMS key policy controls who can access the tokens
-- Optional: `spec.secrets` still available for additional runtime secrets (API keys not in HOME)
-
-```yaml
-spec:
-  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
-  secrets:                              # optional, for secrets not in bootstrap
-    - name: OPENAI_API_KEY
-      valueFrom: /oab/prod/my-agent/openai-key
-```
-
-### Example: Multi-Agent Fleet (5 Kiro + 3 CC + 2 Codex)
-
-```
-agents/
-├── kiro-01.yaml ... kiro-05.yaml
-├── cc-01.yaml ... cc-03.yaml
-└── codex-01.yaml ... codex-02.yaml
-```
-
-```yaml
-# agents/kiro-01.yaml
-apiVersion: oab.dev/v1
-kind: OABService
-metadata:
-  name: kiro-01
-  namespace: prod
-spec:
-  replicas: 1
-  capacityProvider: FARGATE_SPOT
-  cpu: 256
-  memory: 512
-  taskDefinition:
-    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
-  bootstrapFrom: s3://oab-backups/agents/kiro-01/latest.tar.gz
-  networking:
-    subnets: [subnet-aaa, subnet-bbb]
-    securityGroups: [sg-oab]
-```
-
-```yaml
-# agents/cc-01.yaml
-apiVersion: oab.dev/v1
-kind: OABService
-metadata:
-  name: cc-01
-  namespace: prod
-spec:
-  replicas: 1
-  capacityProvider: FARGATE_SPOT
-  cpu: 512
-  memory: 1024
-  taskDefinition:
-    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
-  bootstrapFrom: s3://oab-backups/agents/cc-01/latest.tar.gz
-  networking:
-    subnets: [subnet-aaa, subnet-bbb]
-    securityGroups: [sg-oab]
-```
-
-```yaml
-# agents/codex-01.yaml
-apiVersion: oab.dev/v1
-kind: OABService
-metadata:
-  name: codex-01
-  namespace: prod
-spec:
-  replicas: 1
-  capacityProvider: FARGATE_SPOT
-  cpu: 1024
-  memory: 2048
-  taskDefinition:
-    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
-  bootstrapFrom: s3://oab-backups/agents/codex-01/latest.tar.gz
-  networking:
-    subnets: [subnet-aaa, subnet-bbb]
-    securityGroups: [sg-oab]
-```
-
-Deploy all 10 agents:
-
-```bash
-$ oabctl apply -f agents/
-
-✓ kiro-01  applied (FARGATE_SPOT, 256cpu/512mem)
-✓ kiro-02  applied (FARGATE_SPOT, 256cpu/512mem)
-✓ kiro-03  applied (FARGATE_SPOT, 256cpu/512mem)
-✓ kiro-04  applied (FARGATE_SPOT, 256cpu/512mem)
-✓ kiro-05  applied (FARGATE_SPOT, 256cpu/512mem)
-✓ cc-01    applied (FARGATE_SPOT, 512cpu/1024mem)
-✓ cc-02    applied (FARGATE_SPOT, 512cpu/1024mem)
-✓ cc-03    applied (FARGATE_SPOT, 512cpu/1024mem)
-✓ codex-01 applied (FARGATE_SPOT, 1024cpu/2048mem)
-✓ codex-02 applied (FARGATE_SPOT, 1024cpu/2048mem)
-
-10 services reconciled.
-```
-
-```bash
-$ oabctl get oabservice
-
-NAME       NAMESPACE  CPU   MEM   CAPACITY      STATUS   AGE
-kiro-01    prod       256   512   FARGATE_SPOT  Running  2m
-kiro-02    prod       256   512   FARGATE_SPOT  Running  2m
-kiro-03    prod       256   512   FARGATE_SPOT  Running  2m
-kiro-04    prod       256   512   FARGATE_SPOT  Running  2m
-kiro-05    prod       256   512   FARGATE_SPOT  Running  2m
-cc-01      prod       512   1024  FARGATE_SPOT  Running  2m
-cc-02      prod       512   1024  FARGATE_SPOT  Running  2m
-cc-03      prod       512   1024  FARGATE_SPOT  Running  2m
-codex-01   prod       1024  2048  FARGATE_SPOT  Running  1m
-codex-02   prod       1024  2048  FARGATE_SPOT  Running  1m
-```
-
-Each agent's identity (bot token, steering, backend config) lives in its own `bootstrapFrom` archive. The manifest only manages infrastructure.
-
-### Structured config.toml
-
-Instead of relying solely on the bootstrap archive for `config.toml`, the spec models it structurally. The controller renders the YAML into a valid `config.toml` and mounts it into the container.
-
-```yaml
-apiVersion: oab.dev/v1
-kind: OABService
-metadata:
-  name: chaodu
-  namespace: prod
-spec:
-  config:
     agent:
-      name: chaodu
-      backend: kiro
-      workingDir: /home/agent
+      name: my-agent
+      backend: bedrock
       model: us.anthropic.claude-sonnet-4-20250514
     discord:
       enabled: true
-      botId: "1490365068863606784"
-      guildId: "1490282656913559672"
-      channelIds:
-        - "1490282656913559673"
-    telegram:
-      enabled: false
+      botId: "123456789"
+      guildId: "987654321"
+      channelIds: ["111111111"]
     steering:
       source: s3
       bucket: oab-steering
-      prefix: agents/chaodu/
+      prefix: agents/my-agent/
     memory:
       backend: s3
       bucket: oab-memory
-      prefix: agents/chaodu/
+      prefix: agents/my-agent/
     tools:
-      github:
-        enabled: true
-      web:
-        enabled: true
+      github: { enabled: true }
+      web: { enabled: true }
+status:
+  phase: Running                   # Pending | Running | Failed | Terminating
+  observedGeneration: 4            # last generation the controller reconciled
+  taskArns:
+    - arn:aws:ecs:us-east-1:123456789012:task/cluster/abc123
+  lastReconciled: "2026-05-18T22:50:00Z"
+  conditions:
+    - type: Available
+      status: "True"
+      lastTransitionTime: "2026-05-18T22:50:00Z"
 ```
 
-**Controller renders to config.toml:**
+### Key Fields
 
-```toml
-[agent]
-name = "chaodu"
-backend = "kiro"
-working_dir = "/home/agent"
-model = "us.anthropic.claude-sonnet-4-20250514"
+| Field | Description |
+|-------|-------------|
+| `metadata.generation` | Monotonically increasing counter, bumped by `oabctl apply` |
+| `spec.capacityProvider` | `FARGATE` (on-demand) or `FARGATE_SPOT` (up to 70% savings, tolerates interruption) |
+| `spec.cpu` / `spec.memory` | Maps to ECS task definition (must be valid Fargate combination) |
+| `spec.taskDefinition.image` | Container image |
+| `spec.bootstrapFrom` | S3 path to mutable state archive (memory, knowledge base — **no secrets**) |
+| `spec.secrets` | Per-agent secret references (SSM / Secrets Manager) |
+| `spec.config` | Structured agent config; controller renders to `config.toml` |
+| `spec.networking` | ECS awsvpc configuration |
+| `status.observedGeneration` | Last generation the controller successfully reconciled |
 
-[discord]
-enabled = true
-bot_id = "1490365068863606784"
-guild_id = "1490282656913559672"
-channel_ids = ["1490282656913559673"]
+### Replicas Semantics
 
-[telegram]
-enabled = false
+WebSocket-based adapters (Discord, Telegram, Slack RTM) are **single-consumer** — only one instance can hold the gateway connection. Running multiple replicas would cause duplicate message processing.
 
-[steering]
-source = "s3"
-bucket = "oab-steering"
-prefix = "agents/chaodu/"
+**Rules:**
+- `replicas: 1` — default and required for WebSocket adapters
+- `replicas > 1` — only valid when all enabled adapters use **webhook mode** (HTTP-based, load-balanceable)
+- Controller **rejects** `replicas > 1` at validation time if any WebSocket adapter is enabled
 
-[memory]
-backend = "s3"
-bucket = "oab-memory"
-prefix = "agents/chaodu/"
+```yaml
+# ✅ Valid: webhook mode, can scale
+spec:
+  replicas: 3
+  config:
+    discord:
+      enabled: true
+      mode: webhook    # HTTP interactions endpoint
 
-[tools.github]
-enabled = true
-
-[tools.web]
-enabled = true
+# ❌ Rejected: websocket mode cannot scale
+spec:
+  replicas: 2
+  config:
+    discord:
+      enabled: true
+      # mode defaults to websocket → validation error
 ```
-
-**Benefits of structured config:**
-- Schema validation at `oabctl apply` time — catch typos before deploy
-- `oabctl diff` shows exactly what config changed
-- Controller can make decisions based on config (e.g., open ports for enabled adapters)
-- GitOps friendly — config changes are reviewable YAML diffs
-
-**Precedence:** `spec.config` takes priority over config.toml in `bootstrapFrom` archive. If both exist, controller merges them (spec.config wins on conflict).
 
 ---
 
-## 4. State Store Design (S3-Only)
+## 4. Config Delivery Model
 
-```
-s3://oab-control-plane/
-  ├── manifests/{namespace}/{name}.yaml   ← desired state (oabctl writes)
-  └── status/{namespace}/{name}.json      ← observed state (controller writes)
-```
+The controller does **not** mount config into containers (ECS/Fargate has no shared volume equivalent to K8s ConfigMap). Instead:
 
-| Concern | Mechanism | Rationale |
-|---------|-----------|-----------|
-| Desired state | `s3://…/manifests/` | Human-readable, git-syncable, versioned via S3 versioning |
-| Status / observed state | `s3://…/status/` | Controller writes after each reconcile cycle |
-| Generation tracking | S3 object VersionId | Each `oabctl apply` creates a new version; controller compares |
-| Change detection | S3 Event Notifications → EventBridge | Triggers controller on manifest PUT/DELETE |
-| Consistency | S3 strong read-after-write | Sufficient for single-controller architecture |
-
-**Why no DynamoDB in Phase 1:**
-- Single controller instance — no leader election needed
-- S3 strong read-after-write consistency (since Dec 2020) is sufficient
-- Fewer moving parts, zero additional infra cost
-- DDB can be added in Phase 2 for multi-replica leader election and fast status queries
-
----
-
-## 5. CLI UX (`oabctl`)
-
-### Core Commands
-
-```bash
-oabctl apply -f agent.yaml          # declare/update desired state
-oabctl get oabservice               # list all services + status
-oabctl get oabservice my-agent      # single service detail
-oabctl delete oabservice my-agent   # mark for deletion
-oabctl diff -f agent.yaml           # show local vs remote diff
-oabctl logs my-agent                # shortcut to ECS task logs
-oabctl wait my-agent --for=Available # block until condition met
-```
-
-### `apply` Semantics
-
-```
-$ oabctl apply -f prod/my-agent.yaml
-
-✓ Schema validated
-✓ Uploaded to s3://oab-control-plane/manifests/prod/my-agent.yaml
-✓ Generation: v3 → v4
-⏳ Waiting for reconciliation...
-✓ Service my-agent reconciled (2/2 tasks running)
-```
-
-Behavior:
-- Object doesn't exist → create (PUT to S3)
-- Object exists → update (PUT overwrites, new S3 version)
-- Immutable fields (namespace) → reject with error
-- `--wait=false` to skip waiting for reconciliation
-
-### `apply` Implementation (Phase 1)
+### Flow
 
 ```
 oabctl apply -f agent.yaml
-  │
-  ├─ 1. Parse & validate YAML against schema (local, fast fail)
-  ├─ 2. s3:PutObject → s3://oab-control-plane/manifests/{ns}/{name}.yaml
-  └─ 3. (if --wait) Poll status/{ns}/{name}.json until phase=Running or timeout
+  → writes manifest to S3 (manifests/{ns}/{name}.yaml)
+
+Controller reconcile:
+  → reads spec.config from manifest
+  → renders config.toml
+  → writes to s3://oab-control-plane/artifacts/{ns}/{name}/config.toml
+  → registers new ECS TaskDefinition (or forces new deployment)
+
+ECS Task startup (entrypoint wrapper):
+  → s3:GetObject artifacts/{ns}/{name}/config.toml → /home/agent/config.toml
+  → s3:GetObject ${bootstrapFrom} → tar xzf → /home/agent/ (mutable state only)
+  → exec openab
 ```
 
-No API server needed — `oabctl` talks directly to S3 via AWS SDK. Auth is standard IAM (role, profile, env vars).
+### Entrypoint Wrapper
+
+```bash
+#!/bin/bash
+set -e
+# Download controller-rendered config
+aws s3 cp "s3://oab-control-plane/artifacts/${NAMESPACE}/${NAME}/config.toml" /home/agent/config.toml
+# Restore mutable state (memory, knowledge base) if bootstrapFrom is set
+if [ -n "$BOOTSTRAP_FROM" ]; then
+  aws s3 cp "$BOOTSTRAP_FROM" /tmp/bootstrap.tar.gz
+  tar xzf /tmp/bootstrap.tar.gz -C /home/agent/
+  rm /tmp/bootstrap.tar.gz
+fi
+exec /usr/local/bin/openab
+```
+
+### What Goes Where
+
+| Content | Location | Managed By |
+|---------|----------|------------|
+| `config.toml` | S3 artifact (controller renders) | `spec.config` in manifest |
+| Secrets (bot tokens, API keys) | SSM / Secrets Manager | `spec.secrets` in manifest |
+| Memory / knowledge base | `bootstrapFrom` archive | `oabctl snapshot` |
+| Steering files | S3 (referenced in config.toml) | Separate steering bucket |
+
+**Secrets never go in the bootstrap archive.** The archive contains only mutable runtime state that the agent accumulates over time.
 
 ---
 
-## 6. Controller Lifecycle
+## 5. Per-Agent Secret Injection
 
-### Reconcile Actions
+Each agent/bot has its **own** credentials — no token sharing between agents.
 
-| Diff | Action |
-|------|--------|
-| Manifest exists, no ECS service | RegisterTaskDefinition → CreateService |
-| Manifest spec changed (new S3 version) | RegisterTaskDefinition (new revision) → UpdateService |
-| Manifest deleted from S3 | UpdateService (desiredCount=0) → DeleteService → DeregisterTaskDefinition |
-| ECS state drifted from spec | UpdateService to re-converge |
+### Design Principles
 
-### Finalizers
-
-Before deleting an ECS service, the controller:
-1. Drains active connections (set desiredCount=0, wait for task stop)
-2. Cleans up CloudMap service discovery entries
-3. Removes the status JSON from S3
-4. Only then acknowledges deletion
-
----
-
-## 7. MVP Scope
-
-### Phase 1 (minimal viable control plane)
-
-1. **S3 bucket** — manifests/ and status/ prefixes, versioning enabled
-2. **Single-instance ECS task** running the controller
-3. **Poll-based** — ListObjects + GetObject every 30s
-4. **`oabctl apply`** — validates and uploads YAML to S3
-5. **`oabctl get`** — reads status/ prefix, displays table
-6. Support `create` and `update` only (delete = manual remove from S3)
-
-### Phase 2
-
-- Event-driven triggers (S3 → EventBridge → controller wakes immediately)
-- `oabctl delete` with finalizer support
-- `oabctl diff` and `oabctl logs`
-- DynamoDB for leader election (multi-replica controller)
-- Rollback via S3 version history (`oabctl rollback my-agent --to-version=v3`)
-
-### Phase 3
-
-- Multi-region (controller per region, shared manifest bucket with replication)
-- Dependency graph (service A depends on service B)
-- Auto-scaling policies in manifest spec
-- GitOps integration (GitHub Actions → `oabctl apply` on push)
-
----
-
-## 8. Alternatives Considered
-
-| Alternative | Why not chosen |
-|-------------|---------------|
-| AWS Proton | Opinionated, limited customization for OAB-specific logic |
-| AWS Copilot | Good for simple apps, no custom reconciliation loop |
-| CDK Pipelines | Deployment tool, not a runtime controller with drift detection |
-| Step Functions orchestrator | Stateless execution model, no continuous reconciliation |
-| Run K8s anyway (EKS) | Valid but adds operational overhead for teams that chose ECS |
-| DynamoDB as primary store | Adds infra; S3 sufficient for single-controller Phase 1 |
-
----
-
-## 9. Per-Agent Secret Injection
-
-Each agent/bot has its **own** bot token and credentials — no token sharing between agents.
-
-### Design Principle
-
-- Each `AgentDeployment` owns its secrets (1:1 mapping)
+- Each `OABService` owns its secrets (1:1 mapping)
 - Controller never touches secret values — it only wires references into ECS Task Definitions
 - ECS native `secrets` field handles injection at runtime
 - IAM scoping ensures each task role can only read its own secret path
@@ -512,14 +233,10 @@ Each agent/bot has its **own** bot token and credentials — no token sharing be
 ### Spec
 
 ```yaml
-apiVersion: openab.dev/v1
-kind: AgentDeployment
-metadata:
-  name: chaodu
 spec:
   secrets:
     - name: DISCORD_BOT_TOKEN
-      source: ssm                      # ssm | secretsmanager
+      source: ssm
       path: /oab/chaodu/discord-token
     - name: LLM_API_KEY
       source: secretsmanager
@@ -537,7 +254,7 @@ spec:
      ]
    }
    ```
-2. **IAM** — controller creates/assigns a task execution role scoped to the agent's secret path:
+2. **IAM** — task execution role scoped to the agent's secret path:
    ```json
    {
      "Effect": "Allow",
@@ -548,19 +265,215 @@ spec:
      ]
    }
    ```
-3. **Rotation** — when a secret is rotated in SSM/Secrets Manager, user runs `oabctl restart <agent>` (or sets `spec.secrets.autoRestart: true`) to force a new task deployment that picks up the new value.
+
+### Secret Rotation Lifecycle
+
+```
+1. Operator rotates secret in SSM/Secrets Manager (manual or auto-rotation)
+2. Controller detects rotation:
+   - Option A: spec.secrets[].autoRestart: true → controller forces new deployment
+   - Option B: operator runs `oabctl restart my-agent`
+3. ECS launches new task → new task fetches fresh secret value at startup
+4. Old task drains and stops (ECS rolling update)
+5. Controller updates status:
+   - conditions[].type: SecretsRefreshed
+   - conditions[].lastTransitionTime: <now>
+```
+
+**Failure handling:**
+- If new task fails to start (bad secret value), ECS circuit breaker stops the rollout
+- Controller sets `status.phase: Failed`, `conditions[].type: SecretInjectionFailed`
+- Old task remains running (ECS deployment circuit breaker preserves last healthy state)
 
 ---
 
-## 10. Open Questions
+## 6. State Store Design (S3-Only)
+
+```
+s3://oab-control-plane/
+  ├── manifests/{namespace}/{name}.yaml     ← desired state (oabctl writes)
+  ├── status/{namespace}/{name}.json        ← observed state (controller writes)
+  └── artifacts/{namespace}/{name}/         ← rendered config.toml (controller writes)
+```
+
+| Concern | Mechanism | Rationale |
+|---------|-----------|-----------|
+| Desired state | `manifests/` prefix | Human-readable, git-syncable, versioned via S3 versioning |
+| Status | `status/` prefix | Controller writes after each reconcile cycle |
+| Config artifacts | `artifacts/` prefix | Controller-rendered config.toml for task startup |
+| Generation tracking | `metadata.generation` in manifest YAML | Explicit counter, not tied to S3 VersionId |
+| Change detection | S3 Event Notifications → EventBridge (Phase 2) | Phase 1 uses polling |
+| Consistency | S3 strong read-after-write | Sufficient for single-controller |
+| Optimistic locking | S3 conditional writes (If-None-Match / ETag) | Prevents concurrent `oabctl apply` conflicts |
+
+### Generation vs S3 VersionId
+
+S3 VersionId is an opaque string — not suitable for comparing "which is newer." Instead:
+- `metadata.generation` is an explicit integer, incremented by `oabctl apply`
+- `status.observedGeneration` records the last generation the controller reconciled
+- Controller skips reconcile if `observedGeneration == generation` (no-op)
+- Stale status writes are detected: if status.observedGeneration < manifest.generation, the status is outdated
+
+### Delete Semantics (Phase 2)
+
+Phase 1: `oabctl delete` removes the manifest from S3; controller detects absence and tears down ECS resources.
+
+Phase 2: Proper deletion with finalizers:
+1. `oabctl delete` sets `metadata.deletionTimestamp` in the manifest (tombstone)
+2. Controller runs finalizers (drain connections, cleanup CloudMap, remove artifacts)
+3. Controller removes manifest and status objects only after all finalizers complete
+
+---
+
+## 7. Controller Upgrade Strategy
+
+The controller runs as a single-replica ECS Service.
+
+### Phase 1 (acceptable brief gap)
+
+```yaml
+# Controller's own ECS Service config
+deploymentConfiguration:
+  minimumHealthyPercent: 0      # allow old to stop before new starts
+  maximumPercent: 100
+```
+
+- ECS rolling update: stop old → start new
+- Brief reconciliation gap (30-60s) during upgrade
+- No in-flight reconcile is lost — next cycle picks up any drift
+- Acceptable for Phase 1 because reconcile is idempotent
+
+### Phase 2 (zero-downtime)
+
+- DynamoDB-based leader election (two controller replicas)
+- Active/standby: standby takes over within seconds if active fails health check
+- Version skew handling: new controller must handle manifests written by old `oabctl` versions (schema backward compatibility)
+
+### Rollback
+
+- Controller image is pinned in its own ECS TaskDefinition
+- Rollback = `aws ecs update-service --task-definition <previous-revision>`
+- Controller state is in S3 (stateless process), so rollback is safe
+
+---
+
+## 8. CLI UX (`oabctl`)
+
+### Core Commands
+
+```bash
+oabctl apply -f agent.yaml          # declare/update desired state
+oabctl get oabservice               # list all services + status
+oabctl get oabservice my-agent      # single service detail
+oabctl delete oabservice my-agent   # remove (Phase 1: immediate; Phase 2: finalizer)
+oabctl diff -f agent.yaml           # show local vs remote diff
+oabctl logs my-agent                # shortcut to ECS task logs (CloudWatch)
+oabctl restart my-agent             # force new deployment (pick up rotated secrets)
+oabctl snapshot my-agent            # capture runtime state → bootstrapFrom archive
+oabctl wait my-agent --for=Available # block until condition met
+```
+
+### `apply` Semantics
+
+```
+$ oabctl apply -f prod/my-agent.yaml
+
+✓ Schema validated (oab.dev/v1 OABService)
+✓ Replicas check passed (replicas=1, websocket adapter)
+✓ Uploaded to s3://oab-control-plane/manifests/prod/my-agent.yaml
+✓ Generation: 3 → 4
+⏳ Waiting for reconciliation...
+✓ Service my-agent reconciled (observedGeneration=4, 1/1 tasks running)
+```
+
+### `diff` Granularity
+
+```bash
+oabctl diff -f agent.yaml              # spec-only: local YAML vs remote manifest
+oabctl diff -f agent.yaml --rendered   # rendered: show generated config.toml diff
+oabctl diff -f agent.yaml --status     # include status comparison
+```
+
+### Implementation
+
+`oabctl` talks directly to S3 via AWS SDK. No API server needed. Auth is standard IAM (role, profile, env vars). Config stored in `~/.oabctl/config`:
+
+```toml
+[default]
+region = "us-east-1"
+bucket = "oab-control-plane"
+cluster = "oab-prod"
+```
+
+---
+
+## 9. Phase Scope
+
+### Phase 1 — MVP (target)
+
+| In Scope | Out of Scope |
+|----------|--------------|
+| S3 manifest store (versioning enabled) | EventBridge triggers |
+| Single-instance controller (poll every 30s) | Multi-replica controller / leader election |
+| `oabctl apply` / `oabctl get` | `oabctl delete` with finalizers |
+| Controller renders config.toml → S3 artifact | DynamoDB state store |
+| ECS service create / update | Rollback (`oabctl rollback`) |
+| Startup wrapper downloads config + bootstrap | EFS / shared volumes |
+| `metadata.generation` / `status.observedGeneration` | Multi-region |
+| Per-agent secrets via SSM/SM | Auto-rotation detection |
+| Replicas validation (reject >1 for WS) | Auto-scaling policies |
+
+### Phase 2
+
+- Event-driven triggers (S3 → EventBridge → controller)
+- `oabctl delete` with tombstone + finalizers
+- `oabctl diff`, `oabctl logs`, `oabctl restart`
+- DynamoDB for leader election (active/standby controller)
+- Secret auto-rotation detection + auto-restart
+- Rollback via generation history
+
+### Phase 3
+
+- Multi-region (controller per region, S3 cross-region replication)
+- Dependency graph (service A depends on service B)
+- Auto-scaling policies in manifest spec
+- GitOps integration (GitHub Actions → `oabctl apply` on push)
+- Schema versioning + migration tooling
+
+---
+
+## 10. Alternatives Considered
+
+| Alternative | Why not chosen |
+|-------------|---------------|
+| AWS Proton | Opinionated, limited customization for OAB-specific logic |
+| AWS Copilot | Good for simple apps, no custom reconciliation loop |
+| CDK Pipelines | Deployment tool, not a runtime controller with drift detection |
+| Step Functions orchestrator | Stateless execution model, no continuous reconciliation |
+| Run K8s anyway (EKS) | Valid but adds operational overhead for teams that chose ECS |
+| DynamoDB as primary store | Adds infra; S3 sufficient for single-controller Phase 1 |
+
+---
+
+## 11. Open Questions
 
 1. **Multi-region** — single controller per region, or global controller with regional reconcilers?
 2. **Observability** — CloudWatch metrics from the controller, or push to a shared OAB dashboard?
-3. **Upgrade strategy** — how does the controller upgrade itself without downtime?
-4. **Networking isolation** — shared VPC or per-service security group rules?
+3. **Networking isolation** — shared VPC with per-service SG rules, or per-namespace VPC?
+4. **Schema versioning** — how to handle `oab.dev/v2` migration when spec evolves?
 
 ---
 
-## 11. Decision
+## 12. Decision
 
-We adopt the CRD + Operator pattern on ECS with an **S3-only state store** and a **`oabctl` CLI** for the operator interface. The controller runs as a single ECS service that reconciles OABService manifests (stored in S3) against actual ECS state. DynamoDB is deferred to Phase 2 when multi-replica HA is needed. This gives ECS-native teams the same declarative, self-healing deployment experience that K8s operators provide — with minimal infrastructure footprint.
+We adopt the CRD + Operator pattern on ECS with an **S3-only state store**, **explicit generation tracking**, and a **`oabctl` CLI** for the operator interface. The controller runs as a single ECS service that reconciles `OABService` manifests against actual ECS state.
+
+Key design choices:
+- **Config delivery**: controller renders `config.toml` to S3 artifact; startup wrapper downloads it
+- **Secrets**: per-agent SSM/Secrets Manager references; never in bootstrap archive
+- **Bootstrap**: mutable runtime state only (memory, knowledge base)
+- **Replicas**: validated at apply time; WebSocket adapters locked to 1
+- **Generation**: explicit `metadata.generation` / `status.observedGeneration` (not S3 VersionId)
+- **Phase 1 scope**: narrow (create/update only, poll-based, single controller)
+
+DynamoDB, EventBridge, finalizers, and multi-region are deferred to Phase 2+.

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -29,7 +29,7 @@ This enables a "GitOps for ECS" workflow where pushing a YAML change triggers th
 │                                                      │
 │  ┌────────────┐  ┌──────────────┐  ┌─────────────┐  │
 │  │ State Store│  │  Reconciler  │  │  ECS API /  │  │
-│  │ (S3 + DDB) │◄─│  Controller  │─►│  CloudMap   │  │
+│  │   (S3)     │◄─│  Controller  │─►│  CloudMap   │  │
 │  │            │  │              │  │             │  │
 │  └────────────┘  └──────────────┘  └─────────────┘  │
 │                        ▲                             │
@@ -48,7 +48,7 @@ This enables a "GitOps for ECS" workflow where pushing a YAML change triggers th
 2. Describe current ECS services/tasks (observed state)
 3. Compute diff
 4. Apply changes: create, update, or delete ECS resources
-5. Write status back to DynamoDB
+5. Write status back to S3 (separate prefix)
 6. Sleep / wait for next event
 
 ---
@@ -77,83 +77,135 @@ spec:
     subnets: [subnet-abc, subnet-def]
     securityGroups: [sg-123]
     assignPublicIp: false
-status:
-  phase: Running
-  observedGeneration: 3
-  conditions:
-    - type: Available
-      status: "True"
-      lastTransitionTime: "2026-05-18T10:00:00Z"
 ```
 
 Key fields:
 - `spec.taskDefinition` — maps directly to ECS RegisterTaskDefinition
 - `spec.backend` — OAB-specific config injected as environment/secrets
 - `spec.networking` — ECS awsvpc configuration
-- `status` — written back by the controller (stored in DDB, not in the S3 YAML)
 
 ---
 
-## 4. State Store Design
+## 4. State Store Design (S3-Only)
 
-| Concern | Store | Rationale |
-|---------|-------|-----------|
-| Desired state (manifests) | S3 | Human-readable, versioned, git-syncable |
-| Status + generation tracking | DynamoDB | Fast reads, conditional writes for optimistic concurrency |
-| Leader election lock | DynamoDB | TTL-based lease via conditional PutItem |
+```
+s3://oab-control-plane/
+  ├── manifests/{namespace}/{name}.yaml   ← desired state (oabctl writes)
+  └── status/{namespace}/{name}.json      ← observed state (controller writes)
+```
 
-S3 event notifications (→ EventBridge → SQS) trigger the controller on manifest changes. A periodic full-reconciliation (every 30–60s) catches drift from out-of-band changes.
+| Concern | Mechanism | Rationale |
+|---------|-----------|-----------|
+| Desired state | `s3://…/manifests/` | Human-readable, git-syncable, versioned via S3 versioning |
+| Status / observed state | `s3://…/status/` | Controller writes after each reconcile cycle |
+| Generation tracking | S3 object VersionId | Each `oabctl apply` creates a new version; controller compares |
+| Change detection | S3 Event Notifications → EventBridge | Triggers controller on manifest PUT/DELETE |
+| Consistency | S3 strong read-after-write | Sufficient for single-controller architecture |
+
+**Why no DynamoDB in Phase 1:**
+- Single controller instance — no leader election needed
+- S3 strong read-after-write consistency (since Dec 2020) is sufficient
+- Fewer moving parts, zero additional infra cost
+- DDB can be added in Phase 2 for multi-replica leader election and fast status queries
 
 ---
 
-## 5. Controller Lifecycle
+## 5. CLI UX (`oabctl`)
+
+### Core Commands
+
+```bash
+oabctl apply -f agent.yaml          # declare/update desired state
+oabctl get oabservice               # list all services + status
+oabctl get oabservice my-agent      # single service detail
+oabctl delete oabservice my-agent   # mark for deletion
+oabctl diff -f agent.yaml           # show local vs remote diff
+oabctl logs my-agent                # shortcut to ECS task logs
+oabctl wait my-agent --for=Available # block until condition met
+```
+
+### `apply` Semantics
+
+```
+$ oabctl apply -f prod/my-agent.yaml
+
+✓ Schema validated
+✓ Uploaded to s3://oab-control-plane/manifests/prod/my-agent.yaml
+✓ Generation: v3 → v4
+⏳ Waiting for reconciliation...
+✓ Service my-agent reconciled (2/2 tasks running)
+```
+
+Behavior:
+- Object doesn't exist → create (PUT to S3)
+- Object exists → update (PUT overwrites, new S3 version)
+- Immutable fields (namespace) → reject with error
+- `--wait=false` to skip waiting for reconciliation
+
+### `apply` Implementation (Phase 1)
+
+```
+oabctl apply -f agent.yaml
+  │
+  ├─ 1. Parse & validate YAML against schema (local, fast fail)
+  ├─ 2. s3:PutObject → s3://oab-control-plane/manifests/{ns}/{name}.yaml
+  └─ 3. (if --wait) Poll status/{ns}/{name}.json until phase=Running or timeout
+```
+
+No API server needed — `oabctl` talks directly to S3 via AWS SDK. Auth is standard IAM (role, profile, env vars).
+
+---
+
+## 6. Controller Lifecycle
 
 ### Reconcile Actions
 
 | Diff | Action |
 |------|--------|
 | Manifest exists, no ECS service | RegisterTaskDefinition → CreateService |
-| Manifest spec changed | RegisterTaskDefinition (new revision) → UpdateService |
-| Manifest deleted | UpdateService (desiredCount=0) → DeleteService → DeregisterTaskDefinition |
+| Manifest spec changed (new S3 version) | RegisterTaskDefinition (new revision) → UpdateService |
+| Manifest deleted from S3 | UpdateService (desiredCount=0) → DeleteService → DeregisterTaskDefinition |
 | ECS state drifted from spec | UpdateService to re-converge |
-
-### Leader Election
-
-When running multiple controller replicas for HA:
-- Use DynamoDB conditional writes with a TTL-based lease
-- Only the leader performs reconciliation; standbys poll for lease expiry
-- Single-replica deployments skip leader election entirely
 
 ### Finalizers
 
 Before deleting an ECS service, the controller:
 1. Drains active connections (set desiredCount=0, wait for task stop)
 2. Cleans up CloudMap service discovery entries
-3. Removes the DynamoDB status record
+3. Removes the status JSON from S3
 4. Only then acknowledges deletion
 
 ---
 
-## 6. MVP Scope
+## 7. MVP Scope
 
-Phase 1 (minimal viable control plane):
+### Phase 1 (minimal viable control plane)
 
-1. **S3 bucket** with YAML manifests (one file per OABService)
-2. **Single-instance ECS task** running the controller (no leader election)
-3. **Poll S3 every 30s**, reconcile against ECS DescribeServices
-4. **Write status** to DynamoDB table
-5. Support `create` and `update` operations only (manual delete via console)
+1. **S3 bucket** — manifests/ and status/ prefixes, versioning enabled
+2. **Single-instance ECS task** running the controller
+3. **Poll-based** — ListObjects + GetObject every 30s
+4. **`oabctl apply`** — validates and uploads YAML to S3
+5. **`oabctl get`** — reads status/ prefix, displays table
+6. Support `create` and `update` only (delete = manual remove from S3)
 
-Phase 2 additions:
-- Event-driven triggers (S3 → EventBridge → controller)
-- Multi-replica with DDB leader election
-- Delete reconciliation with finalizers
-- CLI tool for `oab apply -f manifest.yaml` (uploads to S3)
-- Rollback via manifest generation history
+### Phase 2
+
+- Event-driven triggers (S3 → EventBridge → controller wakes immediately)
+- `oabctl delete` with finalizer support
+- `oabctl diff` and `oabctl logs`
+- DynamoDB for leader election (multi-replica controller)
+- Rollback via S3 version history (`oabctl rollback my-agent --to-version=v3`)
+
+### Phase 3
+
+- Multi-region (controller per region, shared manifest bucket with replication)
+- Dependency graph (service A depends on service B)
+- Auto-scaling policies in manifest spec
+- GitOps integration (GitHub Actions → `oabctl apply` on push)
 
 ---
 
-## 7. Alternatives Considered
+## 8. Alternatives Considered
 
 | Alternative | Why not chosen |
 |-------------|---------------|
@@ -162,18 +214,20 @@ Phase 2 additions:
 | CDK Pipelines | Deployment tool, not a runtime controller with drift detection |
 | Step Functions orchestrator | Stateless execution model, no continuous reconciliation |
 | Run K8s anyway (EKS) | Valid but adds operational overhead for teams that chose ECS |
+| DynamoDB as primary store | Adds infra; S3 sufficient for single-controller Phase 1 |
 
 ---
 
-## 8. Open Questions
+## 9. Open Questions
 
-1. **Secrets management** — inject via ECS Secrets (SSM/SecretsManager) or controller-managed env vars?
-2. **Multi-region** — single controller per region, or a global controller with regional reconcilers?
+1. **Secrets management** — inject via ECS Secrets (SSM/SecretsManager reference in task def) or controller-managed?
+2. **Multi-region** — single controller per region, or global controller with regional reconcilers?
 3. **Observability** — CloudWatch metrics from the controller, or push to a shared OAB dashboard?
 4. **Upgrade strategy** — how does the controller upgrade itself without downtime?
+5. **Networking isolation** — shared VPC or per-service security group rules?
 
 ---
 
-## 9. Decision
+## 10. Decision
 
-We adopt the CRD + Operator pattern on ECS as described above. The controller will be implemented as a standalone ECS service that reconciles OABService manifests stored in S3 against actual ECS state. This gives ECS-native teams the same declarative, self-healing deployment experience that K8s operators provide, without requiring a Kubernetes cluster.
+We adopt the CRD + Operator pattern on ECS with an **S3-only state store** and a **`oabctl` CLI** for the operator interface. The controller runs as a single ECS service that reconciles OABService manifests (stored in S3) against actual ECS state. DynamoDB is deferred to Phase 2 when multi-replica HA is needed. This gives ECS-native teams the same declarative, self-healing deployment experience that K8s operators provide — with minimal infrastructure footprint.

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -252,7 +252,89 @@ The controller does **not** monitor agent health — ECS Service already maintai
 
 ---
 
-## 4. Config Delivery Model
+## 4. Multi-Runtime Support (ECS + K8s)
+
+The same YAML manifest can deploy to **both ECS and Kubernetes**. The spec is platform-agnostic; platform-specific details live in an optional `platform:` overlay.
+
+### Design Principle
+
+```
+┌─────────────────────┐
+│  oab.dev/v1 YAML    │  ← one spec, platform-agnostic core
+└──────────┬──────────┘
+           │
+    ┌──────┴──────┐
+    ▼             ▼
+┌────────┐   ┌────────┐
+│  ECS   │   │  K8s   │
+│Controller│   │Operator│
+└────┬───┘   └────┬───┘
+     ▼             ▼
+  ECS Service   Deployment + ConfigMap + ExternalSecret
+```
+
+Each controller reads the core spec and its own `platform:` overlay, ignoring the other.
+
+### Spec with Platform Overlay
+
+```yaml
+apiVersion: oab.dev/v1
+kind: OABService
+metadata:
+  name: chaodu
+  namespace: prod
+spec:
+  # Core (cross-platform)
+  cpu: 512
+  memory: 1024
+  config:
+    agent: { backend: kiro }
+    discord: { enabled: true, botId: "123" }
+  secrets:
+    - name: DISCORD_BOT_TOKEN
+      source: ssm
+      path: /oab/chaodu/discord-token
+
+  # Platform-specific (each controller reads only its own key)
+  platform:
+    ecs:
+      capacityProvider: FARGATE_SPOT
+      networking:
+        subnets: [subnet-abc, subnet-def]
+        securityGroups: [sg-oab]
+        assignPublicIp: false
+    k8s:
+      nodeSelector: { node.kubernetes.io/capacity-type: spot }
+      serviceAccount: oab-agent
+      storageClass: gp3
+```
+
+### Translation Table
+
+| Core Spec | ECS Controller | K8s Operator |
+|-----------|---------------|--------------|
+| `cpu: 512` | TaskDef `cpu=512` | `resources.requests.cpu: 500m` |
+| `memory: 1024` | TaskDef `memory=1024` | `resources.requests.memory: 1Gi` |
+| `spec.config` | Render → S3 artifact → startup wrapper | Render → ConfigMap → volume mount |
+| `spec.secrets[].source: ssm` | ECS native `secrets` field | ExternalSecret → K8s Secret |
+| `platform.ecs.capacityProvider` | Fargate capacity provider | _(ignored)_ |
+| `platform.k8s.nodeSelector` | _(ignored)_ | Pod nodeSelector |
+
+### Rules
+
+- `platform:` is optional. If omitted, controller uses its own defaults.
+- Controller **ignores** unknown platform keys (ECS controller skips `platform.k8s`, and vice versa).
+- Core spec fields (`cpu`, `memory`, `config`, `secrets`) are mandatory and cross-platform.
+- `OABFleet` also supports `platform:` at both `defaults` and per-agent level.
+
+### Phase Plan
+
+- **Phase 1**: ECS controller only. `platform.ecs` supported, `platform.k8s` ignored.
+- **Phase 3**: K8s operator reads same manifests (from S3 or as native CRD). Shared schema, different runtime.
+
+---
+
+## 5. Config Delivery Model
 
 The controller does **not** mount config into containers (ECS/Fargate has no shared volume equivalent to K8s ConfigMap). Instead:
 
@@ -303,7 +385,7 @@ exec /usr/local/bin/openab
 
 ---
 
-## 5. Per-Agent Secret Injection
+## 6. Per-Agent Secret Injection
 
 Each agent/bot has its **own** credentials — no token sharing between agents.
 
@@ -371,7 +453,7 @@ spec:
 
 ---
 
-## 6. State Store Design (S3-Only)
+## 7. State Store Design (S3-Only)
 
 ```
 s3://oab-control-plane/
@@ -409,7 +491,7 @@ Phase 2: Proper deletion with finalizers:
 
 ---
 
-## 7. Controller Upgrade Strategy
+## 8. Controller Upgrade Strategy
 
 The controller runs as a single-replica ECS Service.
 
@@ -441,7 +523,7 @@ deploymentConfiguration:
 
 ---
 
-## 8. CLI UX (`oabctl`)
+## 9. CLI UX (`oabctl`)
 
 ### Core Commands
 
@@ -491,7 +573,7 @@ cluster = "oab-prod"
 
 ---
 
-## 9. Phase Scope
+## 10. Phase Scope
 
 ### Phase 1 — MVP (target)
 
@@ -518,6 +600,7 @@ cluster = "oab-prod"
 
 ### Phase 3
 
+- **K8s Operator** — same `oab.dev/v1` schema consumed as native CRD; `platform.k8s` overlay
 - Multi-region (controller per region, S3 cross-region replication)
 - Dependency graph (service A depends on service B)
 - Auto-scaling policies in manifest spec
@@ -526,7 +609,7 @@ cluster = "oab-prod"
 
 ---
 
-## 10. Alternatives Considered
+## 11. Alternatives Considered
 
 | Alternative | Why not chosen |
 |-------------|---------------|
@@ -539,7 +622,7 @@ cluster = "oab-prod"
 
 ---
 
-## 11. Open Questions
+## 12. Open Questions
 
 1. **Multi-region** — single controller per region, or global controller with regional reconcilers?
 2. **Observability** — CloudWatch metrics from the controller, or push to a shared OAB dashboard?
@@ -548,7 +631,7 @@ cluster = "oab-prod"
 
 ---
 
-## 12. Decision
+## 13. Decision
 
 We adopt the CRD + Operator pattern on ECS with an **S3-only state store**, **explicit generation tracking**, and a **`oabctl` CLI** for the operator interface. The controller runs as a single ECS service that reconciles `OABService` manifests against actual ECS state.
 

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -246,9 +246,10 @@ The controller does **not** monitor agent health — ECS Service already maintai
 
 ### Prerequisites for Auto-Registration
 
-- Discord Developer Portal credentials stored in SSM: `/oab/discord-developer/token`
+- Discord **user OAuth2 bearer token** (not bot token) stored in SSM: `/oab/discord-developer/user-token` — required to call `POST /applications`
 - Controller IAM role needs `ssm:PutParameter` to store generated bot tokens
 - Discord API rate limit: ~5 app creations per minute (controller handles backoff)
+- **Note:** `OABFleet` + `autoRegister` is **Phase 2**. Phase 1 requires manual Bot creation in Discord Developer Portal.
 
 ---
 
@@ -299,6 +300,8 @@ spec:
   platform:
     ecs:
       capacityProvider: FARGATE_SPOT
+      executionRole: arn:aws:iam::123456789012:role/oab-task-execution
+      taskRole: arn:aws:iam::123456789012:role/oab-chaodu-task
       networking:
         subnets: [subnet-abc, subnet-def]
         securityGroups: [sg-oab]
@@ -318,6 +321,8 @@ spec:
 | `spec.config` | Render → S3 artifact → startup wrapper | Render → ConfigMap → volume mount |
 | `spec.secrets[].source: ssm` | ECS native `secrets` field | ExternalSecret → K8s Secret |
 | `platform.ecs.capacityProvider` | Fargate capacity provider | _(ignored)_ |
+| `platform.ecs.executionRole` | ECS task execution role | _(ignored)_ |
+| `platform.ecs.taskRole` | ECS task role | _(ignored)_ |
 | `platform.k8s.nodeSelector` | _(ignored)_ | Pod nodeSelector |
 
 ### Rules
@@ -382,6 +387,23 @@ exec /usr/local/bin/openab
 | Steering files | S3 (referenced in config.toml) | Separate steering bucket |
 
 **Secrets never go in the bootstrap archive.** The archive contains only mutable runtime state that the agent accumulates over time.
+
+### IAM Requirements (Task Execution Role)
+
+The ECS task execution role (`platform.ecs.executionRole`) must have:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["s3:GetObject"],
+  "Resource": [
+    "arn:aws:s3:::oab-control-plane/artifacts/${namespace}/${name}/*",
+    "arn:aws:s3:::oab-state/agents/${name}/*"
+  ]
+}
+```
+
+This allows the startup wrapper to download the controller-rendered `config.toml` and the bootstrap archive.
 
 ---
 
@@ -591,6 +613,7 @@ cluster = "oab-prod"
 
 ### Phase 2
 
+- `OABFleet` kind + Discord `autoRegister` (batch Bot provisioning)
 - Event-driven triggers (S3 → EventBridge → controller)
 - `oabctl delete` with tombstone + finalizers
 - `oabctl diff`, `oabctl logs`, `oabctl restart`

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -69,12 +69,7 @@ spec:
     image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
     cpu: 256                       # override when size=custom
     memory: 512                    # override when size=custom
-    environment:
-      - name: BACKEND_TYPE
-        value: bedrock
-  backend:
-    type: bedrock
-    model: anthropic.claude-sonnet-4-20250514
+  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
   networking:
     subnets: [subnet-abc, subnet-def]
     securityGroups: [sg-123]
@@ -85,8 +80,10 @@ Key fields:
 - `spec.capacityProvider` — `FARGATE` (default, on-demand) or `FARGATE_SPOT` (up to 70% cost savings, with interruption risk)
 - `spec.size` — predefined instance sizes (see table below); use `custom` to set cpu/memory directly
 - `spec.taskDefinition` — maps directly to ECS RegisterTaskDefinition
-- `spec.backend` — OAB-specific config injected as environment/secrets
+- `spec.bootstrapFrom` — S3 path to agent HOME archive (contains config, OAuth, steering, memory)
 - `spec.networking` — ECS awsvpc configuration
+
+The manifest only manages **infrastructure** (container, compute, networking). Agent-level config (backend, model, channels, steering) lives inside the bootstrap archive's `config.toml`.
 
 ### Instance Sizes
 

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -114,45 +114,57 @@ spec:
 
 FARGATE_SPOT is suitable for stateless agents that can tolerate interruption (OAB reconnects automatically). For agents with long-running sessions or strict SLA requirements, use FARGATE.
 
-### Secrets & Bot Provisioning
+### Bootstrap & Agent HOME
 
-Each agent owns its own bot token. The controller **provisions** the Discord bot token automatically by calling the Discord API, then stores it in AWS Secrets Manager.
+Each agent's HOME directory (containing OAuth tokens, config, steering, memory) is restored from an S3 archive on startup via `bootstrapFrom`:
 
 ```yaml
 spec:
-  channel:
-    type: discord
-    applicationId: "1234567890"    # Discord Application ID (pre-created)
-  secrets:
+  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
+```
+
+**Startup flow:**
+
+```
+ECS Task starts
+  → init: s3:GetObject ${bootstrapFrom}
+  → init: tar xzf → $HOME/
+  → OAB process starts with fully populated HOME
+       ├── config.toml
+       ├── .oauth/discord-token
+       ├── steering/
+       └── memory/
+```
+
+**What's in the bootstrap archive:**
+- OAuth tokens (Discord bot token, Slack OAuth, etc.)
+- `config.toml` (channel bindings, backend config)
+- Steering files (personality, system prompts)
+- Memory / knowledge base snapshots
+- Any agent-specific tooling or scripts
+
+**Lifecycle:**
+
+| Event | Action |
+|-------|--------|
+| First deploy | Operator prepares bootstrap archive manually or via `oabctl snapshot` |
+| Redeploy / scale-out | New tasks restore from same `bootstrapFrom` path |
+| Agent state changes | Periodic `oabctl snapshot my-agent` → uploads new archive to S3 |
+| Disaster recovery | Point `bootstrapFrom` to any previous snapshot |
+
+**Secrets handling:**
+- OAuth tokens live inside the bootstrap archive (encrypted at rest via S3 SSE-KMS)
+- No need for controller to call Discord API or manage Secrets Manager
+- The S3 bucket + KMS key policy controls who can access the tokens
+- Optional: `spec.secrets` still available for additional runtime secrets (API keys not in HOME)
+
+```yaml
+spec:
+  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
+  secrets:                              # optional, for secrets not in bootstrap
     - name: OPENAI_API_KEY
-      valueFrom: /oab/prod/my-agent/openai-key   # operator-managed
+      valueFrom: /oab/prod/my-agent/openai-key
 ```
-
-**Controller-managed secrets (auto-provisioned):**
-
-On first `oabctl apply`, the controller:
-1. Calls Discord API to generate/reset the bot token for the given `applicationId`
-2. Stores the token in Secrets Manager at `oab/{namespace}/{name}/discord-token`
-3. References it in the ECS task definition `secrets` field
-
-```
-oabctl apply -f my-agent.yaml
-  → Controller detects new OABService
-  → POST https://discord.com/api/v10/applications/{id}/bot/reset
-  → secretsmanager:CreateSecret → oab/prod/my-agent/discord-token
-  → RegisterTaskDefinition (with secret reference)
-  → CreateService
-```
-
-**Operator-managed secrets (manual):**
-
-Non-bot secrets (API keys, model credentials) are managed by the operator via AWS console/CLI and referenced by path in `spec.secrets`.
-
-Design principles:
-- **Bot token = controller-managed** — provisioned via Discord API, stored in Secrets Manager, rotated by controller
-- **API keys = operator-managed** — stored in SSM/Secrets Manager by operator, referenced by path
-- **Naming convention**: `oab/{namespace}/{service-name}/{secret-name}`
-- **No secrets in S3** — manifests never contain secret values, only references or application IDs
 
 ---
 

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -114,6 +114,35 @@ spec:
 
 FARGATE_SPOT is suitable for stateless agents that can tolerate interruption (OAB reconnects automatically). For agents with long-running sessions or strict SLA requirements, use FARGATE.
 
+### Secrets (OAuth / API Keys)
+
+Each agent owns its own bot token and credentials — no shared secrets across services. Secrets are stored in SSM Parameter Store (or Secrets Manager) and referenced by path in the manifest:
+
+```yaml
+spec:
+  secrets:
+    - name: DISCORD_TOKEN
+      valueFrom: /oab/prod/my-agent/discord-token
+    - name: OPENAI_API_KEY
+      valueFrom: /oab/prod/my-agent/openai-key
+```
+
+The controller maps these to ECS task definition `secrets` (injected at runtime, never stored in S3):
+
+```json
+{
+  "secrets": [
+    { "name": "DISCORD_TOKEN", "valueFrom": "arn:aws:ssm:us-east-1:123456789:parameter/oab/prod/my-agent/discord-token" }
+  ]
+}
+```
+
+Design principles:
+- **One bot token per agent** — no shared credentials, no routing complexity
+- **Controller references only** — it never reads, creates, or rotates secrets
+- **Operator manages secret lifecycle** — via AWS console, CLI, or Terraform
+- **Naming convention**: `/oab/{namespace}/{service-name}/{secret-name}`
+
 ---
 
 ## 4. State Store Design (S3-Only)

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -73,16 +73,41 @@ spec:
     subnets: [subnet-abc, subnet-def]
     securityGroups: [sg-123]
     assignPublicIp: false
+  config:
+    channels:
+      - type: discord
+        guild_id: "1490282656913559673"
+    backend:
+      type: bedrock
+      model_id: anthropic.claude-sonnet-4-20250514
+      region: us-east-1
+    steering:
+      system_prompt: "You are 超渡法師(Kiro), an OpenAB agent..."
+    features:
+      stt: true
+      cronjob: true
 ```
 
 Key fields:
 - `spec.capacityProvider` — `FARGATE` (default, on-demand) or `FARGATE_SPOT` (up to 70% cost savings, with interruption risk)
 - `spec.cpu` / `spec.memory` — maps directly to ECS task definition (must be a valid Fargate combination)
 - `spec.taskDefinition` — container image and optional overrides
-- `spec.bootstrapFrom` — S3 path to agent HOME archive (contains config, OAuth, steering, memory)
+- `spec.bootstrapFrom` — S3 path to agent HOME archive (contains OAuth tokens, memory, scripts)
 - `spec.networking` — ECS awsvpc configuration
+- `spec.config` — structured agent configuration (channels, backend, steering, features); controller validates and generates `config.toml`
 
-The manifest only manages **infrastructure** (container, compute, networking). Agent-level config (backend, model, channels, steering) lives inside the bootstrap archive's `config.toml`.
+The manifest manages both **infrastructure** and **agent configuration**. On reconcile, the controller generates `config.toml` from `spec.config` and injects it into the running task.
+
+### Config Reconciliation
+
+| Change | Controller Action |
+|--------|-------------------|
+| `spec.config` changed | Generate new config.toml → write to agent's config volume → restart task |
+| `spec.cpu/memory/capacityProvider` changed | New task definition revision → UpdateService (rolling restart) |
+| `spec.bootstrapFrom` changed | Next task start uses new archive |
+| Infra + config changed together | Single rolling restart with both changes applied |
+
+`spec.config` takes precedence over any config.toml in the bootstrap archive. Bootstrap provides the initial HOME state; `spec.config` is the live desired state for configuration.
 
 ### Capacity Provider
 

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -148,6 +148,108 @@ OAB agents are **single-instance** by design — each agent holds one adapter co
 - Controller **rejects** `replicas > 1` at validation time
 - Scaling is horizontal by deploying **more agents** (each with its own bot token), not by replicating one agent
 
+### Fleet Provisioning (`OABFleet`)
+
+Enterprise scenario: provision 10-20 agents in one apply. Controller handles everything including Discord Bot registration.
+
+```yaml
+apiVersion: oab.dev/v1
+kind: OABFleet
+metadata:
+  name: enterprise-team
+  namespace: prod
+spec:
+  defaults:
+    capacityProvider: FARGATE_SPOT
+    cpu: 512
+    memory: 1024
+    taskDefinition:
+      image: ghcr.io/openabdev/openab:latest
+    networking:
+      subnets: [subnet-abc, subnet-def]
+      securityGroups: [sg-oab]
+    discord:
+      autoRegister: true          # controller creates Bot via Discord API
+  agents:
+    - name: kiro-01
+      config: { agent: { backend: kiro } }
+    - name: kiro-02
+      config: { agent: { backend: kiro } }
+    - name: kiro-03
+      config: { agent: { backend: kiro } }
+    - name: codex-01
+      config: { agent: { backend: codex } }
+      cpu: 1024
+      memory: 2048               # override defaults
+    - name: codex-02
+      config: { agent: { backend: codex } }
+      cpu: 1024
+      memory: 2048
+    - name: gemini-01
+      config: { agent: { backend: gemini } }
+    - name: gemini-02
+      config: { agent: { backend: gemini } }
+    - name: gemini-03
+      config: { agent: { backend: gemini } }
+    - name: gemini-04
+      config: { agent: { backend: gemini } }
+    - name: gemini-05
+      config: { agent: { backend: gemini } }
+```
+
+### Discord Auto-Registration Flow
+
+When `discord.autoRegister: true`, the controller provisions Discord Bots automatically:
+
+```
+oabctl apply -f fleet.yaml
+  │
+  │  For each agent:
+  ├─ 1. Discord API: POST /applications → create Bot Application
+  ├─ 2. Discord API: POST /applications/{id}/bot → get Bot Token
+  ├─ 3. Store token → SSM /oab/{namespace}/{name}/discord-token
+  ├─ 4. Generate OAuth2 invite URL
+  ├─ 5. Create ECS Service (desiredCount=1)
+  └─ 6. Write status (phase=Running, inviteUrl=...)
+```
+
+**Apply output:**
+
+```bash
+$ oabctl apply -f fleet.yaml
+
+✓ kiro-01   provisioned → https://discord.com/oauth2/authorize?client_id=AAA&scope=bot
+✓ kiro-02   provisioned → https://discord.com/oauth2/authorize?client_id=BBB&scope=bot
+✓ kiro-03   provisioned → https://discord.com/oauth2/authorize?client_id=CCC&scope=bot
+✓ codex-01  provisioned → https://discord.com/oauth2/authorize?client_id=DDD&scope=bot
+✓ codex-02  provisioned → https://discord.com/oauth2/authorize?client_id=EEE&scope=bot
+✓ gemini-01 provisioned → https://discord.com/oauth2/authorize?client_id=FFF&scope=bot
+✓ gemini-02 provisioned → https://discord.com/oauth2/authorize?client_id=GGG&scope=bot
+✓ gemini-03 provisioned → https://discord.com/oauth2/authorize?client_id=HHH&scope=bot
+✓ gemini-04 provisioned → https://discord.com/oauth2/authorize?client_id=III&scope=bot
+✓ gemini-05 provisioned → https://discord.com/oauth2/authorize?client_id=JJJ&scope=bot
+
+10 agents provisioned. Add them to your server using the URLs above.
+```
+
+**User's only manual step:** paste the OAuth URL into a browser → authorize the bot to join their Discord server.
+
+### Responsibility Model
+
+| Layer | Responsibility |
+|-------|---------------|
+| `oabctl` / Controller | Desired state: create Bots, store tokens, create ECS Services |
+| ECS | Runtime health: task dies → auto-restart (desiredCount=1) |
+| User | One-time: add bots to Discord server via OAuth URL |
+
+The controller does **not** monitor agent health — ECS Service already maintains desired state. If a task crashes, ECS replaces it automatically. The controller only acts when the **desired state** (manifest) changes.
+
+### Prerequisites for Auto-Registration
+
+- Discord Developer Portal credentials stored in SSM: `/oab/discord-developer/token`
+- Controller IAM role needs `ssm:PutParameter` to store generated bot tokens
+- Discord API rate limit: ~5 app creations per minute (controller handles backoff)
+
 ---
 
 ## 4. Config Delivery Model

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -169,7 +169,7 @@ spec:
       subnets: [subnet-abc, subnet-def]
       securityGroups: [sg-oab]
     discord:
-      autoRegister: true          # controller creates Bot via Discord API
+      enabled: true               # all agents use Discord
   agents:
     - name: kiro-01
       config: { agent: { backend: kiro } }
@@ -197,20 +197,24 @@ spec:
       config: { agent: { backend: gemini } }
 ```
 
-### Discord Auto-Registration Flow
+### Discord Bot Provisioning Flow
 
-When `discord.autoRegister: true`, the controller provisions Discord Bots automatically:
+Since Discord does not offer a public API for Bot creation, the actual flow for fleet provisioning is:
 
 ```
+Pre-requisite (manual, one-time per agent):
+  → Create Bot in Discord Developer Portal
+  → Store token in SSM: /oab/{namespace}/{name}/discord-token
+  → Note the OAuth2 invite URL
+
 oabctl apply -f fleet.yaml
   │
   │  For each agent:
-  ├─ 1. Discord API: POST /applications → create Bot Application
-  ├─ 2. Discord API: POST /applications/{id}/bot → get Bot Token
-  ├─ 3. Store token → SSM /oab/{namespace}/{name}/discord-token
-  ├─ 4. Generate OAuth2 invite URL
-  ├─ 5. Create ECS Service (desiredCount=1)
-  └─ 6. Write status (phase=Running, inviteUrl=...)
+  ├─ 1. Validate spec + verify secret exists in SSM
+  ├─ 2. Render config.toml → S3 artifact (immutable, per generation)
+  ├─ 3. Register ECS TaskDefinition (pinned to config artifact + secrets)
+  ├─ 4. Create ECS Service (desiredCount=1)
+  └─ 5. Write status (phase=Running)
 ```
 
 **Apply output:**
@@ -218,38 +222,47 @@ oabctl apply -f fleet.yaml
 ```bash
 $ oabctl apply -f fleet.yaml
 
-✓ kiro-01   provisioned → https://discord.com/oauth2/authorize?client_id=AAA&scope=bot
-✓ kiro-02   provisioned → https://discord.com/oauth2/authorize?client_id=BBB&scope=bot
-✓ kiro-03   provisioned → https://discord.com/oauth2/authorize?client_id=CCC&scope=bot
-✓ codex-01  provisioned → https://discord.com/oauth2/authorize?client_id=DDD&scope=bot
-✓ codex-02  provisioned → https://discord.com/oauth2/authorize?client_id=EEE&scope=bot
-✓ gemini-01 provisioned → https://discord.com/oauth2/authorize?client_id=FFF&scope=bot
-✓ gemini-02 provisioned → https://discord.com/oauth2/authorize?client_id=GGG&scope=bot
-✓ gemini-03 provisioned → https://discord.com/oauth2/authorize?client_id=HHH&scope=bot
-✓ gemini-04 provisioned → https://discord.com/oauth2/authorize?client_id=III&scope=bot
-✓ gemini-05 provisioned → https://discord.com/oauth2/authorize?client_id=JJJ&scope=bot
+✓ kiro-01   provisioned (ECS service created, task running)
+✓ kiro-02   provisioned (ECS service created, task running)
+✓ kiro-03   provisioned (ECS service created, task running)
+✓ codex-01  provisioned (ECS service created, task running)
+✓ codex-02  provisioned (ECS service created, task running)
+✓ gemini-01 provisioned (ECS service created, task running)
+...
 
-10 agents provisioned. Add them to your server using the URLs above.
+10 agents provisioned.
 ```
 
-**User's only manual step:** paste the OAuth URL into a browser → authorize the bot to join their Discord server.
+**User's manual steps (one-time):** create bots in Discord Developer Portal, store tokens, add bots to server via OAuth URL.
 
 ### Responsibility Model
 
 | Layer | Responsibility |
 |-------|---------------|
-| `oabctl` / Controller | Desired state: create Bots, store tokens, create ECS Services |
+| `oabctl` / Controller | Desired state: create ECS Services; **observe** ECS task/service status → write back to `status/` |
 | ECS | Runtime health: task dies → auto-restart (desiredCount=1) |
-| User | One-time: add bots to Discord server via OAuth URL |
+| User | One-time: create bots in Discord Developer Portal, add to server via OAuth URL |
 
-The controller does **not** monitor agent health — ECS Service already maintains desired state. If a task crashes, ECS replaces it automatically. The controller only acts when the **desired state** (manifest) changes.
+The controller does **not** restart tasks — ECS handles that. But the controller **does** observe ECS service/task/deployment status on each reconcile cycle and writes it back to `status/{ns}/{name}.json`. This enables `oabctl get`, `oabctl wait --for=Available`, and `status.phase` / `status.conditions` to work.
 
 ### Prerequisites for Auto-Registration
 
-- Discord **user OAuth2 bearer token** (not bot token) stored in SSM: `/oab/discord-developer/user-token` — required to call `POST /applications`
-- Controller IAM role needs `ssm:PutParameter` to store generated bot tokens
-- Discord API rate limit: ~5 app creations per minute (controller handles backoff)
-- **Note:** `OABFleet` + `autoRegister` is **Phase 2**. Phase 1 requires manual Bot creation in Discord Developer Portal.
+> **⚠️ Note:** Discord does not provide a public API to programmatically create Bot Applications. `autoRegister` is a **future research item** pending Discord API changes or partnership access. For now, bot credentials must be pre-created manually in the Discord Developer Portal.
+
+**Phase 1/2 approach:** Each agent's bot token is pre-created and stored in SSM/Secrets Manager. The `OABFleet` spec references existing credentials:
+
+```yaml
+spec:
+  agents:
+    - name: kiro-01
+      config: { agent: { backend: kiro } }
+      secrets:
+        - name: DISCORD_BOT_TOKEN
+          source: ssm
+          path: /oab/kiro-01/discord-token   # pre-created
+```
+
+**Future (if Discord API allows):** `autoRegister: true` would automate Bot creation. This requires a separate research ADR.
 
 ---
 
@@ -370,16 +383,18 @@ Config artifacts are **immutable per generation** — once written, never overwr
 ```bash
 #!/bin/bash
 set -e
-# Download controller-rendered config (pinned to specific generation)
-aws s3 cp "$CONFIG_ARTIFACT_PATH" /home/agent/config.toml
-# Restore mutable state (memory, knowledge base) if bootstrapFrom is set
+# 1. Restore mutable state FIRST (memory, knowledge base)
 if [ -n "$BOOTSTRAP_FROM" ]; then
   aws s3 cp "$BOOTSTRAP_FROM" /tmp/bootstrap.tar.gz
   tar xzf /tmp/bootstrap.tar.gz -C /home/agent/
   rm /tmp/bootstrap.tar.gz
 fi
+# 2. Download controller-rendered config LAST (overwrites any config.toml from archive)
+aws s3 cp "$CONFIG_ARTIFACT_PATH" /home/agent/config.toml
 exec /usr/local/bin/openab
 ```
+
+**Order matters:** bootstrap archive is restored first, then the controller-rendered `config.toml` overwrites any stale config from the archive. `oabctl snapshot` must exclude `config.toml` from the archive (it's controller-managed, not user state).
 
 ### What Goes Where
 

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -63,10 +63,12 @@ metadata:
   namespace: prod
 spec:
   replicas: 2
+  capacityProvider: FARGATE        # FARGATE (default) or FARGATE_SPOT
+  size: small                      # small | medium | large | custom
   taskDefinition:
     image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
-    cpu: 256
-    memory: 512
+    cpu: 256                       # override when size=custom
+    memory: 512                    # override when size=custom
     environment:
       - name: BACKEND_TYPE
         value: bedrock
@@ -80,9 +82,37 @@ spec:
 ```
 
 Key fields:
+- `spec.capacityProvider` — `FARGATE` (default, on-demand) or `FARGATE_SPOT` (up to 70% cost savings, with interruption risk)
+- `spec.size` — predefined instance sizes (see table below); use `custom` to set cpu/memory directly
 - `spec.taskDefinition` — maps directly to ECS RegisterTaskDefinition
 - `spec.backend` — OAB-specific config injected as environment/secrets
 - `spec.networking` — ECS awsvpc configuration
+
+### Instance Sizes
+
+| Size | vCPU | Memory | Use Case |
+|------|------|--------|----------|
+| `small` | 256 (.25 vCPU) | 512 MB | Lightweight agents, low traffic |
+| `medium` | 512 (.5 vCPU) | 1024 MB | Standard workloads |
+| `large` | 1024 (1 vCPU) | 2048 MB | High-throughput or multi-backend |
+| `xlarge` | 2048 (2 vCPU) | 4096 MB | Heavy compute, large context |
+| `custom` | user-defined | user-defined | Full control via cpu/memory fields |
+
+When `size` is set to a named value, `cpu` and `memory` in `taskDefinition` are ignored. When `size=custom`, `cpu` and `memory` are required.
+
+### Capacity Provider Strategy
+
+```yaml
+# Cost-optimized: prefer spot, fall back to on-demand
+spec:
+  capacityProvider: FARGATE_SPOT
+
+# Production: guaranteed capacity
+spec:
+  capacityProvider: FARGATE
+```
+
+FARGATE_SPOT is suitable for stateless agents that can tolerate interruption (OAB reconnects automatically). For agents with long-running sessions or strict SLA requirements, use FARGATE.
 
 ---
 

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -145,7 +145,7 @@ Bot agents (Discord, Telegram, Slack) are inherently **single-instance** — the
 Rules:
 - `replicas: 1` — default and only valid value for bot-type agents
 - Schema validation rejects `replicas > 1` when `spec.config.channels` contains bot-type channels
-- Future: `replicas > 1` allowed for stateless HTTP/webhook agents with a load balancer
+- Future: `replicas > 1` may be considered for stateless webhook receivers with deduplication, but is not planned
 
 For HA of bot agents, the controller relies on ECS service auto-recovery (task restart on failure) rather than multiple replicas.
 

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -1,0 +1,179 @@
+# ADR: ECS Control Plane (CRD + Operator Pattern on ECS)
+
+- **Status:** Proposed
+- **Date:** 2026-05-18
+- **Author:** @pahud.hsieh
+- **Related:** [Multi-Platform Adapters](./multi-platform-adapters.md), [Basic CronJob](./basic-cronjob.md)
+
+---
+
+## 1. Context & Motivation
+
+OpenAB currently deploys on Kubernetes using Helm charts. While K8s provides a mature operator pattern (CRD + Controller), many teams prefer or require **Amazon ECS** for its operational simplicity and tighter AWS integration.
+
+We want to bring the same declarative, self-healing deployment model to ECS:
+
+- Operators declare desired state in YAML manifests (analogous to CRDs)
+- A controller reconciles desired state against actual ECS resources
+- OAB instances + arbitrary backends are deployed and maintained automatically
+
+This enables a "GitOps for ECS" workflow where pushing a YAML change triggers the controller to converge the cluster to the new desired state.
+
+---
+
+## 2. Design Overview
+
+```
+┌──────────────────────────────────────────────────────┐
+│  ECS Control Plane (runs as ECS Service)             │
+│                                                      │
+│  ┌────────────┐  ┌──────────────┐  ┌─────────────┐  │
+│  │ State Store│  │  Reconciler  │  │  ECS API /  │  │
+│  │ (S3 + DDB) │◄─│  Controller  │─►│  CloudMap   │  │
+│  │            │  │              │  │             │  │
+│  └────────────┘  └──────────────┘  └─────────────┘  │
+│                        ▲                             │
+│                        │ events / poll               │
+│                        ▼                             │
+│                 ┌──────────────┐                     │
+│                 │ S3 Events /  │                     │
+│                 │ EventBridge  │                     │
+│                 └──────────────┘                     │
+└──────────────────────────────────────────────────────┘
+```
+
+### Core Loop (Reconciliation)
+
+1. Load all YAML manifests from S3 (desired state)
+2. Describe current ECS services/tasks (observed state)
+3. Compute diff
+4. Apply changes: create, update, or delete ECS resources
+5. Write status back to DynamoDB
+6. Sleep / wait for next event
+
+---
+
+## 3. Manifest Schema
+
+```yaml
+apiVersion: oab.dev/v1
+kind: OABService
+metadata:
+  name: my-agent
+  namespace: prod
+spec:
+  replicas: 2
+  taskDefinition:
+    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
+    cpu: 256
+    memory: 512
+    environment:
+      - name: BACKEND_TYPE
+        value: bedrock
+  backend:
+    type: bedrock
+    model: anthropic.claude-sonnet-4-20250514
+  networking:
+    subnets: [subnet-abc, subnet-def]
+    securityGroups: [sg-123]
+    assignPublicIp: false
+status:
+  phase: Running
+  observedGeneration: 3
+  conditions:
+    - type: Available
+      status: "True"
+      lastTransitionTime: "2026-05-18T10:00:00Z"
+```
+
+Key fields:
+- `spec.taskDefinition` — maps directly to ECS RegisterTaskDefinition
+- `spec.backend` — OAB-specific config injected as environment/secrets
+- `spec.networking` — ECS awsvpc configuration
+- `status` — written back by the controller (stored in DDB, not in the S3 YAML)
+
+---
+
+## 4. State Store Design
+
+| Concern | Store | Rationale |
+|---------|-------|-----------|
+| Desired state (manifests) | S3 | Human-readable, versioned, git-syncable |
+| Status + generation tracking | DynamoDB | Fast reads, conditional writes for optimistic concurrency |
+| Leader election lock | DynamoDB | TTL-based lease via conditional PutItem |
+
+S3 event notifications (→ EventBridge → SQS) trigger the controller on manifest changes. A periodic full-reconciliation (every 30–60s) catches drift from out-of-band changes.
+
+---
+
+## 5. Controller Lifecycle
+
+### Reconcile Actions
+
+| Diff | Action |
+|------|--------|
+| Manifest exists, no ECS service | RegisterTaskDefinition → CreateService |
+| Manifest spec changed | RegisterTaskDefinition (new revision) → UpdateService |
+| Manifest deleted | UpdateService (desiredCount=0) → DeleteService → DeregisterTaskDefinition |
+| ECS state drifted from spec | UpdateService to re-converge |
+
+### Leader Election
+
+When running multiple controller replicas for HA:
+- Use DynamoDB conditional writes with a TTL-based lease
+- Only the leader performs reconciliation; standbys poll for lease expiry
+- Single-replica deployments skip leader election entirely
+
+### Finalizers
+
+Before deleting an ECS service, the controller:
+1. Drains active connections (set desiredCount=0, wait for task stop)
+2. Cleans up CloudMap service discovery entries
+3. Removes the DynamoDB status record
+4. Only then acknowledges deletion
+
+---
+
+## 6. MVP Scope
+
+Phase 1 (minimal viable control plane):
+
+1. **S3 bucket** with YAML manifests (one file per OABService)
+2. **Single-instance ECS task** running the controller (no leader election)
+3. **Poll S3 every 30s**, reconcile against ECS DescribeServices
+4. **Write status** to DynamoDB table
+5. Support `create` and `update` operations only (manual delete via console)
+
+Phase 2 additions:
+- Event-driven triggers (S3 → EventBridge → controller)
+- Multi-replica with DDB leader election
+- Delete reconciliation with finalizers
+- CLI tool for `oab apply -f manifest.yaml` (uploads to S3)
+- Rollback via manifest generation history
+
+---
+
+## 7. Alternatives Considered
+
+| Alternative | Why not chosen |
+|-------------|---------------|
+| AWS Proton | Opinionated, limited customization for OAB-specific logic |
+| AWS Copilot | Good for simple apps, no custom reconciliation loop |
+| CDK Pipelines | Deployment tool, not a runtime controller with drift detection |
+| Step Functions orchestrator | Stateless execution model, no continuous reconciliation |
+| Run K8s anyway (EKS) | Valid but adds operational overhead for teams that chose ECS |
+
+---
+
+## 8. Open Questions
+
+1. **Secrets management** — inject via ECS Secrets (SSM/SecretsManager) or controller-managed env vars?
+2. **Multi-region** — single controller per region, or a global controller with regional reconcilers?
+3. **Observability** — CloudWatch metrics from the controller, or push to a shared OAB dashboard?
+4. **Upgrade strategy** — how does the controller upgrade itself without downtime?
+
+---
+
+## 9. Decision
+
+We adopt the CRD + Operator pattern on ECS as described above. The controller will be implemented as a standalone ECS service that reconciles OABService manifests stored in S3 against actual ECS state. This gives ECS-native teams the same declarative, self-healing deployment experience that K8s operators provide, without requiring a Kubernetes cluster.

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -3,6 +3,7 @@
 - **Status:** Proposed
 - **Date:** 2026-05-18
 - **Author:** @pahud.hsieh
+- **Reviewers:** 擺渡法師(Codex), 普渡法師(CC), 口渡法師(Copilot), 超渡法師(Kiro)
 - **Related:** [Multi-Platform Adapters](./multi-platform-adapters.md), [Basic CronJob](./basic-cronjob.md)
 
 ---
@@ -47,32 +48,56 @@ This enables a "GitOps for ECS" workflow where pushing a YAML change triggers th
 1. Load all YAML manifests from S3 (desired state)
 2. Describe current ECS services/tasks (observed state)
 3. Compute diff
-4. Apply changes: create, update, or delete ECS resources
-5. Write status back to S3 (separate prefix)
-6. Sleep / wait for next event
+4. Render config artifact → upload to S3
+5. Apply changes: create, update, or delete ECS resources
+6. Write status back to S3 (with observedGeneration)
+7. Sleep / wait for next event
 
 ---
 
-## 3. Manifest Schema
+## 3. API Identity
+
+| Field | Value |
+|-------|-------|
+| API Group | `oab.dev` |
+| API Version | `oab.dev/v1` |
+| Kind | `OABService` |
+| Plural resource | `oabservices` |
+| CLI noun | `oabservice` |
+
+All paths (S3, SSM, IAM) use this identity consistently:
+- S3: `manifests/{namespace}/{name}.yaml`
+- SSM: `/oab/{namespace}/{name}/{secret-name}`
+- ECS: service name = `oab-{namespace}-{name}`
+
+---
+
+## 4. Manifest Schema
 
 ```yaml
 apiVersion: oab.dev/v1
 kind: OABService
 metadata:
-  name: my-agent
+  name: kiro-01
   namespace: prod
+  generation: 4                        # incremented by oabctl on each apply
 spec:
-  replicas: 2
-  capacityProvider: FARGATE        # FARGATE (default) or FARGATE_SPOT
-  cpu: 256                         # vCPU units (256 = 0.25 vCPU)
-  memory: 512                      # MB
+  replicas: 1                          # see "Replicas & HA" section
+  capacityProvider: FARGATE_SPOT       # FARGATE (default) or FARGATE_SPOT
+  cpu: 256                             # vCPU units (256 = 0.25 vCPU)
+  memory: 512                          # MB
   taskDefinition:
     image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
-  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
+  bootstrapFrom: s3://oab-backups/agents/kiro-01/latest.tar.gz
   networking:
-    subnets: [subnet-abc, subnet-def]
-    securityGroups: [sg-123]
+    subnets: [subnet-aaa, subnet-bbb]
+    securityGroups: [sg-oab]
     assignPublicIp: false
+  secrets:
+    - name: DISCORD_TOKEN
+      valueFrom: /oab/prod/kiro-01/discord-token
+    - name: OPENAI_API_KEY
+      valueFrom: /oab/prod/kiro-01/openai-key
   config:
     channels:
       - type: discord
@@ -82,169 +107,152 @@ spec:
       model_id: anthropic.claude-sonnet-4-20250514
       region: us-east-1
     steering:
-      system_prompt: "You are 超渡法師(Kiro), an OpenAB agent..."
+      system_prompt: "You are 超渡法師(Kiro)..."
     features:
       stt: true
       cronjob: true
+status:
+  phase: Running
+  observedGeneration: 4
+  conditions:
+    - type: Available
+      status: "True"
+      lastTransitionTime: "2026-05-18T10:00:00Z"
 ```
 
-Key fields:
-- `spec.capacityProvider` — `FARGATE` (default, on-demand) or `FARGATE_SPOT` (up to 70% cost savings, with interruption risk)
-- `spec.cpu` / `spec.memory` — maps directly to ECS task definition (must be a valid Fargate combination)
-- `spec.taskDefinition` — container image and optional overrides
-- `spec.bootstrapFrom` — S3 path to agent HOME archive (contains OAuth tokens, memory, scripts)
-- `spec.networking` — ECS awsvpc configuration
-- `spec.config` — structured agent configuration (channels, backend, steering, features); controller validates and generates `config.toml`
+### Field Responsibilities
 
-The manifest manages both **infrastructure** and **agent configuration**. On reconcile, the controller generates `config.toml` from `spec.config` and injects it into the running task.
+| Field | Purpose | Who writes |
+|-------|---------|-----------|
+| `spec.bootstrapFrom` | Mutable HOME state (memory, runtime data, scripts) | Operator |
+| `spec.config` | Desired agent configuration (channels, backend, steering) | Operator |
+| `spec.secrets` | SSM/Secrets Manager references for tokens & keys | Operator |
+| `metadata.generation` | Monotonic counter, incremented on each apply | oabctl |
+| `status.observedGeneration` | Last generation the controller successfully reconciled | Controller |
 
-### Config Reconciliation
+### Separation of Concerns
 
-| Change | Controller Action |
-|--------|-------------------|
-| `spec.config` changed | Generate new config.toml → write to agent's config volume → restart task |
-| `spec.cpu/memory/capacityProvider` changed | New task definition revision → UpdateService (rolling restart) |
-| `spec.bootstrapFrom` changed | Next task start uses new archive |
-| Infra + config changed together | Single rolling restart with both changes applied |
+- **`bootstrapFrom`** = mutable state (memory, knowledge base, scripts). Does NOT contain secrets or config.
+- **`spec.config`** = desired configuration. Controller renders this to `config.toml` artifact.
+- **`spec.secrets`** = all credentials. Always SSM/Secrets Manager references, never in archive or manifest values.
 
-`spec.config` takes precedence over any config.toml in the bootstrap archive. Bootstrap provides the initial HOME state; `spec.config` is the live desired state for configuration.
+---
 
-### Capacity Provider
+## 5. Replicas & HA
+
+Bot agents (Discord, Telegram, Slack) are inherently **single-instance** — the same bot token cannot have multiple consumers without duplicate responses.
+
+Rules:
+- `replicas: 1` — default and only valid value for bot-type agents
+- Schema validation rejects `replicas > 1` when `spec.config.channels` contains bot-type channels
+- Future: `replicas > 1` allowed for stateless HTTP/webhook agents with a load balancer
+
+For HA of bot agents, the controller relies on ECS service auto-recovery (task restart on failure) rather than multiple replicas.
+
+---
+
+## 6. State Store Design (S3-Only, Phase 1)
+
+```
+s3://oab-control-plane/
+  ├── manifests/{namespace}/{name}.yaml       ← desired state (oabctl writes)
+  ├── config/{namespace}/{name}/config.toml   ← rendered config (controller writes)
+  └── status/{namespace}/{name}.json          ← observed state (controller writes)
+```
+
+| Concern | Mechanism | Rationale |
+|---------|-----------|-----------|
+| Desired state | `manifests/` | Human-readable, git-syncable, versioned via S3 versioning |
+| Rendered config | `config/` | Controller generates config.toml from spec.config |
+| Status | `status/` | Contains observedGeneration, phase, conditions |
+| Generation tracking | Explicit `metadata.generation` counter in manifest | Unambiguous; S3 VersionId alone is insufficient for reconcile tracking |
+| Change detection | S3 Event Notifications → EventBridge (Phase 2) | Phase 1 uses polling |
+| Consistency | S3 strong read-after-write | Sufficient for single-controller |
+
+---
+
+## 7. Controller Lifecycle
+
+### Task Startup (Entrypoint Wrapper)
+
+ECS/Fargate has no init container. The OAB container uses an **entrypoint wrapper script**:
+
+```bash
+#!/bin/bash
+# 1. Download bootstrap (mutable state)
+aws s3 cp "${BOOTSTRAP_FROM}" /tmp/bootstrap.tar.gz
+tar xzf /tmp/bootstrap.tar.gz -C $HOME
+
+# 2. Download rendered config (controller-generated)
+aws s3 cp "s3://oab-control-plane/config/${NAMESPACE}/${NAME}/config.toml" $HOME/config.toml
+
+# 3. Start OAB (secrets injected via ECS task definition)
+exec /usr/bin/openab
+```
+
+The controller passes `BOOTSTRAP_FROM`, `NAMESPACE`, `NAME` as environment variables in the task definition.
+
+### Reconcile Actions
+
+| Diff | Controller Action |
+|------|-------------------|
+| Manifest exists, no ECS service | Render config → upload to S3 → RegisterTaskDefinition → CreateService |
+| `spec.config` changed | Render new config.toml → upload to S3 → restart task (new config on next start) |
+| `spec.cpu/memory/image` changed | New task definition revision → UpdateService (rolling restart) |
+| `spec.secrets` changed | Update task definition secrets → UpdateService |
+| Deletion marker present | desiredCount=0 → wait for drain → DeleteService → cleanup status/config |
+| ECS state drifted | UpdateService to re-converge |
+| `status.observedGeneration < metadata.generation` | Reconcile needed |
+
+### Deletion (Tombstone Pattern)
+
+`oabctl delete` does NOT remove the manifest from S3. Instead:
 
 ```yaml
-# Cost-optimized: spot instances, tolerates interruption
-spec:
-  capacityProvider: FARGATE_SPOT
-
-# Production: guaranteed capacity
-spec:
-  capacityProvider: FARGATE
-```
-
-FARGATE_SPOT is suitable for stateless agents that can tolerate interruption (OAB reconnects automatically). For agents with strict SLA requirements, use FARGATE.
-
-### Bootstrap & Agent HOME
-
-Each agent's HOME directory (containing OAuth tokens, config, steering, memory) is restored from an S3 archive on startup via `bootstrapFrom`:
-
-```yaml
-spec:
-  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
-```
-
-**Startup flow:**
-
-```
-ECS Task starts
-  → init: s3:GetObject ${bootstrapFrom}
-  → init: tar xzf → $HOME/
-  → OAB process starts with fully populated HOME
-       ├── config.toml
-       ├── .oauth/discord-token
-       ├── steering/
-       └── memory/
-```
-
-**What's in the bootstrap archive:**
-- OAuth tokens (Discord bot token, Slack OAuth, etc.)
-- `config.toml` (channel bindings, backend config)
-- Steering files (personality, system prompts)
-- Memory / knowledge base snapshots
-- Any agent-specific tooling or scripts
-
-**Lifecycle:**
-
-| Event | Action |
-|-------|--------|
-| First deploy | Operator prepares bootstrap archive manually or via `oabctl snapshot` |
-| Redeploy / scale-out | New tasks restore from same `bootstrapFrom` path |
-| Agent state changes | Periodic `oabctl snapshot my-agent` → uploads new archive to S3 |
-| Disaster recovery | Point `bootstrapFrom` to any previous snapshot |
-
-**Secrets handling:**
-- OAuth tokens live inside the bootstrap archive (encrypted at rest via S3 SSE-KMS)
-- No need for controller to call Discord API or manage Secrets Manager
-- The S3 bucket + KMS key policy controls who can access the tokens
-- Optional: `spec.secrets` still available for additional runtime secrets (API keys not in HOME)
-
-```yaml
-spec:
-  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
-  secrets:                              # optional, for secrets not in bootstrap
-    - name: OPENAI_API_KEY
-      valueFrom: /oab/prod/my-agent/openai-key
-```
-
-### Example: Multi-Agent Fleet (5 Kiro + 3 CC + 2 Codex)
-
-```
-agents/
-├── kiro-01.yaml ... kiro-05.yaml
-├── cc-01.yaml ... cc-03.yaml
-└── codex-01.yaml ... codex-02.yaml
-```
-
-```yaml
-# agents/kiro-01.yaml
-apiVersion: oab.dev/v1
-kind: OABService
 metadata:
   name: kiro-01
   namespace: prod
-spec:
-  replicas: 1
-  capacityProvider: FARGATE_SPOT
-  cpu: 256
-  memory: 512
-  taskDefinition:
-    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
-  bootstrapFrom: s3://oab-backups/agents/kiro-01/latest.tar.gz
-  networking:
-    subnets: [subnet-aaa, subnet-bbb]
-    securityGroups: [sg-oab]
+  generation: 5
+  deletionTimestamp: "2026-05-19T00:10:00Z"   # ← marks intent to delete
 ```
 
-```yaml
-# agents/cc-01.yaml
-apiVersion: oab.dev/v1
-kind: OABService
-metadata:
-  name: cc-01
-  namespace: prod
-spec:
-  replicas: 1
-  capacityProvider: FARGATE_SPOT
-  cpu: 512
-  memory: 1024
-  taskDefinition:
-    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
-  bootstrapFrom: s3://oab-backups/agents/cc-01/latest.tar.gz
-  networking:
-    subnets: [subnet-aaa, subnet-bbb]
-    securityGroups: [sg-oab]
+Controller sees `deletionTimestamp`:
+1. Scale to 0, wait for task drain
+2. Delete ECS service
+3. Remove `config/{ns}/{name}/` from S3
+4. Remove `status/{ns}/{name}.json` from S3
+5. Remove `manifests/{ns}/{name}.yaml` from S3 (final cleanup)
+
+---
+
+## 8. CLI UX (`oabctl`)
+
+### Core Commands
+
+```bash
+oabctl apply -f agent.yaml          # declare/update desired state
+oabctl get oabservice               # list all services + status
+oabctl get oabservice kiro-01       # single service detail
+oabctl delete oabservice kiro-01    # set deletionTimestamp (tombstone)
+oabctl diff -f agent.yaml           # show local vs remote diff
+oabctl logs kiro-01                 # shortcut to ECS task logs
+oabctl snapshot kiro-01             # backup current HOME to S3
 ```
 
-```yaml
-# agents/codex-01.yaml
-apiVersion: oab.dev/v1
-kind: OABService
-metadata:
-  name: codex-01
-  namespace: prod
-spec:
-  replicas: 1
-  capacityProvider: FARGATE_SPOT
-  cpu: 1024
-  memory: 2048
-  taskDefinition:
-    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
-  bootstrapFrom: s3://oab-backups/agents/codex-01/latest.tar.gz
-  networking:
-    subnets: [subnet-aaa, subnet-bbb]
-    securityGroups: [sg-oab]
+### `apply` Flow
+
+```
+$ oabctl apply -f prod/kiro-01.yaml
+
+✓ Schema validated (oab.dev/v1 OABService)
+✓ Secrets verified (SSM paths exist)
+✓ Uploaded to s3://oab-control-plane/manifests/prod/kiro-01.yaml
+✓ Generation: 3 → 4
+⏳ Waiting for reconciliation...
+✓ Service kiro-01 reconciled (observedGeneration=4, phase=Running)
 ```
 
-Deploy all 10 agents:
+### Directory Apply
 
 ```bash
 $ oabctl apply -f agents/
@@ -266,143 +274,76 @@ $ oabctl apply -f agents/
 ```bash
 $ oabctl get oabservice
 
-NAME       NAMESPACE  CPU   MEM   CAPACITY      STATUS   AGE
-kiro-01    prod       256   512   FARGATE_SPOT  Running  2m
-kiro-02    prod       256   512   FARGATE_SPOT  Running  2m
-kiro-03    prod       256   512   FARGATE_SPOT  Running  2m
-kiro-04    prod       256   512   FARGATE_SPOT  Running  2m
-kiro-05    prod       256   512   FARGATE_SPOT  Running  2m
-cc-01      prod       512   1024  FARGATE_SPOT  Running  2m
-cc-02      prod       512   1024  FARGATE_SPOT  Running  2m
-cc-03      prod       512   1024  FARGATE_SPOT  Running  2m
-codex-01   prod       1024  2048  FARGATE_SPOT  Running  1m
-codex-02   prod       1024  2048  FARGATE_SPOT  Running  1m
+NAME       NAMESPACE  CPU   MEM   CAPACITY      STATUS   GEN  OBS-GEN  AGE
+kiro-01    prod       256   512   FARGATE_SPOT  Running  4    4        2m
+kiro-02    prod       256   512   FARGATE_SPOT  Running  4    4        2m
+kiro-03    prod       256   512   FARGATE_SPOT  Running  4    4        2m
+kiro-04    prod       256   512   FARGATE_SPOT  Running  4    4        2m
+kiro-05    prod       256   512   FARGATE_SPOT  Running  4    4        2m
+cc-01      prod       512   1024  FARGATE_SPOT  Running  4    4        2m
+cc-02      prod       512   1024  FARGATE_SPOT  Running  4    4        2m
+cc-03      prod       512   1024  FARGATE_SPOT  Running  4    4        2m
+codex-01   prod       1024  2048  FARGATE_SPOT  Running  4    4        1m
+codex-02   prod       1024  2048  FARGATE_SPOT  Running  4    4        1m
 ```
-
-Each agent's identity (bot token, steering, backend config) lives in its own `bootstrapFrom` archive. The manifest only manages infrastructure.
 
 ---
 
-## 4. State Store Design (S3-Only)
+## 9. Schema Versioning & Validation
 
-```
-s3://oab-control-plane/
-  ├── manifests/{namespace}/{name}.yaml   ← desired state (oabctl writes)
-  └── status/{namespace}/{name}.json      ← observed state (controller writes)
-```
-
-| Concern | Mechanism | Rationale |
-|---------|-----------|-----------|
-| Desired state | `s3://…/manifests/` | Human-readable, git-syncable, versioned via S3 versioning |
-| Status / observed state | `s3://…/status/` | Controller writes after each reconcile cycle |
-| Generation tracking | S3 object VersionId | Each `oabctl apply` creates a new version; controller compares |
-| Change detection | S3 Event Notifications → EventBridge | Triggers controller on manifest PUT/DELETE |
-| Consistency | S3 strong read-after-write | Sufficient for single-controller architecture |
-
-**Why no DynamoDB in Phase 1:**
-- Single controller instance — no leader election needed
-- S3 strong read-after-write consistency (since Dec 2020) is sufficient
-- Fewer moving parts, zero additional infra cost
-- DDB can be added in Phase 2 for multi-replica leader election and fast status queries
+- `oabctl` validates manifests against a built-in JSON Schema for `oab.dev/v1`
+- Controller also validates on reconcile (defense in depth)
+- Unknown fields are rejected (strict mode) to prevent silent misconfiguration
+- Schema version is tied to `oabctl` / controller version; version skew policy:
+  - Controller must be >= oabctl version
+  - Controller accepts current version and one prior version
 
 ---
 
-## 5. CLI UX (`oabctl`)
+## 10. MVP Scope
 
-### Core Commands
+### Phase 1 (In Scope)
 
-```bash
-oabctl apply -f agent.yaml          # declare/update desired state
-oabctl get oabservice               # list all services + status
-oabctl get oabservice my-agent      # single service detail
-oabctl delete oabservice my-agent   # mark for deletion
-oabctl diff -f agent.yaml           # show local vs remote diff
-oabctl logs my-agent                # shortcut to ECS task logs
-oabctl wait my-agent --for=Available # block until condition met
-```
-
-### `apply` Semantics
-
-```
-$ oabctl apply -f prod/my-agent.yaml
-
-✓ Schema validated
-✓ Uploaded to s3://oab-control-plane/manifests/prod/my-agent.yaml
-✓ Generation: v3 → v4
-⏳ Waiting for reconciliation...
-✓ Service my-agent reconciled (2/2 tasks running)
-```
-
-Behavior:
-- Object doesn't exist → create (PUT to S3)
-- Object exists → update (PUT overwrites, new S3 version)
-- Immutable fields (namespace) → reject with error
-- `--wait=false` to skip waiting for reconciliation
-
-### `apply` Implementation (Phase 1)
-
-```
-oabctl apply -f agent.yaml
-  │
-  ├─ 1. Parse & validate YAML against schema (local, fast fail)
-  ├─ 2. s3:PutObject → s3://oab-control-plane/manifests/{ns}/{name}.yaml
-  └─ 3. (if --wait) Poll status/{ns}/{name}.json until phase=Running or timeout
-```
-
-No API server needed — `oabctl` talks directly to S3 via AWS SDK. Auth is standard IAM (role, profile, env vars).
-
----
-
-## 6. Controller Lifecycle
-
-### Reconcile Actions
-
-| Diff | Action |
-|------|--------|
-| Manifest exists, no ECS service | RegisterTaskDefinition → CreateService |
-| Manifest spec changed (new S3 version) | RegisterTaskDefinition (new revision) → UpdateService |
-| Manifest deleted from S3 | UpdateService (desiredCount=0) → DeleteService → DeregisterTaskDefinition |
-| ECS state drifted from spec | UpdateService to re-converge |
-
-### Finalizers
-
-Before deleting an ECS service, the controller:
-1. Drains active connections (set desiredCount=0, wait for task stop)
-2. Cleans up CloudMap service discovery entries
-3. Removes the status JSON from S3
-4. Only then acknowledges deletion
-
----
-
-## 7. MVP Scope
-
-### Phase 1 (minimal viable control plane)
-
-1. **S3 bucket** — manifests/ and status/ prefixes, versioning enabled
+1. **S3 bucket** — manifests/, config/, status/ prefixes, versioning enabled
 2. **Single-instance ECS task** running the controller
 3. **Poll-based** — ListObjects + GetObject every 30s
-4. **`oabctl apply`** — validates and uploads YAML to S3
-5. **`oabctl get`** — reads status/ prefix, displays table
-6. Support `create` and `update` only (delete = manual remove from S3)
+4. **`oabctl apply`** — validates, increments generation, uploads to S3
+5. **`oabctl get`** — reads status/, displays table with generation tracking
+6. **`oabctl delete`** — writes deletionTimestamp (tombstone), controller cleans up
+7. **Config rendering** — controller generates config.toml from spec.config → S3
+8. **Entrypoint wrapper** — downloads bootstrap + config on task start
+9. **Secrets via SSM** — referenced in task definition, never in S3
+
+### Phase 1 (Out of Scope)
+
+- Event-driven triggers (EventBridge)
+- Multi-replica controller / leader election (DynamoDB)
+- `oabctl diff`, `oabctl logs`, `oabctl snapshot`
+- Rollback via generation history
+- Secret rotation automation
+- Multi-region
+- OABFleet kind (template for N agents)
 
 ### Phase 2
 
 - Event-driven triggers (S3 → EventBridge → controller wakes immediately)
-- `oabctl delete` with finalizer support
-- `oabctl diff` and `oabctl logs`
-- DynamoDB for leader election (multi-replica controller)
-- Rollback via S3 version history (`oabctl rollback my-agent --to-version=v3`)
+- DynamoDB for leader election (multi-replica controller HA)
+- `oabctl diff` (spec-only vs rendered vs runtime)
+- `oabctl snapshot` (backup HOME → S3)
+- Rollback via generation history
+- GitOps integration (GitHub Actions → `oabctl apply` on push)
 
 ### Phase 3
 
-- Multi-region (controller per region, shared manifest bucket with replication)
-- Dependency graph (service A depends on service B)
-- Auto-scaling policies in manifest spec
-- GitOps integration (GitHub Actions → `oabctl apply` on push)
+- Multi-region (controller per region, S3 cross-region replication)
+- OABFleet kind (deploy N agents from a template)
+- Secret rotation automation
+- Auto-scaling policies
+- Controller self-upgrade (blue/green deployment)
 
 ---
 
-## 8. Alternatives Considered
+## 11. Alternatives Considered
 
 | Alternative | Why not chosen |
 |-------------|---------------|
@@ -412,72 +353,30 @@ Before deleting an ECS service, the controller:
 | Step Functions orchestrator | Stateless execution model, no continuous reconciliation |
 | Run K8s anyway (EKS) | Valid but adds operational overhead for teams that chose ECS |
 | DynamoDB as primary store | Adds infra; S3 sufficient for single-controller Phase 1 |
+| Secrets in bootstrap archive | No per-secret audit trail, broad S3 access = all tokens exposed |
 
 ---
 
-## 9. Per-Agent Secret Injection
+## 12. Open Questions
 
-Each agent/bot has its **own** bot token and credentials — no token sharing between agents.
-
-### Design Principle
-
-- Each `AgentDeployment` owns its secrets (1:1 mapping)
-- Controller never touches secret values — it only wires references into ECS Task Definitions
-- ECS native `secrets` field handles injection at runtime
-- IAM scoping ensures each task role can only read its own secret path
-
-### Spec
-
-```yaml
-apiVersion: openab.dev/v1
-kind: AgentDeployment
-metadata:
-  name: chaodu
-spec:
-  secrets:
-    - name: DISCORD_BOT_TOKEN
-      source: ssm                      # ssm | secretsmanager
-      path: /oab/chaodu/discord-token
-    - name: LLM_API_KEY
-      source: secretsmanager
-      arn: arn:aws:secretsmanager:us-east-1:123:secret:oab/chaodu/llm-key
-```
-
-### Controller Behavior
-
-1. **Deploy** — maps `spec.secrets` to ECS TaskDefinition `secrets` field:
-   ```json
-   {
-     "secrets": [
-       { "name": "DISCORD_BOT_TOKEN", "valueFrom": "/oab/chaodu/discord-token" },
-       { "name": "LLM_API_KEY", "valueFrom": "arn:aws:secretsmanager:us-east-1:123:secret:oab/chaodu/llm-key" }
-     ]
-   }
-   ```
-2. **IAM** — controller creates/assigns a task execution role scoped to the agent's secret path:
-   ```json
-   {
-     "Effect": "Allow",
-     "Action": ["ssm:GetParameters", "secretsmanager:GetSecretValue"],
-     "Resource": [
-       "arn:aws:ssm:*:*:parameter/oab/chaodu/*",
-       "arn:aws:secretsmanager:*:*:secret:oab/chaodu/*"
-     ]
-   }
-   ```
-3. **Rotation** — when a secret is rotated in SSM/Secrets Manager, user runs `oabctl restart <agent>` (or sets `spec.secrets.autoRestart: true`) to force a new task deployment that picks up the new value.
+1. **Controller upgrade strategy** — ECS rolling deployment sufficient for Phase 1; need blue/green for Phase 2 multi-replica
+2. **Runtime state persistence** — how/when does agent snapshot HOME back to S3? (periodic cron? on graceful shutdown?)
+3. **Networking isolation** — per-service SG rules, egress policy, VPC endpoint restrictions
+4. **Observability** — CloudWatch metrics from controller, or push to shared dashboard?
+5. **`oabctl diff` granularity** — spec-only, rendered taskdef, or runtime status?
 
 ---
 
-## 10. Open Questions
+## 13. Decision
 
-1. **Multi-region** — single controller per region, or global controller with regional reconcilers?
-2. **Observability** — CloudWatch metrics from the controller, or push to a shared OAB dashboard?
-3. **Upgrade strategy** — how does the controller upgrade itself without downtime?
-4. **Networking isolation** — shared VPC or per-service security group rules?
+We adopt the CRD + Operator pattern on ECS with:
+- **`oab.dev/v1` / `OABService`** as the fixed API identity
+- **S3-only state store** (manifests + rendered config + status)
+- **`oabctl` CLI** with kubectl-like UX
+- **Explicit generation/observedGeneration** for reconcile tracking
+- **Secrets always in SSM/Secrets Manager**, never in S3 archives
+- **Entrypoint wrapper** pattern for bootstrap + config download
+- **Tombstone deletion** pattern for safe cleanup
+- **`replicas: 1`** enforced for bot-type agents
 
----
-
-## 11. Decision
-
-We adopt the CRD + Operator pattern on ECS with an **S3-only state store** and a **`oabctl` CLI** for the operator interface. The controller runs as a single ECS service that reconciles OABService manifests (stored in S3) against actual ECS state. DynamoDB is deferred to Phase 2 when multi-replica HA is needed. This gives ECS-native teams the same declarative, self-healing deployment experience that K8s operators provide — with minimal infrastructure footprint.
+Phase 1 targets a single-controller, poll-based MVP that can deploy and manage a fleet of OAB agents on ECS Fargate with full declarative lifecycle management.

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -390,16 +390,69 @@ Before deleting an ECS service, the controller:
 
 ---
 
-## 9. Open Questions
+## 9. Per-Agent Secret Injection
 
-1. **Secrets management** — inject via ECS Secrets (SSM/SecretsManager reference in task def) or controller-managed?
-2. **Multi-region** — single controller per region, or global controller with regional reconcilers?
-3. **Observability** — CloudWatch metrics from the controller, or push to a shared OAB dashboard?
-4. **Upgrade strategy** — how does the controller upgrade itself without downtime?
-5. **Networking isolation** — shared VPC or per-service security group rules?
+Each agent/bot has its **own** bot token and credentials — no token sharing between agents.
+
+### Design Principle
+
+- Each `AgentDeployment` owns its secrets (1:1 mapping)
+- Controller never touches secret values — it only wires references into ECS Task Definitions
+- ECS native `secrets` field handles injection at runtime
+- IAM scoping ensures each task role can only read its own secret path
+
+### Spec
+
+```yaml
+apiVersion: openab.dev/v1
+kind: AgentDeployment
+metadata:
+  name: chaodu
+spec:
+  secrets:
+    - name: DISCORD_BOT_TOKEN
+      source: ssm                      # ssm | secretsmanager
+      path: /oab/chaodu/discord-token
+    - name: LLM_API_KEY
+      source: secretsmanager
+      arn: arn:aws:secretsmanager:us-east-1:123:secret:oab/chaodu/llm-key
+```
+
+### Controller Behavior
+
+1. **Deploy** — maps `spec.secrets` to ECS TaskDefinition `secrets` field:
+   ```json
+   {
+     "secrets": [
+       { "name": "DISCORD_BOT_TOKEN", "valueFrom": "/oab/chaodu/discord-token" },
+       { "name": "LLM_API_KEY", "valueFrom": "arn:aws:secretsmanager:us-east-1:123:secret:oab/chaodu/llm-key" }
+     ]
+   }
+   ```
+2. **IAM** — controller creates/assigns a task execution role scoped to the agent's secret path:
+   ```json
+   {
+     "Effect": "Allow",
+     "Action": ["ssm:GetParameters", "secretsmanager:GetSecretValue"],
+     "Resource": [
+       "arn:aws:ssm:*:*:parameter/oab/chaodu/*",
+       "arn:aws:secretsmanager:*:*:secret:oab/chaodu/*"
+     ]
+   }
+   ```
+3. **Rotation** — when a secret is rotated in SSM/Secrets Manager, user runs `oabctl restart <agent>` (or sets `spec.secrets.autoRestart: true`) to force a new task deployment that picks up the new value.
 
 ---
 
-## 10. Decision
+## 10. Open Questions
+
+1. **Multi-region** — single controller per region, or global controller with regional reconcilers?
+2. **Observability** — CloudWatch metrics from the controller, or push to a shared OAB dashboard?
+3. **Upgrade strategy** — how does the controller upgrade itself without downtime?
+4. **Networking isolation** — shared VPC or per-service security group rules?
+
+---
+
+## 11. Decision
 
 We adopt the CRD + Operator pattern on ECS with an **S3-only state store** and a **`oabctl` CLI** for the operator interface. The controller runs as a single ECS service that reconciles OABService manifests (stored in S3) against actual ECS state. DynamoDB is deferred to Phase 2 when multi-replica HA is needed. This gives ECS-native teams the same declarative, self-healing deployment experience that K8s operators provide — with minimal infrastructure footprint.

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -3,7 +3,6 @@
 - **Status:** Proposed
 - **Date:** 2026-05-18
 - **Author:** @pahud.hsieh
-- **Reviewers:** 擺渡法師(Codex), 普渡法師(CC), 口渡法師(Copilot), 超渡法師(Kiro)
 - **Related:** [Multi-Platform Adapters](./multi-platform-adapters.md), [Basic CronJob](./basic-cronjob.md)
 
 ---
@@ -48,56 +47,32 @@ This enables a "GitOps for ECS" workflow where pushing a YAML change triggers th
 1. Load all YAML manifests from S3 (desired state)
 2. Describe current ECS services/tasks (observed state)
 3. Compute diff
-4. Render config artifact → upload to S3
-5. Apply changes: create, update, or delete ECS resources
-6. Write status back to S3 (with observedGeneration)
-7. Sleep / wait for next event
+4. Apply changes: create, update, or delete ECS resources
+5. Write status back to S3 (separate prefix)
+6. Sleep / wait for next event
 
 ---
 
-## 3. API Identity
-
-| Field | Value |
-|-------|-------|
-| API Group | `oab.dev` |
-| API Version | `oab.dev/v1` |
-| Kind | `OABService` |
-| Plural resource | `oabservices` |
-| CLI noun | `oabservice` |
-
-All paths (S3, SSM, IAM) use this identity consistently:
-- S3: `manifests/{namespace}/{name}.yaml`
-- SSM: `/oab/{namespace}/{name}/{secret-name}`
-- ECS: service name = `oab-{namespace}-{name}`
-
----
-
-## 4. Manifest Schema
+## 3. Manifest Schema
 
 ```yaml
 apiVersion: oab.dev/v1
 kind: OABService
 metadata:
-  name: kiro-01
+  name: my-agent
   namespace: prod
-  generation: 4                        # incremented by oabctl on each apply
 spec:
-  replicas: 1                          # see "Replicas & HA" section
-  capacityProvider: FARGATE_SPOT       # FARGATE (default) or FARGATE_SPOT
-  cpu: 256                             # vCPU units (256 = 0.25 vCPU)
-  memory: 512                          # MB
+  replicas: 2
+  capacityProvider: FARGATE        # FARGATE (default) or FARGATE_SPOT
+  cpu: 256                         # vCPU units (256 = 0.25 vCPU)
+  memory: 512                      # MB
   taskDefinition:
     image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
-  bootstrapFrom: s3://oab-backups/agents/kiro-01/latest.tar.gz
+  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
   networking:
-    subnets: [subnet-aaa, subnet-bbb]
-    securityGroups: [sg-oab]
+    subnets: [subnet-abc, subnet-def]
+    securityGroups: [sg-123]
     assignPublicIp: false
-  secrets:
-    - name: DISCORD_TOKEN
-      valueFrom: /oab/prod/kiro-01/discord-token
-    - name: OPENAI_API_KEY
-      valueFrom: /oab/prod/kiro-01/openai-key
   config:
     channels:
       - type: discord
@@ -107,152 +82,169 @@ spec:
       model_id: anthropic.claude-sonnet-4-20250514
       region: us-east-1
     steering:
-      system_prompt: "You are 超渡法師(Kiro)..."
+      system_prompt: "You are 超渡法師(Kiro), an OpenAB agent..."
     features:
       stt: true
       cronjob: true
-status:
-  phase: Running
-  observedGeneration: 4
-  conditions:
-    - type: Available
-      status: "True"
-      lastTransitionTime: "2026-05-18T10:00:00Z"
 ```
 
-### Field Responsibilities
+Key fields:
+- `spec.capacityProvider` — `FARGATE` (default, on-demand) or `FARGATE_SPOT` (up to 70% cost savings, with interruption risk)
+- `spec.cpu` / `spec.memory` — maps directly to ECS task definition (must be a valid Fargate combination)
+- `spec.taskDefinition` — container image and optional overrides
+- `spec.bootstrapFrom` — S3 path to agent HOME archive (contains OAuth tokens, memory, scripts)
+- `spec.networking` — ECS awsvpc configuration
+- `spec.config` — structured agent configuration (channels, backend, steering, features); controller validates and generates `config.toml`
 
-| Field | Purpose | Who writes |
-|-------|---------|-----------|
-| `spec.bootstrapFrom` | Mutable HOME state (memory, runtime data, scripts) | Operator |
-| `spec.config` | Desired agent configuration (channels, backend, steering) | Operator |
-| `spec.secrets` | SSM/Secrets Manager references for tokens & keys | Operator |
-| `metadata.generation` | Monotonic counter, incremented on each apply | oabctl |
-| `status.observedGeneration` | Last generation the controller successfully reconciled | Controller |
+The manifest manages both **infrastructure** and **agent configuration**. On reconcile, the controller generates `config.toml` from `spec.config` and injects it into the running task.
 
-### Separation of Concerns
+### Config Reconciliation
 
-- **`bootstrapFrom`** = mutable state (memory, knowledge base, scripts). Does NOT contain secrets or config.
-- **`spec.config`** = desired configuration. Controller renders this to `config.toml` artifact.
-- **`spec.secrets`** = all credentials. Always SSM/Secrets Manager references, never in archive or manifest values.
+| Change | Controller Action |
+|--------|-------------------|
+| `spec.config` changed | Generate new config.toml → write to agent's config volume → restart task |
+| `spec.cpu/memory/capacityProvider` changed | New task definition revision → UpdateService (rolling restart) |
+| `spec.bootstrapFrom` changed | Next task start uses new archive |
+| Infra + config changed together | Single rolling restart with both changes applied |
 
----
+`spec.config` takes precedence over any config.toml in the bootstrap archive. Bootstrap provides the initial HOME state; `spec.config` is the live desired state for configuration.
 
-## 5. Replicas & HA
-
-Bot agents (Discord, Telegram, Slack) are inherently **single-instance** — the same bot token cannot have multiple consumers without duplicate responses.
-
-Rules:
-- `replicas: 1` — default and only valid value for bot-type agents
-- Schema validation rejects `replicas > 1` when `spec.config.channels` contains bot-type channels
-- Future: `replicas > 1` may be considered for stateless webhook receivers with deduplication, but is not planned
-
-For HA of bot agents, the controller relies on ECS service auto-recovery (task restart on failure) rather than multiple replicas.
-
----
-
-## 6. State Store Design (S3-Only, Phase 1)
-
-```
-s3://oab-control-plane/
-  ├── manifests/{namespace}/{name}.yaml       ← desired state (oabctl writes)
-  ├── config/{namespace}/{name}/config.toml   ← rendered config (controller writes)
-  └── status/{namespace}/{name}.json          ← observed state (controller writes)
-```
-
-| Concern | Mechanism | Rationale |
-|---------|-----------|-----------|
-| Desired state | `manifests/` | Human-readable, git-syncable, versioned via S3 versioning |
-| Rendered config | `config/` | Controller generates config.toml from spec.config |
-| Status | `status/` | Contains observedGeneration, phase, conditions |
-| Generation tracking | Explicit `metadata.generation` counter in manifest | Unambiguous; S3 VersionId alone is insufficient for reconcile tracking |
-| Change detection | S3 Event Notifications → EventBridge (Phase 2) | Phase 1 uses polling |
-| Consistency | S3 strong read-after-write | Sufficient for single-controller |
-
----
-
-## 7. Controller Lifecycle
-
-### Task Startup (Entrypoint Wrapper)
-
-ECS/Fargate has no init container. The OAB container uses an **entrypoint wrapper script**:
-
-```bash
-#!/bin/bash
-# 1. Download bootstrap (mutable state)
-aws s3 cp "${BOOTSTRAP_FROM}" /tmp/bootstrap.tar.gz
-tar xzf /tmp/bootstrap.tar.gz -C $HOME
-
-# 2. Download rendered config (controller-generated)
-aws s3 cp "s3://oab-control-plane/config/${NAMESPACE}/${NAME}/config.toml" $HOME/config.toml
-
-# 3. Start OAB (secrets injected via ECS task definition)
-exec /usr/bin/openab
-```
-
-The controller passes `BOOTSTRAP_FROM`, `NAMESPACE`, `NAME` as environment variables in the task definition.
-
-### Reconcile Actions
-
-| Diff | Controller Action |
-|------|-------------------|
-| Manifest exists, no ECS service | Render config → upload to S3 → RegisterTaskDefinition → CreateService |
-| `spec.config` changed | Render new config.toml → upload to S3 → restart task (new config on next start) |
-| `spec.cpu/memory/image` changed | New task definition revision → UpdateService (rolling restart) |
-| `spec.secrets` changed | Update task definition secrets → UpdateService |
-| Deletion marker present | desiredCount=0 → wait for drain → DeleteService → cleanup status/config |
-| ECS state drifted | UpdateService to re-converge |
-| `status.observedGeneration < metadata.generation` | Reconcile needed |
-
-### Deletion (Tombstone Pattern)
-
-`oabctl delete` does NOT remove the manifest from S3. Instead:
+### Capacity Provider
 
 ```yaml
+# Cost-optimized: spot instances, tolerates interruption
+spec:
+  capacityProvider: FARGATE_SPOT
+
+# Production: guaranteed capacity
+spec:
+  capacityProvider: FARGATE
+```
+
+FARGATE_SPOT is suitable for stateless agents that can tolerate interruption (OAB reconnects automatically). For agents with strict SLA requirements, use FARGATE.
+
+### Bootstrap & Agent HOME
+
+Each agent's HOME directory (containing OAuth tokens, config, steering, memory) is restored from an S3 archive on startup via `bootstrapFrom`:
+
+```yaml
+spec:
+  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
+```
+
+**Startup flow:**
+
+```
+ECS Task starts
+  → init: s3:GetObject ${bootstrapFrom}
+  → init: tar xzf → $HOME/
+  → OAB process starts with fully populated HOME
+       ├── config.toml
+       ├── .oauth/discord-token
+       ├── steering/
+       └── memory/
+```
+
+**What's in the bootstrap archive:**
+- OAuth tokens (Discord bot token, Slack OAuth, etc.)
+- `config.toml` (channel bindings, backend config)
+- Steering files (personality, system prompts)
+- Memory / knowledge base snapshots
+- Any agent-specific tooling or scripts
+
+**Lifecycle:**
+
+| Event | Action |
+|-------|--------|
+| First deploy | Operator prepares bootstrap archive manually or via `oabctl snapshot` |
+| Redeploy / scale-out | New tasks restore from same `bootstrapFrom` path |
+| Agent state changes | Periodic `oabctl snapshot my-agent` → uploads new archive to S3 |
+| Disaster recovery | Point `bootstrapFrom` to any previous snapshot |
+
+**Secrets handling:**
+- OAuth tokens live inside the bootstrap archive (encrypted at rest via S3 SSE-KMS)
+- No need for controller to call Discord API or manage Secrets Manager
+- The S3 bucket + KMS key policy controls who can access the tokens
+- Optional: `spec.secrets` still available for additional runtime secrets (API keys not in HOME)
+
+```yaml
+spec:
+  bootstrapFrom: s3://oab-backups/agents/my-agent/latest.tar.gz
+  secrets:                              # optional, for secrets not in bootstrap
+    - name: OPENAI_API_KEY
+      valueFrom: /oab/prod/my-agent/openai-key
+```
+
+### Example: Multi-Agent Fleet (5 Kiro + 3 CC + 2 Codex)
+
+```
+agents/
+├── kiro-01.yaml ... kiro-05.yaml
+├── cc-01.yaml ... cc-03.yaml
+└── codex-01.yaml ... codex-02.yaml
+```
+
+```yaml
+# agents/kiro-01.yaml
+apiVersion: oab.dev/v1
+kind: OABService
 metadata:
   name: kiro-01
   namespace: prod
-  generation: 5
-  deletionTimestamp: "2026-05-19T00:10:00Z"   # ← marks intent to delete
+spec:
+  replicas: 1
+  capacityProvider: FARGATE_SPOT
+  cpu: 256
+  memory: 512
+  taskDefinition:
+    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
+  bootstrapFrom: s3://oab-backups/agents/kiro-01/latest.tar.gz
+  networking:
+    subnets: [subnet-aaa, subnet-bbb]
+    securityGroups: [sg-oab]
 ```
 
-Controller sees `deletionTimestamp`:
-1. Scale to 0, wait for task drain
-2. Delete ECS service
-3. Remove `config/{ns}/{name}/` from S3
-4. Remove `status/{ns}/{name}.json` from S3
-5. Remove `manifests/{ns}/{name}.yaml` from S3 (final cleanup)
-
----
-
-## 8. CLI UX (`oabctl`)
-
-### Core Commands
-
-```bash
-oabctl apply -f agent.yaml          # declare/update desired state
-oabctl get oabservice               # list all services + status
-oabctl get oabservice kiro-01       # single service detail
-oabctl delete oabservice kiro-01    # set deletionTimestamp (tombstone)
-oabctl diff -f agent.yaml           # show local vs remote diff
-oabctl logs kiro-01                 # shortcut to ECS task logs
-oabctl snapshot kiro-01             # backup current HOME to S3
+```yaml
+# agents/cc-01.yaml
+apiVersion: oab.dev/v1
+kind: OABService
+metadata:
+  name: cc-01
+  namespace: prod
+spec:
+  replicas: 1
+  capacityProvider: FARGATE_SPOT
+  cpu: 512
+  memory: 1024
+  taskDefinition:
+    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
+  bootstrapFrom: s3://oab-backups/agents/cc-01/latest.tar.gz
+  networking:
+    subnets: [subnet-aaa, subnet-bbb]
+    securityGroups: [sg-oab]
 ```
 
-### `apply` Flow
-
+```yaml
+# agents/codex-01.yaml
+apiVersion: oab.dev/v1
+kind: OABService
+metadata:
+  name: codex-01
+  namespace: prod
+spec:
+  replicas: 1
+  capacityProvider: FARGATE_SPOT
+  cpu: 1024
+  memory: 2048
+  taskDefinition:
+    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
+  bootstrapFrom: s3://oab-backups/agents/codex-01/latest.tar.gz
+  networking:
+    subnets: [subnet-aaa, subnet-bbb]
+    securityGroups: [sg-oab]
 ```
-$ oabctl apply -f prod/kiro-01.yaml
 
-✓ Schema validated (oab.dev/v1 OABService)
-✓ Secrets verified (SSM paths exist)
-✓ Uploaded to s3://oab-control-plane/manifests/prod/kiro-01.yaml
-✓ Generation: 3 → 4
-⏳ Waiting for reconciliation...
-✓ Service kiro-01 reconciled (observedGeneration=4, phase=Running)
-```
-
-### Directory Apply
+Deploy all 10 agents:
 
 ```bash
 $ oabctl apply -f agents/
@@ -274,76 +266,226 @@ $ oabctl apply -f agents/
 ```bash
 $ oabctl get oabservice
 
-NAME       NAMESPACE  CPU   MEM   CAPACITY      STATUS   GEN  OBS-GEN  AGE
-kiro-01    prod       256   512   FARGATE_SPOT  Running  4    4        2m
-kiro-02    prod       256   512   FARGATE_SPOT  Running  4    4        2m
-kiro-03    prod       256   512   FARGATE_SPOT  Running  4    4        2m
-kiro-04    prod       256   512   FARGATE_SPOT  Running  4    4        2m
-kiro-05    prod       256   512   FARGATE_SPOT  Running  4    4        2m
-cc-01      prod       512   1024  FARGATE_SPOT  Running  4    4        2m
-cc-02      prod       512   1024  FARGATE_SPOT  Running  4    4        2m
-cc-03      prod       512   1024  FARGATE_SPOT  Running  4    4        2m
-codex-01   prod       1024  2048  FARGATE_SPOT  Running  4    4        1m
-codex-02   prod       1024  2048  FARGATE_SPOT  Running  4    4        1m
+NAME       NAMESPACE  CPU   MEM   CAPACITY      STATUS   AGE
+kiro-01    prod       256   512   FARGATE_SPOT  Running  2m
+kiro-02    prod       256   512   FARGATE_SPOT  Running  2m
+kiro-03    prod       256   512   FARGATE_SPOT  Running  2m
+kiro-04    prod       256   512   FARGATE_SPOT  Running  2m
+kiro-05    prod       256   512   FARGATE_SPOT  Running  2m
+cc-01      prod       512   1024  FARGATE_SPOT  Running  2m
+cc-02      prod       512   1024  FARGATE_SPOT  Running  2m
+cc-03      prod       512   1024  FARGATE_SPOT  Running  2m
+codex-01   prod       1024  2048  FARGATE_SPOT  Running  1m
+codex-02   prod       1024  2048  FARGATE_SPOT  Running  1m
 ```
 
+Each agent's identity (bot token, steering, backend config) lives in its own `bootstrapFrom` archive. The manifest only manages infrastructure.
+
+### Structured config.toml
+
+Instead of relying solely on the bootstrap archive for `config.toml`, the spec models it structurally. The controller renders the YAML into a valid `config.toml` and mounts it into the container.
+
+```yaml
+apiVersion: oab.dev/v1
+kind: OABService
+metadata:
+  name: chaodu
+  namespace: prod
+spec:
+  config:
+    agent:
+      name: chaodu
+      backend: kiro
+      workingDir: /home/agent
+      model: us.anthropic.claude-sonnet-4-20250514
+    discord:
+      enabled: true
+      botId: "1490365068863606784"
+      guildId: "1490282656913559672"
+      channelIds:
+        - "1490282656913559673"
+    telegram:
+      enabled: false
+    steering:
+      source: s3
+      bucket: oab-steering
+      prefix: agents/chaodu/
+    memory:
+      backend: s3
+      bucket: oab-memory
+      prefix: agents/chaodu/
+    tools:
+      github:
+        enabled: true
+      web:
+        enabled: true
+```
+
+**Controller renders to config.toml:**
+
+```toml
+[agent]
+name = "chaodu"
+backend = "kiro"
+working_dir = "/home/agent"
+model = "us.anthropic.claude-sonnet-4-20250514"
+
+[discord]
+enabled = true
+bot_id = "1490365068863606784"
+guild_id = "1490282656913559672"
+channel_ids = ["1490282656913559673"]
+
+[telegram]
+enabled = false
+
+[steering]
+source = "s3"
+bucket = "oab-steering"
+prefix = "agents/chaodu/"
+
+[memory]
+backend = "s3"
+bucket = "oab-memory"
+prefix = "agents/chaodu/"
+
+[tools.github]
+enabled = true
+
+[tools.web]
+enabled = true
+```
+
+**Benefits of structured config:**
+- Schema validation at `oabctl apply` time — catch typos before deploy
+- `oabctl diff` shows exactly what config changed
+- Controller can make decisions based on config (e.g., open ports for enabled adapters)
+- GitOps friendly — config changes are reviewable YAML diffs
+
+**Precedence:** `spec.config` takes priority over config.toml in `bootstrapFrom` archive. If both exist, controller merges them (spec.config wins on conflict).
+
 ---
 
-## 9. Schema Versioning & Validation
+## 4. State Store Design (S3-Only)
 
-- `oabctl` validates manifests against a built-in JSON Schema for `oab.dev/v1`
-- Controller also validates on reconcile (defense in depth)
-- Unknown fields are rejected (strict mode) to prevent silent misconfiguration
-- Schema version is tied to `oabctl` / controller version; version skew policy:
-  - Controller must be >= oabctl version
-  - Controller accepts current version and one prior version
+```
+s3://oab-control-plane/
+  ├── manifests/{namespace}/{name}.yaml   ← desired state (oabctl writes)
+  └── status/{namespace}/{name}.json      ← observed state (controller writes)
+```
+
+| Concern | Mechanism | Rationale |
+|---------|-----------|-----------|
+| Desired state | `s3://…/manifests/` | Human-readable, git-syncable, versioned via S3 versioning |
+| Status / observed state | `s3://…/status/` | Controller writes after each reconcile cycle |
+| Generation tracking | S3 object VersionId | Each `oabctl apply` creates a new version; controller compares |
+| Change detection | S3 Event Notifications → EventBridge | Triggers controller on manifest PUT/DELETE |
+| Consistency | S3 strong read-after-write | Sufficient for single-controller architecture |
+
+**Why no DynamoDB in Phase 1:**
+- Single controller instance — no leader election needed
+- S3 strong read-after-write consistency (since Dec 2020) is sufficient
+- Fewer moving parts, zero additional infra cost
+- DDB can be added in Phase 2 for multi-replica leader election and fast status queries
 
 ---
 
-## 10. MVP Scope
+## 5. CLI UX (`oabctl`)
 
-### Phase 1 (In Scope)
+### Core Commands
 
-1. **S3 bucket** — manifests/, config/, status/ prefixes, versioning enabled
+```bash
+oabctl apply -f agent.yaml          # declare/update desired state
+oabctl get oabservice               # list all services + status
+oabctl get oabservice my-agent      # single service detail
+oabctl delete oabservice my-agent   # mark for deletion
+oabctl diff -f agent.yaml           # show local vs remote diff
+oabctl logs my-agent                # shortcut to ECS task logs
+oabctl wait my-agent --for=Available # block until condition met
+```
+
+### `apply` Semantics
+
+```
+$ oabctl apply -f prod/my-agent.yaml
+
+✓ Schema validated
+✓ Uploaded to s3://oab-control-plane/manifests/prod/my-agent.yaml
+✓ Generation: v3 → v4
+⏳ Waiting for reconciliation...
+✓ Service my-agent reconciled (2/2 tasks running)
+```
+
+Behavior:
+- Object doesn't exist → create (PUT to S3)
+- Object exists → update (PUT overwrites, new S3 version)
+- Immutable fields (namespace) → reject with error
+- `--wait=false` to skip waiting for reconciliation
+
+### `apply` Implementation (Phase 1)
+
+```
+oabctl apply -f agent.yaml
+  │
+  ├─ 1. Parse & validate YAML against schema (local, fast fail)
+  ├─ 2. s3:PutObject → s3://oab-control-plane/manifests/{ns}/{name}.yaml
+  └─ 3. (if --wait) Poll status/{ns}/{name}.json until phase=Running or timeout
+```
+
+No API server needed — `oabctl` talks directly to S3 via AWS SDK. Auth is standard IAM (role, profile, env vars).
+
+---
+
+## 6. Controller Lifecycle
+
+### Reconcile Actions
+
+| Diff | Action |
+|------|--------|
+| Manifest exists, no ECS service | RegisterTaskDefinition → CreateService |
+| Manifest spec changed (new S3 version) | RegisterTaskDefinition (new revision) → UpdateService |
+| Manifest deleted from S3 | UpdateService (desiredCount=0) → DeleteService → DeregisterTaskDefinition |
+| ECS state drifted from spec | UpdateService to re-converge |
+
+### Finalizers
+
+Before deleting an ECS service, the controller:
+1. Drains active connections (set desiredCount=0, wait for task stop)
+2. Cleans up CloudMap service discovery entries
+3. Removes the status JSON from S3
+4. Only then acknowledges deletion
+
+---
+
+## 7. MVP Scope
+
+### Phase 1 (minimal viable control plane)
+
+1. **S3 bucket** — manifests/ and status/ prefixes, versioning enabled
 2. **Single-instance ECS task** running the controller
 3. **Poll-based** — ListObjects + GetObject every 30s
-4. **`oabctl apply`** — validates, increments generation, uploads to S3
-5. **`oabctl get`** — reads status/, displays table with generation tracking
-6. **`oabctl delete`** — writes deletionTimestamp (tombstone), controller cleans up
-7. **Config rendering** — controller generates config.toml from spec.config → S3
-8. **Entrypoint wrapper** — downloads bootstrap + config on task start
-9. **Secrets via SSM** — referenced in task definition, never in S3
-
-### Phase 1 (Out of Scope)
-
-- Event-driven triggers (EventBridge)
-- Multi-replica controller / leader election (DynamoDB)
-- `oabctl diff`, `oabctl logs`, `oabctl snapshot`
-- Rollback via generation history
-- Secret rotation automation
-- Multi-region
-- OABFleet kind (template for N agents)
+4. **`oabctl apply`** — validates and uploads YAML to S3
+5. **`oabctl get`** — reads status/ prefix, displays table
+6. Support `create` and `update` only (delete = manual remove from S3)
 
 ### Phase 2
 
 - Event-driven triggers (S3 → EventBridge → controller wakes immediately)
-- DynamoDB for leader election (multi-replica controller HA)
-- `oabctl diff` (spec-only vs rendered vs runtime)
-- `oabctl snapshot` (backup HOME → S3)
-- Rollback via generation history
-- GitOps integration (GitHub Actions → `oabctl apply` on push)
+- `oabctl delete` with finalizer support
+- `oabctl diff` and `oabctl logs`
+- DynamoDB for leader election (multi-replica controller)
+- Rollback via S3 version history (`oabctl rollback my-agent --to-version=v3`)
 
 ### Phase 3
 
-- Multi-region (controller per region, S3 cross-region replication)
-- OABFleet kind (deploy N agents from a template)
-- Secret rotation automation
-- Auto-scaling policies
-- Controller self-upgrade (blue/green deployment)
+- Multi-region (controller per region, shared manifest bucket with replication)
+- Dependency graph (service A depends on service B)
+- Auto-scaling policies in manifest spec
+- GitOps integration (GitHub Actions → `oabctl apply` on push)
 
 ---
 
-## 11. Alternatives Considered
+## 8. Alternatives Considered
 
 | Alternative | Why not chosen |
 |-------------|---------------|
@@ -353,30 +495,72 @@ codex-02   prod       1024  2048  FARGATE_SPOT  Running  4    4        1m
 | Step Functions orchestrator | Stateless execution model, no continuous reconciliation |
 | Run K8s anyway (EKS) | Valid but adds operational overhead for teams that chose ECS |
 | DynamoDB as primary store | Adds infra; S3 sufficient for single-controller Phase 1 |
-| Secrets in bootstrap archive | No per-secret audit trail, broad S3 access = all tokens exposed |
 
 ---
 
-## 12. Open Questions
+## 9. Per-Agent Secret Injection
 
-1. **Controller upgrade strategy** — ECS rolling deployment sufficient for Phase 1; need blue/green for Phase 2 multi-replica
-2. **Runtime state persistence** — how/when does agent snapshot HOME back to S3? (periodic cron? on graceful shutdown?)
-3. **Networking isolation** — per-service SG rules, egress policy, VPC endpoint restrictions
-4. **Observability** — CloudWatch metrics from controller, or push to shared dashboard?
-5. **`oabctl diff` granularity** — spec-only, rendered taskdef, or runtime status?
+Each agent/bot has its **own** bot token and credentials — no token sharing between agents.
+
+### Design Principle
+
+- Each `AgentDeployment` owns its secrets (1:1 mapping)
+- Controller never touches secret values — it only wires references into ECS Task Definitions
+- ECS native `secrets` field handles injection at runtime
+- IAM scoping ensures each task role can only read its own secret path
+
+### Spec
+
+```yaml
+apiVersion: openab.dev/v1
+kind: AgentDeployment
+metadata:
+  name: chaodu
+spec:
+  secrets:
+    - name: DISCORD_BOT_TOKEN
+      source: ssm                      # ssm | secretsmanager
+      path: /oab/chaodu/discord-token
+    - name: LLM_API_KEY
+      source: secretsmanager
+      arn: arn:aws:secretsmanager:us-east-1:123:secret:oab/chaodu/llm-key
+```
+
+### Controller Behavior
+
+1. **Deploy** — maps `spec.secrets` to ECS TaskDefinition `secrets` field:
+   ```json
+   {
+     "secrets": [
+       { "name": "DISCORD_BOT_TOKEN", "valueFrom": "/oab/chaodu/discord-token" },
+       { "name": "LLM_API_KEY", "valueFrom": "arn:aws:secretsmanager:us-east-1:123:secret:oab/chaodu/llm-key" }
+     ]
+   }
+   ```
+2. **IAM** — controller creates/assigns a task execution role scoped to the agent's secret path:
+   ```json
+   {
+     "Effect": "Allow",
+     "Action": ["ssm:GetParameters", "secretsmanager:GetSecretValue"],
+     "Resource": [
+       "arn:aws:ssm:*:*:parameter/oab/chaodu/*",
+       "arn:aws:secretsmanager:*:*:secret:oab/chaodu/*"
+     ]
+   }
+   ```
+3. **Rotation** — when a secret is rotated in SSM/Secrets Manager, user runs `oabctl restart <agent>` (or sets `spec.secrets.autoRestart: true`) to force a new task deployment that picks up the new value.
 
 ---
 
-## 13. Decision
+## 10. Open Questions
 
-We adopt the CRD + Operator pattern on ECS with:
-- **`oab.dev/v1` / `OABService`** as the fixed API identity
-- **S3-only state store** (manifests + rendered config + status)
-- **`oabctl` CLI** with kubectl-like UX
-- **Explicit generation/observedGeneration** for reconcile tracking
-- **Secrets always in SSM/Secrets Manager**, never in S3 archives
-- **Entrypoint wrapper** pattern for bootstrap + config download
-- **Tombstone deletion** pattern for safe cleanup
-- **`replicas: 1`** enforced for bot-type agents
+1. **Multi-region** — single controller per region, or global controller with regional reconcilers?
+2. **Observability** — CloudWatch metrics from the controller, or push to a shared OAB dashboard?
+3. **Upgrade strategy** — how does the controller upgrade itself without downtime?
+4. **Networking isolation** — shared VPC or per-service security group rules?
 
-Phase 1 targets a single-controller, poll-based MVP that can deploy and manage a fleet of OAB agents on ECS Fargate with full declarative lifecycle management.
+---
+
+## 11. Decision
+
+We adopt the CRD + Operator pattern on ECS with an **S3-only state store** and a **`oabctl` CLI** for the operator interface. The controller runs as a single ECS service that reconciles OABService manifests (stored in S3) against actual ECS state. DynamoDB is deferred to Phase 2 when multi-replica HA is needed. This gives ECS-native teams the same declarative, self-healing deployment experience that K8s operators provide — with minimal infrastructure footprint.

--- a/docs/adr/ecs-control-plane.md
+++ b/docs/adr/ecs-control-plane.md
@@ -141,30 +141,12 @@ status:
 
 ### Replicas Semantics
 
-WebSocket-based adapters (Discord, Telegram, Slack RTM) are **single-consumer** — only one instance can hold the gateway connection. Running multiple replicas would cause duplicate message processing.
+OAB agents are **single-instance** by design — each agent holds one adapter connection (WebSocket gateway for Discord/Telegram/Slack). There is no load balancing across agent replicas.
 
 **Rules:**
-- `replicas: 1` — default and required for WebSocket adapters
-- `replicas > 1` — only valid when all enabled adapters use **webhook mode** (HTTP-based, load-balanceable)
-- Controller **rejects** `replicas > 1` at validation time if any WebSocket adapter is enabled
-
-```yaml
-# ✅ Valid: webhook mode, can scale
-spec:
-  replicas: 3
-  config:
-    discord:
-      enabled: true
-      mode: webhook    # HTTP interactions endpoint
-
-# ❌ Rejected: websocket mode cannot scale
-spec:
-  replicas: 2
-  config:
-    discord:
-      enabled: true
-      # mode defaults to websocket → validation error
-```
+- `replicas: 1` — the only valid value
+- Controller **rejects** `replicas > 1` at validation time
+- Scaling is horizontal by deploying **more agents** (each with its own bot token), not by replicating one agent
 
 ---
 
@@ -379,7 +361,7 @@ oabctl wait my-agent --for=Available # block until condition met
 $ oabctl apply -f prod/my-agent.yaml
 
 ✓ Schema validated (oab.dev/v1 OABService)
-✓ Replicas check passed (replicas=1, websocket adapter)
+✓ Replicas check passed (replicas=1)
 ✓ Uploaded to s3://oab-control-plane/manifests/prod/my-agent.yaml
 ✓ Generation: 3 → 4
 ⏳ Waiting for reconciliation...
@@ -421,7 +403,7 @@ cluster = "oab-prod"
 | Startup wrapper downloads config + bootstrap | EFS / shared volumes |
 | `metadata.generation` / `status.observedGeneration` | Multi-region |
 | Per-agent secrets via SSM/SM | Auto-rotation detection |
-| Replicas validation (reject >1 for WS) | Auto-scaling policies |
+| Replicas validation (reject >1) | Auto-scaling policies |
 
 ### Phase 2
 
@@ -472,7 +454,7 @@ Key design choices:
 - **Config delivery**: controller renders `config.toml` to S3 artifact; startup wrapper downloads it
 - **Secrets**: per-agent SSM/Secrets Manager references; never in bootstrap archive
 - **Bootstrap**: mutable runtime state only (memory, knowledge base)
-- **Replicas**: validated at apply time; WebSocket adapters locked to 1
+- **Replicas**: always 1; scale by deploying more agents, not replicating one
 - **Generation**: explicit `metadata.generation` / `status.observedGeneration` (not S3 VersionId)
 - **Phase 1 scope**: narrow (create/update only, poll-based, single controller)
 


### PR DESCRIPTION
## Summary

Proposes an Architecture Decision Record for running a Kubernetes-style CRD + Operator reconciliation loop on Amazon ECS.

## What's in this ADR

- **Manifest schema** — declarative YAML (OABService kind) stored in S3
- **Reconciler design** — poll/event-driven controller that diffs desired vs observed ECS state
- **State store** — S3 for manifests, DynamoDB for status + leader election
- **Phased MVP** — starts with single-instance poll-based controller, evolves to event-driven multi-replica
- **Alternatives considered** — Proton, Copilot, CDK Pipelines, Step Functions, EKS

## Motivation

Give ECS-native teams the same declarative, self-healing deployment experience that K8s operators provide — without requiring a Kubernetes cluster.

## Open Questions

- Secrets management strategy
- Multi-region topology
- Controller self-upgrade path

---

cc @pahud