### PR TITLE
feat(gateway): media proxy colocate mode — filesystem store replaces base64 inline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -165,14 +165,14 @@ The gateway downloads and forwards image and text file attachments to the AI age
 | Feishu msg_type | Handling |
 |-----------------|----------|
 | `text` | Text extracted, forwarded as prompt |
-| `image` | Image downloaded, resized (max 1200px), JPEG compressed, base64 encoded → `ContentBlock::Image` |
+| `image` | Image downloaded, resized (max 1200px), JPEG compressed, stored to `~/.openab/media/inbound/<uuid>` → `ContentBlock::Image` |
 | `file` | Text files only (`.txt`, `.py`, `.rs`, `.md`, `.json`, etc., max 512KB). Non-text files (`.pdf`, `.zip`, etc.) are silently ignored. |
-| `audio` | Voice message downloaded (opus/ogg, max 25MB), base64 encoded, forwarded to core. If `[stt]` is enabled, core transcribes via Whisper API and injects `[Voice message transcript]: ...` into the prompt. If STT is disabled or fails, the message is silently skipped. |
+| `audio` | Voice message downloaded (opus/ogg, max 25MB), stored to filesystem, forwarded to core. If `[stt]` is enabled, core transcribes via Whisper API and injects `[Voice message transcript]: ...` into the prompt. If STT is disabled or fails, the message is silently skipped. |
 | `post` | Rich text: text nodes extracted as prompt, `img` nodes downloaded as image attachments. This is the format Feishu uses when @mention + paste image in a group. |
 
 **Group chat limitation:** Feishu does not allow @mention and image upload in the same message. However, @mention + paste (Ctrl+V) an image works — Feishu sends this as a `post` message containing both the mention and the image. Direct image upload (via the attachment button) cannot include @mention, so the bot will not respond in groups.
 
-**Processing pipeline:** Gateway downloads media using `GET /im/v1/messages/{message_id}/resources/{key}?type=image` with `tenant_access_token`, resizes to max 1200px, compresses to JPEG (quality 75), base64 encodes, and embeds in the `GatewayEvent.content.attachments` field. OAB core decodes attachments into `ContentBlock::Image` or `ContentBlock::Text` for the AI agent.
+**Processing pipeline:** Gateway downloads media using `GET /im/v1/messages/{message_id}/resources/{key}?type=image` with `tenant_access_token`, resizes to max 1200px, compresses to JPEG (quality 75), and stores to `~/.openab/media/inbound/<uuid>`. The file path is passed in `GatewayEvent.content.attachments[].path`. OAB core reads the file directly from disk and converts to `ContentBlock::Image` or `ContentBlock::Text` for the AI agent.
 
 ## Streaming (Typewriter)
 

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -143,7 +143,7 @@ working_dir = "/home/agent"
   - Inline code, fenced code blocks: pass through unchanged
   - Tables and other unsupported syntax pass through as-is
 - **Streaming (edit_message)** — when OAB streaming is enabled, the bot edits its initial reply in-place as tokens arrive (typewriter effect)
