### PR TITLE
fix: capture ACP agent stderr and extract error.data from JSON-RPC errors

### DIFF
--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -121,6 +121,7 @@ pub struct AcpConnection {
     pub last_active: Instant,
     pub session_reset: bool,
     _reader_handle: JoinHandle<()>,
+    _stderr_handle: Option<JoinHandle<()>>,
 }
 
 /// Build the final set of env vars for the agent subprocess.
@@ -358,9 +359,9 @@ impl AcpConnection {
 
         // Capture agent stderr and log it (ACP spec: agents MAY write to stderr
         // for logging; clients MAY capture or ignore it).
-        if let Some(stderr) = proc.stderr.take() {
+        let stderr_handle = if let Some(stderr) = proc.stderr.take() {
             let cmd_name = command.to_string();
-            tokio::spawn(async move {
+            Some(tokio::spawn(async move {
                 let mut reader = BufReader::new(stderr);
                 let mut line = String::new();
                 loop {
@@ -381,8 +382,10 @@ impl AcpConnection {
                         Err(_) => break,
                     }
                 }
-            });
-        }
+            }))
+        } else {
+            None
+        };
 
         let pending: Arc<Mutex<HashMap<u64, oneshot::Sender<JsonRpcMessage>>>> =
             Arc::new(Mutex::new(HashMap::new()));
@@ -409,6 +412,7 @@ impl AcpConnection {
             last_active: Instant::now(),
             session_reset: false,
             _reader_handle: reader_handle,
+            _stderr_handle: stderr_handle,
         })
     }
 
