### PR TITLE
docs: add PR lifecycle flow to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,3 +80,51 @@ cargo check
 - Run `cargo fmt` before committing
 - Run `cargo clippy` and address warnings
 - Keep PRs focused — one feature or fix per PR
+
+## PR Lifecycle
+
+Every PR follows a label-driven lifecycle that keeps the review loop moving.
+
+```
+┌──────────────┐
+│  PR Created  │
+└──────┬───────┘
+       │
+       ▼
+┌──────────────────────┐   author comments   ┌───────────────────────┐
+│ pending-maintainer   │◄────────────────────│  pending-contributor   │
+└──────────────────────┘                     └───────────┬─────────────┘
+       │                                                 │
+       │  review done,                                   │ stale 3 days
+       │  ball to contributor                            │ (no author activity)
+       │                                                 ▼
+       └────────────────────────────────────────►┌───────────────┐
+                                                 │ closing-soon  │
+                                                 └───────┬───────┘
+                                                         │
+                                            ┌────────────┴────────────┐
+                                            │                         │
+                                            ▼                         ▼
+                                  author comments              3 more days
+                                  within 3 days                no activity
+                                            │                         │
+                                            ▼                         ▼
+                                  ┌────────────────────┐    ┌────────────┐
+                                  │ pending-maintainer  │    │  PR Closed │
+                                  │ (labels removed)    │    └────────────┘
+                                  └────────────────────┘
+```
+
+### Label Transitions
+
+| Current State | Trigger | Action |
+|---------------|---------|--------|
+| `pending-contributor` | No author activity for 3 days | Add `closing-soon` |
+| `closing-soon` | No author activity for 3 more days | Auto-close PR |
+| `pending-contributor` / `closing-soon` | Author adds a comment | Remove both labels, add `pending-maintainer` |
+
+### Key Rules
+
+- **`pending-contributor`** — the ball is on the contributor; maintainers are waiting for updates.
+- **`closing-soon`** — warning that the PR will be auto-closed if no response within 3 days.
+- **Author comment resets the clock** — any comment by the PR author removes `pending-contributor` and `closing-soon`, flipping the PR back to `pending-maintainer`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,8 @@ Every PR follows a label-driven lifecycle that keeps the review loop moving.
        │                                   └──────────┬───────────┘
        │                                              │
        │                                              │ review done,
-       │                                              │ ball to contributor
+       │                                              │ pending actions
+       │                                              │ for contributor
        │                                              ▼
        └── any fail ──────────────────────►┌──────────────────────┐
                                            │ pending-contributor  │◄─────────┐

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,3 +129,4 @@ Every PR follows a label-driven lifecycle that keeps the review loop moving.
 - **`pending-contributor`** — the ball is on the contributor; maintainers are waiting for updates.
 - **`closing-soon`** — warning that the PR will be auto-closed if no response within 3 days.
 - **Author comment resets the clock** — any comment by the PR author removes `pending-contributor` and `closing-soon`, flipping the PR back to `pending-maintainer`.
+- **Immediate `closing-soon`** — in some cases (e.g., missing Discord Discussion URL), `closing-soon` is applied immediately without waiting for the stale period.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,9 +91,9 @@ Every PR follows a label-driven lifecycle that keeps the review loop moving.
 └──────┬───────┘
        │
        ▼
-┌──────────────────────┐   author comments   ┌───────────────────────┐
-│ pending-maintainer   │◄────────────────────│  pending-contributor   │
-└──────────────────────┘                     └───────────┬─────────────┘
+┌──────────────────────┐   author comments   ┌──────────────────────┐
+│ pending-maintainer   │◄────────────────────│ pending-contributor  │
+└──────────────────────┘                     └──────────┬───────────┘
        │                                                 │
        │  review done,                                   │ stale 3 days
        │  ball to contributor                            │ (no author activity)
@@ -121,7 +121,8 @@ Every PR follows a label-driven lifecycle that keeps the review loop moving.
 |---------------|---------|--------|
 | `pending-contributor` | No author activity for 3 days | Add `closing-soon` |
 | `closing-soon` | No author activity for 3 more days | Auto-close PR |
-| `pending-contributor` / `closing-soon` | Author adds a comment | Remove both labels, add `pending-maintainer` |
+| `pending-contributor` | Author adds a comment | Remove `pending-contributor`, add `pending-maintainer` |
+| `closing-soon` | Author adds a comment | Remove `closing-soon` and `pending-contributor`, add `pending-maintainer` |
 
 ### Key Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,10 +100,13 @@ Every PR follows a label-driven lifecycle that keeps the review loop moving.
        │                                   │ pending-maintainer   │
        │                                   └──────────┬───────────┘
        │                                              │
-       │                                              │ review done,
-       │                                              │ pending actions
-       │                                              │ for contributor
-       │                                              ▼
+       │                                              ├── LGTM → approve & merge (or request
+       │                                              │          another maintainer review)
+       │                                              │          stays pending-maintainer
+       │                                              │
+       │                                              └── pending actions for contributor
+       │                                                         │
+       │                                                         ▼
        └── any fail ──────────────────────►┌──────────────────────┐
                                            │ pending-contributor  │◄─────────┐
                                            └──────────┬───────────┘          │

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,28 +91,44 @@ Every PR follows a label-driven lifecycle that keeps the review loop moving.
 └──────┬───────┘
        │
        ▼
