### PR TITLE
feat(chart): add serviceAccountName support at per-agent and global level

### DIFF
--- a/charts/openab/README.md
+++ b/charts/openab/README.md
@@ -12,6 +12,7 @@ This page highlights commonly used values and deployment patterns. For the compl
 |-------|-------------|---------|
 | `nameOverride` | Override the chart name portion used in generated resource names. For per-agent resource names, use `agents.<name>.nameOverride`. | `""` |
 | `fullnameOverride` | Override the full generated release name for chart resources. Useful when deploying multiple instances with predictable names. | `""` |
+| `serviceAccountName` | Chart-global ServiceAccount name attached to every agent pod that doesn't define its own. Empty = cluster `default` SA. Per-agent `agents.<name>.serviceAccountName` fully overrides this. Chart references an existing SA only — does not create one. Required to activate IRSA on EKS. | `""` |
 
 ### Agent values
 
@@ -50,6 +51,7 @@ Each agent lives under `agents.<name>`.
 | `persistence.enabled` | Enable persistent storage for auth and settings. | `true` |
 | `persistence.existingClaim` | Reuse an existing PVC instead of creating one. | `""` |
 | `agentsMd` | Contents of `AGENTS.md` mounted into the working directory. | `""` |
+| `serviceAccountName` | Per-agent ServiceAccount name. When set (non-empty), fully overrides chart-global `serviceAccountName`. Useful when only some agents need an IRSA-bound SA. | `""` |
 | `extraInitContainers` | Additional init containers for the agent pod. | `[]` |
 | `extraContainers` | Additional sidecar containers for the agent pod. | `[]` |
 | `extraVolumeMounts` | Additional volume mounts for the main agent container. | `[]` |

--- a/charts/openab/README.md
+++ b/charts/openab/README.md
@@ -12,7 +12,7 @@ This page highlights commonly used values and deployment patterns. For the compl
 |-------|-------------|---------|
 | `nameOverride` | Override the chart name portion used in generated resource names. For per-agent resource names, use `agents.<name>.nameOverride`. | `""` |
 | `fullnameOverride` | Override the full generated release name for chart resources. Useful when deploying multiple instances with predictable names. | `""` |
-| `serviceAccountName` | Chart-global ServiceAccount name attached to every agent pod that doesn't define its own. Empty = cluster `default` SA. Per-agent `agents.<name>.serviceAccountName` fully overrides this. Chart references an existing SA only — does not create one. Required to activate IRSA on EKS. | `""` |
+| `serviceAccountName` | Chart-global ServiceAccount name attached to every agent pod that doesn't define its own. Empty = cluster `default` SA. Per-agent `agents.<name>.serviceAccountName` fully overrides this. Chart references an existing SA only — does not create one. Required for workload identity and pod-level RBAC. | `""` |
 
 ### Agent values
 
@@ -51,7 +51,7 @@ Each agent lives under `agents.<name>`.
 | `persistence.enabled` | Enable persistent storage for auth and settings. | `true` |
 | `persistence.existingClaim` | Reuse an existing PVC instead of creating one. | `""` |
 | `agentsMd` | Contents of `AGENTS.md` mounted into the working directory. | `""` |
