### PR TITLE
fix(gateway/googlechat): handle HTTP endpoint URL events + correct JWT signer email

### DIFF
--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -25,11 +25,22 @@ const TEXT_FILE_COUNT_CAP: usize = 5;
 /// Cap on aggregate text file bytes per message (matches Discord/Slack 1 MB).
 const TEXT_TOTAL_CAP: u64 = 1024 * 1024;
 
-// --- Google Chat types (v2 envelope format) ---
+// --- Google Chat types ---
+//
+// Google Chat delivers webhooks in two shapes depending on the App's
+// Connection settings in the Cloud Console:
+//   - HTTP endpoint URL mode: top-level fields (message, user, space, ...)
+//   - Pub/Sub mode:           wrapped under `chat.messagePayload`
+// Both are supported via the optional fields below; the handler prefers
+// the wrapped form and falls back to top-level when `chat` is absent.
 
 #[derive(Debug, Deserialize)]
 pub struct GoogleChatEnvelope {
     pub chat: Option<ChatPayload>,
+    // HTTP endpoint URL top-level fields (used when `chat` is None)
+    pub message: Option<GoogleChatMessage>,
+    pub user: Option<GoogleChatUser>,
+    pub space: Option<GoogleChatSpace>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -132,20 +143,20 @@ pub struct GoogleChatSpace {
 
 const GOOGLE_CHAT_ISSUER: &str = "https://accounts.google.com";
 const GOOGLE_CHAT_JWKS_URL: &str = "https://www.googleapis.com/oauth2/v3/certs";
-const GOOGLE_CHAT_EMAIL_SUFFIX: &str = "@gcp-sa-gsuiteaddons.iam.gserviceaccount.com";
+const GOOGLE_CHAT_SIGNER_EMAIL: &str = "chat@system.gserviceaccount.com";
 const JWKS_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(3600);
 
-/// Verify the JWT's `email` claim belongs to a Google Chat service account.
-/// Google Chat webhooks use `service-{PROJECT_NUMBER}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`.
+/// Verify the JWT's `email` claim belongs to Google Chat.
+/// HTTP endpoint URL webhooks are signed by `chat@system.gserviceaccount.com`.
 /// Without this check, any Google-issued ID token would be accepted.
 fn verify_email_claim(claims: &serde_json::Value) -> Result<(), String> {
     let email = claims
         .get("email")
         .and_then(|v| v.as_str())
         .ok_or("missing email claim")?;
-    if !email.ends_with(GOOGLE_CHAT_EMAIL_SUFFIX) {
+    if email != GOOGLE_CHAT_SIGNER_EMAIL {
         return Err(format!(
-            "email claim mismatch: expected *{GOOGLE_CHAT_EMAIL_SUFFIX}, got {email}"
+            "email claim mismatch: expected {GOOGLE_CHAT_SIGNER_EMAIL}, got {email}"
         ));
     }
     Ok(())
@@ -484,13 +495,20 @@ pub async fn webhook(
         }
     };
 
-    let Some(chat) = envelope.chat else {
-        return empty_json_response();
+    // Try the Pub/Sub `chat`-wrapped shape first, then fall back to the
+    // HTTP endpoint URL top-level shape.
+    let (msg_opt, top_user, top_space) = if let Some(chat) = envelope.chat {
+        let user = chat.user;
+        let (msg, space) = match chat.message_payload {
+            Some(p) => (p.message, p.space),
+            None => (None, None),
+        };
+        (msg, user, space)
+    } else {
+        (envelope.message, envelope.user, envelope.space)
     };
-    let Some(payload) = chat.message_payload else {
-        return empty_json_response();
-    };
-    let Some(ref msg) = payload.message else {
+
+    let Some(ref msg) = msg_opt else {
         return empty_json_response();
     };
 
@@ -507,8 +525,8 @@ pub async fn webhook(
         return empty_json_response();
     }
 
-    let sender = msg.sender.as_ref().or(chat.user.as_ref());
-    let space = msg.space.as_ref().or(payload.space.as_ref());
+    let sender = msg.sender.as_ref().or(top_user.as_ref());
+    let space = msg.space.as_ref().or(top_space.as_ref());
 
     let is_bot = sender.map(|s| s.user_type == "BOT").unwrap_or(false);
     if is_bot {
@@ -1641,8 +1659,8 @@ mod tests {
     }
 
     #[test]
-    fn email_claim_accepts_gsuite_addons_account() {
-        let claims = serde_json::json!({"email": "service-123456@gcp-sa-gsuiteaddons.iam.gserviceaccount.com"});
+    fn email_claim_accepts_chat_system_account() {
+        let claims = serde_json::json!({"email": "chat@system.gserviceaccount.com"});
         assert!(verify_email_claim(&claims).is_ok());
     }
 

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -2439,4 +2439,32 @@ mod tests {
         .await;
         assert!(result.is_none(), "oversized image must be rejected");
     }
+
+    #[test]
+    fn parses_http_endpoint_url_top_level_envelope() {
+        let envelope: GoogleChatEnvelope = serde_json::from_value(serde_json::json!({
+            "message": {
+                "name": "spaces/AAAA/messages/BBBB",
+                "text": "hello",
+                "attachment": []
+            },
+            "user": {
+                "name": "users/123",
+                "displayName": "Test User",
+                "type": "HUMAN"
+            },
+            "space": {
+                "name": "spaces/AAAA",
+                "type": "DM"
+            }
+        }))
+        .unwrap();
+        assert!(envelope.chat.is_none());
+        assert!(envelope.message.is_some());
+        assert_eq!(envelope.message.unwrap().name, "spaces/AAAA/messages/BBBB");
+        assert!(envelope.user.is_some());
+        assert_eq!(envelope.user.unwrap().name, "users/123");
+        assert!(envelope.space.is_some());
+        assert_eq!(envelope.space.unwrap().name, "spaces/AAAA");
+    }
 }


### PR DESCRIPTION
## What problem does this solve?

Following `docs/google-chat.md` end-to-end produces a 100% non-working
Google Chat bot. Two independent bugs in `gateway/src/adapters/googlechat.rs`
make the documented HTTP endpoint URL connection mode unusable:

1. **Envelope schema mismatch** — `GoogleChatEnvelope` only deserializes a
   `chat`-wrapped payload (Pub/Sub style), but HTTP endpoint URL connections
   deliver a top-level shape (`message`, `user`, `space`, `thread`,
   `common`). All real webhooks silently drop at `envelope.chat is None`
   with a 200 response, so Google considers them "delivered" but no event
   reaches the agent.

2. **JWT email allow-list incorrect** — `GOOGLE_CHAT_EMAIL_SUFFIX` requires
   `@gcp-sa-gsuiteaddons.iam.gserviceaccount.com` (Workspace Add-ons
   signer), but Google Chat HTTP webhooks are signed as
   `chat@system.gserviceaccount.com`. Setting `GOOGLE_CHAT_AUDIENCE` per
   docs returns 401 to every webhook.

Together, a fresh setup yields "OpenAB not responding" (audience set) or
zero replies (audience unset).

Closes #899

Discord Discussion URL: N/A — bug discovered during personal Google
Workspace setup; reproduction details and captured webhook body are in
issue #899.

## At a Glance

```
Before:
  Google Chat ──HTTPS POST──▶ gateway
                                │
                                ├─ JWT verify (Bug 2)
                                │   expected: *@gcp-sa-gsuiteaddons...
                                │   got:      chat@system.gserviceaccount.com
                                │   → 401
                                │
                                └─ (audience unset) envelope.chat is None (Bug 1)
                                   → silent 200 drop
  Result: bot never replies

After:
  Google Chat ──HTTPS POST──▶ gateway
                                │
                                ├─ JWT verify
                                │   accept: chat@system.gserviceaccount.com → pass
                                │
                                └─ envelope parse
                                   try wrapped (chat.messagePayload.message),
                                   fall back to top-level (message, user, space)
                                   → event forwarded to OAB → reply via Chat API
  Result: bot replies as expected
```

## Prior Art & Industry Research

**OpenClaw:** No Google Chat adapter; not applicable.

**Hermes Agent:** No Google Chat adapter; not applicable.

**Other references:**
- Google Chat JWT signer (HTTP endpoint URL mode):
  https://developers.google.com/workspace/chat/verify-requests-from-chat
  — explicitly documents the `email` claim as `chat@system.gserviceaccount.com`.
- HTTP endpoint URL event payload shape: my evidence is empirical
  rather than from official docs — a sanitised real webhook body is
  captured in #899. (Earlier revisions of this PR cited
  `/workspace/chat/format-events`, which does not exist; corrected here.)
- Original adapter implementation: #718 — chose the Pub/Sub wrapped
  schema, likely assuming Workspace Add-ons SDK deployment (Config A,
  per the review discussion below).

## Proposed Solution

**Bug 1 — envelope schema:**

- Extend `GoogleChatEnvelope` with optional top-level `message`, `user`,
  `space` fields.
- In `webhook()`, prefer the wrapped path; fall back to top-level when
  `envelope.chat` is `None`.
- Both formats now parse; existing tests covering the wrapped schema
  remain unchanged and still pass.

**Bug 2 — JWT email allow-list:**

- Rename `GOOGLE_CHAT_EMAIL_SUFFIX` → `GOOGLE_CHAT_SIGNER_EMAIL` and set
  the value to `chat@system.gserviceaccount.com` (Google Chat's actual
  signer for HTTP endpoint URL mode).
- Tighten the check from `ends_with` (suffix match) to exact equality.
- Update the existing `email_claim_accepts_*` test to assert the new
  signer.

## Why this approach?

Schema fallback rather than format-detection by an env var:

- Both formats are unambiguously distinguishable structurally (presence
  of the `chat` field), so serde + `Option` gives us a zero-cost branch
  with no new config surface.
- Existing Pub/Sub deployments (if any) keep working with zero changes.

For Bug 2, narrowing the email check rather than removing JWT verification
preserves the security posture (proves the request came from Google Chat
specifically, not just any Google service) while matching reality.

## Alternatives Considered

1. **`GOOGLE_CHAT_EVENT_FORMAT=wrapped|toplevel` env var** — explicit
   but adds config burden; users would need to know which mode their
   Chat App uses. The schema fallback is zero-config.
2. **Drop JWT verification entirely** — what current docs label
   "insecure (local development only)". Bad default; anyone who learns
   the webhook URL can inject events.
3. **Accept any `@system.gserviceaccount.com`** — broader than needed,
   could let other Google internal services spoof Chat events. Narrow
   to `chat@system.gserviceaccount.com`.
4. **Update docs to recommend Cloud Pub/Sub mode** — pushes a different
   deployment model on every user; HTTP endpoint URL is what
   `docs/google-chat.md` currently recommends and what current users
   follow.

## Validation

- [x] `cargo check --release` passes (fresh build on `rust:1-bookworm`)
- [x] `cargo test --release --package openab-gateway` — **170 passed, 0 failed**
      (existing wrapped-shape tests untouched; updated email-claim test asserts new signer)
- [x] **Manual end-to-end** (production K3s cluster, Cloudflare Tunnel sidecar):
  - Patched binary running in production `cc-agent` pod
  - 1:1 DM "test" → `gateway: googlechat webhook received → googlechat → gateway → OAB spawn → cc-agent reply via Chat API` → reply visible in Chat client
  - Space @mention → same flow, reply visible in thread
- [x] No silent drops or JWT email mismatch warnings in gateway log after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://discord.com/channels/1491295327620169908/1491365158868619404/1507822388883230721

