### PR TITLE
feat(steering): Add mid-turn steering message support

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -134,6 +134,16 @@ tables = "code"  # "code" (default) | "bullets" | "off"
                  # bullets: convert each row into bullet points (• Header: Value)
                  # off: pass through unchanged
 
+# --- Steering messages (mid-turn injection) ---
+# When enabled, messages matching the steering criteria are written directly
+# to the agent's stdin while it is busy, allowing real-time redirection.
+#
+# [steering]
+# enabled = false                    # default: false (backward compatible)
+# prefix = "!!"                      # trigger prefix for prefix mode
+# mode = "prefix"                    # "off" | "prefix" (default) | "implicit"
+# fallback = "queue"                 # "queue" (default) | "drop" | "error"
+
 [reactions]
 enabled = true
 remove_after_reply = false

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -222,6 +222,27 @@ Speech-to-text transcription for voice messages. Uses an OpenAI-compatible `/aud
 
 ---
 
+## `[steering]`
+
+Mid-turn steering message support. When enabled, messages matching the configured criteria are injected directly into a running agent session's stdin, bypassing the normal dispatch queue.
+
+```toml
+[steering]
+enabled  = false       # default: false (backward compatible)
+prefix   = "!!"        # trigger prefix
+mode     = "prefix"    # "off" | "prefix" | "implicit"
+fallback = "queue"     # "queue" | "drop" | "error"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `false` | Enable steering message support. |
+| `prefix` | string | `"!!"` | Trigger prefix for `mode = "prefix"`. The prefix is stripped before the message is sent to the agent. |
+| `mode` | string | `"prefix"` | Detection mode: `"off"` disables steering; `"prefix"` only steers messages starting with `prefix`; `"implicit"` treats any message sent while the agent is busy as steering. |
+| `fallback` | string | `"queue"` | Behavior when steering injection fails (e.g. agent does not support mid-turn input): `"queue"` falls back to normal buffered dispatch; `"drop"` silently drops the message; `"error"` sends an error reply to the user. |
+
+---
+
 ## `[cron]`
 
 Everything cron-related lives under `[cron]`.

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -338,6 +338,74 @@ impl SessionPool {
         Ok(())
     }
 
+    /// Inject a steering message directly into a running agent session.
+    ///
+    /// Returns `Ok(true)` if the message was injected, `Ok(false)` if the session
+    /// is idle or absent (caller should fall through to normal dispatch),
+    /// and `Err` if the write to stdin failed.
+    ///
+    /// The prompt is sent as a `session/prompt` JSON-RPC request with a UUID id
+    /// so it does not collide with the connection's sequential `next_id`. The agent
+    /// may process it concurrently with the in-flight turn; its intermediate output
+    /// (text, tool notifications) arrives through the existing subscriber channel.
+    /// The final response bearing the UUID id is treated as stale by the recv loop
+    /// and harmlessly skipped.
+    pub async fn steer_session(
+        &self,
+        thread_id: &str,
+        stripped_text: &str,
+    ) -> Result<bool> {
+        // 1. Look up the lock-free stdin handle and session id.
+        let (stdin, session_id) = {
+            let state = self.state.read().await;
+            match state.cancel_handles.get(thread_id) {
+                Some((stdin, sid)) => (stdin.clone(), sid.clone()),
+                None => return Ok(false),
+            }
+        };
+
+        // 2. Check whether the connection is actually busy.
+        // If try_lock succeeds the session is idle → fall through to normal dispatch.
+        let is_busy = {
+            let state = self.state.read().await;
+            match state.active.get(thread_id) {
+                Some(conn) => conn.try_lock().is_err(),
+                None => return Ok(false),
+            }
+        };
+        if !is_busy {
+            return Ok(false);
+        }
+
+        // 3. Build the steering prompt as a single text block.
+        let prompt_json = serde_json::json!([
+            {
+                "type": "text",
+                "text": stripped_text
+            }
+        ]);
+
+        // 4. Use a UUID request id so it can never collide with the connection's u64 ids.
+        let req_id = format!("steer_{}", uuid::Uuid::new_v4());
+        let data = serde_json::to_string(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": prompt_json,
+            }
+        }))?;
+
+        tracing::info!(session_id, "injecting steering message");
+        use tokio::io::AsyncWriteExt;
+        let mut w = stdin.lock().await;
+        w.write_all(data.as_bytes()).await?;
+        w.write_all(b"\n").await?;
+        w.flush().await?;
+        Ok(true)
+    }
+
     /// Reset a session: cancel any in-flight operation, remove the active connection,
     /// and clear all suspended state. The ACP process will be killed once the last
     /// Arc reference is dropped (after streaming finishes). The next message will
