### PR TITLE
feat(openab): add existingSecret support for Slack agent credentials

### DIFF
--- a/charts/openab/README.md
+++ b/charts/openab/README.md
@@ -28,6 +28,7 @@ Each agent lives under `agents.<name>`.
 | `slack.enabled` | Enable the Slack adapter for the agent. | `false` |
 | `slack.botToken` | Slack Bot User OAuth token. | `""` |
 | `slack.appToken` | Slack App-Level token for Socket Mode. | `""` |
+| `slack.existingSecret` | Name of a pre-existing K8s Secret containing `slack-bot-token` and `slack-app-token`. When set, `botToken`/`appToken` above are ignored and the chart skips creating those keys. Enables External Secrets Operator / Vault / SealedSecrets workflows. | `""` |
 | `slack.allowedChannels` | Slack channel allowlist. Empty means allow all channels by default. | `[]` |
 | `slack.allowedUsers` | Slack user allowlist. Empty means allow all users by default. | `[]` |
 | `nameOverride` | Override this agent's generated resource name. | `""` |

--- a/charts/openab/templates/_helpers.tpl
+++ b/charts/openab/templates/_helpers.tpl
@@ -49,8 +49,8 @@ app.kubernetes.io/component: {{ .agent }}
      If existingSecret is set, reference it; otherwise fall back to the chart-managed agent secret.
      Call with: dict "ctx" $ "agent" $name "cfg" $cfg */}}
 {{- define "openab.slackSecretName" -}}
-{{- if and .cfg.slack .cfg.slack.existingSecret -}}
-{{- .cfg.slack.existingSecret -}}
+{{- if and .cfg.slack (.cfg.slack.existingSecret | default "" | trim) -}}
+{{- .cfg.slack.existingSecret | trim -}}
 {{- else -}}
 {{- include "openab.agentFullname" . -}}
 {{- end -}}

--- a/charts/openab/templates/_helpers.tpl
+++ b/charts/openab/templates/_helpers.tpl
@@ -45,6 +45,17 @@ app.kubernetes.io/component: {{ .agent }}
 {{- end }}
 {{- end }}
 
+{{/* Secret name to use for Slack credentials.
+     If existingSecret is set, reference it; otherwise fall back to the chart-managed agent secret.
+     Call with: dict "ctx" $ "agent" $name "cfg" $cfg */}}
+{{- define "openab.slackSecretName" -}}
+{{- if and .cfg.slack .cfg.slack.existingSecret -}}
+{{- .cfg.slack.existingSecret -}}
+{{- else -}}
+{{- include "openab.agentFullname" . -}}
+{{- end -}}
+{{- end }}
+
 {{/* Resolve image: agent-level string override → global default (repository:tag, tag defaults to appVersion).
     Caveat: "contains :" treats registry ports (e.g. my-registry:5000/img) as tagged.
     Not an issue for ghcr.io / Docker Hub; revisit if custom registries with ports are needed. */}}

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -49,18 +49,18 @@ spec:
                   name: {{ include "openab.agentFullname" $d }}
                   key: discord-bot-token
             {{- end }}
-            {{- if and ($cfg.slack).enabled ($cfg.slack).botToken }}
+            {{- if and ($cfg.slack).enabled (or ($cfg.slack).botToken ($cfg.slack).existingSecret) }}
             - name: SLACK_BOT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "openab.agentFullname" $d }}
+                  name: {{ include "openab.slackSecretName" $d }}
                   key: slack-bot-token
             {{- end }}
-            {{- if and ($cfg.slack).enabled ($cfg.slack).appToken }}
+            {{- if and ($cfg.slack).enabled (or ($cfg.slack).appToken ($cfg.slack).existingSecret) }}
             - name: SLACK_APP_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "openab.agentFullname" $d }}
+                  name: {{ include "openab.slackSecretName" $d }}
                   key: slack-app-token
             {{- end }}
             {{- if and ($cfg.stt).enabled ($cfg.stt).apiKey }}