-┌──────────────────────┐   author comments   ┌──────────────────────┐
-│ pending-maintainer   │◄────────────────────│ pending-contributor  │
-└──────────────────────┘                     └──────────┬───────────┘
-       │                                                 │
-       │  review done,                                   │ stale 2 days
-       │  ball to contributor                            │ (no author activity)
-       │                                                 ▼
-       └────────────────────────────────────────►┌───────────────┐
-                                                 │ closing-soon  │
-                                                 └───────┬───────┘
-                                                         │
-                                            ┌────────────┴────────────┐
-                                            │                         │
-                                            ▼                         ▼
-                                  author comments              3 more days
-                                  within 3 days                no activity
-                                            │                         │
-                                            ▼                         ▼
-                                  ┌────────────────────┐    ┌────────────┐
-                                  │ pending-maintainer  │    │  PR Closed │
-                                  │ (labels removed)    │    └────────────┘
-                                  └────────────────────┘
+┌──────────────────────┐
+│  Automated Checks    │
+│  (CI, rebase, etc.)  │
+└──────┬───────────────┘
+       │
+       ├── all pass ──────────────────────►┌──────────────────────┐
+       │                                   │ pending-maintainer   │
+       │                                   └──────────┬───────────┘
+       │                                              │
+       │                                              │ review done,
+       │                                              │ ball to contributor
+       │                                              ▼
+       └── any fail ──────────────────────►┌──────────────────────┐
+                                           │ pending-contributor  │◄─────────┐
+                                           └──────────┬───────────┘          │
+                                                      │                      │
+                                                      │ stale 2 days         │
+                                                      │ (no author activity) │
+                                                      ▼                      │
+                                           ┌───────────────────┐             │
+                                           │   closing-soon    │             │
+                                           │ (or immediate if  │             │
+                                           │  blocker detected)│             │
+                                           └────────┬──────────┘             │
+                                                    │                        │
+                                       ┌────────────┴──────────┐             │
+                                       │                       │             │
+                                       ▼                       ▼             │
+                             author comments            3 more days          │
+                             within 3 days             no activity           │
+                                       │                       │             │
+                                       ▼                       ▼             │
+                             ┌────────────────────┐  ┌────────────┐          │
+                             │ pending-maintainer  │  │  PR Closed │          │
+                             │ (labels removed)    │  └────────────┘          │
+                             └────────┬───────────┘                          │
+                                      │                                      │
+                                      └── re-check fails ────────────────────┘
 ```
 
 ### Label Transitions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Every PR follows a label-driven lifecycle that keeps the review loop moving.
 │ pending-maintainer   │◄────────────────────│ pending-contributor  │
 └──────────────────────┘                     └──────────┬───────────┘
        │                                                 │
-       │  review done,                                   │ stale 3 days
+       │  review done,                                   │ stale 2 days
        │  ball to contributor                            │ (no author activity)
        │                                                 ▼
        └────────────────────────────────────────►┌───────────────┐
@@ -119,7 +119,7 @@ Every PR follows a label-driven lifecycle that keeps the review loop moving.
 
 | Current State | Trigger | Action |
 |---------------|---------|--------|
-| `pending-contributor` | No author activity for 3 days | Add `closing-soon` |
+| `pending-contributor` | No author activity for 2 days | Add `closing-soon` |
 | `closing-soon` | No author activity for 3 more days | Auto-close PR |
 | `pending-contributor` | Author adds a comment | Remove `pending-contributor`, add `pending-maintainer` |
 | `closing-soon` | Author adds a comment | Remove `closing-soon` and `pending-contributor`, add `pending-maintainer` |
@@ -128,5 +128,6 @@ Every PR follows a label-driven lifecycle that keeps the review loop moving.
 
 - **`pending-contributor`** — the ball is on the contributor; maintainers are waiting for updates.
 - **`closing-soon`** — warning that the PR will be auto-closed if no response within 3 days.
-- **Author comment resets the clock** — any comment by the PR author removes `pending-contributor` and `closing-soon`, flipping the PR back to `pending-maintainer`.
+- **Author comment always resets** — any comment by the PR author removes `pending-contributor` and `closing-soon`, flipping the PR back to `pending-maintainer`.
+- **Re-check may re-apply `closing-soon`** — after the flip, automated checks still run. If blockers remain (e.g., missing Discord URL, CI failure, `needs-rebase`), `closing-soon` will be re-applied immediately, keeping the ball on the contributor.
 - **Immediate `closing-soon`** — in some cases (e.g., missing Discord Discussion URL), `closing-soon` is applied immediately without waiting for the stale period.


### PR DESCRIPTION
## What problem does this solve?

Contributors and maintainers need a clear, documented understanding of how PR labels drive the review lifecycle — specifically when PRs go stale and get auto-closed.

## At a Glance

Adds an ASCII diagram and label transition table to CONTRIBUTING.md documenting:

- `pending-contributor` → stale 3 days → `closing-soon` → auto-close after 3 more days
- Author comment resets the clock → flips back to `pending-maintainer`

## Proposed Solution

Append a **PR Lifecycle** section to the end of CONTRIBUTING.md with:
1. ASCII flow diagram
2. Label transition table
3. Key rules explanation

## Validation

- Docs-only change; renders correctly in GitHub preview