### PR TITLE
ci: scope each CI job to its own paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,7 @@ on:
     paths:
       - "src/**"
       - "gateway/**"
-      - "gateway/Cargo.lock"
       - "operator/**"
-      - "operator/Cargo.lock"
       - "Cargo.toml"
       - "Cargo.lock"
       - "Dockerfile*"
@@ -16,75 +14,86 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+      gateway: ${{ steps.filter.outputs.gateway }}
+      operator: ${{ steps.filter.outputs.operator }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - 'src/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            gateway:
+              - 'gateway/**'
+            operator:
+              - 'operator/**'
+
   check:
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-
       - uses: Swatinem/rust-cache@v2
-
       - name: cargo check
         run: cargo check
-
       - name: cargo clippy
         run: cargo clippy -- -D warnings
-
       - name: cargo test
         run: cargo test
 
   gateway:
+    needs: changes
+    if: needs.changes.outputs.gateway == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: gateway
     steps:
       - uses: actions/checkout@v6
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: gateway
-
       - name: cargo check
         run: cargo check
-
       - name: cargo clippy
         run: cargo clippy -- -D warnings
-
       - name: cargo test
         run: cargo test
 
   operator:
+    needs: changes
+    if: needs.changes.outputs.operator == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: operator
     steps:
       - uses: actions/checkout@v6
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: operator
-
       - name: cargo check
         run: cargo check
-
       - name: cargo clippy
         run: cargo clippy -- -D warnings
-
       - name: cargo test
         run: cargo test
-
       - name: cargo build
         run: cargo build --release


### PR DESCRIPTION
## Summary

Each CI job now only runs when its own paths are modified, using `dorny/paths-filter@v3`:

| Job | Triggers on |
|-----|-------------|
| check | `src/**`, `Cargo.toml`, `Cargo.lock` |
| gateway | `gateway/**` |
| operator | `operator/**` |

Previously a change in `gateway/` would also trigger the `operator` and `check` jobs unnecessarily.

## What changed

- Added a `changes` job using `dorny/paths-filter` to detect which paths were modified
- Each downstream job uses `needs: changes` + `if:` to only run when relevant