@@ -490,5 +558,19 @@ mod tests {
 
         assert!(Arc::ptr_eq(&first, &second));
         assert_eq!(map.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn steer_session_returns_false_when_no_session() {
+        let agent_cfg = crate::config::AgentConfig {
+            command: "/bin/true".into(),
+            args: vec![],
+            working_dir: "/tmp".into(),
+            env: std::collections::HashMap::new(),
+            inherit_env: vec![],
+        };
+        let pool = SessionPool::new(agent_cfg, 1);
+        let result = pool.steer_session("missing", "stop").await.unwrap();
+        assert!(!result, "steer_session should return false when no session exists");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,90 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
 
+/// Controls whether steering messages are enabled and how they are detected.
+///
+/// - `Off` (default): feature disabled; all messages use normal queueing.
+/// - `Prefix`: only messages starting with the configured prefix are treated as steering.
+/// - `Implicit`: any message sent while the agent is busy is treated as steering (opt-in).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SteeringMode {
+    #[default]
+    Off,
+    Prefix,
+    Implicit,
+}
+
+impl<'de> Deserialize<'de> for SteeringMode {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        match s.to_lowercase().as_str() {
+            "off" | "false" | "none" => Ok(Self::Off),
+            "prefix" => Ok(Self::Prefix),
+            "implicit" => Ok(Self::Implicit),
+            other => Err(serde::de::Error::unknown_variant(
+                other,
+                &["off", "prefix", "implicit"],
+            )),
+        }
+    }
+}
+
+/// Controls fallback behavior when a steering message cannot be injected.
+///
+/// - `Queue` (default): fall back to normal buffered dispatch.
+/// - `Drop`: silently drop the message.
+/// - `Error`: send an error reply to the user.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SteeringFallback {
+    #[default]
+    Queue,
+    Drop,
+    Error,
+}
+
+impl<'de> Deserialize<'de> for SteeringFallback {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        match s.to_lowercase().as_str() {
+            "queue" => Ok(Self::Queue),
+            "drop" => Ok(Self::Drop),
+            "error" => Ok(Self::Error),
+            other => Err(serde::de::Error::unknown_variant(
+                other,
+                &["queue", "drop", "error"],
+            )),
+        }
+    }
+}
+
+/// Steering message configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SteeringConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_steering_prefix")]
+    pub prefix: String,
+    #[serde(default)]
+    pub mode: SteeringMode,
+    #[serde(default)]
+    pub fallback: SteeringFallback,
+}
+
+fn default_steering_prefix() -> String {
+    "!!".into()
+}
+
+impl Default for SteeringConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            prefix: default_steering_prefix(),
+            mode: SteeringMode::default(),
+            fallback: SteeringFallback::default(),
+        }
+    }
+}
+
 /// Controls how incoming messages are dispatched to ACP turns.
 ///
 /// - `Message` (default): each message becomes its own ACP turn (v0.8.2-beta.1 behaviour).
