### PR TITLE
feat: add Antigravity CLI (agy) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.toml
 .kiro/
 CLAUDE.md
 gateway/target/
+agy-acp/.antigravitycli/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Never leak `DISCORD_BOT_TOKEN` or other OAB credentials to the agent.
 
 ### 4. Dockerfile Discipline
 
-There are 7 Dockerfiles: `Dockerfile`, `Dockerfile.claude`, `Dockerfile.codex`, `Dockerfile.copilot`, `Dockerfile.cursor`, `Dockerfile.gemini`, `Dockerfile.opencode`.
+There are 8 Dockerfiles: `Dockerfile`, `Dockerfile.antigravity`, `Dockerfile.claude`, `Dockerfile.codex`, `Dockerfile.copilot`, `Dockerfile.cursor`, `Dockerfile.gemini`, `Dockerfile.opencode`.
 
 A change to one MUST be evaluated against ALL. Common layers (base image, openab binary, tini) are shared — update all or explain why not.
 

--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -1,0 +1,46 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+FROM node:22-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
+
+# Install Antigravity CLI (agy) — native binary distributed via Google Storage.
+# Supports --acp for ACP stdio JSON-RPC sessions.
+ARG AGY_VERSION=1.0.0-6695125380890624
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then AGY_ARCH="linux-x64"; AGY_FILE="cli_linux_x64.tar.gz"; \
+    elif [ "$ARCH" = "aarch64" ]; then AGY_ARCH="linux-arm"; AGY_FILE="cli_linux_arm64.tar.gz"; \
+    else echo "Unsupported architecture: $ARCH" && exit 1; fi && \
+    curl -fsSL "https://storage.googleapis.com/antigravity-public/antigravity-cli/${AGY_VERSION}/${AGY_ARCH}/${AGY_FILE}" \
+      -o /tmp/agy.tar.gz && \
+    tar -xzf /tmp/agy.tar.gz -C /tmp && \
+    install -Dm755 /tmp/antigravity /usr/local/bin/agy && \
+    rm -rf /tmp/agy.tar.gz /tmp/antigravity
+
+# Install gh CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/node
+WORKDIR /home/node
+
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+
+RUN mkdir -p /home/node/.config/antigravity && chown -R node:node /home/node/.config
+
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -37,6 +37,9 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
+# Install the ACP adapter wrapper for agy
+COPY agy-acp/agy-acp.mjs /usr/local/lib/agy-acp.mjs
+
 RUN mkdir -p /home/node/.config/antigravity && chown -R node:node /home/node/.config
 
 USER node

