### PR TITLE
feat(slack): outbound file attachments via marker syntax

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -13,9 +13,13 @@ use tokio_tungstenite::tungstenite;
 use tracing::{debug, error, info, warn};
 
 /// Marker syntax for outbound file attachments in agent text output.
-/// Tifa writes `<<openab:send-file:/abs/path/to/file>>` in her response, OpenAB
+/// Tifa writes `<<openab-send-file /abs/path/to/file>>` in her response, OpenAB
 /// intercepts before posting and uploads the file via Slack's files API.
-const FILE_SEND_MARKER_PREFIX: &str = "<<openab:send-file:";
+///
+/// IMPORTANT: do NOT use colons in this marker (`:something:` would collide
+/// with Slack's emoji shortcode parser and get rendered as a gray-box
+/// placeholder even before our interceptor runs).
+const FILE_SEND_MARKER_PREFIX: &str = "<<openab-send-file ";
 const FILE_SEND_MARKER_SUFFIX: &str = ">>";
 /// Sanity cap so an agent typo doesn't try to upload /Users/jazlim or similar.
 /// Slack's own per-file limit is 1 GB by default; we cap at 100 MB.

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -12,6 +12,15 @@ use tokio::sync::watch;
 use tokio_tungstenite::tungstenite;
 use tracing::{debug, error, info, warn};
 
+/// Marker syntax for outbound file attachments in agent text output.
+/// Tifa writes `<<openab:send-file:/abs/path/to/file>>` in her response, OpenAB
+/// intercepts before posting and uploads the file via Slack's files API.
+const FILE_SEND_MARKER_PREFIX: &str = "<<openab:send-file:";
+const FILE_SEND_MARKER_SUFFIX: &str = ">>";
+/// Sanity cap so an agent typo doesn't try to upload /Users/jazlim or similar.
+/// Slack's own per-file limit is 1 GB by default; we cap at 100 MB.
+const FILE_SEND_MAX_BYTES: u64 = 100 * 1024 * 1024;
+
 const SLACK_API: &str = "https://slack.com/api";
 
 /// Map Unicode emoji to Slack short names for reactions API.
@@ -336,6 +345,232 @@ impl SlackAdapter {
         cache.insert(thread_ts.to_string(), tokio::time::Instant::now());
         enforce_cache_bounds(&mut cache, self.session_ttl);
     }