@@ -81,6 +165,8 @@ pub struct Config {
     pub markdown: MarkdownConfig,
     #[serde(default)]
     pub cron: CronConfig,
+    #[serde(default)]
+    pub steering: SteeringConfig,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -921,5 +1007,73 @@ echo_transcript = false
         let cfg = parse_config(toml, "test").unwrap();
         assert!(cfg.stt.enabled);
         assert!(!cfg.stt.echo_transcript);
+    }
+
+    #[test]
+    fn steering_defaults_to_disabled() {
+        let cfg = parse_config(MINIMAL_TOML, "test").unwrap();
+        assert!(!cfg.steering.enabled);
+        assert_eq!(cfg.steering.mode, SteeringMode::Off);
+        assert_eq!(cfg.steering.prefix, "!!");
+        assert_eq!(cfg.steering.fallback, SteeringFallback::Queue);
+    }
+
+    #[test]
+    fn steering_parses_prefix_mode() {
+        let toml = r#"
+[agent]
+command = "echo"
+
+[steering]
+enabled = true
+prefix = "/steer"
+mode = "prefix"
+fallback = "drop"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        assert!(cfg.steering.enabled);
+        assert_eq!(cfg.steering.mode, SteeringMode::Prefix);
+        assert_eq!(cfg.steering.prefix, "/steer");
+        assert_eq!(cfg.steering.fallback, SteeringFallback::Drop);
+    }
+
+    #[test]
+    fn steering_parses_implicit_mode() {
+        let toml = r#"
+[agent]
+command = "echo"
+
+[steering]
+enabled = true
+mode = "implicit"
+fallback = "error"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        assert_eq!(cfg.steering.mode, SteeringMode::Implicit);
+        assert_eq!(cfg.steering.fallback, SteeringFallback::Error);
+    }
+
+    #[test]
+    fn steering_invalid_mode_errors() {
+        let toml = r#"
+[agent]
+command = "echo"
+
+[steering]
+mode = "bogus"
+"#;
+        assert!(parse_config(toml, "test").is_err());
+    }
+
+    #[test]
+    fn steering_invalid_fallback_errors() {
+        let toml = r#"
+[agent]
+command = "echo"
+
+[steering]
+fallback = "bogus"
+"#;
+        assert!(parse_config(toml, "test").is_err());
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -216,6 +216,8 @@ pub struct Handler {
     pub reminder_store: ReminderStore,
     /// Track scheduled reminder IDs to prevent duplicate scheduling on reconnect.
     pub scheduled_ids: tokio::sync::Mutex<std::collections::HashSet<String>>,
+    /// Steering message configuration (mid-turn injection).
+    pub steering_config: crate::config::SteeringConfig,
 }
 
 impl Handler {
@@ -775,7 +777,32 @@ impl EventHandler for Handler {
             sender.thread_id = Some(thread_channel.channel_id.clone());
         }
 
+        // --- Steering message injection ---
+        // If the message qualifies as steering and the session is busy, inject
+        // directly into the agent's stdin. Otherwise fall through to normal dispatch.
+        let steering_config = self.steering_config.clone();
         let dispatcher = self.dispatcher.clone();
+        let thread_key_for_steering = format!("discord:{}", thread_channel.channel_id);
+        if let Some(stripped) = crate::steering::detect_steering(&prompt, &steering_config) {
+            match dispatcher.steer_session(&thread_key_for_steering, &stripped).await {
+                Ok(true) => return, // injected successfully
+                Ok(false) => {}    // session idle/absent — fall through
+                Err(e) => {
+                    match steering_config.fallback {
+                        crate::config::SteeringFallback::Drop => return,
+                        crate::config::SteeringFallback::Error => {
+                            let _ = adapter.send_message(
+                                &thread_channel,
+                                &crate::steering::format_steering_error(&e.to_string()),
+                            ).await;
+                            return;
+                        }
+                        crate::config::SteeringFallback::Queue => {} // fall through
+                    }
+                }
+            }
+        }
+
         let stt_cfg = self.stt_config.clone();
 
         tokio::spawn(async move {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -120,6 +120,10 @@ pub trait DispatchTarget: Send + Sync + 'static {
     /// Ensure the ACP session for `session_key` exists (idempotent).
     async fn ensure_session(&self, session_key: &str) -> Result<()>;
 
+    /// Inject a steering message directly into a running session.
+    /// Returns `Ok(true)` if injected, `Ok(false)` if session is idle/absent.
+    async fn steer_session(&self, thread_id: &str, stripped_text: &str) -> Result<bool>;
+
     /// Drive one ACP turn with the pre-packed `content_blocks`.
     #[allow(clippy::too_many_arguments)]
     async fn stream_prompt_blocks(
@@ -141,6 +145,10 @@ impl DispatchTarget for AdapterRouter {
 
     async fn ensure_session(&self, session_key: &str) -> Result<()> {
         self.pool().get_or_create(session_key).await
+    }
+
+    async fn steer_session(&self, thread_id: &str, stripped_text: &str) -> Result<bool> {
+        self.pool().steer_session(thread_id, stripped_text).await
     }
 
     async fn stream_prompt_blocks(
@@ -464,6 +472,13 @@ impl Dispatcher {
             }
         }
         false
+    }
+
+    /// Inject a steering message directly into a running session via the
+    /// underlying `DispatchTarget`. Returns `Ok(true)` if injected,
+    /// `Ok(false)` if the session is idle or absent.
+    pub async fn steer_session(&self, thread_id: &str, stripped_text: &str) -> Result<bool> {
+        self.target.steer_session(thread_id, stripped_text).await
     }
 
     /// Remove map entries whose consumer task has finished (idle timeout or
@@ -1268,6 +1283,10 @@ mod tests {
                 return Err(anyhow::anyhow!(msg));
             }
             Ok(())
+        }
+
+        async fn steer_session(&self, _thread_id: &str, _stripped_text: &str) -> Result<bool> {
+            Ok(false)
         }
 
         async fn stream_prompt_blocks(

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -534,6 +534,7 @@ pub struct GatewayParams {
     pub allowed_users: Vec<String>,
     pub streaming: bool,
     pub stt: crate::config::SttConfig,
+    pub steering: crate::config::SteeringConfig,
 }
 
 pub async fn run_gateway_adapter(
@@ -553,6 +554,7 @@ pub async fn run_gateway_adapter(
     let allowed_users = params.allowed_users;
     let streaming = params.streaming;
     let stt_config = params.stt;
+    let steering_config = params.steering;
 
     let connect_url = match &params.token {
         Some(token) => {
@@ -845,6 +847,29 @@ pub async fn run_gateway_adapter(
                                             .thread_id
                                             .as_deref()
                                             .unwrap_or(&thread_channel.channel_id);
+
+                                        // --- Steering message injection ---
+                                        let thread_key_for_steering = format!("{}:{thread_id}", thread_channel.platform);
+                                        if let Some(stripped) = crate::steering::detect_steering(&prompt, &steering_config) {
+                                            match dispatcher.steer_session(&thread_key_for_steering, &stripped).await {
+                                                Ok(true) => return, // injected successfully
+                                                Ok(false) => {}    // session idle/absent — fall through
+                                                Err(e) => {
+                                                    match steering_config.fallback {
+                                                        crate::config::SteeringFallback::Drop => return,
+                                                        crate::config::SteeringFallback::Error => {
+                                                            let _ = adapter.send_message(
+                                                                &thread_channel,
+                                                                &crate::steering::format_steering_error(&e.to_string()),
+                                                            ).await;
+                                                            return;
+                                                        }
+                                                        crate::config::SteeringFallback::Queue => {} // fall through
+                                                    }
+                                                }
+                                            }
+                                        }
+
                                         let thread_key = dispatcher.key(
                                             &thread_channel.platform,
                                             thread_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod reactions;
 mod remind;
 mod setup;
 mod slack;
+mod steering;
 mod stt;
 mod timestamp;
 
@@ -256,6 +257,7 @@ async fn main() -> anyhow::Result<()> {
                 stt,
                 slack_shutdown_rx,
                 slack_dispatcher,
+                cfg.steering.clone(),
             )
             .await
             {
@@ -300,6 +302,7 @@ async fn main() -> anyhow::Result<()> {
             allowed_users: gw_cfg.allowed_users,
             streaming: gw_cfg.streaming,
             stt: cfg.stt.clone(),
+            steering: cfg.steering.clone(),
         };
         let gw_router = router.clone();
         Some(tokio::spawn(async move {
@@ -436,6 +439,7 @@ async fn main() -> anyhow::Result<()> {
             dispatcher: discord_dispatcher,
             reminder_store: reminder_store.clone(),
             scheduled_ids: tokio::sync::Mutex::new(std::collections::HashSet::new()),
+            steering_config: cfg.steering.clone(),
         };
 
         let intents = GatewayIntents::GUILD_MESSAGES

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -488,6 +488,7 @@ pub async fn run_slack_adapter(
     stt_config: SttConfig,
     mut shutdown_rx: watch::Receiver<bool>,
     dispatcher: Arc<crate::dispatch::Dispatcher>,
+    steering_config: crate::config::SteeringConfig,
 ) -> Result<()> {
     let bot_token = adapter.bot_token().to_string();
     let bot_turns = Arc::new(tokio::sync::Mutex::new(BotTurnTracker::new(max_bot_turns)));
@@ -583,6 +584,7 @@ pub async fn run_slack_adapter(
                                                 let allowed_users = allowed_users.clone();
                                                 let stt_config = stt_config.clone();
                                                 let dispatcher = dispatcher.clone();
+                                                let steering_cfg = steering_config.clone();
                                                 tokio::spawn(async move {
                                                     handle_message(
                                                         &event,
@@ -594,6 +596,7 @@ pub async fn run_slack_adapter(
                                                         &allowed_users,
                                                         &stt_config,
                                                         &dispatcher,
+                                                        &steering_cfg,
                                                     )
                                                     .await;
                                                 });
@@ -812,6 +815,7 @@ pub async fn run_slack_adapter(
                                                 let allowed_users = allowed_users.clone();
                                                 let stt_config = stt_config.clone();
                                                 let dispatcher = dispatcher.clone();
+                                                let steering_cfg = steering_config.clone();
                                                 tokio::spawn(async move {
                                                     handle_message(
                                                         &event,
@@ -823,6 +827,7 @@ pub async fn run_slack_adapter(
                                                         &allowed_users,
                                                         &stt_config,
                                                         &dispatcher,
+                                                        &steering_cfg,
                                                     )
                                                     .await;
                                                 });
@@ -894,6 +899,7 @@ async fn handle_message(
     allowed_users: &HashSet<String>,
     stt_config: &SttConfig,
     dispatcher: &Arc<crate::dispatch::Dispatcher>,
+    steering_config: &crate::config::SteeringConfig,
 ) {
     let channel_id = match event["channel"].as_str() {
         Some(ch) => ch.to_string(),
@@ -1135,6 +1141,32 @@ async fn handle_message(
         })
     };
 
+    // --- Steering message injection ---
+    let thread_id = thread_channel
+        .thread_id
+        .as_deref()
+        .unwrap_or(&thread_channel.channel_id);
+    let thread_key_for_steering = format!("slack:{thread_id}");
+    if let Some(stripped) = crate::steering::detect_steering(&prompt, steering_config) {
+        match dispatcher.steer_session(&thread_key_for_steering, &stripped).await {
+            Ok(true) => return, // injected successfully
+            Ok(false) => {}    // session idle/absent — fall through
+            Err(e) => {
+                match steering_config.fallback {
+                    crate::config::SteeringFallback::Drop => return,
+                    crate::config::SteeringFallback::Error => {
+                        let _ = adapter_dyn.send_message(
+                            &thread_channel,
+                            &crate::steering::format_steering_error(&e.to_string()),
+                        ).await;
+                        return;
+                    }
+                    crate::config::SteeringFallback::Queue => {} // fall through
+                }
+            }
+        }
+    }
+
     // Best-effort echo before the agent reply so the user can verify STT.
     crate::stt::post_echo(
         &adapter_dyn,
@@ -1145,10 +1177,6 @@ async fn handle_message(
     )
     .await;
 
-    let thread_id = thread_channel
-        .thread_id
-        .as_deref()
-        .unwrap_or(&thread_channel.channel_id);
     let thread_key = dispatcher.key("slack", thread_id, &sender.sender_id);
     let estimated_tokens = crate::dispatch::estimate_tokens(&prompt, &extra_blocks);
     let buf_msg = crate::dispatch::BufferedMessage {

--- a/src/steering.rs
+++ b/src/steering.rs
@@ -1,0 +1,140 @@
+use crate::config::{SteeringConfig, SteeringFallback, SteeringMode};
+
+/// Check whether a raw prompt text qualifies as a steering message under
+/// the given configuration. Returns `Some(stripped_text)` when steering
+/// applies (prefix stripped), or `None` when normal queueing should proceed.
+///
+/// Rules:
+/// - `SteeringMode::Off` → never steering.
+/// - `SteeringMode::Prefix` → steering only if text starts with the configured prefix.
+/// - `SteeringMode::Implicit` → always steering (caller must verify session is busy).
+pub fn detect_steering(prompt: &str, config: &SteeringConfig) -> Option<String> {
+    if !config.enabled {
+        return None;
+    }
+    match config.mode {
+        SteeringMode::Off => None,
+        SteeringMode::Prefix => {
+            let trimmed = prompt.trim_start();
+            if let Some(rest) = trimmed.strip_prefix(&config.prefix) {
+                let stripped = rest.trim_start();
+                if stripped.is_empty() {
+                    None
+                } else {
+                    Some(stripped.to_string())
+                }
+            } else {
+                None
+            }
+        }
+        SteeringMode::Implicit => {
+            let trimmed = prompt.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+    }
+}
+
+/// Build a user-facing error message when steering injection fails and
+/// the configured fallback is `SteeringFallback::Error`.
+pub fn format_steering_error(err: &str) -> String {
+    format!("⚠️ Steering failed: {err}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn prefix_config() -> SteeringConfig {
+        SteeringConfig {
+            enabled: true,
+            prefix: "!!".into(),
+            mode: SteeringMode::Prefix,
+            fallback: SteeringFallback::Queue,
+        }
+    }
+
+    fn implicit_config() -> SteeringConfig {
+        SteeringConfig {
+            enabled: true,
+            prefix: "!!".into(),
+            mode: SteeringMode::Implicit,
+            fallback: SteeringFallback::Queue,
+        }
+    }
+
+    #[test]
+    fn disabled_mode_never_steers() {
+        let cfg = SteeringConfig {
+            enabled: false,
+            ..prefix_config()
+        };
+        assert_eq!(detect_steering("!! stop", &cfg), None);
+    }
+
+    #[test]
+    fn prefix_detects_and_strips() {
+        let cfg = prefix_config();
+        assert_eq!(
+            detect_steering("!! stop — use staging", &cfg),
+            Some("stop — use staging".into())
+        );
+    }
+
+    #[test]
+    fn prefix_requires_exact_prefix() {
+        let cfg = prefix_config();
+        assert_eq!(detect_steering("! stop", &cfg), None);
+        assert_eq!(detect_steering("!!! stop", &cfg), None);
+    }
+
+    #[test]
+    fn prefix_strips_leading_whitespace() {
+        let cfg = prefix_config();
+        assert_eq!(
+            detect_steering("  !!   stop now", &cfg),
+            Some("stop now".into())
+        );
+    }
+
+    #[test]
+    fn prefix_empty_after_stripping_is_none() {
+        let cfg = prefix_config();
+        assert_eq!(detect_steering("!!", &cfg), None);
+        assert_eq!(detect_steering("!!   ", &cfg), None);
+    }
+
+    #[test]
+    fn implicit_mode_always_matches_non_empty() {
+        let cfg = implicit_config();
+        assert_eq!(
+            detect_steering("just a normal message", &cfg),
+            Some("just a normal message".into())
+        );
+    }
+
+    #[test]
+    fn implicit_mode_rejects_empty() {
+        let cfg = implicit_config();
+        assert_eq!(detect_steering("", &cfg), None);
+        assert_eq!(detect_steering("   ", &cfg), None);
+    }
+
+    #[test]
+    fn custom_prefix_works() {
+        let cfg = SteeringConfig {
+            enabled: true,
+            prefix: "/steer".into(),
+            mode: SteeringMode::Prefix,
+            fallback: SteeringFallback::Queue,
+        };
+        assert_eq!(
+            detect_steering("/steer revert that change", &cfg),
+            Some("revert that change".into())
+        );
+        assert_eq!(detect_steering("!! revert", &cfg), None);
+    }
+}


### PR DESCRIPTION
## What problem does this solve?

OpenAB currently processes messages in strictly turn-based fashion: any message that arrives while an agent is busy is buffered until the current turn completes. This means a user cannot redirect or abort a running agent mid-execution without waiting for it to finish — wasting time and tokens when the agent is heading in the wrong direction.

Every major agentic client (Claude Code terminal, GitHub Copilot CLI, Codex, Cursor, Kiro CLI) supports mid-execution steering natively. Routing through OpenAB silently downgrades that capability.

Closes #844

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365157010542652/1505905979219378286

## At a Glance

```
User message arrives
        │
        ▼
Is agent session busy?
   │              │
  NO             YES
   │              │
   ▼              ▼
Normal        Has steering prefix?
dispatch        │              │
               YES             NO
                │               │
                ▼               ▼
           Inject to        Buffer to
           agent stdin      next turn
           (steering)       (queueing)
                │               │
                ▼               ▼
         Agent adjusts    Existing behavior
         immediately      (no change)
```

## Prior Art & Industry Research

**OpenClaw:** OpenClaw's agent gateway does not currently expose a mid-turn steering primitive in its public API. It uses a request/response model over HTTP where each prompt is a discrete turn. The steering pattern is not implemented there.

**Hermes Agent:** Hermes Agent runs as a local CLI with an interactive TUI. It supports mid-run user input because the agent process reads from the same terminal stdin continuously — this is the same primitive we are exposing here (continuous stdin access), but bridged across network messaging platforms.

**GitHub Copilot SDK:** The Copilot SDK [explicitly distinguishes](https://docs.github.com/copilot/how-tos/copilot-sdk/use-copilot-sdk/steering-and-queueing) between two modes:
- **Steering**: message is injected into the agent's active turn; agent sees it immediately
- **Queueing**: message is buffered to the next turn (FIFO, existing behavior)

**Other references:**
- Claude Code terminal: type at any time during execution
- Codex: supports mid-run user input
- Cursor: interrupt + redirect

## Proposed Solution

### Prefix-based steering (recommended default)

Users mark a message as steering with a configurable prefix:

```
!! stop — use the staging environment, not production
```

OpenAB detects the prefix → checks if the target session is busy → if busy, writes a `session/prompt` JSON-RPC request directly to the agent's lock-free stdin handle. The agent receives it within the current turn.

### Config

```toml
[steering]
enabled  = false       # default: backward-compatible off
prefix   = "!!"
mode     = "prefix"    # "off" | "prefix" | "implicit"
fallback = "queue"     # "queue" | "drop" | "error"
```

### Implementation details

1. **Detection** (`src/steering.rs`): `detect_steering()` strips the prefix and returns the clean prompt, or `None` for normal messages.
2. **Injection** (`src/acp/pool.rs`): `steer_session()`:
   - Looks up the pre-stored `(stdin, session_id)` cancel handle (lock-free, no connection mutex needed)
   - Verifies the session is actually busy via `try_lock()` on the active connection
   - Builds a `session/prompt` JSON-RPC request with a UUID id (never collides with the connection's sequential u64 ids)
   - Writes to the agent's stdin
3. **Integration**: Each platform adapter (Discord, Slack, Gateway) checks steering *before* `Dispatcher::submit()`. If injected, the message bypasses the queue entirely. If the session is idle/absent, it falls through to normal dispatch.
4. **Race safety**: If the agent completes between the busy-check and the write, `try_lock()` succeeds → `Ok(false)` → fall through to queue. If the write fails because the process died, fallback config applies.

### Why UUID request ids?

The injected `session/prompt` uses a UUID id so it cannot collide with the connection's own `AtomicU64` id sequence. The reader loop will see the response as a "stale id-bearing message" (no pending entry for that id), log a trace, forward it to the subscriber, and the subscriber skips it because `id != request_id`. This is harmless — the steering message's *intermediate* output (text, thinking, tool notifications) still flows through the existing subscriber channel and is displayed to the user.

## Why this approach?

- **No ACP protocol changes**: Works with any ACP-compatible agent that can handle concurrent `session/prompt` requests on the same session.
- **Zero breaking changes**: Default `enabled = false`; existing deployments see no behavior change.
- **Consistent across all platforms**: The steering check lives in each adapter's message handler, using the shared `Dispatcher::steer_session()` seam.
- **Fail-soft**: If the agent doesn't support mid-turn input, fallback config lets operators choose queue/drop/error behavior.

### Tradeoffs accepted

- The final JSON-RPC response for the steering prompt is dropped (harmlessly) by the recv loop because its id doesn't match the in-flight turn's `request_id`. We accepted this because capturing it would require significant changes to the single-subscriber notification architecture.
- Steering messages are sent as simple text blocks without `sender_context` wrapping. This keeps them lightweight and directive-like, but agents lose sender metadata for steering inputs.

## Alternatives Considered

### Implicit steering (all busy-time messages)

`mode = "implicit"` is supported as an opt-in config value, but not the default. Automatically treating every message sent during agent execution as steering risks unintentional interruption. The issue author recommended prefix-based as the default.

### Reaction-based steering

User adds a specific emoji reaction to their own message → OpenAB promotes it to steering. Rejected because it creates inconsistency across platforms (Discord/Slack have reactions, Gateway platforms may not) and adds UI friction.

### ACP protocol extension

Add a `steering: true` flag to the ACP message schema. Rejected because it requires coordinated changes across all ACP-compatible agents. Scope is too large for an initial validation; better as a follow-up once broker-side steering is proven.

### Replace the subscriber channel with a broadcast bus

So steering responses could be consumed by a separate task. Rejected as over-engineering for the initial implementation. The current "stale id" path is safe and the intermediate output is still visible.

## Validation

- [ ] `cargo check` passes
- [ ] `cargo test` passes (including new tests in `config.rs`, `steering.rs`, `pool.rs`, `dispatch.rs`)
- [ ] `cargo clippy` clean
- [ ] Manual testing: verified steering detection strips prefix correctly
- [ ] Manual testing: verified `steer_session` returns `false` when no session exists
- [ ] Manual testing: verified `steer_session` returns `false` when session is idle

**Files changed:**
- `src/config.rs` — `SteeringConfig`, `SteeringMode`, `SteeringFallback`
- `src/steering.rs` — detection logic + unit tests
- `src/acp/pool.rs` — `steer_session()` injection + unit tests
- `src/dispatch.rs` — `DispatchTarget::steer_session()` + `Dispatcher::steer_session()`
- `src/discord.rs` — steering integration in message handler
- `src/slack.rs` — steering integration in message handler
- `src/gateway.rs` — steering integration in event handler
- `src/main.rs` — wire config to all three adapters
- `config.toml.example` — add steering section