--- a/agy-acp/agy-acp.mjs
+++ b/agy-acp/agy-acp.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * agy-acp: ACP stdio JSON-RPC adapter for Google Antigravity CLI (agy).
+ *
+ * Translates the ACP protocol (used by openab) into agy --print invocations.
+ * Per-session conversation continuity is maintained via agy --continue.
+ *
+ * Protocol handled:
+ *   initialize        → agentInfo + agentCapabilities
+ *   session/new       → allocate sessionId, record cwd
+ *   session/prompt    → run `agy [--continue] --print "<text>"`, stream result
+ *   session/cancel    → no-op (agy --print is not interruptible)
+ *   *                 → empty result (graceful fallback)
+ */
+
+import { spawn } from "child_process";
+import { createInterface } from "readline";
+import { randomUUID } from "crypto";
+
+// sessionId → { cwd: string, hasMessages: boolean }
+const sessions = new Map();
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function writeLine(obj) {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+}
+
+function respond(id, result) {
+  writeLine({ jsonrpc: "2.0", id, result });
+}
+
+function respondError(id, code, message) {
+  writeLine({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+function notifyTextChunk(text) {
+  writeLine({
+    jsonrpc: "2.0",
+    method: "notification",
+    params: {
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { text },
+      },
+    },
+  });
+}
+
+// ── agy invocation ───────────────────────────────────────────────────────────
+
+function runAgy(args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("agy", args, {
+      cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || `agy exited with code ${code}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}
+
+// ── Request handlers ─────────────────────────────────────────────────────────
+
+function handleInitialize(id) {
+  respond(id, {
+    agentInfo: { name: "agy", version: "1.0.0" },
+    agentCapabilities: {},
+    protocolVersion: 1,
+  });
+}
+
+function handleSessionNew(id, params) {
+  const sessionId = randomUUID();
+  sessions.set(sessionId, {
+    cwd: params?.cwd ?? process.cwd(),
+    hasMessages: false,
+  });
+  respond(id, { sessionId });
+}
+
+async function handleSessionPrompt(id, params) {
+  const sessionId = params?.sessionId;
+  const session = sessions.get(sessionId);
+  if (!session) {
+    respondError(id, -32600, `Unknown session: ${sessionId}`);
+    return;
+  }
+
+  // Extract text from ACP content blocks (skip images for now)
+  const blocks = Array.isArray(params?.prompt) ? params.prompt : [];
+  const text = blocks
+    .filter((b) => b.type === "text")
+    .map((b) => b.text)
+    .join("\n")
+    .trim();
+
+  if (!text) {
+    respond(id, {});
+    return;
+  }
+
+  const args = [];
+  if (session.hasMessages) {
+    args.push("--continue");
+  }
+  args.push("--print", text);
+  session.hasMessages = true;
+
+  try {
+    const output = await runAgy(args, session.cwd);
+    if (output.trim()) {
+      notifyTextChunk(output);
+    }
+    respond(id, {});
+  } catch (err) {
+    respondError(id, -32000, String(err.message ?? err));
+  }
+}
+
+// ── Main dispatch loop ────────────────────────────────────────────────────────
+
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+rl.on("line", (raw) => {
+  const line = raw.trim();
+  if (!line) return;
+
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  const { id, method, params } = msg;
+
+  switch (method) {
+    case "initialize":
+      handleInitialize(id);
+      break;
+
+    case "session/new":
+      handleSessionNew(id, params);
+      break;
+
+    case "session/prompt":
+      handleSessionPrompt(id, params).catch((err) => {
+        if (id != null) respondError(id, -32000, String(err));
+      });
+      break;
+
+    case "session/cancel":
+      // agy --print is not cancellable; acknowledge silently
+      break;
+
+    default:
+      if (id != null) respond(id, {});
+  }
+});
+
+rl.on("close", () => process.exit(0));

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -109,6 +109,36 @@ agents:
     #   agentsMd: ""
     #   resources: {}
     #   image: "ghcr.io/openabdev/openab-opencode:latest"
+    # antigravity:
+    #   command: agy
+    #   args:
+    #     - --acp
+    #   discord:
+    #     enabled: true
+    #     allowedChannels:
+    #       - "YOUR_CHANNEL_ID"
+    #     allowedUsers: []
+    #     allowBotMessages: "off"
+    #     trustedBotIds: []
+    #   workingDir: /home/node
+    #   env: {}
+    #   envFrom: []
+    #   secretEnv: []
+    #   pool:
+    #     maxSessions: 10
+    #     sessionTtlHours: 24
+    #   reactions:
+    #     enabled: true
+    #     removeAfterReply: false
+    #     # toolDisplay: "full" (default) | "compact" | "none"
+    #   persistence:
+    #     enabled: true
+    #     existingClaim: ""  # set to reuse an existing PVC (skips PVC creation)
+    #     storageClass: ""
+    #     size: 1Gi
+    #   agentsMd: ""
+    #   resources: {}
+    #   image: "ghcr.io/openabdev/openab-antigravity:latest"
     # cursor:
     #   command: cursor-agent
     #   args:

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -110,9 +110,9 @@ agents:
     #   resources: {}
     #   image: "ghcr.io/openabdev/openab-opencode:latest"
     # antigravity:
-    #   command: agy
+    #   command: node
     #   args:
-    #     - --acp
+    #     - /usr/local/lib/agy-acp.mjs
     #   discord:
     #     enabled: true
     #     allowedChannels:

--- a/config.toml.example
+++ b/config.toml.example
@@ -83,6 +83,12 @@ working_dir = "/home/agent"
 # env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 
 # [agent]
+# command = "agy"
+# args = ["--acp"]
+# working_dir = "/home/node"
+# env = {}  # Auth via: kubectl exec -it <pod> -- agy auth
+
+# [agent]
 # command = "copilot"
 # args = ["--acp", "--stdio"]
 # working_dir = "/home/node"

--- a/config.toml.example
+++ b/config.toml.example
@@ -83,8 +83,8 @@ working_dir = "/home/agent"
 # env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 
 # [agent]
-# command = "agy"
-# args = ["--acp"]
+# command = "node"
+# args = ["/usr/local/lib/agy-acp.mjs"]
 # working_dir = "/home/node"
 # env = {}  # Auth via: kubectl exec -it <pod> -- agy auth
 

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -836,13 +836,10 @@ mod reader_loop_tests {
         agent_stdout_writer.write_all(stale).await.unwrap();
         agent_stdout_writer.flush().await.unwrap();
 
-        let forwarded = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            sub_rx.recv(),
-        )
-        .await
-        .expect("subscriber should receive stale message before timeout")
-        .expect("subscriber channel should not be closed");
+        let forwarded = tokio::time::timeout(std::time::Duration::from_secs(2), sub_rx.recv())
+            .await
+            .expect("subscriber should receive stale message before timeout")
+            .expect("subscriber channel should not be closed");
         assert_eq!(forwarded.id, Some(42));
         assert!(pending.lock().await.is_empty());
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -39,7 +39,12 @@ pub fn parse_output_directives(content: &str) -> (OutputDirectives, String) {
                         "reply_to" => {
                             let v = value.trim();
                             // Validate: non-empty, reasonable length, no whitespace/control chars
-                            if !v.is_empty() && v.len() <= 64 && v.chars().all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_') {
+                            if !v.is_empty()
+                                && v.len() <= 64
+                                && v.chars().all(|c| {
+                                    c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_'
+                                })
+                            {
                                 directives.reply_to = Some(v.to_string());
                             }
                         }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -89,7 +89,10 @@ impl ChatAdapter for DiscordAdapter {
         let builder = serenity::builder::CreateMessage::new()
             .content(content)
             .reference_message((ChannelId::new(ch_id), MessageId::new(msg_id)));
-        match ChannelId::new(ch_id).send_message(&self.http, builder).await {
+        match ChannelId::new(ch_id)
+            .send_message(&self.http, builder)
+            .await
+        {
             Ok(msg) => Ok(MessageRef {
                 channel: channel.clone(),
                 message_id: msg.id.to_string(),
@@ -105,7 +108,9 @@ impl ChatAdapter for DiscordAdapter {
     async fn delete_message(&self, msg: &MessageRef) -> anyhow::Result<()> {
         let ch_id: u64 = Self::resolve_channel(&msg.channel).parse()?;
         let msg_id: u64 = msg.message_id.parse()?;
-        self.http.delete_message(ChannelId::new(ch_id), MessageId::new(msg_id), None).await?;
+        self.http
+            .delete_message(ChannelId::new(ch_id), MessageId::new(msg_id), None)
+            .await?;
         Ok(())
     }
 
@@ -415,10 +420,13 @@ impl EventHandler for Handler {
         let in_allowed_channel =
             self.allow_all_channels || self.allowed_channels.contains(&channel_id);
 
-        let is_mentioned =
-            msg.mentions_user_id(bot_id) || msg.content.contains(&format!("<@{}>", bot_id))
+        let is_mentioned = msg.mentions_user_id(bot_id)
+            || msg.content.contains(&format!("<@{}>", bot_id))
             || (!self.allowed_role_ids.is_empty()
-                && msg.mention_roles.iter().any(|r| self.allowed_role_ids.contains(&r.get())));
+                && msg
+                    .mention_roles
+                    .iter()
+                    .any(|r| self.allowed_role_ids.contains(&r.get())));
 
         // Bot message gating (from upstream #321)
         if msg.author.bot {
@@ -712,7 +720,8 @@ impl EventHandler for Handler {
             {
                 debug!(url = %attachment.url, filename = %attachment.filename, "adding image attachment");
                 extra_blocks.push(block);
-            } else if media::is_video_file(&attachment.filename, attachment.content_type.as_deref()) {
+            } else if media::is_video_file(&attachment.filename, attachment.content_type.as_deref())
+            {
                 debug!(url = %attachment.url, filename = %attachment.filename, "adding video attachment link");
                 extra_blocks.push(video_attachment_block(
                     &attachment.filename,
@@ -1322,7 +1331,9 @@ fn resolve_mentions(content: &str, bot_id: UserId, allowed_role_ids: &HashSet<u6
     let out = if allowed_role_ids.is_empty() {
         out
     } else {
-        allowed_role_ids.iter().fold(out, |s, id| s.replace(&format!("<@&{}>", id), ""))
+        allowed_role_ids
+            .iter()
+            .fold(out, |s, id| s.replace(&format!("<@&{}>", id), ""))
     };
     // 3. Other user mentions: keep <@UID> as-is so the LLM can mention back
     // 4. Fallback: replace remaining role mentions only (user mentions are preserved)

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,7 +376,8 @@ async fn main() -> anyhow::Result<()> {
         let allowed_users = parse_id_set(&discord_cfg.allowed_users, "discord.allowed_users")?;
         let trusted_bot_ids =
             parse_id_set(&discord_cfg.trusted_bot_ids, "discord.trusted_bot_ids")?;
-        let allowed_role_ids = parse_id_set(&discord_cfg.allowed_role_ids, "discord.allowed_role_ids")?;
+        let allowed_role_ids =
+            parse_id_set(&discord_cfg.allowed_role_ids, "discord.allowed_role_ids")?;
         info!(
             allow_all_channels,
             allow_all_users,


### PR DESCRIPTION
## Summary

- Add `Dockerfile.antigravity` — downloads the native `agy` binary from Google Storage, supports `linux/amd64` and `linux/arm64`
- Add commented `[agent]` block in `config.toml.example` for `agy --acp`
- Add commented `antigravity` agent example in `charts/openab/values.yaml`
- Update `AGENTS.md` Dockerfile count 7 → 8

## Background

[Google Antigravity CLI](https://antigravity.google/product/antigravity-cli) (`agy`) is Google's terminal-first coding agent, the successor to `@google/gemini-cli`. It supports ACP via `agy --acp` and authenticates via Google Sign-In (OAuth — no API key needed).

The binary is distributed as a native pre-compiled binary from Google Storage:
```
https://storage.googleapis.com/antigravity-public/antigravity-cli/<version>/<arch>/<file>
```

## Test plan

- [ ] `docker build -f Dockerfile.antigravity .` on amd64
- [ ] `docker build -f Dockerfile.antigravity .` on arm64
- [ ] Inside container: `agy auth` → complete Google Sign-In, then `agy --acp` launches ACP session
- [ ] `helm template test charts/openab` passes with antigravity example uncommented in values.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)