### PR TITLE
fix: publish gateway image with v-prefixed tag

### DIFF
--- a/.github/workflows/build-gateway.yml
+++ b/.github/workflows/build-gateway.yml
@@ -115,6 +115,7 @@ jobs:
           cd /tmp/digests
           docker buildx imagetools create \
             -t ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.version }} \
+            -t ${{ env.IMAGE_NAME }}:v${{ steps.tag.outputs.version }} \
             -t ${{ env.IMAGE_NAME }}:latest \
             $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
 


### PR DESCRIPTION
The `openab-telegram` chart (PR #873) defaults `gateway.tag` to `v0.5.0`, but the build workflow only publishes `0.5.0` (no `v` prefix). This causes `ImagePullBackOff` on fresh installs.

Adds `v$VERSION` as an additional Docker tag so both conventions work.

Discovered while installing `openab-telegram` on zz.