### PR TITLE
chore: bump all coding CLI versions to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install kiro-cli (auto-detect arch, copy binary directly)
-ARG KIRO_CLI_VERSION=2.2.0
+ARG KIRO_CLI_VERSION=2.4.0
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-aarch64-linux.zip"; \
     else URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-x86_64-linux.zip"; fi && \

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -8,13 +8,13 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini bubblewrap socat && rm -rf /var/lib/apt/lists/*
 
 # Install claude-agent-acp adapter and Claude Code CLI.
 # Without CLAUDE_CODE_EXECUTABLE the adapter uses its own bundled SDK cli.js,
 # ignoring the globally installed claude-code binary (see #418).
 ARG CLAUDE_AGENT_ACP_VERSION=0.29.2
-ARG CLAUDE_CODE_VERSION=2.1.124
+ARG CLAUDE_CODE_VERSION=2.1.146
 RUN npm install -g @agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION} @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} --retry 3
 ENV CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude
 

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 
 # Pre-install codex-acp and codex CLI globally
 ARG CODEX_ACP_VERSION=0.10.0
-ARG CODEX_VERSION=0.128.0
+ARG CODEX_VERSION=0.133.0
 RUN npm install -g @zed-industries/codex-acp@${CODEX_ACP_VERSION} @openai/codex@${CODEX_VERSION} --retry 3
 
 # Install gh CLI

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
-ARG COPILOT_VERSION=1.0.40
+ARG COPILOT_VERSION=1.0.51
 RUN npm install -g @github/copilot@${COPILOT_VERSION} --retry 3
 
 # Install gh CLI (for auth and token management)

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # URL scheme scraped from Cursor's official downloads page — no apt/yum package exists.
 # If Cursor changes this pattern, the build fails with curl 404. Monitor
 # https://cursor.com/cli or https://docs.cursor.com/cli for version/URL updates.
-ARG CURSOR_VERSION=2026.04.30-4edb302
+ARG CURSOR_VERSION=2026.05.20-2b5dd59
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
     curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
-ARG GEMINI_CLI_VERSION=0.40.1
+ARG GEMINI_CLI_VERSION=0.42.0
 RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} --retry 3
 
 # Install gh CLI

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -26,7 +26,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Install opencode
-ARG OPENCODE_VERSION=1.14.31
+ARG OPENCODE_VERSION=1.15.7
 RUN npm install -g opencode-ai@${OPENCODE_VERSION} --retry 3
 
 # Install gh CLI (matches Dockerfile.claude / Dockerfile.gemini / Dockerfile.codex)


### PR DESCRIPTION
## Summary

Bump all 7 coding CLI versions to their latest stable releases.

| CLI | Previous | New | Notes |
|-----|----------|-----|-------|
| kiro-cli | 2.2.0 | 2.4.0 | — |
| claude-code | 2.1.124 | 2.1.146 | + bubblewrap/socat for sandbox |
| codex | 0.128.0 | 0.133.0 | — |
| copilot | 1.0.40 | 1.0.51 | — |
| cursor | 2026.04.30-4edb302 | 2026.05.20-2b5dd59 | — |
| gemini-cli | 0.40.1 | 0.42.0 | — |
| opencode-ai | 1.14.31 | 1.15.7 | — |

## Why bubblewrap and socat in Dockerfile.claude?

Claude Code v2.1.144+ introduced mandatory sandbox mode for bash tool calls on Linux:

- **bubblewrap (`bwrap`)**: Lightweight Linux namespace sandbox. Claude Code uses it to isolate every bash command execution into a restricted namespace (filesystem, PID, network).
- **socat**: Socket relay tool. Claude Code uses it to pipe stdin/stdout between the sandboxed process and the main Claude Code process.

**The problem**: If these binaries are missing, Claude Code v2.1.144+ **silently exits** on launch with no error message (anthropics/claude-code#61094). There is no fallback to unsandboxed mode.

Since openab already runs inside Docker containers, this is effectively sandbox-inside-container — redundant but harmless. Both packages add ~400KB total to the image layer. The alternative (pinning to 2.1.143) would miss 22 patch releases of fixes and improvements.

### Why not Dockerfile.codex too?

Codex CLI also uses bubblewrap for its Linux sandbox, but **bundles its own `bwrap` binary**. If the system `bwrap` is not found on PATH, Codex prints a warning and falls back to its bundled copy — it does NOT crash. No additional system packages needed for Codex.

## Regression Check

Reviewed open issues on all public trackers. Key findings:

- **claude-code #61094**: v2.1.144+ silently exits on Linux when `bubblewrap` and `socat` are missing. **Mitigated** by adding both packages to Dockerfile.claude.
- **claude-code #61141**: MCP permissions lost in ephemeral containers (Remote Routines specific — does not affect openab's ACP-based invocation).
- **claude-code #61232**: Worktree isolation bleed on Linux (intermittent, multi-agent worktree specific).
- **codex #23651**: Zellij scrollback over SSH (TUI-specific, not applicable to headless Docker).
- **codex #23857**: Sandbox supervision unreliable (macOS-specific).
- **opencode #27908**: Spinner garbage in non-TTY (cosmetic only).
- **gemini-cli**: Zero open bugs.
- **copilot / cursor / kiro-cli**: No public regression trackers or zero relevant issues.

## Testing

- [ ] Docker build smoke test (CI)
