### PR TITLE
ci: add Dockerfile.antigravity to build matrices

### DIFF
--- a/.github/workflows/build-operator.yml
+++ b/.github/workflows/build-operator.yml
@@ -74,6 +74,7 @@ jobs:
           - { suffix: "-cursor", dockerfile: "Dockerfile.cursor", artifact: "cursor" }
           - { suffix: "-hermes", dockerfile: "Dockerfile.hermes", artifact: "hermes" }
           - { suffix: "-grok", dockerfile: "Dockerfile.grok", artifact: "grok" }
+          - { suffix: "-antigravity", dockerfile: "Dockerfile.antigravity", artifact: "antigravity" }
         platform:
           - { os: linux/amd64, runner: ubuntu-latest }
           - { os: linux/arm64, runner: ubuntu-24.04-arm }
@@ -139,6 +140,7 @@ jobs:
           - { suffix: "-cursor", artifact: "cursor" }
           - { suffix: "-hermes", artifact: "hermes" }
           - { suffix: "-grok", artifact: "grok" }
+          - { suffix: "-antigravity", artifact: "antigravity" }
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -192,6 +194,7 @@ jobs:
           - { suffix: "-cursor" }
           - { suffix: "-hermes" }
           - { suffix: "-grok" }
+          - { suffix: "-antigravity" }
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -22,6 +22,7 @@ jobs:
           - { dockerfile: Dockerfile.cursor, suffix: "-cursor", agent: "cursor-agent", agent_args: "acp" }
           - { dockerfile: Dockerfile.hermes, suffix: "-hermes", agent: "hermes-acp", agent_args: "" }
           - { dockerfile: Dockerfile.grok, suffix: "-grok", agent: "grok", agent_args: "agent stdio" }
+          - { dockerfile: Dockerfile.antigravity, suffix: "-antigravity", agent: "agy-acp", agent_args: "" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Add `Dockerfile.antigravity` to:
- `build-operator.yml` — builds and pushes `ghcr.io/openabdev/openab-antigravity` on tag push (pre-release + stable)
- `docker-smoke-test.yml` — validates the Dockerfile builds on PRs
- `pr-preview.yml` — adds `antigravity` variant option for PR preview builds

This is why `openab-antigravity:0.8.4-beta.2` was missing — the variant wasn't in the release build matrix.

Follow-up to #896.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365150664560881/1507258404375232512