### PR TITLE
fix(openab-telegram): default allowAllUsers to false

### DIFF
--- a/charts/openab-telegram/README.md
+++ b/charts/openab-telegram/README.md
@@ -102,7 +102,7 @@ curl -s "https://api.telegram.org/bot${BOT_TOKEN}/setWebhook" \
 
 ```bash
 # Find your Telegram user ID by messaging @userinfobot on Telegram.
-helm install my-bot ./charts/openab-telegram \
+helm install my-bot oci://ghcr.io/openabdev/charts/openab-telegram \
   --set telegramBotToken="<token-from-botfather>" \
   --set cloudflareTunnelToken="$(cloudflared tunnel token my-telegram-bot)" \
   --set webhookDomain=bot.example.com \
@@ -117,7 +117,7 @@ Three options, from simplest to most secure:
 ### Option 1: `--set` (simple, least secure)
 
 ```bash
-helm install my-bot ./charts/openab-telegram \
+helm install my-bot oci://ghcr.io/openabdev/charts/openab-telegram \
   --set telegramBotToken="123:ABC" \
   --set cloudflareTunnelToken="eyJ..." \
   --namespace openab --create-namespace
@@ -134,7 +134,7 @@ kubectl create secret generic my-bot-creds -n openab \
   --from-literal=telegram-bot-token="123:ABC" \
   --from-literal=cloudflare-tunnel-token="eyJ..."
 
-helm install my-bot ./charts/openab-telegram \
+helm install my-bot oci://ghcr.io/openabdev/charts/openab-telegram \
   --set existingSecret=my-bot-creds \
   --namespace openab
 ```
@@ -151,7 +151,7 @@ kubectl create secret generic my-bot-creds -n openab \
     --secret-id oab --query SecretString --output text | \
     jq -r '{"telegram-bot-token": .telegramBotToken, "cloudflare-tunnel-token": .cloudflareTunnelToken} | to_entries[] | "\(.key)=\(.value)"')
 
-helm install my-bot ./charts/openab-telegram \
+helm install my-bot oci://ghcr.io/openabdev/charts/openab-telegram \
   --set existingSecret=my-bot-creds \
   --namespace openab
 ```

--- a/charts/openab-telegram/README.md
+++ b/charts/openab-telegram/README.md
@@ -101,10 +101,12 @@ curl -s "https://api.telegram.org/bot${BOT_TOKEN}/setWebhook" \
 ## Quick Start
 
 ```bash
+# Find your Telegram user ID by messaging @userinfobot on Telegram.
 helm install my-bot ./charts/openab-telegram \
   --set telegramBotToken="<token-from-botfather>" \
   --set cloudflareTunnelToken="$(cloudflared tunnel token my-telegram-bot)" \
   --set webhookDomain=bot.example.com \
+  --set platform.allowedUsers="{<your-telegram-user-id>}" \
   --namespace openab --create-namespace
 ```
 
@@ -231,8 +233,8 @@ To have an AI agent handle the full install, prompt it with:
 | `image.tag` | No | `appVersion` | Agent image tag |
 | `gateway.tag` | No | `v0.5.0` | Gateway image tag |
 | `agent.command` | No | `kiro-cli` | Agent command |
