### PR TITLE
feat(slack): inject metadata for unhandled inbound file types

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -13,9 +13,13 @@ use tokio_tungstenite::tungstenite;
 use tracing::{debug, error, info, warn};
 
 /// Marker syntax for outbound file attachments in agent text output.
-/// Tifa writes `<<openab:send-file:/abs/path/to/file>>` in her response, OpenAB
+/// Tifa writes `<<openab-send-file /abs/path/to/file>>` in her response, OpenAB
 /// intercepts before posting and uploads the file via Slack's files API.
-const FILE_SEND_MARKER_PREFIX: &str = "<<openab:send-file:";
+///
+/// IMPORTANT: do NOT use colons in this marker (`:something:` would collide
+/// with Slack's emoji shortcode parser and get rendered as a gray-box
+/// placeholder even before our interceptor runs).
+const FILE_SEND_MARKER_PREFIX: &str = "<<openab-send-file ";
 const FILE_SEND_MARKER_SUFFIX: &str = ">>";
 /// Sanity cap so an agent typo doesn't try to upload /Users/jazlim or similar.
 /// Slack's own per-file limit is 1 GB by default; we cap at 100 MB.

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -12,6 +12,15 @@ use tokio::sync::watch;
 use tokio_tungstenite::tungstenite;
 use tracing::{debug, error, info, warn};
 
+/// Marker syntax for outbound file attachments in agent text output.
+/// Tifa writes `<<openab:send-file:/abs/path/to/file>>` in her response, OpenAB
+/// intercepts before posting and uploads the file via Slack's files API.
+const FILE_SEND_MARKER_PREFIX: &str = "<<openab:send-file:";
+const FILE_SEND_MARKER_SUFFIX: &str = ">>";
+/// Sanity cap so an agent typo doesn't try to upload /Users/jazlim or similar.
+/// Slack's own per-file limit is 1 GB by default; we cap at 100 MB.
+const FILE_SEND_MAX_BYTES: u64 = 100 * 1024 * 1024;
+
 const SLACK_API: &str = "https://slack.com/api";
 
 /// Map Unicode emoji to Slack short names for reactions API.
@@ -336,6 +345,232 @@ impl SlackAdapter {
         cache.insert(thread_ts.to_string(), tokio::time::Instant::now());
         enforce_cache_bounds(&mut cache, self.session_ttl);
     }
