### PR TITLE
fix: use standard runner labels for macOS build

### DIFF
--- a/.github/workflows/build-operator-branch.yml
+++ b/.github/workflows/build-operator-branch.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-macos:
-    runs-on: openab-runner-macos
+    runs-on: [self-hosted, macOS, ARM64]
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Use `[self-hosted, macOS, ARM64]` instead of custom label `openab-runner-macos` — the runner's custom labels may not be visible without org admin configuration.