### PR TITLE
feat: add :stable and :beta floating image tags

### DIFF
--- a/.github/workflows/build-operator.yml
+++ b/.github/workflows/build-operator.yml
@@ -167,6 +167,7 @@ jobs:
           tags: |
             type=sha,prefix=
             type=semver,pattern={{version}},value=${{ needs.resolve-tag.outputs.tag }}
+            type=raw,value=beta
 
       - name: Create manifest list
         working-directory: /tmp/digests
@@ -237,11 +238,12 @@ jobs:
           CHART_VERSION="${{ needs.resolve-tag.outputs.chart_version }}"
           MAJOR_MINOR="${CHART_VERSION%.*}"
 
-          echo "Promoting ${IMAGE}:${PRERELEASE_VERSION} → ${CHART_VERSION}, ${MAJOR_MINOR}, latest"
+          echo "Promoting ${IMAGE}:${PRERELEASE_VERSION} → ${CHART_VERSION}, ${MAJOR_MINOR}, latest, stable"
           docker buildx imagetools create \
             -t "${IMAGE}:${CHART_VERSION}" \
             -t "${IMAGE}:${MAJOR_MINOR}" \
             -t "${IMAGE}:latest" \
+            -t "${IMAGE}:stable" \
             "${IMAGE}:${PRERELEASE_VERSION}"
 
   # ── Chart release (runs after either path) ───────────────────

--- a/docs/image-tags.md
+++ b/docs/image-tags.md
@@ -1,0 +1,55 @@
+# Docker Image Tagging Convention
+
+## Core (`ghcr.io/openabdev/openab`)
+
+| Tag | Points to | Updated when |
+|-----|-----------|--------------|
+| `0.8.3-beta.12` | Exact pre-release build | Pre-release tag pushed |
+| `beta` | Latest pre-release | Every pre-release build |
+| `0.8.3` | Promoted stable build | Stable tag pushed |
+| `0.8` | Latest patch in minor | Stable promotion |
+| `stable` | Latest stable | Stable promotion |
+| `latest` | Latest stable (= `stable`) | Stable promotion |
+
+Variant images (e.g. `-codex`, `-claude`, `-gemini`) follow the same convention with a suffix: `ghcr.io/openabdev/openab-codex:beta`.
+
+## Gateway (`ghcr.io/openabdev/openab-gateway`)
+
+| Tag | Points to | Updated when |
+|-----|-----------|--------------|
+| `0.5.1` | Exact release | `gateway-v*` tag pushed |
+| `v0.5.1` | Same as above (v-prefixed alias) | Same |
+| `latest` | Latest release | Every release |
+
+## Which tag to use
+
+| Use case | Recommended tag |
+|----------|----------------|
+| Production (pinned) | Exact version (`0.8.3-beta.12`) |
+| Helm chart default | `stable` or `beta` (channel-based) |
+| Local dev / quick test | `beta` |
+| CI | Exact version or SHA |
+
+## Release flow
+
+```
+release PR merged → tag-on-merge → v0.8.3-beta.12
+                                         │
+                                         ▼
+                                  build-operator.yml
+                                         │
+                              ┌──────────┴──────────┐
+                              │ is_prerelease=true   │
+                              ▼                      │
+                    tag: 0.8.3-beta.12               │
+                    tag: beta                        │
+                                                    │
+                              ┌──────────────────────┘
+                              │ is_prerelease=false (stable)
+                              ▼
+                    promote latest beta image →
+                    tag: 0.8.3
+                    tag: 0.8
+                    tag: stable
+                    tag: latest
+```


### PR DESCRIPTION
Adds floating channel tags to the core build workflow:

- **Pre-release** (`v0.8.3-beta.12`): now also tags `:beta`
- **Stable** (`v0.8.3`): now also tags `:stable`

This enables the `openab-telegram` chart (PR #873) to resolve images by channel name without needing exact version numbers baked into `Chart.yaml`.

| Channel | Image tag | Updated when |
|---------|-----------|--------------|
| `stable` | `:stable` | Stable release merged |
| `beta` | `:beta` | Pre-release merged |

Users who want pinning can still `--set image.tag=0.8.3-beta.12`.