### PR TITLE
feat(chart): add imagePullSecrets support at per-agent and global level

### DIFF
--- a/charts/openab/README.md
+++ b/charts/openab/README.md
@@ -13,6 +13,7 @@ This page highlights commonly used values and deployment patterns. For the compl
 | `nameOverride` | Override the chart name portion used in generated resource names. For per-agent resource names, use `agents.<name>.nameOverride`. | `""` |
 | `fullnameOverride` | Override the full generated release name for chart resources. Useful when deploying multiple instances with predictable names. | `""` |
 | `serviceAccountName` | Chart-global ServiceAccount name attached to every agent pod that doesn't define its own. Empty = cluster `default` SA. Per-agent `agents.<name>.serviceAccountName` fully overrides this. Chart references an existing SA only — does not create one. Required for workload identity and pod-level RBAC. | `""` |
+| `imagePullSecrets` | Chart-global image pull secrets attached to every agent pod that doesn't define its own. Per-agent `agents.<name>.imagePullSecrets` fully overrides this. | `[]` |
 
 ### Agent values
 
@@ -53,6 +54,7 @@ Each agent lives under `agents.<name>`.
 | `persistence.existingClaim` | Reuse an existing PVC instead of creating one. | `""` |
 | `agentsMd` | Contents of `AGENTS.md` mounted into the working directory. | `""` |
 | `serviceAccountName` | Per-agent ServiceAccount name. When set (non-empty), fully overrides chart-global `serviceAccountName`. Useful when only some agents need a dedicated SA. | `""` |
+| `imagePullSecrets` | Per-agent image pull secrets. When set, fully overrides chart-global `imagePullSecrets`. Useful when only some agents pull from a private registry. | `[]` |
 | `extraInitContainers` | Additional init containers for the agent pod. | `[]` |
 | `extraContainers` | Additional sidecar containers for the agent pod. | `[]` |
 | `extraVolumeMounts` | Additional volume mounts for the main agent container. | `[]` |

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
       {{- if $svcAcct }}
       serviceAccountName: {{ $svcAcct }}
       {{- end }}
+      {{- with (default $.Values.imagePullSecrets $cfg.imagePullSecrets) }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $cfg.extraInitContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/charts/openab/tests/imagepullsecrets_test.yaml
+++ b/charts/openab/tests/imagepullsecrets_test.yaml
@@ -1,0 +1,64 @@
+suite: imagePullSecrets support (chart-global + per-agent override)
+templates:
+  - templates/deployment.yaml
+
+tests:
+  - it: does not render imagePullSecrets when neither global nor per-agent is set
+    asserts:
+      - notExists:
+          path: spec.template.spec.imagePullSecrets
+
+  - it: renders chart-global imagePullSecrets when only the global value is set
+    set:
+      imagePullSecrets:
+        - name: regcred
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: regcred
+
+  - it: renders per-agent imagePullSecrets when only the per-agent value is set
+    set:
+      agents.kiro.imagePullSecrets:
+        - name: kiro-regcred
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: kiro-regcred
+
+  - it: per-agent imagePullSecrets fully overrides chart-global (no merge)
+    set:
+      imagePullSecrets:
+        - name: global-regcred
+      agents.kiro.imagePullSecrets:
+        - name: kiro-regcred
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: kiro-regcred
+
+  - it: falls back to chart-global when per-agent imagePullSecrets is an empty list
+    set:
+      imagePullSecrets:
+        - name: global-regcred
+      agents.kiro.imagePullSecrets: []
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: global-regcred
+
+  - it: supports multiple secrets in the list
+    set:
+      imagePullSecrets:
+        - name: regcred-a
+        - name: regcred-b
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: regcred-a
+            - name: regcred-b

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -20,6 +20,14 @@ fullnameOverride: ""
 # serviceAccountName: "openab"
 serviceAccountName: ""
 
+# Chart-global image pull secrets, used when an agent doesn't set its own
+# `imagePullSecrets`. Per-agent values (agents.<name>.imagePullSecrets) take
+# precedence — when set, they fully override (do not merge with) this list.
+# Example:
+# imagePullSecrets:
+#   - name: regcred
+imagePullSecrets: []
+
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000
@@ -420,6 +428,12 @@ agents:
     # multi-agent deployments where only some agents need a dedicated SA.
     # serviceAccountName: "openab"
     serviceAccountName: ""
+    # Per-agent image pull secrets. When set, overrides the chart-global
+    # `imagePullSecrets` for this agent only. Useful in multi-agent deployments
+    # where only some agents pull from a private registry.
+    # imagePullSecrets:
+    #   - name: regcred
+    imagePullSecrets: []
     # extraInitContainers adds init containers to the pod (runs before the main container)
     extraInitContainers: []
     # extraContainers adds sidecar containers to the pod


### PR DESCRIPTION
## Summary

- Adds `imagePullSecrets` at both chart-global (`$.Values.imagePullSecrets`) and per-agent (`agents.<name>.imagePullSecrets`) level
- Per-agent value wins when set; otherwise falls back to chart-global. Both empty preserves current behaviour (no `imagePullSecrets` field rendered) — zero impact on existing users
- Enables multi-agent deployments where only some agents pull from a private registry, without forcing pull credentials onto every pod
- Follows the same per-agent K8s-native secrets pattern as PR #901 (`slack.existingSecret`)

Closes #910

Discord discussion: https://discord.com/channels/1491295327620169908/1491365157010542652/1507675217827201106

## Changes

| File | Purpose |
|------|---------|
| `charts/openab/values.yaml` | Add chart-global `imagePullSecrets: []` + per-agent `imagePullSecrets: []` on the `kiro` agent |
| `charts/openab/templates/deployment.yaml` | Render `imagePullSecrets` between `securityContext` and `initContainers` using `default $.Values.imagePullSecrets $cfg.imagePullSecrets` |
| `charts/openab/README.md` | Document both values in the Common Values tables |
| `charts/openab/tests/imagepullsecrets_test.yaml` | 6 helm-unittest cases covering default / global-only / per-agent-only / per-agent-wins-over-global / empty-list-falls-back / multi-secret |

## Test plan

- [x] `helm unittest charts/openab` — all 113 tests pass (6 new + 107 existing)
- [x] `helm lint charts/openab` — clean
- [x] `helm template testrelease charts/openab --set 'imagePullSecrets[0].name=regcred'` renders `imagePullSecrets` at pod spec level
- [x] `helm template` with no values set renders no `imagePullSecrets` field (backwards-compat verified)

## Why not ServiceAccount `imagePullSecrets`?

The chart doesn't create a `serviceAccountName`-bound SA per agent, so operators can't reliably attach pull secrets to the right SA without touching cluster state outside the chart. Keeping the value in the chart makes it explicit, per-agent, and chart-managed.