### PR TITLE
feat(setup): add Antigravity CLI preset for ACP integration

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -95,7 +95,7 @@ The AI agent subprocess that OpenAB spawns to handle messages via ACP.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `command` | string | *required* | Agent binary (e.g. `kiro-cli`, `claude`, `codex`, `gemini`, `copilot`, `opencode`, `cursor-agent`). |
+| `command` | string | *required* | Agent binary (e.g. `kiro-cli`, `claude`, `codex`, `gemini`, `antigravity`, `copilot`, `opencode`, `cursor-agent`). |
 | `args` | string[] | `[]` | CLI arguments passed to the agent. |
 | `working_dir` | string | `"/tmp"` | Working directory for the agent process. |
 | `env` | map | `{}` | Extra environment variables (e.g. `{ ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}" }`). |
@@ -131,7 +131,13 @@ env = { OPENAI_API_KEY = "${OPENAI_API_KEY}" }
 command = "gemini"
 args = ["--acp"]
 working_dir = "/home/node"
-env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
+env = { GEMINI_API_KEY="***" }
+
+# Antigravity CLI
+[agent]
+command = "antigravity"
+args = ["acp"]
+working_dir = "/home/node"
 
 # GitHub Copilot
 [agent]

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -89,6 +89,7 @@ pub fn generate_config(
                 "claude" => ("claude-agent-acp", vec![]),
                 "codex" => ("codex-acp", vec![]),
                 "gemini" => ("gemini", vec!["--acp".into()]),
+                "antigravity" => ("antigravity", vec!["acp".into()]),
                 other => (other, vec![]),
             };
             AgentConfigToml {

--- a/src/setup/validate.rs
+++ b/src/setup/validate.rs
@@ -24,7 +24,7 @@ pub fn validate_bot_token(token: &str) -> anyhow::Result<()> {
 /// Validate agent command
 #[cfg(test)]
 pub fn validate_agent_command(cmd: &str) -> anyhow::Result<()> {
-    let valid = ["kiro", "claude", "codex", "gemini"];
+    let valid = ["kiro", "claude", "codex", "gemini", "antigravity"];
     if !valid.contains(&cmd) {
         anyhow::bail!("Agent must be one of: {}", valid.join(", "));
     }
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     fn test_validate_agent_command() {
-        for agent in &["kiro", "claude", "codex", "gemini"] {
+        for agent in &["kiro", "claude", "codex", "gemini", "antigravity"] {
             assert!(validate_agent_command(agent).is_ok());
         }
         assert!(validate_agent_command("invalid").is_err());

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -383,12 +383,13 @@ fn section_agent() -> (String, String, bool) {
         "kiro:    npm install -g @koryhutchison/kiro-cli",
         "codex:   npm install -g openai-codex (requires OpenAI API key)",
         "gemini:  npm install -g @google/gemini-cli",
+        "antigravity: install the official Google Antigravity CLI",
         "",
         "Make sure the agent is in your PATH before continuing.",
     ]);
     println!();
 
-    let choices = ["claude", "kiro", "codex", "gemini"];
+    let choices = ["claude", "kiro", "codex", "gemini", "antigravity"];
     let idx = prompt_choice("  Select agent:", &choices);
     let agent = choices[idx];
 


### PR DESCRIPTION
## Summary
- Add `antigravity` as a first-class setup wizard agent option
- Map setup preset to `command = "antigravity"` and `args = ["acp"]`
- Extend setup validation/tests to include `antigravity`
- Document Antigravity in `docs/config-reference.md` under `[agent]`

## Why
Google Antigravity CLI was released and users asked for OpenAB integration. OpenAB already supports arbitrary ACP-compatible commands; this PR makes Antigravity discoverable and easy via the interactive setup flow.

## Verification
- `cargo fmt`
- `cargo test -q` (362 passed)

## Notes
- Non-breaking and additive only
- Existing configurations are unaffected
