### PR TITLE
fix: raise BotTurnTracker hard cap to 1000

### DIFF
--- a/src/bot_turns.rs
+++ b/src/bot_turns.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 /// A human message resets both soft and hard counters to 0, allowing bots to
 /// resume. This is *not* a lifetime total — it guards against runaway loops
 /// between human resets.
-pub const HARD_BOT_TURN_LIMIT: u32 = 100;
+pub const HARD_BOT_TURN_LIMIT: u32 = 1000;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum TurnResult {
@@ -159,6 +159,14 @@ mod tests {
             assert_eq!(t.on_bot_message("t1"), TurnResult::Ok);
         }
         assert_eq!(t.on_bot_message("t1"), TurnResult::HardLimit);
+    }
+
+    #[test]
+    fn hard_limit_does_not_fire_at_legacy_100() {
+        let mut t = BotTurnTracker::new(HARD_BOT_TURN_LIMIT + 1);
+        for i in 1..=100 {
+            assert_eq!(t.on_bot_message("t1"), TurnResult::Ok, "turn {i}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What problem does this solve?

Closes #843

`max_bot_turns` is documented as a soft limit with a compiled-in hard cap of 1000, but the shared `BotTurnTracker` still enforced `HARD_BOT_TURN_LIMIT = 100`. As a result, bot-to-bot conversations configured with `max_bot_turns = 1000` still stopped at 100 turns.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404/1506223007792627723 — issue #843 contains the reproduction and maintainer confirmation.

## At a Glance

```text
config/docs intent
  max_bot_turns = 1000
  hard cap = 1000
        |
        v
src/bot_turns.rs
  HARD_BOT_TURN_LIMIT: 100 -> 1000
        |
        v
BotTurnTracker no longer hard-stops at legacy turn 100
```

## Prior Art & Industry Research

Not applicable — trivial bug fix aligning the shared enforcement constant with existing documentation and PR #741 intent.

## Proposed Solution

- Change `HARD_BOT_TURN_LIMIT` in `src/bot_turns.rs` from `100` to `1000`.
- Add a regression test confirming the tracker does not hard-stop at the legacy 100-turn boundary.

## Why this approach?

The docs already state that the compiled-in hard cap is 1000. Updating the shared tracker constant fixes the runtime behavior at the actual enforcement point while keeping the existing soft-limit behavior unchanged.

## Alternatives Considered

- Update docs back to 100: rejected because PR #741 already established the intended hard cap as 1000.
- Add a new config option for the hard cap: rejected because this issue is about aligning an existing compiled-in constant, not introducing a new configuration surface.

## Validation

Rust changes:
- [x] `cargo check` passes
- [x] `cargo test` passes (including new tests)
- [x] `cargo clippy` clean