--- a/charts/openab/templates/secret.yaml
+++ b/charts/openab/templates/secret.yaml
@@ -1,7 +1,7 @@
 {{- range $name, $cfg := .Values.agents }}
 {{- if ne (include "openab.agentEnabled" $cfg) "false" }}
 {{- $hasDiscord := and (ne (toString ($cfg.discord).enabled) "false") ($cfg.discord).botToken }}
-{{- $hasSlack := and ($cfg.slack).enabled (or ($cfg.slack).botToken ($cfg.slack).appToken) }}
+{{- $hasSlack := and ($cfg.slack).enabled (or ($cfg.slack).botToken ($cfg.slack).appToken) (not ($cfg.slack).existingSecret) }}
 {{- $hasStt := and ($cfg.stt).enabled ($cfg.stt).apiKey }}
 {{- $hasGateway := and ($cfg.gateway).enabled ($cfg.gateway).token }}
 {{- if or $hasDiscord $hasSlack $hasStt $hasGateway }}
@@ -20,10 +20,10 @@ data:
   {{- if $hasDiscord }}
   discord-bot-token: {{ $cfg.discord.botToken | b64enc | quote }}
   {{- end }}
-  {{- if and ($cfg.slack).enabled ($cfg.slack).botToken }}
+  {{- if and ($cfg.slack).enabled ($cfg.slack).botToken (not ($cfg.slack).existingSecret) }}
   slack-bot-token: {{ $cfg.slack.botToken | b64enc | quote }}
   {{- end }}
-  {{- if and ($cfg.slack).enabled ($cfg.slack).appToken }}
+  {{- if and ($cfg.slack).enabled ($cfg.slack).appToken (not ($cfg.slack).existingSecret) }}
   slack-app-token: {{ $cfg.slack.appToken | b64enc | quote }}
   {{- end }}
   {{- if $hasStt }}

--- a/charts/openab/tests/slack-existing-secret_test.yaml
+++ b/charts/openab/tests/slack-existing-secret_test.yaml
@@ -130,3 +130,67 @@ tests:
               secretKeyRef:
                 name: my-slack-creds
                 key: slack-bot-token
+
+  # ── Mixed-adapter deployment ──────────────────────────────────────────────
+
+  - it: renders Discord from chart-managed Secret and Slack from existingSecret in same Deployment
+    template: templates/deployment.yaml
+    set:
+      agents.kiro.discord.enabled: true
+      agents.kiro.discord.botToken: "disc-token"
+      agents.kiro.slack.enabled: true
+      agents.kiro.slack.existingSecret: "my-slack-creds"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISCORD_BOT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-kiro
+                key: discord-bot-token
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SLACK_BOT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-slack-creds
+                key: slack-bot-token
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SLACK_APP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-slack-creds
+                key: slack-app-token
+
+  # ── Multi-agent scoping ───────────────────────────────────────────────────
+
+  - it: agent with existingSecret does not affect another agent using inline tokens
+    template: templates/deployment.yaml
+    documentIndex: 1
+    set:
+      agents.alpha.slack.enabled: true
+      agents.alpha.slack.existingSecret: "alpha-ext-creds"
+      agents.beta.slack.enabled: true
+      agents.beta.slack.botToken: "xoxb-beta"
+      agents.beta.slack.appToken: "xapp-beta"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SLACK_BOT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-beta
+                key: slack-bot-token
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SLACK_APP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-beta
+                key: slack-app-token