-- **Inbound attachments** — image, text file, and audio attachments are downloaded via Google Chat Media API and forwarded to the agent as base64 (PR #731 pattern):
+- **Inbound attachments** — image, text file, and audio attachments are downloaded via Google Chat Media API and stored to `~/.openab/media/inbound/<uuid>` (colocate filesystem store):
   - Images: resized to ≤1200px JPEG (q75); GIFs preserved. Max 10 MB.
   - Text files: only known text extensions (`.txt`, `.md`, `.json`, `.py`, `.rs`, etc.). Max 512 KB.
   - Audio: forwarded as-is for STT processing by core. Max 25 MB.

--- a/docs/inbound-attachments.md
+++ b/docs/inbound-attachments.md
@@ -62,8 +62,8 @@ Binary files (zip, pdf, exe, docx), video, and stickers are **silently skipped**
 | Type | Max Size | Enforced By |
 |------|----------|-------------|
 | Images | 10 MB | Gateway (pre-download Content-Length + post-download bytes) |
-| Audio | 20 MB (gateway) / 25 MB (Feishu) | Gateway |
-| Text files | 512 KB | Gateway |
+| Audio | 20 MB | Gateway |
+| Text files | 20 MB | Gateway (same as store cap) |
 | GIF passthrough | 5 MB | `resize_and_compress()` |
 | Store (defense-in-depth) | 20 MB | `store_media()` |
 

--- a/docs/inbound-attachments.md
+++ b/docs/inbound-attachments.md
@@ -1,0 +1,100 @@
+# Inbound Attachments
+
+How OAB handles images, audio, and files sent by users across all platforms.
+
+## Architecture
+
+```
+User sends media (photo/voice/file)
+  → Platform webhook delivers to Gateway
+  → Gateway downloads via platform API (auth stays in Gateway)
+  → Image: resize ≤1200px, JPEG compress (GIF passthrough ≤5MB)
+  → Store to ~/.openab/media/inbound/<uuid>
+  → WS event includes file path in attachments[].path
+  → Core reads from disk (zero encoding overhead)
+  → Processes: image → LLM, audio → STT, text_file → code block
+  → File auto-evicted after 2 minutes
+```
+
+## Platform Support Matrix
+
+| Platform | Images | Audio/Voice | Text Files | Video | Binary Files |
+|----------|--------|-------------|------------|-------|--------------|
+| **Discord** | ✅ | ✅ (STT) | ✅ | metadata only | skipped |
+| **Telegram** | ✅ | ✅ (STT) | ✅ (whitelist) | skipped | skipped |
+| **Feishu** | ✅ | ✅ (STT) | ✅ (whitelist) | skipped | skipped |
+| **Google Chat** | ✅ | ✅ (STT) | ✅ (whitelist) | skipped | Drive files skipped |
+| **WeCom** | ✅ | — | ✅ (whitelist) | skipped | skipped |
+| **LINE** | planned | planned | — | — | — |
+| **Slack** | ✅ | ✅ (STT) | ✅ | — | skipped |
+
+## Processing Pipeline
+
+### Images
+
+1. Gateway downloads from platform API
+2. `resize_and_compress()` — longest side ≤1200px, JPEG quality 75
+3. GIFs ≤5MB passed through unchanged (preserves animation)
+4. Stored to `~/.openab/media/inbound/<uuid>`
+5. Core reads bytes → `ContentBlock::Image` → sent to LLM
+
+### Audio / Voice Messages
+
+1. Gateway downloads raw audio (ogg/m4a/mp3)
+2. Stored to filesystem (no transcoding)
+3. Core reads bytes → STT transcription (Whisper/Groq) → `[Voice message transcript]: ...`
+4. If STT disabled: silently skipped
+
+### Text Files (Documents)
+
+1. Gateway downloads file
+2. Extension whitelist check: `.txt`, `.csv`, `.md`, `.json`, `.yaml`, `.rs`, `.py`, `.js`, `.ts`, `.go`, `.java`, `.c`, `.cpp`, `.sh`, `.sql`, `.html`, `.css`, `.toml`, `.xml`, `.ini`, `.cfg`, `.conf`, etc.
+3. UTF-8 validation — non-UTF-8 files rejected
+4. Stored to filesystem
+5. Core reads → wraps in markdown code block: `` ```filename.ext\n<content>\n``` ``
+
+### Unsupported Types
+
+Binary files (zip, pdf, exe, docx), video, and stickers are **silently skipped**. The agent does not receive any notification that a file was sent.
+
+## Size Limits
+
+| Type | Max Size | Enforced By |
+|------|----------|-------------|
+| Images | 10 MB | Gateway (pre-download Content-Length + post-download bytes) |
+| Audio | 20 MB (gateway) / 25 MB (Feishu) | Gateway |
+| Text files | 512 KB | Gateway |
+| GIF passthrough | 5 MB | `resize_and_compress()` |
+| Store (defense-in-depth) | 20 MB | `store_media()` |
+
+## Storage (Colocate Mode)
+
+Media is stored at `~/.openab/media/inbound/<uuid>`:
+
+- **Filenames**: Server-generated UUID v4, no extension (MIME type in event payload)
+- **TTL**: 2 minutes — background task evicts expired files every 30 seconds
+- **Trust boundary**: Gateway and Core share the same `$HOME` (same pod / sidecar)
+- **No auth required**: Core reads directly from filesystem, no HTTP/token needed
+
+### Security
+
+- **Path traversal**: Impossible — filenames are UUID only, never user-supplied
+- **Token leakage**: Platform auth tokens (Telegram bot token, LINE access token, Feishu tenant token) stay in Gateway, never reach Core or agent
+- **Disk exhaustion**: TTL eviction + size limits prevent unbounded growth
+- **No executable content**: Files are raw data, never executed
+
+### Future: HTTP Proxy Mode
+
+For separated deployments (Gateway ≠ Core pod), a future PR will add `GET /media/<uuid>` on the Gateway, allowing Core to fetch via internal HTTP. The `attachments[].path` field will be replaced by `attachments[].url` in that mode.
+
+## Configuration
+
+No additional configuration required. The filesystem store is always active when Gateway is running. Ensure Gateway and Core share the same `$HOME` (default in Helm colocate/sidecar mode).
+
+## Related
+
+- [Telegram](telegram.md) — Telegram-specific behavior and limitations
+- [Feishu](feishu.md) — Feishu image/file/audio handling
+- [Google Chat](google-chat.md) — Google Chat attachment support
+- [STT (Speech-to-Text)](stt.md) — Audio transcription configuration
+- [Sending Files (Outbound)](sendfiles.md) — Agent → user file delivery (separate mechanism)

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -168,6 +168,19 @@ explain VPC peering              ← ignored in groups
 
 DMs and replies within forum topics always trigger the agent (no @mention needed).
 
+### File Attachments (Inbound)
+
+The gateway downloads media from Telegram and stores it locally (`~/.openab/media/inbound/<uuid>`). Core reads directly from disk — no base64 encoding overhead.
+
+| Type | Handling |
+|------|----------|
+| **Images** | Downloaded, resized (max 1200px), JPEG compressed, stored to filesystem. Agent sees the image. |
+| **Documents** | Text-based files (`.txt`, `.csv`, `.rs`, `.py`, etc.) up to 512KB read as UTF-8 and passed to agent. Binary files silently skipped. |
+| **Audio/Voice** | Downloaded and stored. If STT is enabled in Core, automatically transcribed and passed as text. |
+
+**Not supported (inbound):** video, stickers, animations (silently skipped).
+**Not supported (outbound):** bot cannot send images/files back to the user yet.
+
 ### Emoji reactions
 
 The bot shows status reactions on your message as the agent works:

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -175,7 +175,7 @@ The gateway downloads media from Telegram and stores it locally (`~/.openab/medi
 | Type | Handling |
 |------|----------|
 | **Images** | Downloaded, resized (max 1200px), JPEG compressed, stored to filesystem. Agent sees the image. |
-| **Documents** | Text-based files (`.txt`, `.csv`, `.rs`, `.py`, etc.) up to 512KB read as UTF-8 and passed to agent. Binary files silently skipped. |
+| **Documents** | Text-based files (`.txt`, `.csv`, `.rs`, `.py`, etc.) up to 20MB read as UTF-8 and passed to agent. Binary files silently skipped. |
 | **Audio/Voice** | Downloaded and stored. If STT is enabled in Core, automatically transcribed and passed as text. |
 
 **Not supported (inbound):** video, stickers, animations (silently skipped).

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -1458,6 +1458,7 @@ pub async fn download_feishu_image(
         mime_type: mime,
         data,
         size: compressed.len() as u64,
+        path: None,
     })
 }
 
@@ -1520,6 +1521,7 @@ pub async fn download_feishu_file(
         mime_type: "text/plain".into(),
         data,
         size: bytes.len() as u64,
+        path: None,
     })
 }
 
@@ -1577,6 +1579,7 @@ pub async fn download_feishu_audio(
         mime_type: content_type,
         data,
         size: bytes.len() as u64,
+        path: None,
     })
 }
 

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -1449,16 +1449,15 @@ pub async fn download_feishu_image(
             return None;
         }
     };
-    use base64::Engine;
-    let data = base64::engine::general_purpose::STANDARD.encode(&compressed);
+    let path = crate::store::store_media(&compressed).await?;
     let ext = if mime == "image/gif" { "gif" } else { "jpg" };
     Some(crate::schema::Attachment {
         attachment_type: "image".into(),
         filename: format!("{}.{}", image_key, ext),
         mime_type: mime,
-        data,
+        data: String::new(),
         size: compressed.len() as u64,
-        path: None,
+        path: Some(path),
     })
 }
 
@@ -1512,16 +1511,14 @@ pub async fn download_feishu_file(
         tracing::warn!(file_name, size = bytes.len(), "feishu file exceeds 512KB limit");
         return None;
     }
-    let text = String::from_utf8_lossy(&bytes);
-    use base64::Engine;
-    let data = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+    let path = crate::store::store_media(&bytes).await?;
     Some(crate::schema::Attachment {
         attachment_type: "text_file".into(),
         filename: file_name.to_string(),
         mime_type: "text/plain".into(),
-        data,
+        data: String::new(),
         size: bytes.len() as u64,
-        path: None,
+        path: Some(path),
     })
 }
 
@@ -1571,15 +1568,14 @@ pub async fn download_feishu_audio(
         return None;
     }
     tracing::debug!(file_key, size = bytes.len(), "feishu audio downloaded");
-    use base64::Engine;
-    let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    let path = crate::store::store_media(&bytes).await?;
     Some(crate::schema::Attachment {
         attachment_type: "audio".into(),
         filename: format!("{}.ogg", file_key),
         mime_type: content_type,
-        data,
+        data: String::new(),
         size: bytes.len() as u64,
-        path: None,
+        path: Some(path),
     })
 }
 

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -1265,6 +1265,7 @@ pub async fn download_googlechat_image(
         mime_type: mime,
         data,
         size: compressed.len() as u64,
+        path: None,
     })
 }
 
@@ -1317,6 +1318,7 @@ pub async fn download_googlechat_file(
         mime_type: "text/plain".into(),
         data,
         size: bytes.len() as u64,
+        path: None,
     })
 }
 
@@ -1363,6 +1365,7 @@ pub async fn download_googlechat_audio(
         mime_type: content_type.to_string(),
         data,
         size: bytes.len() as u64,
+        path: None,
     })
 }
 

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -1257,15 +1257,14 @@ pub async fn download_googlechat_image(
             return None;
         }
     };
-    use base64::Engine;
-    let data = base64::engine::general_purpose::STANDARD.encode(&compressed);
+    let path = crate::store::store_media(&compressed).await?;
     Some(crate::schema::Attachment {
         attachment_type: "image".into(),
         filename: content_name.to_string(),
         mime_type: mime,
-        data,
+        data: String::new(),
         size: compressed.len() as u64,
-        path: None,
+        path: Some(path),
     })
 }
 
@@ -1310,19 +1309,18 @@ pub async fn download_googlechat_file(
         warn!(content_name, size = bytes.len(), limit = max_size, "googlechat file exceeds size limit");
         return None;
     }
-    use base64::Engine;
-    let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    let path = crate::store::store_media(&bytes).await?;
     Some(crate::schema::Attachment {
         attachment_type: "text_file".into(),
         filename: content_name.to_string(),
         mime_type: "text/plain".into(),
-        data,
+        data: String::new(),
         size: bytes.len() as u64,
-        path: None,
+        path: Some(path),
     })
 }
 
-/// Download an audio attachment as-is (no resize/transcode) → base64.
+/// Download an audio attachment as-is (no resize/transcode) → filesystem store.
 /// Core's STT pipeline (when available) consumes this as `audio` attachment_type.
 pub async fn download_googlechat_audio(
     client: &reqwest::Client,
@@ -1357,15 +1355,14 @@ pub async fn download_googlechat_audio(
         warn!(content_name, size = bytes.len(), "googlechat audio exceeds 25MB limit");
         return None;
     }
-    use base64::Engine;
-    let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    let path = crate::store::store_media(&bytes).await?;
     Some(crate::schema::Attachment {
         attachment_type: "audio".into(),
         filename: content_name.to_string(),
         mime_type: content_type.to_string(),
-        data,
+        data: String::new(),
         size: bytes.len() as u64,
-        path: None,
+        path: Some(path),
     })
 }
 
@@ -2318,7 +2315,7 @@ mod tests {
         assert_eq!(att.attachment_type, "image");
         assert_eq!(att.filename, "photo.png");
         assert_eq!(att.mime_type, "image/jpeg"); // resized PNG → JPEG
-        assert!(!att.data.is_empty());
+        assert!(att.path.is_some()); // stored to filesystem
         assert!(att.size > 0);
     }
 

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -1,4 +1,6 @@
+use crate::media::{resize_and_compress, MediaKind, AUDIO_MAX_DOWNLOAD, FILE_MAX_DOWNLOAD, IMAGE_MAX_DOWNLOAD};
 use crate::schema::*;
+use crate::store;
 use axum::extract::State;
 use axum::Json;
 use serde::Deserialize;
@@ -25,8 +27,46 @@ struct TelegramMessage {
     chat: TelegramChat,
     from: Option<TelegramUser>,
     text: Option<String>,
+    caption: Option<String>,
     #[serde(default)]
     entities: Vec<TelegramEntity>,
+    #[serde(default)]
+    caption_entities: Vec<TelegramEntity>,
+    #[serde(default)]
+    photo: Vec<TelegramPhoto>,
+    document: Option<TelegramDocument>,
+    voice: Option<TelegramVoice>,
+    audio: Option<TelegramAudio>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramPhoto {
+    file_id: String,
+    width: u32,
+    height: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramDocument {
+    file_id: String,
+    file_name: Option<String>,
+    mime_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramVoice {
+    file_id: String,
+    #[allow(dead_code)] // TODO: use for Content-Type hint
+    mime_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramAudio {
+    file_id: String,
+    #[allow(dead_code)] // TODO: use for filename
+    file_name: Option<String>,
+    #[allow(dead_code)] // TODO: use for Content-Type hint
+    mime_type: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -75,11 +115,46 @@ pub async fn webhook(
     let Some(msg) = update.message else {
         return axum::http::StatusCode::OK;
     };
-    let Some(text) = msg.text.as_deref() else {
+    let is_photo = !msg.photo.is_empty();
+    let is_document = msg.document.is_some();
+    let is_voice = msg.voice.is_some();
+    let is_audio = msg.audio.is_some();
+    let text = msg.text.as_deref().or(msg.caption.as_deref()).unwrap_or("");
+
+    if text.trim().is_empty() && !is_photo && !is_document && !is_voice && !is_audio {
         return axum::http::StatusCode::OK;
-    };
-    if text.trim().is_empty() {
-        return axum::http::StatusCode::OK;
+    }
+
+    let mut attachments = Vec::new();
+    if is_photo || is_document || is_voice || is_audio {
+        if let Some(ref token) = state.telegram_bot_token {
+            let client = &state.client;
+            if is_photo {
+                if let Some(largest) = msg.photo.iter().max_by_key(|p| p.width * p.height) {
+                    if let Some(att) =
+                        download_telegram_media(client, token, &largest.file_id, MediaKind::Image).await
+                    {
+                        attachments.push(att);
+                    }
+                }
+            } else if let Some(doc) = msg.document {
+                let file_name = doc.file_name.unwrap_or_else(|| "unknown.txt".to_string());
+                let mime_type = doc.mime_type.unwrap_or_else(|| "text/plain".to_string());
+                if let Some(att) =
+                    download_telegram_document(client, token, &doc.file_id, &file_name, &mime_type).await
+                {
+                    attachments.push(att);
+                }
+            } else if let Some(voice) = msg.voice {
+                if let Some(att) = download_telegram_media(client, token, &voice.file_id, MediaKind::Audio).await {
+                    attachments.push(att);
+                }
+            } else if let Some(audio) = msg.audio {
+                if let Some(att) = download_telegram_media(client, token, &audio.file_id, MediaKind::Audio).await {
+                    attachments.push(att);
+                }
+            }
+        }
     }
 
     let from = msg.from.as_ref();
@@ -100,6 +175,7 @@ pub async fn webhook(
     let mentions: Vec<String> = msg
         .entities
         .iter()
+        .chain(msg.caption_entities.iter())
         .filter(|e| e.entity_type == "mention")
         .filter_map(|e| {
             text.get(e.offset..e.offset + e.length)
@@ -107,7 +183,7 @@ pub async fn webhook(
         })
         .collect();
 
-    let event = GatewayEvent::new(
+    let mut event = GatewayEvent::new(
         "telegram",
         ChannelInfo {
             id: msg.chat.id.to_string(),
@@ -124,6 +200,12 @@ pub async fn webhook(
         &msg.message_id.to_string(),
         mentions,
     );
+    event.content.attachments = attachments;
+
+    // Guard: skip empty events (no text + no attachments)
+    if event.content.text.trim().is_empty() && event.content.attachments.is_empty() {
+        return axum::http::StatusCode::OK;
+    }
 
     let json = serde_json::to_string(&event).unwrap();
     info!(chat_id = %msg.chat.id, sender = %sender_name, "telegram → gateway");
@@ -261,4 +343,143 @@ pub async fn handle_reply(
         .send()
         .await
         .map_err(|e| error!("telegram send error: {e}"));
+}
+
+/// Download media from Telegram via getFile → store to filesystem (colocate mode).
+async fn download_telegram_media(
+    client: &reqwest::Client,
+    bot_token: &str,
+    file_id: &str,
+    kind: MediaKind,
+) -> Option<Attachment> {
+    let get_file_url = format!("{TELEGRAM_API_BASE}/bot{}/getFile", bot_token);
+    let resp = client.get(&get_file_url).query(&[("file_id", file_id)]).send().await.ok()?;
+    let body: serde_json::Value = resp.json().await.ok()?;
+    let file_path = body["result"]["file_path"].as_str()?;
+
+    let download_url = format!("{TELEGRAM_API_BASE}/file/bot{}/{}", bot_token, file_path);
+    let resp = client.get(&download_url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+
+    let max_size = match kind {
+        MediaKind::Image => IMAGE_MAX_DOWNLOAD,
+        MediaKind::Audio => AUDIO_MAX_DOWNLOAD,
+    };
+
+    if let Some(cl) = resp.headers().get(reqwest::header::CONTENT_LENGTH) {
+        if let Ok(size) = cl.to_str().unwrap_or("0").parse::<u64>() {
+            if size > max_size {
+                warn!(file_id, size, kind = ?kind, "Telegram media Content-Length exceeds limit");
+                return None;
+            }
+        }
+    }
+
+    let default_mime = match kind {
+        MediaKind::Image => "image/jpeg",
+        MediaKind::Audio => "audio/ogg",
+    };
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or(default_mime)
+        .to_string();
+
+    let bytes = resp.bytes().await.ok()?;
+    if bytes.len() as u64 > max_size {
+        warn!(file_id, size = bytes.len(), kind = ?kind, "Telegram media exceeds limit");
+        return None;
+    }
+
+    let (data_bytes, mime) = match kind {
+        MediaKind::Image => match resize_and_compress(&bytes) {
+            Ok((c, m)) => (c, m),
+            Err(e) => {
+                error!(err = %e, "Telegram image processing failed");
+                return None;
+            }
+        },
+        MediaKind::Audio => (bytes.to_vec(), content_type),
+    };
+
+    // Store to filesystem instead of base64 encoding
+    let path = store::store_media(&data_bytes).await?;
+    let att_type = match kind {
+        MediaKind::Image => "image",
+        MediaKind::Audio => "audio",
+    };
+    info!(file_id, size = data_bytes.len(), kind = ?kind, "Telegram media stored");
+
+    Some(Attachment {
+        attachment_type: att_type.into(),
+        filename: format!("{}.{}", file_id, match kind {
+            MediaKind::Image => "jpg",
+            MediaKind::Audio => crate::media::audio_extension(&mime),
+        }),
+        mime_type: mime,
+        data: String::new(), // No base64 — using file path
+        size: data_bytes.len() as u64,
+        path: Some(path),
+    })
+}
+
+/// Download text document from Telegram → store to filesystem.
+async fn download_telegram_document(
+    client: &reqwest::Client,
+    bot_token: &str,
+    file_id: &str,
+    file_name: &str,
+    mime_type: &str,
+) -> Option<Attachment> {
+    if !crate::media::is_text_extension(file_name) {
+        tracing::debug!(file_name, "skipping non-text file attachment");
+        return None;
+    }
+
+    let get_file_url = format!("{TELEGRAM_API_BASE}/bot{}/getFile", bot_token);
+    let resp = client.get(&get_file_url).query(&[("file_id", file_id)]).send().await.ok()?;
+    let body: serde_json::Value = resp.json().await.ok()?;
+    let file_path = body["result"]["file_path"].as_str()?;
+
+    let download_url = format!("{TELEGRAM_API_BASE}/file/bot{}/{}", bot_token, file_path);
+    let resp = client.get(&download_url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+
+    if let Some(cl) = resp.headers().get(reqwest::header::CONTENT_LENGTH) {
+        if let Ok(size) = cl.to_str().unwrap_or("0").parse::<u64>() {
+            if size > FILE_MAX_DOWNLOAD {
+                warn!(file_id, size, "Telegram document Content-Length exceeds limit");
+                return None;
+            }
+        }
+    }
+
+    let bytes = resp.bytes().await.ok()?;
+    if bytes.len() as u64 > FILE_MAX_DOWNLOAD {
+        warn!(file_id, size = bytes.len(), "Telegram document exceeds limit");
+        return None;
+    }
+
+    // Validate UTF-8 — reject binary files
+    if String::from_utf8(bytes.to_vec()).is_err() {
+        warn!(file_id, file_name, "Telegram document is not valid UTF-8, skipping");
+        return None;
+    }
+
+    let path = store::store_media(&bytes).await?;
+    info!(file_id, file_name, size = bytes.len(), "Telegram document stored");
+
+    Some(Attachment {
+        attachment_type: "text_file".into(),
+        filename: file_name.to_string(),
+        mime_type: mime_type.to_string(),
+        data: String::new(),
+        size: bytes.len() as u64,
+        path: Some(path),
+    })
 }

--- a/gateway/src/adapters/wecom.rs
+++ b/gateway/src/adapters/wecom.rs
@@ -1156,6 +1156,7 @@ async fn download_wecom_image(
         mime_type: mime,
         data,
         size: compressed.len() as u64,
+        path: None,
     })
 }
 
@@ -1283,6 +1284,7 @@ async fn download_wecom_file(
         mime_type: "text/plain".into(),
         data,
         size,
+        path: None,
     })
 }
 

--- a/gateway/src/adapters/wecom.rs
+++ b/gateway/src/adapters/wecom.rs
@@ -1147,16 +1147,15 @@ async fn download_wecom_image(
             return None;
         }
     };
-    use base64::Engine;
-    let data = base64::engine::general_purpose::STANDARD.encode(&compressed);
+    let path = crate::store::store_media(&compressed).await?;
     let ext = if mime == "image/gif" { "gif" } else { "jpg" };
     Some(crate::schema::Attachment {
         attachment_type: "image".into(),
         filename: format!("wecom_{}.{}", chrono::Utc::now().timestamp(), ext),
         mime_type: mime,
-        data,
+        data: String::new(),
         size: compressed.len() as u64,
-        path: None,
+        path: Some(path),
     })
 }
 
@@ -1274,17 +1273,16 @@ async fn download_wecom_file(
         }
     };
 
-    use base64::Engine;
-    let data = base64::engine::general_purpose::STANDARD.encode(text_content.as_bytes());
+    let path = crate::store::store_media(text_content.as_bytes()).await?;
     let size = text_content.len() as u64;
 
     Some(crate::schema::Attachment {
         attachment_type: "text_file".into(),
         filename: filename.to_string(),
         mime_type: "text/plain".into(),
-        data,
+        data: String::new(),
         size,
-        path: None,
+        path: Some(path),
     })
 }
 

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -1,5 +1,7 @@
 mod adapters;
+mod media;
 mod schema;
+pub mod store;
 
 use anyhow::Result;
 use axum::{
@@ -60,6 +62,8 @@ pub struct AppState {
     /// the first client to `remove()` a token wins the free Reply API call;
     /// other clients for the same event naturally fall back to Push API.
     pub reply_token_cache: ReplyTokenCache,
+    /// Shared HTTP client for media downloads and API calls
+    pub client: reqwest::Client,
 }
 
 // --- WebSocket handler (OAB connects here) ---
@@ -344,6 +348,11 @@ async fn main() -> Result<()> {
         warn!("no adapters configured — set TELEGRAM_BOT_TOKEN, LINE_CHANNEL_ACCESS_TOKEN, TEAMS_APP_ID + TEAMS_APP_SECRET, FEISHU_APP_ID + FEISHU_APP_SECRET, GOOGLE_CHAT_ENABLED=true, and/or WECOM_CORP_ID + WECOM_SECRET + WECOM_TOKEN + WECOM_ENCODING_AES_KEY + WECOM_AGENT_ID");
     }
 
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .expect("HTTP client must build");
+
     let state = Arc::new(AppState {
         telegram_bot_token,
         telegram_secret_token,
@@ -357,6 +366,7 @@ async fn main() -> Result<()> {
         ws_token,
         event_tx,
         reply_token_cache,
+        client,
     });
 
     // Background task: sweep expired reply tokens every REPLY_TOKEN_TTL_SECS
@@ -405,6 +415,9 @@ async fn main() -> Result<()> {
     }
 
     let app = app.with_state(state.clone());
+
+    // Background task: evict expired media files (colocate store, TTL 2 min)
+    tokio::spawn(store::eviction_loop());
 
     // Spawn feishu WebSocket long-connection if configured
     // feishu_shutdown_tx must remain alive for the lifetime of main() — dropping

--- a/gateway/src/media.rs
+++ b/gateway/src/media.rs
@@ -11,7 +11,7 @@ pub enum MediaKind {
 pub const IMAGE_MAX_DIMENSION_PX: u32 = 1200;
 pub const IMAGE_JPEG_QUALITY: u8 = 75;
 pub const IMAGE_MAX_DOWNLOAD: u64 = 10 * 1024 * 1024; // 10 MB
-pub const FILE_MAX_DOWNLOAD: u64 = 512 * 1024; // 512 KB
+pub const FILE_MAX_DOWNLOAD: u64 = 20 * 1024 * 1024; // 20 MB (same as store cap)
 pub const AUDIO_MAX_DOWNLOAD: u64 = 20 * 1024 * 1024; // 20 MB
 pub const GIF_MAX_SIZE: usize = 5 * 1024 * 1024; // 5 MB — prevents base64 bloat exceeding LLM payload limits
 

--- a/gateway/src/media.rs
+++ b/gateway/src/media.rs
@@ -1,0 +1,123 @@
+use image::ImageReader;
+use std::io::Cursor;
+
+/// Media type for download functions — avoids stringly-typed branching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaKind {
+    Image,
+    Audio,
+}
+
+pub const IMAGE_MAX_DIMENSION_PX: u32 = 1200;
+pub const IMAGE_JPEG_QUALITY: u8 = 75;
+pub const IMAGE_MAX_DOWNLOAD: u64 = 10 * 1024 * 1024; // 10 MB
+pub const FILE_MAX_DOWNLOAD: u64 = 512 * 1024; // 512 KB
+pub const AUDIO_MAX_DOWNLOAD: u64 = 20 * 1024 * 1024; // 20 MB
+pub const GIF_MAX_SIZE: usize = 5 * 1024 * 1024; // 5 MB — prevents base64 bloat exceeding LLM payload limits
+
+/// Resize image so longest side <= 1200px, then encode as JPEG.
+/// GIFs under 5MB are passed through unchanged to preserve animation.
+pub fn resize_and_compress(raw: &[u8]) -> Result<(Vec<u8>, String), image::ImageError> {
+    let reader = ImageReader::new(Cursor::new(raw)).with_guessed_format()?;
+    let format = reader.format();
+    if format == Some(image::ImageFormat::Gif) {
+        if raw.len() > GIF_MAX_SIZE {
+            return Err(image::ImageError::Limits(
+                image::error::LimitError::from_kind(image::error::LimitErrorKind::DimensionError),
+            ));
+        }
+        return Ok((raw.to_vec(), "image/gif".to_string()));
+    }
+    let img = reader.decode()?;
+    let (w, h) = (img.width(), img.height());
+    let img = if w > IMAGE_MAX_DIMENSION_PX || h > IMAGE_MAX_DIMENSION_PX {
+        let max_side = std::cmp::max(w, h);
+        let ratio = f64::from(IMAGE_MAX_DIMENSION_PX) / f64::from(max_side);
+        let new_w = (f64::from(w) * ratio) as u32;
+        let new_h = (f64::from(h) * ratio) as u32;
+        img.resize(new_w, new_h, image::imageops::FilterType::Lanczos3)
+    } else {
+        img
+    };
+    let mut buf = Cursor::new(Vec::new());
+    let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, IMAGE_JPEG_QUALITY);
+    img.write_with_encoder(encoder)?;
+    Ok((buf.into_inner(), "image/jpeg".to_string()))
+}
+
+/// Derive file extension from Content-Type for audio files.
+pub fn audio_extension(content_type: &str) -> &'static str {
+    if content_type.contains("mpeg") || content_type.contains("mp3") {
+        "mp3"
+    } else if content_type.contains("m4a") || content_type.contains("mp4") {
+        "m4a"
+    } else {
+        "ogg"
+    }
+}
+
+/// Check if a filename has a text-like extension suitable for reading as UTF-8.
+pub fn is_text_extension(filename: &str) -> bool {
+    const TEXT_EXTS: &[&str] = &[
+        "txt", "csv", "log", "md", "json", "jsonl", "yaml", "yml", "toml", "xml", "rs", "py",
+        "js", "ts", "jsx", "tsx", "go", "java", "c", "cpp", "h", "hpp", "rb", "sh", "bash",
+        "sql", "html", "css", "ini", "cfg", "conf",
+    ];
+    let ext = filename.rsplit('.').next().unwrap_or("").to_lowercase();
+    TEXT_EXTS.contains(&ext.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gif_under_limit_passes_through() {
+        let gif = b"GIF89a\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff\x00\x00\x00!\xf9\x04\x00\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;";
+        let result = resize_and_compress(gif);
+        assert!(result.is_ok());
+        let (data, mime) = result.unwrap();
+        assert_eq!(mime, "image/gif");
+        assert_eq!(data, gif);
+    }
+
+    #[test]
+    fn gif_over_limit_returns_error() {
+        let mut data = b"GIF89a\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff\x00\x00\x00".to_vec();
+        data.resize(GIF_MAX_SIZE + 1, 0);
+        let result = resize_and_compress(&data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn small_jpeg_not_resized() {
+        let img = image::RgbImage::from_pixel(2, 2, image::Rgb([255, 0, 0]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut buf, image::ImageFormat::Jpeg).unwrap();
+        let result = resize_and_compress(&buf.into_inner());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().1, "image/jpeg");
+    }
+
+    #[test]
+    fn large_image_gets_resized() {
+        let img = image::RgbImage::from_pixel(2000, 2000, image::Rgb([0, 128, 255]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
+        let result = resize_and_compress(&buf.into_inner());
+        assert!(result.is_ok());
+        let (data, mime) = result.unwrap();
+        assert_eq!(mime, "image/jpeg");
+        let decoded = image::load_from_memory(&data).unwrap();
+        assert!(decoded.width() <= IMAGE_MAX_DIMENSION_PX);
+        assert!(decoded.height() <= IMAGE_MAX_DIMENSION_PX);
+    }
+
+    #[test]
+    fn text_extension_check() {
+        assert!(is_text_extension("main.rs"));
+        assert!(is_text_extension("data.csv"));
+        assert!(!is_text_extension("archive.zip"));
+        assert!(!is_text_extension("photo.jpg"));
+    }
+}

--- a/gateway/src/schema.rs
+++ b/gateway/src/schema.rs
@@ -44,11 +44,19 @@ pub struct Content {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Attachment {
     #[serde(rename = "type")]
-    pub attachment_type: String, // "image", "text_file"
+    pub attachment_type: String, // "image", "text_file", "audio"
     pub filename: String,
     pub mime_type: String,
-    pub data: String, // base64 encoded
-    pub size: u64,    // size in bytes (after compression for images)
+    /// Base64-encoded data (deprecated — use `path` for colocate mode).
+    /// Kept for backward compatibility; Core prefers `path` when present.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub data: String,
+    pub size: u64, // size in bytes (after compression for images)
+    /// Local file path for colocate mode (gateway + core share filesystem).
+    /// When set, Core reads bytes directly from this path instead of decoding `data`.
+    /// Path format: ~/.openab/media/inbound/<uuid> (no extension, MIME in mime_type).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 // --- Reply schema (ADR openab.gateway.reply.v1) ---

--- a/gateway/src/store.rs
+++ b/gateway/src/store.rs
@@ -46,9 +46,17 @@ pub async fn media_dir() -> PathBuf {
     dir
 }
 
+/// Maximum file size accepted by store (defense-in-depth, callers should pre-check).
+const MAX_STORE_SIZE: usize = 20 * 1024 * 1024; // 20 MB (matches AUDIO_MAX_DOWNLOAD)
+
 /// Store media bytes to disk, return the absolute file path.
 /// Filename is UUID only (no extension) — MIME type is carried in the event payload.
+/// Rejects files exceeding MAX_STORE_SIZE as a defense-in-depth measure.
 pub async fn store_media(bytes: &[u8]) -> Option<String> {
+    if bytes.len() > MAX_STORE_SIZE {
+        error!(size = bytes.len(), max = MAX_STORE_SIZE, "store_media rejected: exceeds size limit");
+        return None;
+    }
     let dir = media_dir().await;
     let filename = Uuid::new_v4().to_string();
     let path = dir.join(&filename);

--- a/gateway/src/store.rs
+++ b/gateway/src/store.rs
@@ -1,0 +1,124 @@
+use std::path::{Path, PathBuf};
+use tokio::fs;
+use tracing::{error, info};
+use uuid::Uuid;
+
+/// Inbound media directory under $HOME.
+/// Pattern follows OpenClaw's `~/.openclaw/media/inbound/<uuid>`.
+///
+/// # Security Considerations
+///
+/// - **Path traversal prevention**: Filenames are always server-generated UUIDs,
+///   never user-supplied. No extension, no special characters — eliminates path
+///   traversal attacks (e.g. `../../etc/passwd`).
+///
+/// - **No auth token leakage**: Platform media URLs (Telegram getFile, LINE Content API)
+///   contain bot tokens or require auth headers. By downloading in the gateway and
+///   storing locally, tokens never reach Core or the agent.
+///
+/// - **TTL auto-eviction**: Files are evicted after 2 minutes. Prevents disk exhaustion
+///   from accumulated media and limits the window for any leaked file to be exploited.
+///
+/// - **Colocate trust boundary**: This module assumes gateway and core share the same
+///   filesystem (same pod / same $HOME). The file path is passed over the internal WS
+///   connection — never exposed externally. If gateway and core are separated in the
+///   future, switch to HTTP media proxy with internal-only binding.
+///
+/// - **Size limits enforced before write**: Callers must validate file size against
+///   IMAGE_MAX_DOWNLOAD / AUDIO_MAX_DOWNLOAD / FILE_MAX_DOWNLOAD before calling
+///   `store_media()`. This module does NOT re-validate — it trusts the caller.
+///
+/// - **No executable content**: Stored files are raw bytes (images, audio, text).
+///   Core reads them as data only — never executed. The `mime_type` in the event
+///   payload determines processing path, not the file content or name.
+const MEDIA_INBOUND_DIR: &str = ".openab/media/inbound";
+
+/// TTL for stored media files (2 minutes)
+const TTL_SECS: u64 = 120;
+
+/// Get the inbound media directory path, creating it if needed.
+pub async fn media_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let dir = Path::new(&home).join(MEDIA_INBOUND_DIR);
+    if !dir.exists() {
+        let _ = fs::create_dir_all(&dir).await;
+    }
+    dir
+}
+
+/// Store media bytes to disk, return the absolute file path.
+/// Filename is UUID only (no extension) — MIME type is carried in the event payload.
+pub async fn store_media(bytes: &[u8]) -> Option<String> {
+    let dir = media_dir().await;
+    let filename = Uuid::new_v4().to_string();
+    let path = dir.join(&filename);
+    match fs::write(&path, bytes).await {
+        Ok(_) => {
+            info!(path = %path.display(), size = bytes.len(), "media stored");
+            Some(path.to_string_lossy().into_owned())
+        }
+        Err(e) => {
+            error!(error = %e, "failed to store media file");
+            None
+        }
+    }
+}
+
+/// Background task: evict files older than TTL_SECS.
+pub async fn eviction_loop() {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+    loop {
+        interval.tick().await;
+        if let Err(e) = evict_expired().await {
+            error!(error = %e, "media eviction error");
+        }
+    }
+}
+
+async fn evict_expired() -> std::io::Result<()> {
+    let dir = media_dir().await;
+    if !dir.exists() {
+        return Ok(());
+    }
+    let mut entries = fs::read_dir(&dir).await?;
+    let now = std::time::SystemTime::now();
+    while let Some(entry) = entries.next_entry().await? {
+        if let Ok(meta) = entry.metadata().await {
+            if let Ok(modified) = meta.modified() {
+                if let Ok(age) = now.duration_since(modified) {
+                    if age.as_secs() > TTL_SECS {
+                        let path = entry.path();
+                        let _ = fs::remove_file(&path).await;
+                        tracing::debug!(path = %path.display(), "evicted expired media");
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn store_and_read_back() {
+        let data = b"hello media";
+        let path = store_media(data).await.unwrap();
+        let read_back = fs::read(&path).await.unwrap();
+        assert_eq!(read_back, data);
+        // Cleanup
+        let _ = fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn filename_is_uuid_no_extension() {
+        let path = store_media(b"test").await.unwrap();
+        let filename = Path::new(&path).file_name().unwrap().to_str().unwrap();
+        // UUID v4 format: 8-4-4-4-12 hex chars
+        assert_eq!(filename.len(), 36);
+        assert!(!filename.contains('.'));
+        let _ = fs::remove_file(&path).await;
+    }
+}

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -64,9 +64,13 @@ struct GwAttachment {
     attachment_type: String,
     filename: String,
     mime_type: String,
+    #[serde(default)]
     data: String,
     #[allow(dead_code)]
     size: u64,
+    /// Colocate mode: local file path (preferred over base64 `data` when present)
+    #[serde(default)]
+    path: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -705,16 +709,36 @@ pub async fn run_gateway_adapter(
                                     // Convert gateway attachments to ContentBlocks
                                     let mut extra_blocks = Vec::new();
                                     for att in &event.content.attachments {
+                                        // Read bytes: prefer file path (colocate), fallback to base64
+                                        let bytes_result = if let Some(ref path) = att.path {
+                                            tokio::fs::read(path).await.map_err(|e| e.to_string())
+                                        } else if !att.data.is_empty() {
+                                            use base64::Engine;
+                                            base64::engine::general_purpose::STANDARD
+                                                .decode(&att.data)
+                                                .map_err(|e| e.to_string())
+                                        } else {
+                                            Err("no path or data".into())
+                                        };
+
                                         match att.attachment_type.as_str() {
                                             "image" => {
-                                                extra_blocks.push(ContentBlock::Image {
-                                                    media_type: att.mime_type.clone(),
-                                                    data: att.data.clone(),
-                                                });
+                                                match bytes_result {
+                                                    Ok(bytes) => {
+                                                        use base64::Engine;
+                                                        let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                                                        extra_blocks.push(ContentBlock::Image {
+                                                            media_type: att.mime_type.clone(),
+                                                            data: b64,
+                                                        });
+                                                    }
+                                                    Err(e) => {
+                                                        tracing::warn!(filename = %att.filename, error = %e, "gateway image read failed");
+                                                    }
+                                                }
                                             }
                                             "text_file" => {
-                                                use base64::Engine;
-                                                if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(&att.data) {
+                                                if let Ok(bytes) = bytes_result {
                                                     let text = String::from_utf8_lossy(&bytes);
                                                     extra_blocks.push(ContentBlock::Text {
                                                         text: format!("```{}\n{}\n```", att.filename, text),
@@ -722,8 +746,7 @@ pub async fn run_gateway_adapter(
                                                 }
                                             }
                                             "audio" if stt_config.enabled => {
-                                                use base64::Engine;
-                                                match base64::engine::general_purpose::STANDARD.decode(&att.data) {
+                                                match bytes_result {
                                                     Ok(bytes) => {
                                                         match crate::stt::transcribe(
                                                             &crate::media::HTTP_CLIENT,
@@ -749,10 +772,10 @@ pub async fn run_gateway_adapter(
                                                         }
                                                     }
                                                     Err(e) => {
-                                                        tracing::warn!(filename = %att.filename, error = %e, "gateway audio base64 decode failed");
+                                                        tracing::warn!(filename = %att.filename, error = %e, "gateway audio read failed");
                                                         extra_blocks.push(ContentBlock::Text {
                                                             text: format!(
-                                                                "[Voice message — decode failed for {}]",
+                                                                "[Voice message — read failed for {}]",
                                                                 att.filename
                                                             ),
                                                         });


### PR DESCRIPTION
## What problem does this solve?

The gateway currently uses base64-over-WebSocket for media transport. This has fundamental limitations:

- **33% size overhead** — 3MB photo → 4MB base64 payload
- **WebSocket backpressure** — large frames block text events
- **Memory spikes** — download + encode + decode = ~4x RAM per file
- **Cannot scale** — hard ceiling on file size (WS frame limits)
- **No streaming** — must buffer entire file before sending

## How does it solve it?

**Media Proxy (Colocate Mode)** — Gateway downloads media and writes to `~/.openab/media/inbound/<uuid>`. The file path is passed to Core via the WS event. Core reads bytes directly from disk.

```
User sends media (photo/voice/file)
  → Platform webhook delivers to Gateway
  → Gateway downloads via platform API (auth stays in Gateway)
  → Image: resize ≤1200px, JPEG compress (GIF passthrough ≤5MB)
  → Store to ~/.openab/media/inbound/<uuid>
  → WS event includes file path in attachments[].path
  → Core reads from disk (zero encoding overhead)
  → Processes: image → LLM, audio → STT, text_file → code block
  → File auto-evicted after 2 minutes
```

## Architecture

```
┌─────────────────────────────────────────────────────────────────┐
│  Pod: openab-xxx-kiro                                           │
│                                                                 │
│  ┌──────────────┐  ┌──────────────┐  ┌───────────────────┐     │
│  │   openab     │  │   gateway    │  │   cloudflared     │     │
│  │   (core)     │  │   (sidecar)  │  │   (sidecar)       │     │
│  │              │  │              │  │                   │     │
│  │ kiro-cli     │  │ HTTP :8080   │  │ tunnel → :8080   │     │
│  │ agent pool   │  │ /webhook/tg  │  │                   │     │
│  │              │  │ /ws (core)   │  │                   │     │
│  │ reads media ←──── stores media │  │                   │     │
│  │              │  │              │  │                   │     │
│  └──────┬───────┘  └──────┬───────┘  └───────────────────┘     │
│         │                  │                                    │
│         ▼                  ▼                                    │
│  ┌─────────────────────────────────────┐                        │
│  │  PVC: data (mounted at /home/agent) │                        │
│  │                                     │                        │
│  │  /home/agent/                       │  ← shared HOME        │
│  │    .openab/media/inbound/           │  ← gateway writes     │
│  │    .kiro/                           │  ← core agent state   │
│  │    ...                              │                        │
│  └─────────────────────────────────────┘                        │
└─────────────────────────────────────────────────────────────────┘

Data flow (image from Telegram):

Telegram ──HTTPS──→ Cloudflare Tunnel
                         │
                         ▼
                    cloudflared ──HTTP──→ gateway :8080
                                              │
                         ┌────────────────────┘
                         ▼
                    1. Download image from Telegram API
                    2. Store → /home/agent/.openab/media/inbound/<uuid>
                    3. Forward event via WebSocket → core
                         │
                         ▼
                    core (openab)
                    4. Receives event with media path
                    5. Reads image from shared PVC
                    6. Passes to kiro-cli agent
                    7. Agent responds → gateway → Telegram
```

### Why colocate mode?

Gateway runs as a sidecar in the same pod as Core — they share `$HOME`. Simplest, fastest path: no HTTP proxy, no shared PVC config, just filesystem I/O.

### Prior Art

- **OpenClaw**: `~/.openclaw/media/inbound/<uuid>` with 2-min TTL — same pattern we adopt
- **Hermes Agent**: gateway-first design with per-platform capability declarations

## Security Considerations

Documented in `gateway/src/store.rs` comments:

1. **Path traversal prevention** — Filenames are server-generated UUIDs only, never user-supplied
2. **No auth token leakage** — Platform tokens stay in Gateway, never reach Core/Agent
3. **TTL auto-eviction** — Files deleted after 2 minutes, prevents disk exhaustion
4. **Colocate trust boundary** — File path passed over internal WS only, never exposed externally
5. **Size limits** — Unified 20MB cap in `store_media()` (defense-in-depth)
6. **No executable content** — Stored as raw data, never executed; MIME type determines processing

## Platform Support Matrix

| Platform | Images | Audio/Voice | Text Files | Video | Binary |
|----------|--------|-------------|------------|-------|--------|
| **Telegram** | ✅ | ✅ (STT) | ✅ (whitelist) | skipped | skipped |
| **Feishu** | ✅ | ✅ (STT) | ✅ (whitelist) | skipped | skipped |
| **Google Chat** | ✅ | ✅ (STT) | ✅ (whitelist) | skipped | skipped |
| **WeCom** | ✅ | — | ✅ (whitelist) | skipped | skipped |
| **LINE** | follow-up PR | follow-up PR | — | — | — |

## Implementation

| Component | Change |
|-----------|--------|
| `gateway/src/store.rs` | File store + 20MB cap + TTL eviction loop (new) |
| `gateway/src/media.rs` | Shared image resize/compress + `MediaKind` enum (new) |
| `gateway/src/schema.rs` | `Attachment.path: Option<String>` field |
| `gateway/src/adapters/telegram.rs` | Inbound photo/voice/audio/document via file store |
| `gateway/src/adapters/feishu.rs` | Migrated from base64 to file store |
| `gateway/src/adapters/googlechat.rs` | Migrated from base64 to file store |
| `gateway/src/adapters/wecom.rs` | Migrated from base64 to file store |
| `gateway/src/main.rs` | Shared `reqwest::Client`, eviction task spawn |
| `src/gateway.rs` | Core reads from `path` (preferred) with base64 `data` fallback |
| `docs/inbound-attachments.md` | Unified cross-platform media reference (new) |
| `docs/telegram.md` | Added inbound media section |
| `docs/feishu.md` | Updated to filesystem store |
| `docs/google-chat.md` | Updated to filesystem store |

## Supersedes / Closes

- **Supersedes #757** — base64 inline approach (closed)
- **Closes #690** — feat: support images and audio for LINE/Telegram

## Future Roadmap

- HTTP media proxy mode for separated deployments (Gateway ≠ Core pod)
- `~/.openab/media/outbound/` for agent → user file sends
- LINE adapter media support (same pattern, separate PR)
- Core-side truncation for large text files

## Test Plan

- [x] `cargo check` — gateway + core pass
- [x] `cargo test` — 170 gateway tests pass (store, media, adapters)
- [ ] Manual: send photo/voice/document to Telegram bot, verify agent receives content

Thread: 1506327876427845678