### PR TITLE
fix: bump codex-acp 0.10.0 → 0.14.0

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -43,17 +43,16 @@ jobs:
 
       - name: Verify agent responds
         run: |
-          INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{},"clientInfo":{"name":"ci-test","version":"0.0.1"}}}'
+          INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientCapabilities":{},"clientInfo":{"name":"ci-test","version":"0.0.1"}}}'
 
-          RAW=$(echo "$INIT" | timeout 30 docker run --rm -i \
-            --entrypoint ${{ matrix.variant.agent }} \
-            openab-test${{ matrix.variant.suffix }} \
-            ${{ matrix.variant.agent_args }} 2>/dev/null || true)
+          # Start agent in background, send init, capture output with timeout
+          CID=$(docker run -d -i --entrypoint sh openab-test${{ matrix.variant.suffix }} -c 'exec ${{ matrix.variant.agent }} ${{ matrix.variant.agent_args }} 2>/dev/null')
+          echo "$INIT" | docker attach --no-stdin=false "$CID" &
+          sleep 5
+          RESPONSE=$(docker logs "$CID" 2>/dev/null | grep -m1 '^{' || true)
+          docker rm -f "$CID" >/dev/null 2>&1
 
-          echo "Raw output:"
-          echo "$RAW"
-
-          RESPONSE=$(echo "$RAW" | grep -m1 '^{' || true)
+          echo "Response: $RESPONSE"
 
           if [ -n "$RESPONSE" ] && echo "$RESPONSE" | jq -e '.result.agentInfo.name' > /dev/null 2>&1; then
             AGENT_NAME=$(echo "$RESPONSE" | jq -r '.result.agentInfo.name')

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
-ARG CODEX_ACP_VERSION=0.10.0
+ARG CODEX_ACP_VERSION=0.14.0
 ARG CODEX_VERSION=0.133.0
 RUN npm install -g @zed-industries/codex-acp@${CODEX_ACP_VERSION} @openai/codex@${CODEX_VERSION} --retry 3
 


### PR DESCRIPTION
Fixes #887

codex-acp 0.10.0 bundles an older codex core that doesn't request the `model.request` OAuth scope. All Codex bots are returning `-32603 Internal Error` (underlying 401).

Upstream fixes:
- [v0.13.0](https://github.com/zed-industries/codex-acp/releases/tag/v0.13.0) — codex 0.128 + auth reload fix
- [v0.14.0](https://github.com/zed-industries/codex-acp/releases/tag/v0.14.0) — codex 0.129