--- a/charts/openab/tests/slack-existing-secret_test.yaml
+++ b/charts/openab/tests/slack-existing-secret_test.yaml
@@ -1,0 +1,132 @@
+suite: Slack existingSecret support
+templates:
+  - templates/secret.yaml
+  - templates/deployment.yaml
+
+tests:
+  # ── Secret rendering ──────────────────────────────────────────────────────
+
+  - it: omits slack-bot-token and slack-app-token from chart Secret when existingSecret is set (slack-only agent renders no Secret at all)
+    template: templates/secret.yaml
+    set:
+      agents.kiro.discord.enabled: true
+      agents.kiro.discord.botToken: "discord-token"
+      agents.kiro.slack.enabled: true
+      agents.kiro.slack.botToken: "xoxb-ignored"
+      agents.kiro.slack.appToken: "xapp-ignored"
+      agents.kiro.slack.existingSecret: "my-slack-creds"
+    asserts:
+      - notExists:
+          path: data["slack-bot-token"]
+      - notExists:
+          path: data["slack-app-token"]
+
+  - it: skips chart Secret entirely for slack-only agent with existingSecret
+    template: templates/secret.yaml
+    set:
+      agents.kiro.slack.enabled: true
+      agents.kiro.slack.existingSecret: "my-slack-creds"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: still creates chart Secret for non-slack tokens when existingSecret is set
+    template: templates/secret.yaml
+    set:
+      agents.kiro.discord.enabled: true
+      agents.kiro.discord.botToken: "discord-token"
+      agents.kiro.slack.enabled: true
+      agents.kiro.slack.existingSecret: "my-slack-creds"
+    asserts:
+      - matchRegex:
+          path: data["discord-bot-token"]
+          pattern: '.+'
+      - notExists:
+          path: data["slack-bot-token"]
+      - notExists:
+          path: data["slack-app-token"]
+
+  - it: renders chart-managed Slack secret keys when existingSecret is unset
+    template: templates/secret.yaml
+    set:
+      agents.kiro.slack.enabled: true
+      agents.kiro.slack.botToken: "xoxb-test"
+      agents.kiro.slack.appToken: "xapp-test"
+    asserts:
+      - matchRegex:
+          path: data["slack-bot-token"]
+          pattern: '.+'
+      - matchRegex:
+          path: data["slack-app-token"]
+          pattern: '.+'
+
+  # ── Deployment env-var rendering ──────────────────────────────────────────
+
+  - it: references existingSecret name in SLACK_BOT_TOKEN secretKeyRef
+    template: templates/deployment.yaml
+    set:
+      agents.kiro.slack.enabled: true
+      agents.kiro.slack.existingSecret: "my-slack-creds"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SLACK_BOT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-slack-creds
+                key: slack-bot-token
+
+  - it: references existingSecret name in SLACK_APP_TOKEN secretKeyRef
+    template: templates/deployment.yaml
+    set:
+      agents.kiro.slack.enabled: true
+      agents.kiro.slack.existingSecret: "my-slack-creds"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SLACK_APP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-slack-creds
+                key: slack-app-token
+
+  - it: falls back to chart-managed secret name when existingSecret is unset
+    template: templates/deployment.yaml
+    set:
+      agents.kiro.slack.enabled: true
+      agents.kiro.slack.botToken: "xoxb-test"
+      agents.kiro.slack.appToken: "xapp-test"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SLACK_BOT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-kiro
+                key: slack-bot-token
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SLACK_APP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-openab-kiro
+                key: slack-app-token
+
+  - it: omits SLACK env vars when slack is disabled even if existingSecret is set
+    template: templates/deployment.yaml
+    set:
+      agents.kiro.slack.enabled: false
+      agents.kiro.slack.existingSecret: "my-slack-creds"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SLACK_BOT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-slack-creds
+                key: slack-bot-token

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -189,6 +189,14 @@ agents:
       enabled: false
       botToken: ""       # Bot User OAuth Token (xoxb-...)
       appToken: ""       # App-Level Token (xapp-...) for Socket Mode
