### PR TITLE
fix: align workflows to PR lifecycle spec

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -47,7 +47,7 @@ jobs:
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number: pr.number,
-                body: `🔒 Auto-closing: this PR has had the \`${label}\` label for more than ${staleDays} days without a Discord Discussion URL being added.\n\nFeel free to reopen after adding the discussion link to the PR body.`
+                body: `🔒 Auto-closing: this PR has had the \`${label}\` label for more than ${staleDays} days without activity from the author.\n\nIf you'd like to continue working on this, feel free to reopen and leave a comment.`
               });
 
               await github.rest.pulls.update({

--- a/.github/workflows/pending-maintainer.yml
+++ b/.github/workflows/pending-maintainer.yml
@@ -53,12 +53,6 @@ jobs:
                 continue;
               }
 
-              // Skip if closing-soon — contributor has incomplete work
-              if (labels.includes('closing-soon')) {
-                console.log(`#${prNumber} — closing-soon, skipping`);
-                continue;
-              }
-
               // Skip if has merge conflicts or already labeled needs-rebase
               if (pr.mergeable === false || labels.includes('needs-rebase')) {
                 console.log(`#${prNumber} — has conflicts or needs-rebase, skipping`);
@@ -119,6 +113,13 @@ jobs:
                   ...context.repo,
                   issue_number: prNumber,
                   name: CONTRIBUTOR
+                }).catch(() => {});
+              }
+              if (labels.includes('closing-soon')) {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: prNumber,
+                  name: 'closing-soon'
                 }).catch(() => {});
               }
               console.log(`#${prNumber} — all clear, set ${MAINTAINER}`);


### PR DESCRIPTION
## What problem does this solve?

After merging the PR lifecycle spec in #912, three workflows have gaps that don't match the documented behavior.

## Changes

### 1. `pending-maintainer.yml`
- **Removed** the `closing-soon` skip — previously, PRs with `closing-soon` were ignored entirely
- **Added** `closing-soon` label removal when all conditions pass and PR flips to `pending-maintainer`
- This means: author comments → checks pass → `closing-soon` + `pending-contributor` removed → `pending-maintainer` added

### 2. `close-stale-prs.yml`
- **Updated** auto-close comment from Discord-URL-specific message to a generic stale message
- Old: "without a Discord Discussion URL being added"
- New: "without activity from the author"

## Validation

- CI/workflow changes: YAML syntax valid
- Logic reviewed against CONTRIBUTING.md lifecycle spec