### PR TITLE
docs(codex): troubleshoot bubblewrap unavailable in sandboxed runtimes

### DIFF
--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini bubblewrap && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
 ARG CODEX_ACP_VERSION=0.14.0

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -293,7 +293,9 @@ helm install openab openab/openab \
 
 > **Important:** `danger-full-access` disables only Codex's *inner* sandbox. It
 > does **not** remove the outer OpenAB container/VM isolation. The agent remains
-> confined by the runtime's own security boundary.
+> confined by the runtime's own security boundary. Ensure the outer runtime is a
+> non-privileged container (no `--privileged` flag or excessive capabilities) for
+> this security model to hold.
 
 ### Imagegen appears to hang
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -250,6 +250,51 @@ codex exec --dangerously-bypass-approvals-and-sandbox ...
 
 Do not use this flag on an untrusted host.
 
+### `bubblewrap is unavailable: no system bwrap was found on PATH`
+
+Codex's Linux sandbox modes (read-only / workspace-write) rely on `bwrap`
+(bubblewrap) to create an inner sandbox. If the runtime image does not include
+bubblewrap, even basic commands like `pwd` or `ls` will fail before execution
+with this error.
+
+This commonly happens in OpenAB deployments where Codex already runs inside an
+isolated container or VM — the outer runtime provides the desired isolation, so
+the inner sandbox is redundant.
+
+**Option 1 — Install bubblewrap in the image** (keeps inner sandbox active):
+
+```dockerfile
+# Dockerfile.codex
+RUN apt-get update && apt-get install -y bubblewrap && rm -rf /var/lib/apt/lists/*
+```
+
+**Option 2 — Disable Codex's inner sandbox** (recommended when the outer OpenAB
+runtime already provides isolation):
+
+```toml
+# /home/node/.codex/config.toml
+[sandbox]
+sandbox_mode = "danger-full-access"
+approval_policy = "on-request"
+```
+
+Or launch with:
+
+```bash
+codex --sandbox danger-full-access
+```
+
+Or via Helm:
+
+```bash
+helm install openab openab/openab \
+  --set-json 'agents.codex.extraConfig={"sandbox":{"sandbox_mode":"danger-full-access","approval_policy":"on-request"}}'
+```
+
+> **Important:** `danger-full-access` disables only Codex's *inner* sandbox. It
+> does **not** remove the outer OpenAB container/VM isolation. The agent remains
+> confined by the runtime's own security boundary.
+
 ### Imagegen appears to hang
 
 Check whether an image was generated even if the CLI has not returned yet:

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -261,14 +261,7 @@ This commonly happens in OpenAB deployments where Codex already runs inside an
 isolated container or VM — the outer runtime provides the desired isolation, so
 the inner sandbox is redundant.
 
-**Option 1 — Install bubblewrap in the image** (keeps inner sandbox active):
-
-```dockerfile
-# Dockerfile.codex
-RUN apt-get update && apt-get install -y bubblewrap && rm -rf /var/lib/apt/lists/*
-```
-
-**Option 2 — Disable Codex's inner sandbox** (recommended when the outer OpenAB
+**Solution — Disable Codex's inner sandbox** (recommended when the outer OpenAB
 runtime already provides isolation):
 
 ```toml


### PR DESCRIPTION
## Summary

Codex's Linux sandbox relies on `bubblewrap` (`bwrap`) for inner namespace isolation. This PR:

1. **Installs `bubblewrap` in `Dockerfile.codex`** — aligns with `Dockerfile.claude` which already includes it. The official OpenAB Codex image now ships with `bwrap` out of the box.

2. **Documents how to disable the inner sandbox** — for users who prefer not to use it (e.g., when the outer OpenAB runtime already provides container/VM isolation), the troubleshooting section in `docs/codex.md` explains how to set `sandbox_mode = "danger-full-access"` via config.toml, CLI flag, or Helm values.

The inner sandbox is available by default but not mandatory. Users can opt out with a config change.

## Changes

- `Dockerfile.codex`: add `bubblewrap` to apt-get install
- `docs/codex.md`: add troubleshooting entry for `bubblewrap is unavailable` with disable instructions

## What was tested

- Verified Dockerfile syntax
- Confirmed docs render correctly

Closes #908

https://discord.com/channels/1491295327620169908/1491365150664560881/1508104743560417371