+      # Use a pre-existing K8s Secret for slack-bot-token and slack-app-token
+      # instead of having the chart create one from botToken/appToken.
+      # Set to the Secret name; the Secret must contain keys:
+      #   slack-bot-token  → Bot User OAuth Token (xoxb-...)
+      #   slack-app-token  → App-Level Token (xapp-...)
+      # When set, botToken and appToken above are ignored. Recommended path for
+      # External Secrets Operator / Vault / SealedSecrets deployments.
+      existingSecret: ""
       # allowAllChannels/allowAllUsers: same auto-infer logic as discord
       allowedChannels: []  # empty + no allowAllChannels → allow all (auto-inferred)
       allowedUsers: []     # empty + no allowAllUsers → allow all (auto-inferred)


### PR DESCRIPTION
## What problem does this solve?

In GitOps environments using External Secrets Operator (ESO), Vault, or SealedSecrets, Kubernetes Secrets are populated by the operator from an external store. The `openab` chart already supports this pattern for `ANTHROPIC_API_KEY` via `secretEnv` (rendered as `valueFrom.secretKeyRef`).

Slack tokens currently cannot follow the same path. Because the chart creates its own Secret from Helm values, `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` must be passed at `helm install`/`helm upgrade` time via `--set-string` or `helm_release_set_sensitive`. **Every token rotation requires a Helm re-apply**, blocking automation and making platform engineers a bottleneck for what should be a self-service operation.

Closes #900

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404/1507286287428878348

## At a Glance

```
                Before                                After
  ┌──────────────────────────┐         ┌──────────────────────────┐
  │ External Secret Store    │         │ External Secret Store    │
  │  ANTHROPIC_API_KEY  ✅   │         │  ANTHROPIC_API_KEY  ✅   │
  │  SLACK_BOT_TOKEN    ❌   │         │  SLACK_BOT_TOKEN    ✅   │
  │  SLACK_APP_TOKEN    ❌   │         │  SLACK_APP_TOKEN    ✅   │
  └────────────┬─────────────┘         └────────────┬─────────────┘
               │ (slack tokens                       │ (all via ESO)
               │  via helm --set)                    ▼
               ▼                              ┌─────────────┐
        helm upgrade                          │ K8s Secret  │
        (every rotation)                      │ (ESO-synced)│
                                              └──────┬──────┘
                                                     │ secretKeyRef
                                                     ▼
                                              ┌─────────────┐
                                              │ openab pod  │
                                              └─────────────┘
```

## Prior Art & Industry Research

