### PR TITLE
docs(config): fix claude examples to use claude-agent-acp

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -53,14 +53,17 @@ args = ["acp", "--trust-all-tools"]
 working_dir = "/home/agent"
 
 # [agent]
-# command = "claude"
-# args = ["--acp"]
+# command = "claude-agent-acp"
+# args = []
 # working_dir = "/home/node"
+# # Install the adapter first (requires Node >= 20):
+# #   npm install -g @agentclientprotocol/claude-agent-acp
+# # Auth: run `claude auth login` once, or set CLAUDE_CODE_OAUTH_TOKEN.
 # ⚠️ SECURITY WARNING: Any env var listed here is accessible to the agent.
 # A user could trick the agent into leaking these values via prompt injection.
 # All supported backends support OAuth login — prefer that over env var API keys.
 # Note: env vars here can override baseline vars (HOME, PATH, USER) if needed.
-# env = { ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}" }
+# env = { CLAUDE_CODE_OAUTH_TOKEN = "${CLAUDE_CODE_OAUTH_TOKEN}" }
 #
 # By default, the agent subprocess only inherits these baseline vars:
 #   Linux/macOS: HOME, PATH, USER

--- a/config.toml.example
+++ b/config.toml.example
@@ -56,8 +56,6 @@ working_dir = "/home/agent"
 # command = "claude-agent-acp"
 # args = []
 # working_dir = "/home/node"
-# # Install the adapter first (requires Node >= 20):
-# #   npm install -g @anthropic-ai/claude-code @agentclientprotocol/claude-agent-acp
 # # Auth: kubectl exec -it deploy/openab-claude -- claude auth login
 # #       (credentials persist in HOME PVC across restarts; see docs/claude-code.md)
 # ⚠️ SECURITY WARNING: Any env var listed here is accessible to the agent.

--- a/config.toml.example
+++ b/config.toml.example
@@ -57,13 +57,14 @@ working_dir = "/home/agent"
 # args = []
 # working_dir = "/home/node"
 # # Install the adapter first (requires Node >= 20):
-# #   npm install -g @agentclientprotocol/claude-agent-acp
-# # Auth: run `claude auth login` once, or set CLAUDE_CODE_OAUTH_TOKEN.
+# #   npm install -g @anthropic-ai/claude-code @agentclientprotocol/claude-agent-acp
+# # Auth: kubectl exec -it deploy/openab-claude -- claude auth login
+# #       (credentials persist in HOME PVC across restarts; see docs/claude-code.md)
 # ⚠️ SECURITY WARNING: Any env var listed here is accessible to the agent.
 # A user could trick the agent into leaking these values via prompt injection.
 # All supported backends support OAuth login — prefer that over env var API keys.
 # Note: env vars here can override baseline vars (HOME, PATH, USER) if needed.
-# env = { CLAUDE_CODE_OAUTH_TOKEN = "${CLAUDE_CODE_OAUTH_TOKEN}" }
+# env = {}
 #
 # By default, the agent subprocess only inherits these baseline vars:
 #   Linux/macOS: HOME, PATH, USER

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -98,7 +98,7 @@ The AI agent subprocess that OpenAB spawns to handle messages via ACP.
 | `command` | string | *required* | Agent binary (e.g. `kiro-cli`, `claude`, `codex`, `gemini`, `copilot`, `opencode`, `cursor-agent`). |
 | `args` | string[] | `[]` | CLI arguments passed to the agent. |
 | `working_dir` | string | `"/tmp"` | Working directory for the agent process. |
-| `env` | map | `{}` | Extra environment variables (e.g. `{ ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}" }`). |
+| `env` | map | `{}` | Extra environment variables (e.g. `{ OPENAI_API_KEY = "${OPENAI_API_KEY}" }`). |
 | `inherit_env` | string[] | `[]` | Env var names to inherit from the OAB process (e.g. vars injected via K8s `envFrom`). Keys in `env` take precedence. |
 
 > **Default inherited vars:** After `env_clear()`, the agent always receives `HOME`, `PATH`, and `USER` (on Windows: `USERPROFILE`, `USERNAME`, `PATH`, `SystemRoot`, `SystemDrive`). Use `inherit_env` to pass additional vars beyond this baseline.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -114,10 +114,10 @@ working_dir = "/home/agent"
 
 # Claude Code
 [agent]
-command = "claude"
-args = ["--acp"]
+command = "claude-agent-acp"
+args = []
 working_dir = "/home/node"
-env = { ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}" }
+env = { CLAUDE_CODE_OAUTH_TOKEN = "${CLAUDE_CODE_OAUTH_TOKEN}" }
 
 # Codex
 [agent]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -95,7 +95,7 @@ The AI agent subprocess that OpenAB spawns to handle messages via ACP.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `command` | string | *required* | Agent binary (e.g. `kiro-cli`, `claude`, `codex`, `gemini`, `copilot`, `opencode`, `cursor-agent`). |
+| `command` | string | *required* | Agent binary (e.g. `kiro-cli`, `claude-agent-acp`, `codex`, `gemini`, `copilot`, `opencode`, `cursor-agent`). |
 | `args` | string[] | `[]` | CLI arguments passed to the agent. |
 | `working_dir` | string | `"/tmp"` | Working directory for the agent process. |
 | `env` | map | `{}` | Extra environment variables (e.g. `{ OPENAI_API_KEY = "${OPENAI_API_KEY}" }`). |
@@ -117,7 +117,8 @@ working_dir = "/home/agent"
 command = "claude-agent-acp"
 args = []
 working_dir = "/home/node"
-env = { CLAUDE_CODE_OAUTH_TOKEN = "${CLAUDE_CODE_OAUTH_TOKEN}" }
+# Auth: kubectl exec -it deploy/openab-claude -- claude auth login
+# Credentials persist in HOME PVC across restarts. See docs/claude-code.md.
 
 # Codex
 [agent]


### PR DESCRIPTION
Cherry-picked from #829 by @feiyun968-agent — credit goes to the original author for identifying and fixing this issue. Took ownership to remove an unrelated CI workflow commit that was added to that PR.

## Summary

Fixes stale Claude config examples that used `command = "claude"` with `args = ["--acp"]` — a non-existent flag. Updates to the correct `claude-agent-acp` command.

## Changes
- `config.toml.example`: command → `claude-agent-acp`, args → `[]`, auth → `claude auth login` with PVC
- `docs/config-reference.md`: same fixes + updated field-spec table example

## Source of truth
Verified against `docs/claude-code.md`, `docs/multi-agent.md`, `charts/openab/values.yaml`, and `README.md`.

## Credit
Original work by @feiyun968-agent in #829. Reviews by @howie, @canyugs, and @chaodu-agent.

Fixes #632
Supersedes #829

Discord Discussion URL: https://discord.com/channels/1492804973032112279/1504271921532108911