-| `platform.allowAllUsers` | No | `true` | Allow any Telegram user |
-| `platform.allowedUsers` | No | `[]` | Allowed Telegram user IDs |
+| `platform.allowAllUsers` | No | `false` | Allow any Telegram user (opt-in) |
+| `platform.allowedUsers` | No | `[]` | Allowed Telegram user IDs (get yours from [@userinfobot](https://t.me/userinfobot)) |
 | `persistence.enabled` | No | `true` | Enable PVC for agent state |
 | `persistence.size` | No | `1Gi` | PVC size |
 

--- a/charts/openab-telegram/values.yaml
+++ b/charts/openab-telegram/values.yaml
@@ -1,7 +1,7 @@
 # openab-telegram values
 #
 # Install:
-#   helm install my-bot ./charts/openab-telegram \
+#   helm install my-bot oci://ghcr.io/openabdev/charts/openab-telegram \
 #     --set telegramBotToken="123:ABC" \
 #     --set cloudflareTunnelToken="eyJ..." \
 #     --set platform.allowedUsers="{YOUR_TG_USER_ID}" \

--- a/charts/openab-telegram/values.yaml
+++ b/charts/openab-telegram/values.yaml
@@ -4,11 +4,15 @@
 #   helm install my-bot ./charts/openab-telegram \
 #     --set telegramBotToken="123:ABC" \
 #     --set cloudflareTunnelToken="eyJ..." \
+#     --set platform.allowedUsers="{YOUR_TG_USER_ID}" \
 #     --namespace openab --create-namespace
 #
 # Required:
 #   telegramBotToken       -- Telegram bot token from @BotFather
 #   cloudflareTunnelToken   -- Cloudflare Tunnel token
+#
+# Recommended:
+#   platform.allowedUsers  -- Your Telegram user ID (message @userinfobot to find it)
 #
 # Optional:
 #   webhookDomain          -- your tunnel domain (for setWebhook reminder in NOTES.txt)
@@ -74,8 +78,11 @@ agent:
 
 # -- Gateway platform settings
 platform:
-  # allowAllUsers: true = any Telegram user can talk to the bot
-  allowAllUsers: true
+  # allowAllUsers: false = only users listed in allowedUsers can talk to the bot
+  # Set to true to allow any Telegram user (not recommended for production)
+  allowAllUsers: false
+  # Telegram user IDs allowed to interact with the bot.
+  # Find your ID by messaging @userinfobot on Telegram.
   allowedUsers: []
   allowAllChannels: true
   allowedChannels: []


### PR DESCRIPTION
## Summary

Changes the `platform.allowAllUsers` default from `true` to `false` in the openab-telegram chart.

With the previous default, any Telegram user could interact with the bot out of the box — making it wide open. This change requires deployers to explicitly specify their Telegram user ID(s) via `platform.allowedUsers`, or consciously opt in to open access with `--set platform.allowAllUsers=true`.

## Changes

- `values.yaml`: `platform.allowAllUsers` defaults to `false`
- `values.yaml`: Added comments pointing users to `@userinfobot` to find their Telegram user ID
- `README.md`: Updated Values table, Quick Start example now includes `--set platform.allowedUsers`
- `README.md` + `values.yaml`: Use OCI registry path (`oci://ghcr.io/openabdev/charts/openab-telegram`) — no git clone needed

## Prerequisites

```bash
# 1. Get your Telegram user ID by messaging @userinfobot on Telegram

# 2. Get your tunnel token (one-time local setup):
cloudflared login                          # authenticates, saves cert.pem
cloudflared tunnel create my-bot           # creates the tunnel
cloudflared tunnel token my-bot            # outputs the eyJ... token
```

## Install Options

### Option 1: `--set` (simple, good for dev/testing)

```bash
helm install my-bot oci://ghcr.io/openabdev/charts/openab-telegram \
  --set telegramBotToken="123:ABC" \
  --set cloudflareTunnelToken="$(cloudflared tunnel token my-bot)" \
  --set platform.allowedUsers="{123456789}" \
  --namespace openab --create-namespace
```

⚠️ Credentials stored in Helm release metadata, visible via `helm get values`.

### Option 2: Pre-created K8s Secret (good for production)

```bash
kubectl create secret generic my-bot-creds -n openab \
  --from-literal=telegram-bot-token="123:ABC" \
  --from-literal=cloudflare-tunnel-token="eyJ..."

helm install my-bot oci://ghcr.io/openabdev/charts/openab-telegram \
  --set existingSecret=my-bot-creds \
  --set platform.allowedUsers="{123456789}" \
  --namespace openab --create-namespace
```

### Option 3: AWS Secrets Manager → K8s Secret on-the-fly (most secure)

```bash
kubectl create secret generic my-bot-creds -n openab \
  --from-env-file=<(aws secretsmanager get-secret-value \
    --secret-id oab --query SecretString --output text | \
    jq -r '{"telegram-bot-token": .telegramBotToken, "cloudflare-tunnel-token": .cloudflareTunnelToken} | to_entries[] | "\(.key)=\(.value)"')

helm install my-bot oci://ghcr.io/openabdev/charts/openab-telegram \
  --set existingSecret=my-bot-creds \
  --set platform.allowedUsers="{123456789}" \
  --namespace openab --create-namespace
```

Credentials flow from AWS → K8s Secret without touching disk or shell variables.

---

The `cloudflareTunnelToken` is required — it encapsulates tunnel credentials so the cloudflared container can run in remote mode without needing cert.pem or local config files mounted.

Discord Discussion URL: https://discord.com/channels/1490282656913559673/1506756160265654505