### PR TITLE
ci: add macOS native build on operator/* branch push

### DIFF
--- a/.github/workflows/build-operator-branch.yml
+++ b/.github/workflows/build-operator-branch.yml
@@ -1,0 +1,36 @@
+name: Build Operator (Branch)
+
+on:
+  push:
+    branches:
+      - "operator/**"
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: openab-runner-macos
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Build (aarch64-apple-darwin)
+        run: cargo build --release
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/release/openab dist/
+          cd dist && tar czf ../openab-macos-arm64.tar.gz *
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openab-macos-arm64
+          path: openab-macos-arm64.tar.gz
+          retention-days: 7


### PR DESCRIPTION
Adds a workflow that triggers on pushes to `operator/**` branches, builds the openab binary natively on macmini (aarch64-apple-darwin), and uploads it as a downloadable artifact (7-day retention).

- Runs on: `openab-runner-macos` (macmini native runner)
- Trigger: push to `operator/*` branches
- Output: `openab-macos-arm64.tar.gz` artifact