@@ -686,6 +690,9 @@ impl AcpConnection {
 
 impl Drop for AcpConnection {
     fn drop(&mut self) {
+        if let Some(handle) = self._stderr_handle.take() {
+            handle.abort();
+        }
         self.kill_process_group();
     }
 }

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -370,7 +370,12 @@ impl AcpConnection {
                         Ok(_) => {
                             let trimmed = line.trim();
                             if !trimmed.is_empty() {
-                                tracing::warn!(agent = %cmd_name, "{trimmed}");
+                                let sanitized: String = trimmed.chars()
+                                    .filter(|c| !c.is_control() || *c == '\t')
+                                    .collect();
+                                if !sanitized.is_empty() {
+                                    tracing::warn!(agent = %cmd_name, "{sanitized}");
+                                }
                             }
                         }
                         Err(_) => break,

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -246,6 +246,7 @@ pub(crate) async fn run_reader_loop<R, W>(
             error: Some(crate::acp::protocol::JsonRpcError {
                 code: -1,
                 message: "connection closed".into(),
+                data: None,
             }),
             params: None,
         });
@@ -269,7 +270,7 @@ impl AcpConnection {
         cmd.args(args)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
             .current_dir(working_dir);
         // Create a new process group so we can kill the entire tree.
         // SAFETY: setpgid is async-signal-safe (POSIX.1-2008) and called
@@ -354,6 +355,29 @@ impl AcpConnection {
         let stdout = proc.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
         let stdin = proc.stdin.take().ok_or_else(|| anyhow!("no stdin"))?;
         let stdin = Arc::new(Mutex::new(stdin));
+
+        // Capture agent stderr and log it (ACP spec: agents MAY write to stderr
+        // for logging; clients MAY capture or ignore it).
+        if let Some(stderr) = proc.stderr.take() {
+            let cmd_name = command.to_string();
+            tokio::spawn(async move {
+                let mut reader = BufReader::new(stderr);
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    match reader.read_line(&mut line).await {
+                        Ok(0) => break,
+                        Ok(_) => {
+                            let trimmed = line.trim();
+                            if !trimmed.is_empty() {
+                                tracing::warn!(agent = %cmd_name, "{trimmed}");
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+        }
 
         let pending: Arc<Mutex<HashMap<u64, oneshot::Sender<JsonRpcMessage>>>> =
             Arc::new(Mutex::new(HashMap::new()));

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -62,6 +62,10 @@ pub struct JsonRpcError {
 
 impl JsonRpcError {
     /// Extract a human-readable detail from `error.data.message` if present.
+    ///
+    /// The `"message"` key is a convention used by codex-acp and aligns with
+    /// common JSON-RPC practice, but is NOT mandated by the ACP spec.
+    /// Other agents may use `"detail"`, `"reason"`, etc. — extend here if needed.
     pub fn data_message(&self) -> Option<&str> {
         self.data
             .as_ref()

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -55,11 +55,28 @@ pub struct JsonRpcMessage {
 pub struct JsonRpcError {
     pub code: i64,
     pub message: String,
+    /// Optional structured data from the agent (JSON-RPC `error.data`).
+    /// Agents like codex-acp include `{"message": "...", "codex_error_info": "..."}`.
+    pub data: Option<Value>,
+}
+
+impl JsonRpcError {
+    /// Extract a human-readable detail from `error.data.message` if present.
+    pub fn data_message(&self) -> Option<&str> {
+        self.data
+            .as_ref()
+            .and_then(|d| d.get("message"))
+            .and_then(|m| m.as_str())
+    }
 }
 
 impl std::fmt::Display for JsonRpcError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "JSON-RPC error {}: {}", self.code, self.message)
+        write!(f, "JSON-RPC error {}: {}", self.code, self.message)?;
+        if let Some(detail) = self.data_message() {
+            write!(f, " — {detail}")?;
+        }
+        Ok(())
     }
 }
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -564,7 +564,7 @@ impl AdapterRouter {
                                 continue;
                             }
                             if let Some(ref err) = notification.error {
-                                response_error = Some(format_coded_error(err.code, &err.message));
+                                response_error = Some(format_coded_error(err.code, &err.message, err.data_message()));
                             }
                             break;
                         }

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -50,8 +50,9 @@ pub fn format_user_error(message: &str) -> String {
 
 /// Format coded error from ACP agent for display in Discord.
 /// Used for response errors that have a JSON-RPC or HTTP status code.
+/// `data_message` is the optional detail extracted from `error.data.message`.
 /// Public for reuse by other adapters (e.g. Slack).
-pub fn format_coded_error(code: i64, message: &str) -> String {
+pub fn format_coded_error(code: i64, message: &str, data_message: Option<&str>) -> String {
     let prefix = match code {
         400 => "**Bad Request**",
         401 => "**Unauthorized**",
@@ -70,11 +71,18 @@ pub fn format_coded_error(code: i64, message: &str) -> String {
         -32099..=-32000 => "**Server Error**",
         _ => "**Error**",
     };
-    if message.is_empty() {
+    let mut out = if message.is_empty() {
         format!("{} (code: {})", prefix, code)
     } else {
         format!("{} (code: {})\n{}", prefix, code, message)
+    };
+    if let Some(detail) = data_message {
+        if !detail.is_empty() && !message.contains(detail) {
+            out.push_str("\n> ");
+            out.push_str(detail);
+        }
     }
+    out
 }
 
 #[cfg(test)]
@@ -166,7 +174,7 @@ mod tests {
 
     #[test]
     fn test_format_coded_error_401() {
-        let result = format_coded_error(401, "invalid token");
+        let result = format_coded_error(401, "invalid token", None);
         assert!(result.contains("Unauthorized"));
         assert!(result.contains("401"));
         assert!(result.contains("invalid token"));
@@ -174,7 +182,7 @@ mod tests {
 
     #[test]
     fn test_format_coded_error_429() {
-        let result = format_coded_error(429, "");
+        let result = format_coded_error(429, "", None);
         assert!(result.contains("Rate Limited"));
         assert!(result.contains("429"));
         assert!(!result.contains("\n")); // no message, no newline
@@ -182,7 +190,7 @@ mod tests {
 
     #[test]
     fn test_format_coded_error_503() {
-        let result = format_coded_error(503, "service unavailable");
+        let result = format_coded_error(503, "service unavailable", None);
         assert!(result.contains("Service Unavailable"));
         assert!(result.contains("503"));
         assert!(result.contains("service unavailable"));
@@ -190,30 +198,44 @@ mod tests {
 
     #[test]
     fn test_format_coded_error_json_rpc() {
-        let result = format_coded_error(-32602, "missing required parameter");
+        let result = format_coded_error(-32602, "missing required parameter", None);
         assert!(result.contains("Invalid Params"));
         assert!(result.contains("-32602"));
     }
 
     #[test]
     fn test_format_coded_error_server_error_range() {
-        let result = format_coded_error(-32050, "internal failure");
+        let result = format_coded_error(-32050, "internal failure", None);
         assert!(result.contains("Server Error"));
         assert!(result.contains("-32050"));
     }
 
     #[test]
     fn test_format_coded_error_connection_error() {
-        let result = format_coded_error(-32000, "connection refused");
+        let result = format_coded_error(-32000, "connection refused", None);
         assert!(result.contains("Server Error")); // -32000 falls in -32099..=-32000 range
         assert!(result.contains("-32000"));
     }
 
     #[test]
     fn test_format_coded_error_unknown_code() {
-        let result = format_coded_error(999, "something happened");
+        let result = format_coded_error(999, "something happened", None);
         assert!(result.contains("Error"));
         assert!(result.contains("999"));
         assert!(result.contains("something happened"));
+    }
+
+    #[test]
+    fn test_format_coded_error_with_data_message() {
+        let result = format_coded_error(-32603, "Internal error", Some("model not supported"));
+        assert!(result.contains("Internal Error"));
+        assert!(result.contains("model not supported"));
+    }
+
+    #[test]
+    fn test_format_coded_error_data_message_not_duplicated() {
+        // If data_message is already in message, don't repeat it
+        let result = format_coded_error(-32603, "model not supported", Some("model not supported"));
+        assert_eq!(result.matches("model not supported").count(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Closes #854.

When an ACP agent (e.g. `codex-acp`) hits a runtime error, the real cause is emitted on **stderr** and in the JSON-RPC `error.data.message` field — but openab was discarding both. Users only saw the opaque `⚠️ Internal Error (code: -32603) / Internal error` in Discord, and operators had zero visibility in `kubectl logs`.

This PR fixes both gaps:

1. **Capture agent stderr** — pipe it and log each line at `WARN` level, scoped to the agent command name.
2. **Parse `error.data`** — extract `error.data.message` from JSON-RPC error responses and surface it in the Discord error display as a blockquote.

## Before / After

```
BEFORE (Discord):
⚠️ **Internal Error** (code: -32603)
Internal error

AFTER (Discord):
⚠️ **Internal Error** (code: -32603)
Internal error
> The 'gpt-5.2-codex' model is not supported when using Codex with a ChatGPT account.
```

## Data Flow (ASCII)

```
┌─────────────────────────────────────────────────────────────────────┐
│                        openab bridge process                        │
│                                                                     │
│  ┌──────────────┐         spawn          ┌───────────────────────┐ │
│  │ AcpConnection├────────────────────────►│  codex-acp (child)    │ │
│  │              │◄─── stdout (JSON-RPC) ──┤                       │ │
│  │              │                         │  stdout: ACP messages │ │
│  │              │◄─── stderr (logging) ───┤  stderr: diagnostics  │ │
│  └──────┬───────┘                         └───────────────────────┘ │
│         │                                                           │
│         │  JSON-RPC error response:                                 │
│         │  {"error":{"code":-32603,                                 │
│         │            "message":"Internal error",                    │
│         │            "data":{"message":"The gpt-5.2-codex..."}}}   │
│         │                                                           │
│         ▼                                                           │
│  ┌──────────────┐                                                   │
│  │ adapter.rs   │── format_coded_error(code, msg, data_message) ──► │
│  └──────────────┘                                                   │
│         │                                                           │
│         ▼                                                           │
│  ┌──────────────┐                                                   │
│  │   Discord    │  "⚠️ **Internal Error** (code: -32603)            │
│  │   channel    │   Internal error                                  │
│  │              │   > The gpt-5.2-codex model is not supported..."  │
│  └──────────────┘                                                   │
│                                                                     │
│  Meanwhile, stderr lines appear in kubectl logs:                    │
│  WARN agent="codex-acp" ERROR codex_acp: Unhandled error...        │
└─────────────────────────────────────────────────────────────────────┘
```

## Investigation: How the ACP Ecosystem Handles This

### ACP Spec ([agentclientprotocol.com/protocol/transports](https://agentclientprotocol.com/protocol/transports))

The spec explicitly defines the contract:

> _"The agent MAY write UTF-8 strings to its standard error (stderr) for logging purposes. Clients MAY capture, forward, or ignore this logging. The agent MUST NOT write anything to its stdout that is not a valid ACP message."_

- **stdout** = reserved for JSON-RPC ACP messages (the transport channel)
- **stderr** = designated channel for human-readable logs/errors
- The spec leaves it to the **client** to decide whether to capture stderr

openab was choosing "ignore" — this PR switches to "capture and forward to bridge logs".

### acpx ([github.com/openclaw/acpx](https://github.com/openclaw/acpx)) — Headless ACP Client

acpx is the most mature headless ACP client (supports codex, claude, gemini, copilot, hermes, kiro, etc.). It handles this by:

- **Capturing agent stderr** and forwarding it based on output format:
  - `--format text` (default): stderr lines shown to user
  - `--format json --json-strict`: stderr suppressed
  - `--verbose`: full stderr forwarding for debugging
- **Crash reconnect**: dead agent processes are detected; sessions are resumed via `session/load` or transparently fall back to `session/new`
- **Structured error output**: JSON events include stable envelopes with `sessionId`, `requestId`, `seq` for correlation

### Hermes Agent ([github.com/NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)) — Agent Side

Hermes explicitly documents the stderr contract in their [ACP Internals](https://hermes-agent.nousresearch.com/docs/developer-guide/acp-internals):

- _"Stdout is reserved for ACP JSON-RPC transport. Human-readable logs go to stderr."_
- Boot flow explicitly includes `configure stderr logging` as a step
- All runtime errors, tracebacks, and diagnostic info go to stderr
- Unhandled errors during a turn are logged to stderr before a `-32603` error response is sent on stdout

### OpenClaw Gateway ([docs.openclaw.ai/tools/acp-agents](https://clawdhub.mintlify.app/tools/acp-agents))

OpenClaw's ACP integration (via the acpx plugin) handles errors at multiple levels:

- **Gateway logging**: captures console output to rolling JSON-line log files (`/tmp/openclaw/openclaw-YYYY-MM-DD.log`)
- **Error categorization from `error.data`**: documents specific patterns like "Vendor auth error from the harness" and "Model-not-found from the harness" — detected from the JSON-RPC error `data` field
- **`/acp doctor`**: provides health probes for the backend
- **Troubleshooting table** with actionable fixes for each error category
- **Redaction**: sensitive tokens are masked before log output leaves the process

### anomalyco/opencode#25568 — [ACP session/new always returns -32603](https://github.com/anomalyco/opencode/issues/25568)

OpenCode's ACP mode returns `-32603 Internal error` with `"data": {}` (empty data object). The user gets zero diagnostic info from the JSON-RPC response alone. Key observations:

- `initialize` succeeds but `session/new` always fails with opaque `-32603`
- The error `data` field is `{}` — completely empty, no `message` key
- **This proves stderr capture is essential** — when `error.data` is empty, stderr is the *only* diagnostic path
- Issue was closed by PR #25591 (fix was on the agent side), but the client-side observability gap remains

### nexu-io/open-design#443 — [session/set_model returns -32603 then timeout](https://github.com/nexu-io/open-design/issues/443)

Open Design's ACP client treats ALL `-32603` errors as fatal (`fail()` → `child.kill(SIGTERM)` → prompt never sent → 180s timeout). Their analysis:

- `-32603` from `session/set_model` is **recoverable** (just skip model switching, use default)
- `-32603` from `session/new` is **fatal** (session broken)
- **Without `error.data.message`, you cannot distinguish recoverable vs fatal**
- Their fix: gracefully degrade when `session/set_model` fails, proceed with default model
- Explicitly calls out: _"The ideal fix would be... at minimum to return a proper error response that the client can handle gracefully"_

### Key Takeaway Across All Repos

`-32603 Internal error` is **overloaded** across agents for wildly different failure modes:

| Agent | Failure | error.data |
|-------|---------|------------|
| codex-acp | Model not supported for account type | `{"message":"The gpt-5.2-codex model is not supported...","codex_error_info":"other"}` |
| opencode | Session init failure (unknown cause) | `{}` (empty) |
| hermes-agent | Model switching unsupported | No data field |

The two diagnostic channels are:
1. `error.data.message` — structured, when the agent populates it
2. `stderr` — always available, contains the real stack trace / error detail

Our fix captures both.

## Changes

| File | Change |
|------|--------|
| `src/acp/connection.rs` | `Stdio::null()` → `Stdio::piped()` + tokio task logs each stderr line at WARN |
| `src/acp/protocol.rs` | Add `data: Option<Value>` to `JsonRpcError` + `data_message()` helper + updated `Display` |
| `src/adapter.rs` | Pass `err.data_message()` to `format_coded_error` |
| `src/error_display.rs` | `format_coded_error` accepts optional `data_message`, appends as blockquote (deduped) |

## Testing

- Existing unit tests updated for new `format_coded_error` signature
- Added tests for `data_message` extraction and deduplication
- Manual: deploy with `codex-acp` using a ChatGPT account (no gpt-5.2-codex access) → stderr now visible in pod logs, Discord shows the real cause


https://discord.com/channels/1491295327620169908/1491365150664560881/1506975049779773540