### PR TITLE
fix(pi): bump pi-coding-agent to 0.75.5

### DIFF
--- a/Dockerfile.pi
+++ b/Dockerfile.pi
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # Install pi-acp adapter and Pi coding agent CLI.
 # The Pi coding agent npm package was renamed from @mariozechner/pi-coding-agent to @earendil-works/pi-coding-agent.
 ARG PI_ACP_VERSION=0.0.27
-ARG PI_CODING_AGENT_VERSION=0.75.4
+ARG PI_CODING_AGENT_VERSION=0.75.5
 RUN npm install -g pi-acp@${PI_ACP_VERSION} @earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION} --retry 3
 
 # Install gh CLI (matches other Dockerfiles)


### PR DESCRIPTION
Bumps `@earendil-works/pi-coding-agent` from 0.75.4 to 0.75.5 in `Dockerfile.pi`.

The current 0.75.4 causes `Cannot call write after a stream was destroyed` errors when used with `pi-acp`. Version 0.75.5 is the latest stable release.