-| `serviceAccountName` | Per-agent ServiceAccount name. When set (non-empty), fully overrides chart-global `serviceAccountName`. Useful when only some agents need an IRSA-bound SA. | `""` |
+| `serviceAccountName` | Per-agent ServiceAccount name. When set (non-empty), fully overrides chart-global `serviceAccountName`. Useful when only some agents need a dedicated SA. | `""` |
 | `extraInitContainers` | Additional init containers for the agent pod. | `[]` |
 | `extraContainers` | Additional sidecar containers for the agent pod. | `[]` |
 | `extraVolumeMounts` | Additional volume mounts for the main agent container. | `[]` |

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- $svcAcct := default $.Values.serviceAccountName $cfg.serviceAccountName }}
+      {{- if $svcAcct }}
+      serviceAccountName: {{ $svcAcct }}
+      {{- end }}
       {{- with $cfg.extraInitContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/charts/openab/tests/serviceaccount_test.yaml
+++ b/charts/openab/tests/serviceaccount_test.yaml
@@ -1,0 +1,51 @@
+suite: serviceAccountName support (chart-global + per-agent override)
+templates:
+  - templates/deployment.yaml
+
+tests:
+  - it: does not render serviceAccountName when neither global nor per-agent is set
+    asserts:
+      - notExists:
+          path: spec.template.spec.serviceAccountName
+
+  - it: renders chart-global serviceAccountName when only the global value is set
+    set:
+      serviceAccountName: "openab"
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: openab
+
+  - it: renders per-agent serviceAccountName when only the per-agent value is set
+    set:
+      agents.kiro.serviceAccountName: "kiro-sa"
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: kiro-sa
+
+  - it: per-agent serviceAccountName fully overrides chart-global
+    set:
+      serviceAccountName: "openab"
+      agents.kiro.serviceAccountName: "kiro-sa"
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: kiro-sa
+
+  - it: empty per-agent serviceAccountName falls back to chart-global
+    set:
+      serviceAccountName: "openab"
+      agents.kiro.serviceAccountName: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: openab
+
+  - it: explicit empty global + empty per-agent renders no serviceAccountName field
+    set:
+      serviceAccountName: ""
+      agents.kiro.serviceAccountName: ""
+    asserts:
+      - notExists:
+          path: spec.template.spec.serviceAccountName

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -11,6 +11,15 @@ nameOverride: ""
 # Override the full release name used in generated resource names.
 fullnameOverride: ""
 
+# Chart-global ServiceAccount name for agent pods, used when an agent doesn't
+# set its own `serviceAccountName`. Empty string = use cluster default SA.
+# Per-agent values (agents.<name>.serviceAccountName) take precedence — when
+# set, they fully override this. The chart only references an existing SA; it
+# does NOT create one or manage IRSA annotations (provision out-of-band).
+# Example:
+# serviceAccountName: "openab"
+serviceAccountName: ""
+
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000
@@ -349,6 +358,11 @@ agents:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    # Per-agent ServiceAccount name. When set (non-empty), overrides the
+    # chart-global `serviceAccountName` for this agent only. Useful in
+    # multi-agent deployments where only some agents need an IRSA-bound SA.
+    # serviceAccountName: "openab"
+    serviceAccountName: ""
     # extraInitContainers adds init containers to the pod (runs before the main container)
     extraInitContainers: []
     # extraContainers adds sidecar containers to the pod

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -15,7 +15,7 @@ fullnameOverride: ""
 # set its own `serviceAccountName`. Empty string = use cluster default SA.
 # Per-agent values (agents.<name>.serviceAccountName) take precedence — when
 # set, they fully override this. The chart only references an existing SA; it
-# does NOT create one or manage IRSA annotations (provision out-of-band).
+# does NOT create one or manage annotations (provision out-of-band).
 # Example:
 # serviceAccountName: "openab"
 serviceAccountName: ""
@@ -360,7 +360,7 @@ agents:
     affinity: {}
     # Per-agent ServiceAccount name. When set (non-empty), overrides the
     # chart-global `serviceAccountName` for this agent only. Useful in
-    # multi-agent deployments where only some agents need an IRSA-bound SA.
+    # multi-agent deployments where only some agents need a dedicated SA.
     # serviceAccountName: "openab"
     serviceAccountName: ""
     # extraInitContainers adds init containers to the pod (runs before the main container)


### PR DESCRIPTION
## Summary

- Adds `serviceAccountName` at chart-global (`$.Values.serviceAccountName`) and per-agent (`agents.<name>.serviceAccountName`) level
- Per-agent value wins when set; otherwise falls back to chart-global. Both empty preserves current behaviour (no `serviceAccountName` rendered → Kubernetes uses cluster `default` SA) — zero impact on existing users
- **Required to activate IRSA on EKS**: without an explicit `serviceAccountName`, the `pod-identity-webhook` never injects AWS credentials and workloads silently fall back to the broad EC2 node role, breaking least-privilege
- **Scope**: string reference to an existing ServiceAccount only. The chart does NOT create a new SA or manage IRSA annotations (operators provision out-of-band via Terraform / IDP / kubectl) — matches how PR #901 (`existingSecret`) and #910 (`imagePullSecrets`) reference existing K8s resources

Closes #913

Discord discussion: https://discord.com/channels/1491295327620169908/1491365157010542652/1507736112913973268

## Changes

| File | Purpose |
|------|---------|
| `charts/openab/values.yaml` | Add chart-global `serviceAccountName: ""` + per-agent `serviceAccountName: ""` on the `kiro` agent |
| `charts/openab/templates/deployment.yaml` | Render `serviceAccountName` after `securityContext` using `default $.Values.serviceAccountName $cfg.serviceAccountName`; `if` guards against empty value to preserve current "no field rendered" behaviour |
| `charts/openab/README.md` | Document both values in the Common Values tables |
| `charts/openab/tests/serviceaccount_test.yaml` | 6 helm-unittest cases covering default / global-only / per-agent-only / per-agent-wins / empty-fallback / both-empty |

## Test plan

- [x] `helm unittest charts/openab` — all 113 tests pass (6 new + 107 existing)
- [x] `helm lint charts/openab` — clean
- [x] `helm template testrelease charts/openab --set serviceAccountName=openab-sa` renders `serviceAccountName: openab-sa` at pod spec level
- [x] `helm template` with no values set renders no `serviceAccountName` field (backwards-compat verified)

## Out of scope (possible follow-ups)

- `automountServiceAccountToken: false` for agents that don't need K8s API access
- Chart-managed SA creation with IRSA annotations / labels / ClusterRoleBindings — larger surface, separate RFC if there's demand

## Note on diff context

This branch is based on a slightly older fork main, so the diff context does not include PR #911 (`imagePullSecrets`) which is still in review. Once #911 merges, this PR's new `serviceAccountName` block will sit immediately before the `imagePullSecrets` block (both pod-level identity/credential fields grouped together) — no conflict expected.