**Not applicable** — this is a Helm chart credential-injection change, not an architectural/runtime/scheduling/persistence change. The pattern itself (`existingSecret` field that toggles between chart-managed and externally-managed Secrets) is the standard Helm idiom used by community charts such as `bitnami/*`, `prometheus-community/*`, and `external-secrets/external-secrets`. The `openab-telegram` chart (#873) already implements this same pattern within this repo.

## Proposed Solution

Add `agents.<name>.slack.existingSecret` to the `openab` chart. When set, the chart references the named Kubernetes Secret for `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` instead of creating a chart-managed Secret from Helm values.

**Behavior:**

| Agent uses | `existingSecret` set? | Result |
|---|---|---|
| Slack only | No | Chart creates agent Secret with `slack-bot-token`, `slack-app-token` (unchanged) |
| Slack only | Yes | No chart-managed Secret created; Deployment references `existingSecret` directly |
| Slack + Discord/STT/gateway | No | Chart creates agent Secret with all tokens (unchanged) |
| Slack + Discord/STT/gateway | Yes | Chart Secret contains only non-Slack keys; Deployment references `existingSecret` for Slack keys |

**Files changed:**

- `charts/openab/values.yaml` — new `agents.<name>.slack.existingSecret: ""` field
- `charts/openab/templates/secret.yaml` — guard `slack-bot-token`/`slack-app-token` entries with `(not .existingSecret)`; updated `$hasSlack` so a slack-only agent with `existingSecret` skips Secret creation entirely
- `charts/openab/templates/_helpers.tpl` — new `openab.slackSecretName` helper returning `existingSecret` or the chart-managed agent fullname
- `charts/openab/templates/deployment.yaml` — Slack env vars use the new helper for `secretKeyRef.name`; render condition expanded to fire when either `botToken`/`appToken` or `existingSecret` is set
- `charts/openab/tests/slack-existing-secret_test.yaml` — new helm-unittest suite (8 tests)
- `charts/openab/README.md` — new value documented

## Why this approach?

**Scoped per-agent under `agents.<name>.slack.existingSecret`** (not chart-level, not agent-level). The `openab` chart is multi-agent and credentials are already namespaced per-adapter (`slack.botToken`, `discord.botToken`, etc.). Placing `existingSecret` under `slack` keeps it consistent with existing field locations and lets users with mixed-adapter agents manage each credential family independently.

**Dual-secret behavior is intentional.** When an agent uses both Slack (via `existingSecret`) and Discord (via `botToken`), the chart creates one Secret for Discord and the Deployment references the external Secret for Slack. This is consistent with the pattern where each adapter's credentials are independently sourced.

**Backwards compatible.** `existingSecret` defaults to `""`. No change in behavior for any existing deployment.

## Alternatives Considered

1. **Agent-level `agents.<name>.existingSecret`** — would replace all five credential keys (`discord-bot-token`, `slack-bot-token`, `slack-app-token`, `stt-api-key`, `gateway-ws-token`) in a single Secret. Rejected because it forces all credentials into one external Secret, blocking the common case where Slack tokens come from a different store (e.g. team-owned AWS SM path) than Discord/STT tokens (e.g. platform-owned Vault path).

2. **Chart-level `existingSecret`** — mirroring the `openab-telegram` chart exactly. Rejected because `openab-telegram` is single-agent and chart-level was natural there; `openab` is multi-agent and chart-level would force all agents to share one credential Secret.

3. **`secretEnv` only, without `existingSecret`** — `secretEnv` already supports `valueFrom.secretKeyRef`, so a user could in theory configure Slack env vars via `secretEnv`. Rejected because (a) `secretEnv` is documented for inheritable env vars and adds keys to `inherit_env` in `config.toml`, which is not appropriate for `SLACK_BOT_TOKEN` (it's a `secret_keyref` in the adapter config, not an inherited env), and (b) the `existingSecret` pattern is more discoverable for users familiar with the rest of the Helm ecosystem.

## Validation

Helm chart changes:
- [x] `helm lint charts/openab` passes
- [x] `helm template` renders correctly for all three cases (existingSecret unset, existingSecret set with slack-only agent, existingSecret set with mixed Slack+Discord agent)
- [x] `helm unittest charts/openab` — **105/105 pass** (97 baseline + 8 new tests covering both `secret.yaml` and `deployment.yaml` rendering)

Manual `helm template` verification:

```
# Case A: existingSecret unset (baseline)
$ helm template test charts/openab \
    --set agents.kiro.slack.enabled=true \
    --set agents.kiro.slack.botToken=xoxb-test \
    --set agents.kiro.slack.appToken=xapp-test
# → chart-managed Secret has slack-bot-token + slack-app-token
# → Deployment SLACK_*_TOKEN refs chart-managed Secret

# Case B: existingSecret set, slack-only agent
$ helm template test charts/openab \
    --set agents.kiro.slack.enabled=true \
    --set agents.kiro.slack.existingSecret=my-eso-creds
# → no chart-managed Secret rendered
# → Deployment SLACK_*_TOKEN refs my-eso-creds

# Case C: existingSecret set + discord enabled
$ helm template test charts/openab \
    --set agents.kiro.slack.enabled=true \
    --set agents.kiro.slack.existingSecret=my-eso-creds \
    --set agents.kiro.discord.enabled=true \
    --set agents.kiro.discord.botToken=disc-token
# → chart-managed Secret contains ONLY discord-bot-token
# → Deployment SLACK_*_TOKEN refs my-eso-creds; DISCORD_BOT_TOKEN refs chart-managed
```