+
+    /// Post a plain text message — the original `send_message` path, extracted
+    /// so the marker-aware path can reuse it.
+    async fn send_plain_text(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
+        let mrkdwn = markdown_to_mrkdwn(content);
+        let mut body = serde_json::json!({
+            "channel": channel.channel_id,
+            "text": mrkdwn,
+        });
+        if let Some(thread_ts) = &channel.thread_id {
+            body["thread_ts"] = serde_json::Value::String(thread_ts.clone());
+        }
+        let resp = self.api_post("chat.postMessage", body).await?;
+        let ts = resp["ts"]
+            .as_str()
+            .ok_or_else(|| anyhow!("no ts in chat.postMessage response"))?;
+        Ok(MessageRef {
+            channel: ChannelRef {
+                platform: "slack".into(),
+                channel_id: channel.channel_id.clone(),
+                thread_id: channel.thread_id.clone(),
+                parent_id: None,
+                origin_event_id: None,
+            },
+            message_id: ts.to_string(),
+        })
+    }
+
+    /// Upload a file from disk and share it into the given channel/thread.
+    ///
+    /// Implements Slack's 3-step modern upload API:
+    ///   1. `files.getUploadURLExternal` → get an upload_url + file_id
+    ///   2. POST raw bytes to that upload_url (multipart/form-data, field name `file`)
+    ///   3. `files.completeUploadExternal` → publish into the channel
+    ///
+    /// Returns a MessageRef pointing at the share message ts. Failures bubble up
+    /// with the Slack error code in the message; caller is responsible for
+    /// surfacing to the user.
+    ///
+    /// Required Slack bot scopes: `files:write`. The file path must be readable
+    /// by the OpenAB process (host or container — whichever filesystem the
+    /// bridge runs in).
+    async fn send_file_to_slack(&self, channel: &ChannelRef, path: &str) -> Result<MessageRef> {
+        use tokio::io::AsyncReadExt;
+
+        // --- Validate the path ---
+        let path_buf = std::path::PathBuf::from(path);
+        if !path_buf.is_file() {
+            return Err(anyhow!("not a regular file: {path}"));
+        }
+        let metadata = tokio::fs::metadata(&path_buf).await?;
+        let size = metadata.len();
+        if size == 0 {
+            return Err(anyhow!("file is empty: {path}"));
+        }
+        if size > FILE_SEND_MAX_BYTES {
+            return Err(anyhow!(
+                "file too large ({size} bytes > {FILE_SEND_MAX_BYTES} cap): {path}"
+            ));
+        }
+        let filename = path_buf
+            .file_name()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| anyhow!("could not derive filename from path: {path}"))?
+            .to_string();
+
+        debug!(path = %path, filename = %filename, size, "slack: starting file upload");
+
+        // --- Step 1: getUploadURLExternal (form-encoded GET, per Slack docs) ---
+        let step1_resp = self
+            .client
+            .get(format!("{SLACK_API}/files.getUploadURLExternal"))
+            .header("Authorization", format!("Bearer {}", self.bot_token))
+            .query(&[
+                ("filename", filename.as_str()),
+                ("length", size.to_string().as_str()),
+            ])
+            .send()
+            .await?
+            .json::<serde_json::Value>()
+            .await?;
+
+        if step1_resp["ok"].as_bool() != Some(true) {
+            let err = step1_resp["error"]
+                .as_str()
+                .unwrap_or("unknown getUploadURLExternal error");
+            return Err(anyhow!("files.getUploadURLExternal: {err}"));
+        }
+        let upload_url = step1_resp["upload_url"]
+            .as_str()
+            .ok_or_else(|| anyhow!("no upload_url in getUploadURLExternal response"))?
+            .to_string();
+        let file_id = step1_resp["file_id"]
+            .as_str()
+            .ok_or_else(|| anyhow!("no file_id in getUploadURLExternal response"))?
+            .to_string();
+
+        // --- Step 2: PUT raw bytes to the signed URL ---
+        let mut file_bytes = Vec::with_capacity(size as usize);
+        tokio::fs::File::open(&path_buf)
+            .await?
+            .read_to_end(&mut file_bytes)
+            .await?;
+
+        let step2_resp = self
+            .client
+            .post(&upload_url)
+            .body(file_bytes)
+            .send()
+            .await?;
+
+        if !step2_resp.status().is_success() {
+            let status = step2_resp.status();
+            let body = step2_resp.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "upload PUT failed: HTTP {status} — body: {}",
+                body.chars().take(200).collect::<String>()
+            ));
+        }
+
+        // --- Step 3: completeUploadExternal — actually publish into the channel ---
+        let mut complete_body = serde_json::json!({
+            "files": [{ "id": file_id, "title": filename }],
+            "channel_id": channel.channel_id,
+        });
+        if let Some(thread_ts) = &channel.thread_id {
+            complete_body["thread_ts"] = serde_json::Value::String(thread_ts.clone());
+        }
+
+        let step3_resp = self.api_post("files.completeUploadExternal", complete_body).await?;
+
+        // Slack returns the file metadata; we want the share's message timestamp.
+        // It's available under `files[0].shares.public.<channel>[0].ts` or
+        // `files[0].shares.private.<channel>[0].ts`. Probe both.
+        let ts = extract_share_message_ts(&step3_resp, &channel.channel_id).unwrap_or_else(|| {
+            // No ts surfaced — use file_id as a stand-in. MessageRef is mostly
+            // used for reactions and edits, neither of which makes sense for a
+            // file share. So file_id is a reasonable degenerate identity.
+            file_id.clone()
+        });
+
+        info!(
+            file_id = %file_id,
+            filename = %filename,
+            size,
+            channel = %channel.channel_id,
+            "slack: file upload complete"
+        );
+
+        Ok(MessageRef {
+            channel: ChannelRef {
+                platform: "slack".into(),
+                channel_id: channel.channel_id.clone(),
+                thread_id: channel.thread_id.clone(),
+                parent_id: None,
+                origin_event_id: None,
+            },
+            message_id: ts,
+        })
+    }
+}
+
+/// Parse outbound text for file-send markers `<<openab:send-file:PATH>>`.
+/// Returns `Some((text_without_markers, paths))` if at least one marker found,
+/// `None` if the text contains no markers (fast-path).
+///
+/// Marker syntax is deliberately ugly/unambiguous so it never collides with
+/// natural language. Whitespace around markers is collapsed cleanly.
+fn extract_file_send_markers(content: &str) -> Option<(String, Vec<String>)> {
+    if !content.contains(FILE_SEND_MARKER_PREFIX) {
+        return None;
+    }
+
+    let mut paths: Vec<String> = Vec::new();
+    let mut stripped = String::with_capacity(content.len());
+    let mut remaining = content;
+
+    while let Some(start) = remaining.find(FILE_SEND_MARKER_PREFIX) {
+        // Push everything before the marker into the stripped text.
+        stripped.push_str(&remaining[..start]);
+        let after_prefix = &remaining[start + FILE_SEND_MARKER_PREFIX.len()..];
+
+        match after_prefix.find(FILE_SEND_MARKER_SUFFIX) {
+            Some(end) => {
+                let path = after_prefix[..end].trim().to_string();
+                if !path.is_empty() {
+                    paths.push(path);
+                }
+                remaining = &after_prefix[end + FILE_SEND_MARKER_SUFFIX.len()..];
+            }
+            None => {
+                // Unterminated marker — treat as literal text, preserve.
+                stripped.push_str(FILE_SEND_MARKER_PREFIX);
+                stripped.push_str(after_prefix);
+                remaining = "";
+            }
+        }
+    }
+    // Append any trailing text after the last marker.
+    stripped.push_str(remaining);
+
+    if paths.is_empty() {
+        return None;
+    }
+    Some((stripped, paths))
+}
+
+/// Pull the share message timestamp out of a `files.completeUploadExternal`
+/// response, probing both `public` and `private` share entries for the channel.
+/// Returns None if the response shape doesn't match (Slack may change this).
+fn extract_share_message_ts(resp: &serde_json::Value, channel_id: &str) -> Option<String> {
+    let files = resp.get("files")?.as_array()?;
+    let first = files.first()?;
+    let shares = first.get("shares")?;
+    for visibility in ["public", "private"] {
+        if let Some(share_map) = shares.get(visibility) {
+            if let Some(channel_shares) = share_map.get(channel_id) {
+                if let Some(first_share) = channel_shares.as_array().and_then(|a| a.first()) {
+                    if let Some(ts) = first_share.get("ts").and_then(|v| v.as_str()) {
+                        return Some(ts.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Shared eviction policy for positive-only caches.
@@ -369,28 +604,44 @@ impl ChatAdapter for SlackAdapter {
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
-        let mrkdwn = markdown_to_mrkdwn(content);
-        let mut body = serde_json::json!({
-            "channel": channel.channel_id,
-            "text": mrkdwn,
-        });
-        if let Some(thread_ts) = &channel.thread_id {
-            body["thread_ts"] = serde_json::Value::String(thread_ts.clone());
+        // Scan for file-send markers <<openab:send-file:PATH>>. If found, intercept:
+        // upload each file via Slack's files API, then send the remaining text (with
+        // markers stripped). Returns the MessageRef of the last action performed.
+        if let Some((stripped_text, file_paths)) = extract_file_send_markers(content) {
+            let mut last_msg: Option<MessageRef> = None;
+
+            // Post the residual text first (if non-empty), so the file appears AFTER
+            // any caption. Matches the natural reading order users expect.
+            let trimmed = stripped_text.trim();
+            if !trimmed.is_empty() {
+                last_msg = Some(self.send_plain_text(channel, trimmed).await?);
+            }
+
+            // Upload each file. Failure on one shouldn't block the rest — log & continue.
+            for path in &file_paths {
+                match self.send_file_to_slack(channel, path).await {
+                    Ok(msg_ref) => {
+                        info!(path = %path, "slack: file uploaded");
+                        last_msg = Some(msg_ref);
+                    }
+                    Err(e) => {
+                        error!(path = %path, error = %e, "slack: file upload failed");
+                        // Surface the failure to the user so they know it didn't go through.
+                        let err_text = format!(
+                            "⚠️ Failed to send file `{}`: {}\n(See OpenAB logs for details.)",
+                            path, e
+                        );
+                        last_msg = Some(self.send_plain_text(channel, &err_text).await?);
+                    }
+                }
+            }
+
+            // If we somehow had only markers and no surviving text, return a stub.
+            return last_msg.ok_or_else(|| anyhow!("no message sent (empty after marker strip)"));
         }
-        let resp = self.api_post("chat.postMessage", body).await?;
-        let ts = resp["ts"]
-            .as_str()
-            .ok_or_else(|| anyhow!("no ts in chat.postMessage response"))?;
-        Ok(MessageRef {
-            channel: ChannelRef {
-                platform: "slack".into(),
-                channel_id: channel.channel_id.clone(),
-                thread_id: channel.thread_id.clone(),
-                parent_id: None,
-                origin_event_id: None,
-            },
-            message_id: ts.to_string(),
-        })
+
+        // Standard path — no markers, just text.
+        self.send_plain_text(channel, content).await
     }
 
     async fn create_thread(

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -733,6 +733,13 @@ impl ChatAdapter for SlackAdapter {
 
             // Upload each file as a follow-up. Dedup via the cache so we don't
             // re-upload on each streaming edit chunk.
+            //
+            // Race-free check-and-claim: insert into cache FIRST under the lock,
+            // then upload. If insertion returns false (key already present),
+            // another edit_message call already claimed the slot — skip.
+            // The previous version did check-then-act with the lock released
+            // between check and insert, allowing duplicate uploads when two
+            // streaming edits fired within the upload latency window.
             for path in &file_paths {
                 let cache_key = format!(
                     "{}|{}|{}",
@@ -740,21 +747,24 @@ impl ChatAdapter for SlackAdapter {
                     msg.channel.thread_id.as_deref().unwrap_or(""),
                     path
                 );
-                {
-                    let cache = self.file_upload_cache.lock().await;
-                    if cache.contains(&cache_key) {
-                        debug!(path = %path, "skipping duplicate file upload (cached)");
-                        continue;
-                    }
+                let claimed = {
+                    let mut cache = self.file_upload_cache.lock().await;
+                    cache.insert(cache_key.clone()) // returns true if newly inserted
+                };
+                if !claimed {
+                    debug!(path = %path, "skipping duplicate file upload (already claimed)");
+                    continue;
                 }
                 match self.send_file_to_slack(&msg.channel, path).await {
                     Ok(_) => {
                         info!(path = %path, "slack: file uploaded via edit_message");
-                        let mut cache = self.file_upload_cache.lock().await;
-                        cache.insert(cache_key);
                     }
                     Err(e) => {
                         error!(path = %path, error = %e, "slack: file upload failed");
+                        // Roll back the claim so a future retry of the SAME path
+                        // (e.g. user re-asks after fixing the path) isn't blocked.
+                        let mut cache = self.file_upload_cache.lock().await;
+                        cache.remove(&cache_key);
                         let err_text = format!(
                             "⚠️ Failed to send file `{}`: {}\n(See OpenAB logs for details.)",
                             path, e

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -80,6 +80,11 @@ pub struct SlackAdapter {
     multibot_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
     /// TTL for participation cache entries (matches session_ttl_hours from config).
     session_ttl: std::time::Duration,
+    /// Dedup set for file uploads — keyed on `{channel}|{thread_ts}|{path}`.
+    /// Streaming edit_message can fire repeatedly during a single agent turn,
+    /// each potentially containing the file-send marker. Without dedup we'd
+    /// re-upload the same file dozens of times. Cleared once per session restart.
+    file_upload_cache: tokio::sync::Mutex<HashSet<String>>,
 }
 
 impl SlackAdapter {
@@ -97,6 +102,7 @@ impl SlackAdapter {
             participated_threads: tokio::sync::Mutex::new(HashMap::new()),
             multibot_threads: tokio::sync::Mutex::new(HashMap::new()),
             session_ttl,
+            file_upload_cache: tokio::sync::Mutex::new(HashSet::new()),
         }
     }
 
@@ -703,6 +709,63 @@ impl ChatAdapter for SlackAdapter {
     }
 
     async fn edit_message(&self, msg: &MessageRef, content: &str) -> Result<()> {
+        // Marker handling for the streaming path: OpenAB streams the final agent
+        // response via repeated edit_message calls against a placeholder. If the
+        // text contains file-send markers, we strip them from the edit (so the
+        // placeholder shows clean text) and trigger uploads as separate follow-up
+        // messages in the same channel/thread.
+        //
+        // Idempotency: we only want to upload each file ONCE per session, not on
+        // every streaming edit. We track this via the file_upload_cache keyed on
+        // (channel_id, thread_ts, path). The cache lives on the adapter struct.
+        if let Some((stripped_text, file_paths)) = extract_file_send_markers(content) {
+            // Edit the placeholder to the clean text (without markers).
+            let stripped_mrkdwn = markdown_to_mrkdwn(&stripped_text);
+            self.api_post(
+                "chat.update",
+                serde_json::json!({
+                    "channel": msg.channel.channel_id,
+                    "ts": msg.message_id,
+                    "text": stripped_mrkdwn,
+                }),
+            )
+            .await?;
+
+            // Upload each file as a follow-up. Dedup via the cache so we don't
+            // re-upload on each streaming edit chunk.
+            for path in &file_paths {
+                let cache_key = format!(
+                    "{}|{}|{}",
+                    msg.channel.channel_id,
+                    msg.channel.thread_id.as_deref().unwrap_or(""),
+                    path
+                );
+                {
+                    let cache = self.file_upload_cache.lock().await;
+                    if cache.contains(&cache_key) {
+                        debug!(path = %path, "skipping duplicate file upload (cached)");
+                        continue;
+                    }
+                }
+                match self.send_file_to_slack(&msg.channel, path).await {
+                    Ok(_) => {
+                        info!(path = %path, "slack: file uploaded via edit_message");
+                        let mut cache = self.file_upload_cache.lock().await;
+                        cache.insert(cache_key);
+                    }
+                    Err(e) => {
+                        error!(path = %path, error = %e, "slack: file upload failed");
+                        let err_text = format!(
+                            "⚠️ Failed to send file `{}`: {}\n(See OpenAB logs for details.)",
+                            path, e
+                        );
+                        let _ = self.send_plain_text(&msg.channel, &err_text).await;
+                    }
+                }
+            }
+            return Ok(());
+        }
+
         let mrkdwn = markdown_to_mrkdwn(content);
         self.api_post(
             "chat.update",


### PR DESCRIPTION
## What

Adds outbound file-attachment support to the Slack adapter. Agents include a marker in their text output and OpenAB intercepts, uploads, and shares the file via Slack's modern files API.

```
Marker:  <<openab-send-file /absolute/path/to/file>>
```

## Why

ACP is a text-stream protocol — there's no native primitive for "agent says upload this file." Today, agents on the Slack adapter can only paste file contents inline as code blocks, or rely on the user's personal Slack OAuth via a separate MCP. Neither is a real file attachment, neither uses the bot's identity, and neither survives the claude-agent-acp env-var firewall (which deliberately strips bridge tokens from the spawned agent, preventing direct curl calls to Slack's API).

A text marker is the lightest extension that solves this without protocol changes — the agent just emits a string, the bridge does the rest.

## How

**Marker syntax**: `<<openab-send-file /absolute/path>>`. No colons — `:` collides with Slack's mrkdwn emoji parser (`:something:` renders as a gray placeholder before any interceptor runs).

**Where it fires**: Both `send_message` AND `edit_message`. OpenAB streaming uses `edit_message` for the placeholder edit; without patching that path, the marker wouldn't be intercepted during streaming responses (which is the default for solo-bot Slack threads).

**Dedup**: Streaming edits can fire repeatedly within ~200ms. Without dedup, each edit re-uploaded the file. The cache uses atomic check-and-claim under a Mutex — first claimer inserts under the lock, subsequent calls see the slot occupied and skip. Failure path removes the claim so retries aren't blocked.

**Upload flow**: Slack's modern 3-step API:
1. `files.getUploadURLExternal` (filename + length) → upload_url + file_id
2. `POST` raw bytes to the signed upload_url
3. `files.completeUploadExternal` (file_id + channel + thread_ts) → publishes the share

**Failure handling**: Posts a `⚠️ Failed to send file ...` message into the channel and surfaces the Slack error code. Caller doesn't need extra error handling.

## Constraints

- **Absolute paths only.** Bridge resolves the path as-is — no shell expansion.
- **100 MB cap per file** (sanity limit; Slack accepts up to 1 GB).
- **Requires `files:write` bot scope** on the Slack app.
- **File must be readable by the OpenAB process.** Native runs see the full host filesystem; Docker runs see only bind-mounted paths.

## Commits (recommended review order)

1. `feat(slack): send file attachments via marker` — initial implementation on `send_message` only
2. `fix(slack): rename marker to avoid Slack emoji parser collision` — `<<openab:send-file:PATH>>` → `<<openab-send-file PATH>>`
3. `fix(slack): patch edit_message too — streaming bypasses send_message` — required for streaming responses (the more common path)
4. `fix(slack): race-free dedup for file upload claims` — close the check-then-act window observed in production (duplicate uploads 224ms apart)

Each commit is self-contained and bisects cleanly. Splitting them was the result of debugging in real conditions; happy to squash before merge if preferred.

## Testing

Validated end-to-end against a personal Slack workspace (Juwaiiqi team):

- Marker in agent reply → bridge intercepts via `edit_message` → file lands in DM as real attachment (not inline code block)
- Tested with `.md` text files; should work for any MIME type Slack accepts
- Confirmed dedup: streaming edit with the same marker fires once even when the agent's response streams over multiple edit chunks
- Confirmed failure path: invalid path → `⚠️ Failed to send file ...` error message posted to channel
- Verified marker is invisible in the final delivered message (stripped before edit)

## Open questions for maintainers

1. Should this gate behind a config flag (e.g. `[reactions]`-style opt-in)? Currently always-on for any Slack adapter, but I could add `[slack].file_send_marker = true` if you'd prefer explicit enablement.
2. Marker syntax — open to alternatives if you have a preferred convention.
3. Dedup cache TTL — currently lives for the adapter's lifetime. Could add expiry, but streaming edits all happen within seconds of each other, so cache growth is bounded by unique file-send turns.

Happy to iterate on any of the above. This is patch was developed in a real working setup that's been in personal use for several days; reach out if you want test logs or repro steps.