### PR TITLE
chore: rename build.yml to build-operator.yml

### DIFF
--- a/.github/workflows/build-operator.yml
+++ b/.github/workflows/build-operator.yml
@@ -1,4 +1,4 @@
-name: Build & Release
+name: Build Operator
 
 on:
   push:


### PR DESCRIPTION
Rename `build.yml` → `build-operator.yml` and update workflow name to "Build Operator" so it's clearly distinguishable from "Build Gateway" when dispatching manually.

Thread: 1506440911402434560