+
+    /// Post a plain text message — the original `send_message` path, extracted
+    /// so the marker-aware path can reuse it.
+    async fn send_plain_text(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
+        let mrkdwn = markdown_to_mrkdwn(content);
+        let mut body = serde_json::json!({
+            "channel": channel.channel_id,
+            "text": mrkdwn,
+        });
+        if let Some(thread_ts) = &channel.thread_id {
+            body["thread_ts"] = serde_json::Value::String(thread_ts.clone());
+        }
+        let resp = self.api_post("chat.postMessage", body).await?;
+        let ts = resp["ts"]
+            .as_str()
+            .ok_or_else(|| anyhow!("no ts in chat.postMessage response"))?;
+        Ok(MessageRef {
+            channel: ChannelRef {
+                platform: "slack".into(),
+                channel_id: channel.channel_id.clone(),
+                thread_id: channel.thread_id.clone(),
+                parent_id: None,
+                origin_event_id: None,
+            },
+            message_id: ts.to_string(),
+        })
+    }
+
+    /// Upload a file from disk and share it into the given channel/thread.
+    ///
+    /// Implements Slack's 3-step modern upload API:
+    ///   1. `files.getUploadURLExternal` → get an upload_url + file_id
+    ///   2. POST raw bytes to that upload_url (multipart/form-data, field name `file`)
+    ///   3. `files.completeUploadExternal` → publish into the channel
+    ///
+    /// Returns a MessageRef pointing at the share message ts. Failures bubble up
+    /// with the Slack error code in the message; caller is responsible for
+    /// surfacing to the user.
+    ///
+    /// Required Slack bot scopes: `files:write`. The file path must be readable
+    /// by the OpenAB process (host or container — whichever filesystem the
+    /// bridge runs in).
+    async fn send_file_to_slack(&self, channel: &ChannelRef, path: &str) -> Result<MessageRef> {
+        use tokio::io::AsyncReadExt;
+
+        // --- Validate the path ---
+        let path_buf = std::path::PathBuf::from(path);
+        if !path_buf.is_file() {
+            return Err(anyhow!("not a regular file: {path}"));
+        }
+        let metadata = tokio::fs::metadata(&path_buf).await?;
+        let size = metadata.len();
+        if size == 0 {
+            return Err(anyhow!("file is empty: {path}"));
+        }
+        if size > FILE_SEND_MAX_BYTES {
+            return Err(anyhow!(
+                "file too large ({size} bytes > {FILE_SEND_MAX_BYTES} cap): {path}"
+            ));
+        }
+        let filename = path_buf
+            .file_name()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| anyhow!("could not derive filename from path: {path}"))?
+            .to_string();
+
+        debug!(path = %path, filename = %filename, size, "slack: starting file upload");
+
+        // --- Step 1: getUploadURLExternal (form-encoded GET, per Slack docs) ---
+        let step1_resp = self
+            .client
+            .get(format!("{SLACK_API}/files.getUploadURLExternal"))
+            .header("Authorization", format!("Bearer {}", self.bot_token))
+            .query(&[
+                ("filename", filename.as_str()),
+                ("length", size.to_string().as_str()),
+            ])
+            .send()
+            .await?
+            .json::<serde_json::Value>()
+            .await?;
+
+        if step1_resp["ok"].as_bool() != Some(true) {
+            let err = step1_resp["error"]
+                .as_str()
+                .unwrap_or("unknown getUploadURLExternal error");
+            return Err(anyhow!("files.getUploadURLExternal: {err}"));
+        }
+        let upload_url = step1_resp["upload_url"]
+            .as_str()
+            .ok_or_else(|| anyhow!("no upload_url in getUploadURLExternal response"))?
+            .to_string();
+        let file_id = step1_resp["file_id"]
+            .as_str()
+            .ok_or_else(|| anyhow!("no file_id in getUploadURLExternal response"))?
+            .to_string();
+
+        // --- Step 2: PUT raw bytes to the signed URL ---
+        let mut file_bytes = Vec::with_capacity(size as usize);
+        tokio::fs::File::open(&path_buf)
+            .await?
+            .read_to_end(&mut file_bytes)
+            .await?;
+
+        let step2_resp = self
+            .client
+            .post(&upload_url)
+            .body(file_bytes)
+            .send()
+            .await?;
+
+        if !step2_resp.status().is_success() {
+            let status = step2_resp.status();
+            let body = step2_resp.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "upload PUT failed: HTTP {status} — body: {}",
+                body.chars().take(200).collect::<String>()
+            ));
+        }
+
+        // --- Step 3: completeUploadExternal — actually publish into the channel ---
+        let mut complete_body = serde_json::json!({
+            "files": [{ "id": file_id, "title": filename }],
+            "channel_id": channel.channel_id,
+        });
+        if let Some(thread_ts) = &channel.thread_id {
+            complete_body["thread_ts"] = serde_json::Value::String(thread_ts.clone());
+        }
+
+        let step3_resp = self.api_post("files.completeUploadExternal", complete_body).await?;
+
+        // Slack returns the file metadata; we want the share's message timestamp.
+        // It's available under `files[0].shares.public.<channel>[0].ts` or
+        // `files[0].shares.private.<channel>[0].ts`. Probe both.
+        let ts = extract_share_message_ts(&step3_resp, &channel.channel_id).unwrap_or_else(|| {
+            // No ts surfaced — use file_id as a stand-in. MessageRef is mostly
+            // used for reactions and edits, neither of which makes sense for a
+            // file share. So file_id is a reasonable degenerate identity.
+            file_id.clone()
+        });
+
+        info!(
+            file_id = %file_id,
+            filename = %filename,
+            size,
+            channel = %channel.channel_id,
+            "slack: file upload complete"
+        );
+
+        Ok(MessageRef {
+            channel: ChannelRef {
+                platform: "slack".into(),
+                channel_id: channel.channel_id.clone(),
+                thread_id: channel.thread_id.clone(),
+                parent_id: None,
+                origin_event_id: None,
+            },
+            message_id: ts,
+        })
+    }
+}
+
+/// Parse outbound text for file-send markers `<<openab:send-file:PATH>>`.
+/// Returns `Some((text_without_markers, paths))` if at least one marker found,
+/// `None` if the text contains no markers (fast-path).
+///
+/// Marker syntax is deliberately ugly/unambiguous so it never collides with
+/// natural language. Whitespace around markers is collapsed cleanly.
+fn extract_file_send_markers(content: &str) -> Option<(String, Vec<String>)> {
+    if !content.contains(FILE_SEND_MARKER_PREFIX) {
+        return None;
+    }
+
+    let mut paths: Vec<String> = Vec::new();
+    let mut stripped = String::with_capacity(content.len());
+    let mut remaining = content;
+
+    while let Some(start) = remaining.find(FILE_SEND_MARKER_PREFIX) {
+        // Push everything before the marker into the stripped text.
+        stripped.push_str(&remaining[..start]);
+        let after_prefix = &remaining[start + FILE_SEND_MARKER_PREFIX.len()..];
+
+        match after_prefix.find(FILE_SEND_MARKER_SUFFIX) {
+            Some(end) => {
+                let path = after_prefix[..end].trim().to_string();
+                if !path.is_empty() {
+                    paths.push(path);
+                }
+                remaining = &after_prefix[end + FILE_SEND_MARKER_SUFFIX.len()..];
+            }
+            None => {
+                // Unterminated marker — treat as literal text, preserve.
+                stripped.push_str(FILE_SEND_MARKER_PREFIX);
+                stripped.push_str(after_prefix);
+                remaining = "";
+            }
+        }
+    }
+    // Append any trailing text after the last marker.
+    stripped.push_str(remaining);
+
+    if paths.is_empty() {
+        return None;
+    }
+    Some((stripped, paths))
+}
+
+/// Pull the share message timestamp out of a `files.completeUploadExternal`
+/// response, probing both `public` and `private` share entries for the channel.
+/// Returns None if the response shape doesn't match (Slack may change this).
+fn extract_share_message_ts(resp: &serde_json::Value, channel_id: &str) -> Option<String> {
+    let files = resp.get("files")?.as_array()?;
+    let first = files.first()?;
+    let shares = first.get("shares")?;
+    for visibility in ["public", "private"] {
+        if let Some(share_map) = shares.get(visibility) {
+            if let Some(channel_shares) = share_map.get(channel_id) {
+                if let Some(first_share) = channel_shares.as_array().and_then(|a| a.first()) {
+                    if let Some(ts) = first_share.get("ts").and_then(|v| v.as_str()) {
+                        return Some(ts.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Shared eviction policy for positive-only caches.
@@ -369,28 +604,44 @@ impl ChatAdapter for SlackAdapter {
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
-        let mrkdwn = markdown_to_mrkdwn(content);
-        let mut body = serde_json::json!({
-            "channel": channel.channel_id,
-            "text": mrkdwn,
-        });
-        if let Some(thread_ts) = &channel.thread_id {
-            body["thread_ts"] = serde_json::Value::String(thread_ts.clone());
+        // Scan for file-send markers <<openab:send-file:PATH>>. If found, intercept:
+        // upload each file via Slack's files API, then send the remaining text (with
+        // markers stripped). Returns the MessageRef of the last action performed.
+        if let Some((stripped_text, file_paths)) = extract_file_send_markers(content) {
+            let mut last_msg: Option<MessageRef> = None;
+
+            // Post the residual text first (if non-empty), so the file appears AFTER
+            // any caption. Matches the natural reading order users expect.
+            let trimmed = stripped_text.trim();
+            if !trimmed.is_empty() {
+                last_msg = Some(self.send_plain_text(channel, trimmed).await?);
+            }
+
+            // Upload each file. Failure on one shouldn't block the rest — log & continue.
+            for path in &file_paths {
+                match self.send_file_to_slack(channel, path).await {
+                    Ok(msg_ref) => {
+                        info!(path = %path, "slack: file uploaded");
+                        last_msg = Some(msg_ref);
+                    }
+                    Err(e) => {
+                        error!(path = %path, error = %e, "slack: file upload failed");
+                        // Surface the failure to the user so they know it didn't go through.
+                        let err_text = format!(
+                            "⚠️ Failed to send file `{}`: {}\n(See OpenAB logs for details.)",
+                            path, e
+                        );
+                        last_msg = Some(self.send_plain_text(channel, &err_text).await?);
+                    }
+                }
+            }
+
+            // If we somehow had only markers and no surviving text, return a stub.
+            return last_msg.ok_or_else(|| anyhow!("no message sent (empty after marker strip)"));
         }
-        let resp = self.api_post("chat.postMessage", body).await?;
-        let ts = resp["ts"]
-            .as_str()
-            .ok_or_else(|| anyhow!("no ts in chat.postMessage response"))?;
-        Ok(MessageRef {
-            channel: ChannelRef {
-                platform: "slack".into(),
-                channel_id: channel.channel_id.clone(),
-                thread_id: channel.thread_id.clone(),
-                parent_id: None,
-                origin_event_id: None,
-            },
-            message_id: ts.to_string(),
-        })
+
+        // Standard path — no markers, just text.
+        self.send_plain_text(channel, content).await
     }
 
     async fn create_thread(

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -733,6 +733,13 @@ impl ChatAdapter for SlackAdapter {
 
             // Upload each file as a follow-up. Dedup via the cache so we don't
             // re-upload on each streaming edit chunk.
+            //
+            // Race-free check-and-claim: insert into cache FIRST under the lock,
+            // then upload. If insertion returns false (key already present),
+            // another edit_message call already claimed the slot — skip.
+            // The previous version did check-then-act with the lock released
+            // between check and insert, allowing duplicate uploads when two
+            // streaming edits fired within the upload latency window.
             for path in &file_paths {
                 let cache_key = format!(
                     "{}|{}|{}",
@@ -740,21 +747,24 @@ impl ChatAdapter for SlackAdapter {
                     msg.channel.thread_id.as_deref().unwrap_or(""),
                     path
                 );
-                {
-                    let cache = self.file_upload_cache.lock().await;
-                    if cache.contains(&cache_key) {
-                        debug!(path = %path, "skipping duplicate file upload (cached)");
-                        continue;
-                    }
+                let claimed = {
+                    let mut cache = self.file_upload_cache.lock().await;
+                    cache.insert(cache_key.clone()) // returns true if newly inserted
+                };
+                if !claimed {
+                    debug!(path = %path, "skipping duplicate file upload (already claimed)");
+                    continue;
                 }
                 match self.send_file_to_slack(&msg.channel, path).await {
                     Ok(_) => {
                         info!(path = %path, "slack: file uploaded via edit_message");
-                        let mut cache = self.file_upload_cache.lock().await;
-                        cache.insert(cache_key);
                     }
                     Err(e) => {
                         error!(path = %path, error = %e, "slack: file upload failed");
+                        // Roll back the claim so a future retry of the SAME path
+                        // (e.g. user re-asks after fixing the path) isn't blocked.
+                        let mut cache = self.file_upload_cache.lock().await;
+                        cache.remove(&cache_key);
                         let err_text = format!(
                             "⚠️ Failed to send file `{}`: {}\n(See OpenAB logs for details.)",
                             path, e

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -80,6 +80,11 @@ pub struct SlackAdapter {
     multibot_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
     /// TTL for participation cache entries (matches session_ttl_hours from config).
     session_ttl: std::time::Duration,
+    /// Dedup set for file uploads — keyed on `{channel}|{thread_ts}|{path}`.
+    /// Streaming edit_message can fire repeatedly during a single agent turn,
+    /// each potentially containing the file-send marker. Without dedup we'd
+    /// re-upload the same file dozens of times. Cleared once per session restart.
+    file_upload_cache: tokio::sync::Mutex<HashSet<String>>,
 }
 
 impl SlackAdapter {
@@ -97,6 +102,7 @@ impl SlackAdapter {
             participated_threads: tokio::sync::Mutex::new(HashMap::new()),
             multibot_threads: tokio::sync::Mutex::new(HashMap::new()),
             session_ttl,
+            file_upload_cache: tokio::sync::Mutex::new(HashSet::new()),
         }
     }
 
@@ -703,6 +709,63 @@ impl ChatAdapter for SlackAdapter {
     }
 
     async fn edit_message(&self, msg: &MessageRef, content: &str) -> Result<()> {
+        // Marker handling for the streaming path: OpenAB streams the final agent
+        // response via repeated edit_message calls against a placeholder. If the
+        // text contains file-send markers, we strip them from the edit (so the
+        // placeholder shows clean text) and trigger uploads as separate follow-up
+        // messages in the same channel/thread.
+        //
+        // Idempotency: we only want to upload each file ONCE per session, not on
+        // every streaming edit. We track this via the file_upload_cache keyed on
+        // (channel_id, thread_ts, path). The cache lives on the adapter struct.
+        if let Some((stripped_text, file_paths)) = extract_file_send_markers(content) {
+            // Edit the placeholder to the clean text (without markers).
+            let stripped_mrkdwn = markdown_to_mrkdwn(&stripped_text);
+            self.api_post(
+                "chat.update",
+                serde_json::json!({
+                    "channel": msg.channel.channel_id,
+                    "ts": msg.message_id,
+                    "text": stripped_mrkdwn,
+                }),
+            )
+            .await?;
+
+            // Upload each file as a follow-up. Dedup via the cache so we don't
+            // re-upload on each streaming edit chunk.
+            for path in &file_paths {
+                let cache_key = format!(
+                    "{}|{}|{}",
+                    msg.channel.channel_id,
+                    msg.channel.thread_id.as_deref().unwrap_or(""),
+                    path
+                );
+                {
+                    let cache = self.file_upload_cache.lock().await;
+                    if cache.contains(&cache_key) {
+                        debug!(path = %path, "skipping duplicate file upload (cached)");
+                        continue;
+                    }
+                }
+                match self.send_file_to_slack(&msg.channel, path).await {
+                    Ok(_) => {
+                        info!(path = %path, "slack: file uploaded via edit_message");
+                        let mut cache = self.file_upload_cache.lock().await;
+                        cache.insert(cache_key);
+                    }
+                    Err(e) => {
+                        error!(path = %path, error = %e, "slack: file upload failed");
+                        let err_text = format!(
+                            "⚠️ Failed to send file `{}`: {}\n(See OpenAB logs for details.)",
+                            path, e
+                        );
+                        let _ = self.send_plain_text(&msg.channel, &err_text).await;
+                    }
+                }
+            }
+            return Ok(());
+        }
+
         let mrkdwn = markdown_to_mrkdwn(content);
         self.api_post(
             "chat.update",

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1069,6 +1069,35 @@ async fn handle_message(
             {
                 debug!(filename, "adding image attachment");
                 extra_blocks.push(block);
+            } else {
+                // Fallback for unhandled file types (video, PDF, Office docs,
+                // archives, generic binary). Without this, OpenAB silently
+                // drops the file — the agent never knows the user attached
+                // anything and reasons from incomplete context.
+                //
+                // Inject a small text ContentBlock with metadata so the agent
+                // can: (a) acknowledge the file exists, (b) optionally fetch
+                // it via a separate tool (Slack MCP's read_file, manual curl,
+                // etc.) if it has the capability and the content matters.
+                //
+                // Size-bound: only inject metadata, not contents — keeps the
+                // ACP message small regardless of file size.
+                let human_size = format_size_human(size);
+                let metadata = format!(
+                    "[Slack file attachment — not auto-loaded by OpenAB]\n\
+                     - filename: {filename}\n\
+                     - mimetype: {mimetype}\n\
+                     - size: {human_size}\n\
+                     - url: {url}\n\
+                     \n\
+                     This file type isn't auto-forwarded into your context. \
+                     If the contents matter to the user's request, fetch it \
+                     separately (Slack MCP's slack_read_file, or download via \
+                     curl with Bearer token if you have it). Otherwise just \
+                     acknowledge that the user shared the file."
+                );
+                debug!(filename, mimetype, size, "injecting unhandled-file metadata block");
+                extra_blocks.push(ContentBlock::Text { text: metadata });
             }
         }
     }
@@ -1219,6 +1248,25 @@ fn slack_file_download_url(file: &serde_json::Value) -> &str {
 /// Strip MIME parameters like `; charset=utf-8` so type-detection helpers see
 /// the bare media type. Slack occasionally sends mimetypes like
 /// `text/plain; charset=utf-8`; `media::is_text_file` expects the bare form.
+/// Format a byte count in a human-readable way (e.g. "2.2 MB", "456 KB").
+/// Used in the unhandled-file metadata block so the agent sees a friendly size.
+fn format_size_human(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else if bytes > 0 {
+        format!("{bytes} bytes")
+    } else {
+        "unknown size".to_string()
+    }
+}
+
 fn strip_mime_params(mimetype: &str) -> &str {
     mimetype.split(';').next().unwrap_or(mimetype).trim()
 }


### PR DESCRIPTION
## What

When a Slack user sends a file the adapter doesn't auto-forward (video, PDF, Office docs, archives, generic binaries), inject a metadata content block so the agent knows the file exists.

## Why

Today the Slack adapter has explicit handling for three categories of inbound files:

- **Audio** — transcribed via STT if enabled
- **Text files** — read inline (capped at 5 files / 1 MB per message)
- **Images** — base64-encoded as image content blocks

Everything else (video, PDF, Office docs, archives, generic binary) hits an unhandled else branch and gets silently dropped. The result: when the user attaches a video and asks the agent to look at it, the agent's prompt contains text but no reference to the attachment. The agent then reasons from incomplete context — sometimes apologizing for a 'missing' file that was sent successfully.

I noticed this when an agent on my fork received a `.mp4` and replied as if the user hadn't attached anything. The agent eventually worked around it by calling Slack's `files.read` API directly via a separate MCP, but that workaround isn't always available and shouldn't be necessary.

## How

Adds a final `else` clause to the file dispatch in `handle_message`. For any unhandled mimetype, build a small text content block describing the file:

```
[Slack file attachment — not auto-loaded by OpenAB]
- filename: VID-20260507-WA0001.mp4
- mimetype: video/mp4
- size: 2.2 MB
- url: https://files.slack.com/.../download/VID-20260507-WA0001.mp4

This file type isn't auto-forwarded into your context. If the contents
matter to the user's request, fetch it separately (Slack MCP's
slack_read_file, or download via curl with Bearer token if you have it).
Otherwise just acknowledge that the user shared the file.
```

The block is intentionally size-bounded — only describes the file, never embeds contents. ACP message size stays small regardless of how big the attachment is.

The included `format_size_human` helper produces friendly size strings ('2.2 MB' instead of '2306867 bytes').

## What this doesn't try to do

- **Doesn't extract text from PDFs / Office docs.** That requires extra crate dependencies and parsing logic; could be a follow-up. The metadata block is a strict improvement over silent drop.
- **Doesn't download non-text non-image binaries.** Same reasoning — the agent decides whether to fetch.
- **Doesn't change behavior for already-handled types.** Audio/text/images flow through their existing branches unchanged.

## Testing

Patched binary running in production on my macOS setup for several hours. Confirmed:

- Inbound `.mp4` now produces a metadata block (verified via debug log line `injecting unhandled-file metadata block`)
- Agent reply correctly references the attachment by filename and acknowledges receipt
- Audio/text/image flows are unaffected

## Open questions for maintainers

1. **Should the metadata format be configurable?** Currently the message is a hardcoded English template. Could move to a config-driven template if you want.
2. **Should we extend text-file handling to cover PDFs?** The existing TEXT_TOTAL_CAP / TEXT_FILE_COUNT_CAP logic could apply to PDF text extraction if a parser crate (e.g. `lopdf` or `pdf-extract`) is acceptable as a dependency.
3. **Should we add a per-mimetype allowlist instead of catch-all?** Right now any unhandled type produces metadata. Strict workspaces might prefer to silently drop unknown types.

Happy to iterate on any of the above.