### PR TITLE
feat(relay): cross-channel relay marker (Slack ↔ Discord)

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -137,6 +137,10 @@ tables = "code"  # "code" (default) | "bullets" | "off"
 [reactions]
 enabled = true
 remove_after_reply = false
+tool_display = "none"   # none (default) | compact | full
+                        # none: hide tool calls — only the final agent reply is shown
+                        # compact: one-line count summary, e.g. ✅ 3 · 🔧 1 tool(s)
+                        # full: every tool call rendered inline (verbose; useful for debugging)
 
 [reactions.emojis]
 queued = "👀"

--- a/config.toml.example
+++ b/config.toml.example
@@ -179,3 +179,20 @@ error_hold_ms = 2500
 # schedule = "0 0 * * 0"
 # channel = "123456789"
 # message = "generate weekly status report"
+
+# --- Cross-channel relay (Slack ↔ Discord) ---
+# When enabled, agents can emit a `<<openab-relay-to {platform}:{alias}>> ...
+# <<openab-relay-end>>` block in their response, and OpenAB forwards the body
+# to the configured peer adapter. Disabled by default — no behaviour change
+# unless explicitly enabled. Spec: AI-Memory/shared/proposals/2026-05-26-
+# openab-cross-channel-relay.md.
+
+# [relay]
+# enabled = false                              # master switch
+# prefix_template = "[via {sender_persona} from {sender_platform}]"
+#                                              # auto-prepended to relayed body; max 200 bytes
+#                                              # supported substitutions: {sender_persona}, {sender_platform}
+
+# [relay.aliases]
+# "discord:swat-team" = { channel_id = "1485156316480803018" }
+# "slack:tifa-dm"     = { channel_id = "D0B4JKKM9PD" }

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -178,7 +178,7 @@ Emoji reaction feedback on messages to show agent processing status.
 |-----|------|---------|-------------|
 | `enabled` | bool | `true` | Enable/disable reaction feedback. |
 | `remove_after_reply` | bool | `false` | Remove the status reaction after the agent replies. |
-| `tool_display` | string | `"full"` | How tool calls are rendered: `"full"` (complete title), `"compact"` (count summary, e.g. `✅ 3 · 🔧 1 tool(s)`), or `"none"` (hidden). |
+| `tool_display` | string | `"none"` | How tool calls are rendered: `"none"` (hidden — recommended for chat UIs), `"compact"` (count summary, e.g. `✅ 3 · 🔧 1 tool(s)`), or `"full"` (complete title — useful for debugging). |
 
 ### `[reactions.emojis]`
 

--- a/docs/tool-display.md
+++ b/docs/tool-display.md
@@ -6,7 +6,7 @@ Control how tool calls are rendered in chat messages during agent responses.
 
 ```toml
 [reactions]
-tool_display = "full"   # full | compact | none
+tool_display = "none"   # full | compact | none (default: none)
 ```
 
 ### Helm
@@ -15,12 +15,12 @@ tool_display = "full"   # full | compact | none
 agents:
   kiro:
     reactions:
-      toolDisplay: "full"   # full | compact | none
+      toolDisplay: "none"   # full | compact | none (default: none)
 ```
 
 ## Modes
 
-### `full` (default)
+### `full`
 
 Shows each tool call with its complete title. When more than 3 tools finish, they collapse into a count summary automatically.
 
@@ -46,7 +46,7 @@ Agent response text here...
 
 Best for: everyday use, public channels, mobile.
 
-### `none`
+### `none` (default)
 
 Hides tool lines entirely. Only the final agent response is shown. Reaction emojis (🔧→✅) still work, so you can tell the agent is busy.
 
@@ -66,6 +66,6 @@ Best for: clean output when you only care about the final answer.
 
 ## Notes
 
-- **Default**: `full` shows complete tool titles. Use `tool_display = "compact"` for a cleaner count-only summary, or `"none"` to hide tools entirely.
+- **Default**: `none` — tool calls hidden, only the final response is shown. Reaction emojis still surface progress (🔧→✅). Set `tool_display = "compact"` for a count-only summary, or `"full"` to show every tool call inline (useful for debugging).
 - **Reaction emojis are independent**: The emoji reactions on messages (👀→🤔→🔧→🆗) work regardless of `tool_display` setting.
 - **Streaming behavior**: In `compact` mode, the count updates in real-time as tools start and finish. In `full` mode, individual tool lines appear and update during streaming.

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -269,7 +269,12 @@ impl AcpConnection {
         cmd.args(args)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
+            // Capture stderr so cold-start init hangs are debuggable. Without this
+            // the agent's startup errors (missing env, MCP probe failures, auth
+            // issues) silently disappear into /dev/null and the only signal is a
+            // 90s timeout on initialize. A drainer task below logs each line at
+            // WARN so it surfaces in the bridge log alongside spawn events.
+            .stderr(std::process::Stdio::piped())
             .current_dir(working_dir);
         // Create a new process group so we can kill the entire tree.
         // SAFETY: setpgid is async-signal-safe (POSIX.1-2008) and called
@@ -353,6 +358,32 @@ impl AcpConnection {
 
         let stdout = proc.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
         let stdin = proc.stdin.take().ok_or_else(|| anyhow!("no stdin"))?;
+        // Drain stderr line-by-line so the pipe buffer doesn't fill and block
+        // the child. Each non-empty line goes to WARN — agent stderr should be
+        // rare in steady state, so volume isn't a concern. EOF (Ok(0)) breaks
+        // the loop and lets the task drop cleanly when the child exits.
+        if let Some(stderr) = proc.stderr.take() {
+            tokio::spawn(async move {
+                let mut reader = BufReader::new(stderr);
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    match reader.read_line(&mut line).await {
+                        Ok(0) => break,
+                        Ok(_) => {
+                            let trimmed = line.trim_end();
+                            if !trimmed.is_empty() {
+                                tracing::warn!(child_stderr = %trimmed, "agent stderr");
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "agent stderr read failed");
+                            break;
+                        }
+                    }
+                }
+            });
+        }
         let stdin = Arc::new(Mutex::new(stdin));
 
         let pending: Arc<Mutex<HashMap<u64, oneshot::Sender<JsonRpcMessage>>>> =

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -406,7 +406,17 @@ impl AcpConnection {
 
         self.send_raw(&data).await?;
 
-        let timeout_secs = if method == "session/new" { 120 } else { 30 };
+        // session/new and initialize both involve heavyweight startup: initialize spins up
+        // the agent's runtime + auth + MCP server probes (can take 30-60s on a cold first run),
+        // session/new triggers Claude's full session bootstrap (120s is empirically sufficient).
+        // The default 30s for initialize was too tight — agents on first DM after a long
+        // idle window consistently timed out. Bumped to 90s to cover cold-start latency
+        // with headroom for slow networks.
+        let timeout_secs = match method {
+            "session/new" => 120,
+            "initialize" => 90,
+            _ => 30,
+        };
         let resp = tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), rx)
             .await
             .map_err(|_| anyhow!("timeout waiting for {method} response"))?

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -198,6 +198,14 @@ pub enum AcpEvent {
         options: Vec<ConfigOption>,
     },
     Status,
+    UsageUpdate {
+        used: u64,
+        size: u64,
+        // cost_usd is captured from ACP for future USD-display feature
+        // (Tifa proposal step 6). Currently not displayed.
+        #[allow(dead_code)]
+        cost_usd: Option<f64>,
+    },
 }
 
 pub fn classify_notification(msg: &JsonRpcMessage) -> Option<AcpEvent> {
@@ -257,6 +265,19 @@ pub fn classify_notification(msg: &JsonRpcMessage) -> Option<AcpEvent> {
         "config_option_update" => {
             let options = parse_config_options(update);
             Some(AcpEvent::ConfigUpdate { options })
+        }
+        "usage_update" => {
+            let used = update.get("used")?.as_u64()?;
+            let size = update.get("size")?.as_u64()?;
+            let cost_usd = update
+                .get("cost")
+                .and_then(|c| c.get("amount"))
+                .and_then(|a| a.as_f64());
+            Some(AcpEvent::UsageUpdate {
+                used,
+                size,
+                cost_usd,
+            })
         }
         _ => None,
     }
@@ -381,5 +402,59 @@ mod tests {
         let opts = parse_config_options(&result);
         assert_eq!(opts.len(), 1);
         assert_eq!(opts[0].id, "model");
+    }
+
+    #[test]
+    fn classify_usage_update() {
+        let msg = JsonRpcMessage {
+            id: None,
+            method: Some("session/update".into()),
+            params: Some(json!({
+                "sessionId": "abc",
+                "update": {
+                    "sessionUpdate": "usage_update",
+                    "used": 70679,
+                    "size": 1000000,
+                    "cost": {"amount": 1.477, "currency": "USD"}
+                }
+            })),
+            result: None,
+            error: None,
+        };
+        match classify_notification(&msg) {
+            Some(AcpEvent::UsageUpdate { used, size, cost_usd }) => {
+                assert_eq!(used, 70679);
+                assert_eq!(size, 1000000);
+                assert_eq!(cost_usd, Some(1.477));
+            }
+            other => panic!("expected UsageUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_usage_update_without_cost() {
+        // Early usage_update events arrive without cost; should still parse.
+        let msg = JsonRpcMessage {
+            id: None,
+            method: Some("session/update".into()),
+            params: Some(json!({
+                "sessionId": "abc",
+                "update": {
+                    "sessionUpdate": "usage_update",
+                    "used": 1000,
+                    "size": 1000000
+                }
+            })),
+            result: None,
+            error: None,
+        };
+        match classify_notification(&msg) {
+            Some(AcpEvent::UsageUpdate { used, size, cost_usd }) => {
+                assert_eq!(used, 1000);
+                assert_eq!(size, 1000000);
+                assert_eq!(cost_usd, None);
+            }
+            other => panic!("expected UsageUpdate, got {other:?}"),
+        }
     }
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -477,6 +477,9 @@ impl AdapterRouter {
 
                     let mut text_buf = String::new();
                     let mut tool_lines: Vec<ToolEntry> = Vec::new();
+                    // Track the latest usage_update for this prompt; used to
+                    // append a context-usage footer to the final reply (Slack only).
+                    let mut latest_usage: Option<(u64, u64)> = None;
 
                     if reset {
                         text_buf.push_str("⚠️ _Session expired, starting fresh..._\n\n");
@@ -638,6 +641,9 @@ impl AdapterRouter {
                                 AcpEvent::ConfigUpdate { options } => {
                                     conn.config_options = options;
                                 }
+                                AcpEvent::UsageUpdate { used, size, .. } => {
+                                    latest_usage = Some((used, size));
+                                }
                                 _ => {}
                             }
                         }
@@ -669,6 +675,19 @@ impl AdapterRouter {
                     };
 
                     let final_content = markdown::convert_tables(&final_content, table_mode);
+
+                    // Append context-usage footer (Slack only, threshold-gated).
+                    // Per 2026-05-25-openab-context-usage-footer.md proposal.
+                    let final_content = if let Some((used, size)) = latest_usage {
+                        let threshold = context_footer_threshold();
+                        match format_context_footer(adapter.platform(), used, size, threshold) {
+                            Some(footer) => format!("{final_content}\n\n{footer}"),
+                            None => final_content,
+                        }
+                    } else {
+                        final_content
+                    };
+
                     let chunks = format::split_message(&final_content, message_limit);
                     if let Some(msg) = placeholder_msg {
                         if let Some(ref reply_id) = directives.reply_to {
@@ -870,6 +889,62 @@ fn compose_display(
     out
 }
 
+/// Format the context-usage footer per the 2026-05-25 OpenAB proposal.
+///
+/// Returns `None` when usage is below `threshold_pct`, or when called with
+/// non-Slack platform (Discord etc. have their own proposal track).
+///
+/// Returned string is a single italics line (Slack mrkdwn `_..._`) intended
+/// to be appended to the final message body with `\n\n` separator.
+pub(crate) fn format_context_footer(
+    platform: &str,
+    used: u64,
+    size: u64,
+    threshold_pct: u8,
+) -> Option<String> {
+    if platform != "slack" {
+        return None;
+    }
+    if size == 0 {
+        return None;
+    }
+    let pct = (used as f64 / size as f64 * 100.0).round() as u64;
+    if pct < threshold_pct as u64 {
+        return None;
+    }
+    Some(format!(
+        "_⚠ ctx: {pct}% ({used}/{size})_",
+        used = format_token_count(used),
+        size = format_token_count(size),
+    ))
+}
+
+/// Format a token count compactly: 84231 → "84k", 1_000_000 → "1M".
+fn format_token_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        let m = n as f64 / 1_000_000.0;
+        if (m - m.round()).abs() < 0.05 {
+            format!("{}M", m.round() as u64)
+        } else {
+            format!("{m:.1}M")
+        }
+    } else if n >= 1_000 {
+        format!("{}k", (n as f64 / 1_000.0).round() as u64)
+    } else {
+        format!("{n}")
+    }
+}
+
+/// Read `OPENAB_CTX_FOOTER_MIN_PCT` env var, default 70.
+/// Setting `100` disables the footer entirely. Setting `0` enables always-show.
+pub(crate) fn context_footer_threshold() -> u8 {
+    std::env::var("OPENAB_CTX_FOOTER_MIN_PCT")
+        .ok()
+        .and_then(|s| s.parse::<u8>().ok())
+        .filter(|&v| v <= 100)
+        .unwrap_or(70)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1038,6 +1113,48 @@ mod tests {
         )];
         let out = compose_display(&tools, "response text", false, ToolDisplay::None);
         assert_eq!(out, "response text");
+    }
+
+    #[test]
+    fn context_footer_skips_below_threshold() {
+        // 69% on a 1M window with default 70 threshold → no footer.
+        assert!(format_context_footer("slack", 690_000, 1_000_000, 70).is_none());
+    }
+
+    #[test]
+    fn context_footer_appears_at_or_above_threshold() {
+        let out = format_context_footer("slack", 780_000, 1_000_000, 70).unwrap();
+        assert!(out.starts_with("_⚠ ctx: 78%"));
+        assert!(out.contains("(780k/1M)"));
+        assert!(out.ends_with("_"));
+    }
+
+    #[test]
+    fn context_footer_skipped_for_non_slack() {
+        // Proposal scope is Slack only; Discord gets its own track later.
+        assert!(format_context_footer("discord", 900_000, 1_000_000, 70).is_none());
+    }
+
+    #[test]
+    fn context_footer_handles_zero_size_gracefully() {
+        // Defensive: don't divide by zero if ACP ever sends size=0.
+        assert!(format_context_footer("slack", 1000, 0, 70).is_none());
+    }
+
+    #[test]
+    fn context_footer_threshold_zero_always_shows() {
+        // Edge case: threshold=0 means show even at low usage.
+        assert!(format_context_footer("slack", 1000, 1_000_000, 0).is_some());
+    }
+
+    #[test]
+    fn format_token_count_compact() {
+        assert_eq!(format_token_count(999), "999");
+        assert_eq!(format_token_count(1_000), "1k");
+        assert_eq!(format_token_count(84_231), "84k");
+        assert_eq!(format_token_count(999_999), "1000k");
+        assert_eq!(format_token_count(1_000_000), "1M");
+        assert_eq!(format_token_count(1_500_000), "1.5M");
     }
 }
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,6 +1,7 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::sync::Arc;
 use tracing::{error, warn};
 
@@ -10,6 +11,7 @@ use crate::error_display::{format_coded_error, format_user_error};
 use crate::format;
 use crate::markdown::{self, TableMode};
 use crate::reactions::StatusReactionController;
+use crate::relay::{self, RelayContext, RelayDirective};
 
 // --- Output directive parsing ---
 
@@ -273,6 +275,8 @@ pub struct AdapterRouter {
     prompt_hard_timeout: std::time::Duration,
     /// Polling cadence for the recv-loop liveness check (#732).
     liveness_check_interval: std::time::Duration,
+    /// Cross-channel relay registry. `None` = relay disabled or not configured.
+    relay_ctx: Option<Arc<RelayContext>>,
 }
 
 impl AdapterRouter {
@@ -282,6 +286,7 @@ impl AdapterRouter {
         table_mode: TableMode,
         prompt_hard_timeout_secs: u64,
         liveness_check_secs: u64,
+        relay_ctx: Option<Arc<RelayContext>>,
     ) -> Self {
         if liveness_check_secs >= prompt_hard_timeout_secs {
             warn!(
@@ -298,7 +303,17 @@ impl AdapterRouter {
             table_mode,
             prompt_hard_timeout: std::time::Duration::from_secs(prompt_hard_timeout_secs),
             liveness_check_interval: std::time::Duration::from_secs(liveness_check_secs),
+            relay_ctx,
         }
+    }
+
+    /// Cheap relay-enabled check. Called once before the receive loop and
+    /// hoisted into a local bool so the hot streaming path doesn't re-read
+    /// the Arc on every text chunk.
+    fn relay_enabled(&self) -> bool {
+        self.relay_ctx
+            .as_ref()
+            .is_some_and(|c| c.config.enabled)
     }
 
     /// Access the underlying session pool (e.g. for config option queries).
@@ -464,6 +479,10 @@ impl AdapterRouter {
         let tool_display = self.reactions_config.tool_display;
         let prompt_hard_timeout = self.prompt_hard_timeout;
         let liveness_check_interval = self.liveness_check_interval;
+        // Hoist relay state into the closure: bool for the hot streaming path,
+        // Arc<RelayContext> for the post-stream dispatch path.
+        let relay_enabled = self.relay_enabled();
+        let relay_ctx = self.relay_ctx.clone();
 
         self.pool
             .with_connection(thread_key, |conn| {
@@ -577,10 +596,10 @@ impl AdapterRouter {
                                 AcpEvent::Text(t) => {
                                     text_buf.push_str(&t);
                                     if let Some(tx) = &buf_tx {
-                                        let _ = tx.send(compose_display(
+                                        let _ = tx.send(compose_streaming_display(
                                             &tool_lines,
                                             &text_buf,
-                                            true,
+                                            relay_enabled,
                                             tool_display,
                                         ));
                                     }
@@ -602,10 +621,10 @@ impl AdapterRouter {
                                         });
                                     }
                                     if let Some(tx) = &buf_tx {
-                                        let _ = tx.send(compose_display(
+                                        let _ = tx.send(compose_streaming_display(
                                             &tool_lines,
                                             &text_buf,
-                                            true,
+                                            relay_enabled,
                                             tool_display,
                                         ));
                                     }
@@ -630,10 +649,10 @@ impl AdapterRouter {
                                         });
                                     }
                                     if let Some(tx) = &buf_tx {
-                                        let _ = tx.send(compose_display(
+                                        let _ = tx.send(compose_streaming_display(
                                             &tool_lines,
                                             &text_buf,
-                                            true,
+                                            relay_enabled,
                                             tool_display,
                                         ));
                                     }
@@ -658,6 +677,63 @@ impl AdapterRouter {
                     // before tool lines are composed into the display output.
                     let (directives, stripped_text) = parse_output_directives(&text_buf);
                     let text_buf = stripped_text;
+
+                    // Cross-channel relay extraction. Runs on raw agent text BEFORE
+                    // compose_display + split_message. Tool-display lines never enter
+                    // relay parsing. See AI-Memory/shared/proposals/2026-05-26-openab-
+                    // cross-channel-relay.md for the full spec.
+                    let text_buf = if let Some(ctx) = relay_ctx
+                        .as_ref()
+                        .filter(|c| c.config.enabled)
+                    {
+                        let result = relay::extract_relay_blocks(&text_buf);
+
+                        if !result.errors.is_empty() {
+                            reactions.set_error().await;
+                            let detail = result
+                                .errors
+                                .iter()
+                                .map(|e| format!("- {e:?}"))
+                                .collect::<Vec<_>>()
+                                .join("\n");
+                            let _ = adapter
+                                .send_message(
+                                    &thread_channel,
+                                    &format!("⚠️ relay parse error(s):\n{detail}"),
+                                )
+                                .await;
+                        }
+
+                        for block in &result.directives {
+                            if let Err(e) = dispatch_relay_block(
+                                ctx,
+                                &adapter,
+                                &thread_channel,
+                                block,
+                            )
+                            .await
+                            {
+                                warn!(
+                                    error = ?e,
+                                    target = %format!("{}:{}", block.target_platform, block.target_alias),
+                                    "relay dispatch failed"
+                                );
+                                let _ = adapter
+                                    .send_message(
+                                        &thread_channel,
+                                        &format!(
+                                            "⚠️ relay to `{}:{}` failed: {}",
+                                            block.target_platform, block.target_alias, e
+                                        ),
+                                    )
+                                    .await;
+                            }
+                        }
+
+                        result.residual
+                    } else {
+                        text_buf
+                    };
 
                     // Build final content
                     let final_content =
@@ -796,6 +872,26 @@ impl ToolEntry {
 /// Maximum number of finished tool entries to show individually
 /// during streaming before collapsing into a summary line.
 const TOOL_COLLAPSE_THRESHOLD: usize = 3;
+
+/// Streaming-time wrapper around `compose_display`. Masks in-progress relay
+/// blocks from the placeholder edit loop when relay is enabled. Pure
+/// fast-path (`Cow::Borrowed`) when disabled or text has no opener marker.
+///
+/// Centralized so all 3 streaming call sites (`Text`, `ToolStart`, `ToolDone`
+/// arms) route through it — otherwise a relay block can leak via tool events.
+fn compose_streaming_display(
+    tool_lines: &[ToolEntry],
+    text_buf: &str,
+    relay_enabled: bool,
+    tool_display: ToolDisplay,
+) -> String {
+    let masked: Cow<'_, str> = if relay_enabled {
+        relay::mask_streaming_relay_blocks(text_buf)
+    } else {
+        Cow::Borrowed(text_buf)
+    };
+    compose_display(tool_lines, &masked, true, tool_display)
+}
 
 fn compose_display(
     tool_lines: &[ToolEntry],
@@ -943,6 +1039,65 @@ pub(crate) fn context_footer_threshold() -> u8 {
         .and_then(|s| s.parse::<u8>().ok())
         .filter(|&v| v <= 100)
         .unwrap_or(70)
+}
+
+/// Forward a single relay block to its peer adapter. Caller (the post-stream
+/// hook in `stream_prompt_blocks`) handles error reporting back to the origin
+/// channel.
+async fn dispatch_relay_block(
+    ctx: &RelayContext,
+    origin_adapter: &Arc<dyn ChatAdapter>,
+    _origin_channel: &ChannelRef,
+    block: &RelayDirective,
+) -> Result<()> {
+    let alias_key = format!("{}:{}", block.target_platform, block.target_alias);
+    let alias = ctx
+        .config
+        .aliases
+        .get(&alias_key)
+        .ok_or_else(|| anyhow!("unknown relay alias: {}", alias_key))?;
+
+    let peer = ctx
+        .peer(&block.target_platform)
+        .ok_or_else(|| anyhow!("no peer adapter for platform: {}", block.target_platform))?;
+
+    if relay::contains_relay_marker(&block.body) {
+        return Err(anyhow!(
+            "loop-guard: relayed body still contains relay marker"
+        ));
+    }
+
+    let persona = std::env::var("OPENAB_PERSONA_ID").unwrap_or_else(|_| "unknown".to_string());
+    let formatted = relay::format_relay_body(
+        &ctx.config.prefix_template,
+        &persona,
+        origin_adapter.platform(),
+        &block.body,
+    );
+
+    // Security: strip file-send markers from relay bodies. Slack's send_message
+    // extracts and uploads file-send markers (slack.rs:620); a relayed body
+    // containing `<<openab-send-file /path>>` would silently upload when
+    // targeting Slack. Stripped uniformly for audit consistency.
+    let formatted = relay::strip_file_send_markers(&formatted);
+
+    let target = ChannelRef {
+        platform: block.target_platform.clone(),
+        channel_id: alias.channel_id.clone(),
+        thread_id: None,
+        parent_id: None,
+        origin_event_id: None,
+    };
+
+    // Peer-side splitting. Adapters' send_message does NOT split internally
+    // (split is normally done by AdapterRouter before adapter.send_message).
+    // Since relay bypasses that path, we split here using the peer's own
+    // message_limit. Loop send_message over chunks.
+    let chunks = format::split_message(&formatted, peer.message_limit());
+    for chunk in &chunks {
+        peer.send_message(&target, chunk).await?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -375,9 +375,9 @@ fn default_cron_timezone() -> String {
 /// - `none`: hide tool lines entirely, only show final response
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ToolDisplay {
-    #[default]
     Full,
     Compact,
+    #[default]
     None,
 }
 
@@ -789,8 +789,8 @@ command = "echo"
     }
 
     #[test]
-    fn tool_display_default_is_full() {
-        assert_eq!(ToolDisplay::default(), ToolDisplay::Full);
+    fn tool_display_default_is_none() {
+        assert_eq!(ToolDisplay::default(), ToolDisplay::None);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,6 +81,8 @@ pub struct Config {
     pub markdown: MarkdownConfig,
     #[serde(default)]
     pub cron: CronConfig,
+    #[serde(default)]
+    pub relay: Option<crate::relay::RelayConfig>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -722,24 +722,38 @@ impl EventHandler for Handler {
                     debug!(url = %attachment.url, filename = %attachment.filename, "adding image attachment");
                     extra_blocks.push(block);
                 }
-            } else if let Some(block) = media::download_to_disk(
-                &attachment.url,
-                &attachment.filename,
-                mime,
-                u64::from(attachment.size),
-                None,
-                &msg.id.to_string(),
-            ).await {
-                debug!(url = %attachment.url, filename = %attachment.filename, "adding file attachment via disk path");
-                extra_blocks.push(block);
-            } else if media::is_video_file(&attachment.filename, attachment.content_type.as_deref()) {
-                debug!(url = %attachment.url, filename = %attachment.filename, "adding video attachment link");
-                extra_blocks.push(video_attachment_block(
-                    &attachment.filename,
-                    attachment.content_type.as_deref(),
-                    u64::from(attachment.size),
+            } else {
+                // Fallback for unhandled types (video, PDF, Office docs, archives, generic
+                // binary): try disk download first so the agent gets a local path. If that
+                // fails AND the file is a video, fall back to the URL-pass-through block —
+                // Discord CDN URLs are signed and don't need Bearer auth, so they're still
+                // usable. Anything else with a failed disk write is silently dropped (matches
+                // upstream behavior pre-disk-fallback).
+                match media::download_to_disk(
                     &attachment.url,
-                ));
+                    &attachment.filename,
+                    mime,
+                    u64::from(attachment.size),
+                    None,
+                    &msg.id.to_string(),
+                )
+                .await
+                {
+                    Some(block) => {
+                        debug!(url = %attachment.url, filename = %attachment.filename, "adding file attachment via disk path");
+                        extra_blocks.push(block);
+                    }
+                    None if media::is_video_file(&attachment.filename, attachment.content_type.as_deref()) => {
+                        debug!(url = %attachment.url, filename = %attachment.filename, "disk write failed, falling back to video URL block");
+                        extra_blocks.push(video_attachment_block(
+                            &attachment.filename,
+                            attachment.content_type.as_deref(),
+                            u64::from(attachment.size),
+                            &attachment.url,
+                        ));
+                    }
+                    None => {}
+                }
             }
         }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -711,16 +711,26 @@ impl EventHandler for Handler {
                     debug!(filename = %attachment.filename, "adding text file attachment");
                     extra_blocks.push(block);
                 }
-            } else if let Some(block) = media::download_and_encode_image(
+            } else if mime.starts_with("image/") {
+                if let Some(block) = media::download_and_encode_image(
+                    &attachment.url,
+                    attachment.content_type.as_deref(),
+                    &attachment.filename,
+                    u64::from(attachment.size),
+                    None,
+                ).await {
+                    debug!(url = %attachment.url, filename = %attachment.filename, "adding image attachment");
+                    extra_blocks.push(block);
+                }
+            } else if let Some(block) = media::download_to_disk(
                 &attachment.url,
-                attachment.content_type.as_deref(),
                 &attachment.filename,
+                mime,
                 u64::from(attachment.size),
                 None,
-            )
-            .await
-            {
-                debug!(url = %attachment.url, filename = %attachment.filename, "adding image attachment");
+                &msg.id.to_string(),
+            ).await {
+                debug!(url = %attachment.url, filename = %attachment.filename, "adding file attachment via disk path");
                 extra_blocks.push(block);
             } else if media::is_video_file(&attachment.filename, attachment.content_type.as_deref()) {
                 debug!(url = %attachment.url, filename = %attachment.filename, "adding video attachment link");

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1074,6 +1074,7 @@ mod tests {
             crate::markdown::TableMode::Off,
             crate::config::default_prompt_hard_timeout_secs(),
             crate::config::default_liveness_check_secs(),
+            None,
         ));
         Dispatcher::with_idle_timeout(router, 10, 24_000, grouping, DEFAULT_CONSUMER_IDLE_TIMEOUT)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,13 +145,15 @@ async fn main() -> anyhow::Result<()> {
         info!(model = %cfg.stt.model, base_url = %cfg.stt.base_url, "STT enabled");
     }
 
-    let router = Arc::new(AdapterRouter::new(
-        pool.clone(),
-        cfg.reactions,
-        cfg.markdown.tables,
-        cfg.pool.prompt_hard_timeout_secs,
-        cfg.pool.liveness_check_secs,
-    ));
+    // Take relay config out of cfg now (before adapters are built) so we can
+    // validate it early. Actual RelayContext construction is deferred until
+    // shared_*_adapter handles exist (a few dozen lines below).
+    let relay_cfg: Option<relay::RelayConfig> = cfg.relay.take();
+    if let Some(ref rc) = relay_cfg {
+        if let Err(e) = rc.validate() {
+            anyhow::bail!("invalid [relay] config: {e}");
+        }
+    }
 
     // Shutdown signal for Slack adapter
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -191,6 +193,38 @@ async fn main() -> anyhow::Result<()> {
             s.allow_bot_messages,
         ))
     });
+
+    // Build cross-channel relay context. Peers stored as Weak refs to avoid
+    // cross-adapter Arc cycles. Only platforms with a shared adapter handle
+    // are registered as peers.
+    let relay_ctx: Option<Arc<relay::RelayContext>> = relay_cfg
+        .filter(|c| c.enabled)
+        .map(|cfg_inner| {
+            let mut peers: std::collections::HashMap<String, std::sync::Weak<dyn adapter::ChatAdapter>> =
+                std::collections::HashMap::new();
+            if let Some(ref s) = shared_slack_adapter {
+                let s_dyn: Arc<dyn adapter::ChatAdapter> = s.clone();
+                peers.insert("slack".to_string(), Arc::downgrade(&s_dyn));
+            }
+            if let Some(ref d) = shared_discord_adapter {
+                peers.insert("discord".to_string(), Arc::downgrade(d));
+            }
+            info!(peers = peers.len(), "relay enabled");
+            Arc::new(relay::RelayContext {
+                config: Arc::new(cfg_inner),
+                peers,
+            })
+        });
+
+    // Now we can build the AdapterRouter (needs relay_ctx).
+    let router = Arc::new(AdapterRouter::new(
+        pool.clone(),
+        cfg.reactions.clone(),
+        cfg.markdown.tables,
+        cfg.pool.prompt_hard_timeout_secs,
+        cfg.pool.liveness_check_secs,
+        relay_ctx,
+    ));
 
     // Validate cronjob config at startup (fail-fast on bad cron expressions or timezones)
     let mut configured_platforms: Vec<&str> = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod gateway;
 mod markdown;
 mod media;
 mod reactions;
+mod relay;
 mod remind;
 mod setup;
 mod slack;

--- a/src/media.rs
+++ b/src/media.rs
@@ -357,6 +357,29 @@ fn sanitize_path_component(s: &str) -> String {
     }
 }
 
+/// Default per-file size cap when `OPENAB_ATTACHMENTS_MAX_MB` is unset.
+const ATTACHMENT_DEFAULT_MAX_MB: u64 = 200;
+
+/// Default attachments directory when `OPENAB_ATTACHMENTS_DIR` is unset.
+const ATTACHMENT_DEFAULT_DIR: &str = "/tmp/openab-attachments";
+
+/// Resolve the max attachment size in bytes, honoring `OPENAB_ATTACHMENTS_MAX_MB`.
+fn attachments_max_bytes() -> u64 {
+    std::env::var("OPENAB_ATTACHMENTS_MAX_MB")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(ATTACHMENT_DEFAULT_MAX_MB)
+        * 1024
+        * 1024
+}
+
+/// Resolve the configured attachments base directory.
+fn attachments_base_dir() -> std::path::PathBuf {
+    std::env::var("OPENAB_ATTACHMENTS_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from(ATTACHMENT_DEFAULT_DIR))
+}
+
 /// Download an arbitrary attachment to disk and return a ContentBlock::Text
 /// referencing the on-disk path. This is the fallback for files that are
 /// neither audio (handled by STT), nor inlineable text, nor images.
@@ -364,7 +387,14 @@ fn sanitize_path_component(s: &str) -> String {
 /// `bucket_id` is a stable per-message id (Slack `ts`, Discord message id).
 /// Files end up at `${OPENAB_ATTACHMENTS_DIR:-/tmp/openab-attachments}/<bucket>/<filename>`.
 ///
-/// Returns None on download/write failure or when size exceeds 200MB.
+/// Size cap: `OPENAB_ATTACHMENTS_MAX_MB` (default 200 MB).
+///
+/// Path containment: after building the target path, we canonicalize both the
+/// base dir and the target dir and verify the target stays under base. This
+/// guards against pathological filenames slipping past `sanitize_path_component`
+/// (e.g. via symlinks introduced into the base dir out-of-band).
+///
+/// Returns None on download/write failure, oversized files, or containment violation.
 pub async fn download_to_disk(
     url: &str,
     filename: &str,
@@ -373,27 +403,52 @@ pub async fn download_to_disk(
     auth_token: Option<&str>,
     bucket_id: &str,
 ) -> Option<ContentBlock> {
-    const MAX_SIZE: u64 = 200 * 1024 * 1024; // 200 MB
+    let max_size = attachments_max_bytes();
 
     if url.is_empty() {
         return None;
     }
-    if size > 0 && size > MAX_SIZE {
-        tracing::warn!(filename, size, "attachment exceeds 200MB limit, skipping");
+    if size > 0 && size > max_size {
+        tracing::warn!(filename, size, max = max_size, "attachment exceeds size limit, skipping");
         return None;
     }
 
-    let base = std::env::var("OPENAB_ATTACHMENTS_DIR")
-        .unwrap_or_else(|_| "/tmp/openab-attachments".to_string());
+    let base = attachments_base_dir();
     let safe_bucket = sanitize_path_component(bucket_id);
     let safe_name = sanitize_path_component(filename);
-    let target_dir = std::path::PathBuf::from(&base).join(&safe_bucket);
+    let target_dir = base.join(&safe_bucket);
 
     if let Err(e) = tokio::fs::create_dir_all(&target_dir).await {
         tracing::error!(?target_dir, error = %e, "failed to create attachment dir");
         return None;
     }
-    let target_path = target_dir.join(&safe_name);
+
+    // Path containment check: after the dir exists, canonicalize and verify
+    // the target_dir is still under base. Symlinks or `..` in env-provided
+    // base resolve here. We canonicalize base too so both sides are absolute.
+    let canonical_base = match tokio::fs::canonicalize(&base).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(?base, error = %e, "failed to canonicalize attachments base dir");
+            return None;
+        }
+    };
+    let canonical_target_dir = match tokio::fs::canonicalize(&target_dir).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(?target_dir, error = %e, "failed to canonicalize target dir");
+            return None;
+        }
+    };
+    if !canonical_target_dir.starts_with(&canonical_base) {
+        tracing::error!(
+            ?canonical_base,
+            ?canonical_target_dir,
+            "path containment violation, refusing to write"
+        );
+        return None;
+    }
+    let target_path = canonical_target_dir.join(&safe_name);
 
     let mut req = HTTP_CLIENT.get(url);
     if let Some(token) = auth_token {
@@ -417,8 +472,8 @@ pub async fn download_to_disk(
             return None;
         }
     };
-    if bytes.len() as u64 > MAX_SIZE {
-        tracing::error!(filename, size = bytes.len(), "downloaded attachment exceeds 200MB limit");
+    if bytes.len() as u64 > max_size {
+        tracing::error!(filename, size = bytes.len(), max = max_size, "downloaded attachment exceeds size limit");
         return None;
     }
 
@@ -543,4 +598,35 @@ mod tests {
         assert!(is_video_file("clip.MOV", None));
         assert!(!is_video_file("notes.txt", Some("text/plain")));
     }
+
+    #[test]
+    fn sanitize_strips_path_separators_and_control_chars() {
+        // `/` and `\` become `_`. Leading `..` is trimmed (dot-trim), so
+        // `../etc/passwd` -> `.._etc_passwd` -> `_etc_passwd`. The leading
+        // underscore is acceptable: the value is joined under a known base
+        // dir, never used as an absolute path.
+        assert_eq!(sanitize_path_component("../etc/passwd"), "_etc_passwd");
+        assert_eq!(sanitize_path_component("foo\\bar"), "foo_bar");
+        assert_eq!(sanitize_path_component("a\0b"), "a_b");
+        assert_eq!(sanitize_path_component("C:report.xlsx"), "C_report.xlsx");
+        assert_eq!(sanitize_path_component(".....hidden"), "hidden");
+        assert_eq!(sanitize_path_component(""), "file");
+        assert_eq!(sanitize_path_component("..."), "file");
+        // Control chars (newline, tab, etc.) → underscore.
+        assert_eq!(sanitize_path_component("a\nb\tc"), "a_b_c");
+    }
+
+    #[test]
+    fn attachments_max_bytes_honors_env_override() {
+        // SAFETY: tests share env; use a scoped guard pattern.
+        let original = std::env::var("OPENAB_ATTACHMENTS_MAX_MB").ok();
+        std::env::set_var("OPENAB_ATTACHMENTS_MAX_MB", "50");
+        assert_eq!(attachments_max_bytes(), 50 * 1024 * 1024);
+        std::env::remove_var("OPENAB_ATTACHMENTS_MAX_MB");
+        assert_eq!(attachments_max_bytes(), 200 * 1024 * 1024);
+        if let Some(v) = original {
+            std::env::set_var("OPENAB_ATTACHMENTS_MAX_MB", v);
+        }
+    }
+
 }

--- a/src/media.rs
+++ b/src/media.rs
@@ -337,6 +337,120 @@ pub async fn download_and_read_text_file(
     ))
 }
 
+
+/// Sanitize a single path component so it cannot escape its parent dir or
+/// hit reserved characters on common filesystems.
+fn sanitize_path_component(s: &str) -> String {
+    let cleaned: String = s
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | '\0' | ':' => '_',
+            c if c.is_control() => '_',
+            c => c,
+        })
+        .collect();
+    let trimmed = cleaned.trim_matches(|c: char| c == '.' || c.is_whitespace());
+    if trimmed.is_empty() {
+        "file".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Download an arbitrary attachment to disk and return a ContentBlock::Text
+/// referencing the on-disk path. This is the fallback for files that are
+/// neither audio (handled by STT), nor inlineable text, nor images.
+///
+/// `bucket_id` is a stable per-message id (Slack `ts`, Discord message id).
+/// Files end up at `${OPENAB_ATTACHMENTS_DIR:-/tmp/openab-attachments}/<bucket>/<filename>`.
+///
+/// Returns None on download/write failure or when size exceeds 200MB.
+pub async fn download_to_disk(
+    url: &str,
+    filename: &str,
+    mime: &str,
+    size: u64,
+    auth_token: Option<&str>,
+    bucket_id: &str,
+) -> Option<ContentBlock> {
+    const MAX_SIZE: u64 = 200 * 1024 * 1024; // 200 MB
+
+    if url.is_empty() {
+        return None;
+    }
+    if size > 0 && size > MAX_SIZE {
+        tracing::warn!(filename, size, "attachment exceeds 200MB limit, skipping");
+        return None;
+    }
+
+    let base = std::env::var("OPENAB_ATTACHMENTS_DIR")
+        .unwrap_or_else(|_| "/tmp/openab-attachments".to_string());
+    let safe_bucket = sanitize_path_component(bucket_id);
+    let safe_name = sanitize_path_component(filename);
+    let target_dir = std::path::PathBuf::from(&base).join(&safe_bucket);
+
+    if let Err(e) = tokio::fs::create_dir_all(&target_dir).await {
+        tracing::error!(?target_dir, error = %e, "failed to create attachment dir");
+        return None;
+    }
+    let target_path = target_dir.join(&safe_name);
+
+    let mut req = HTTP_CLIENT.get(url);
+    if let Some(token) = auth_token {
+        req = req.header("Authorization", format!("Bearer {token}"));
+    }
+    let resp = match req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(url, error = %e, "attachment download failed");
+            return None;
+        }
+    };
+    if !resp.status().is_success() {
+        tracing::error!(url, status = %resp.status(), "attachment download failed");
+        return None;
+    }
+    let bytes = match resp.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!(url, error = %e, "attachment read failed");
+            return None;
+        }
+    };
+    if bytes.len() as u64 > MAX_SIZE {
+        tracing::error!(filename, size = bytes.len(), "downloaded attachment exceeds 200MB limit");
+        return None;
+    }
+
+    if let Err(e) = tokio::fs::write(&target_path, &bytes).await {
+        tracing::error!(?target_path, error = %e, "failed to write attachment");
+        return None;
+    }
+
+    let mime_label = if mime.is_empty() {
+        "application/octet-stream"
+    } else {
+        mime
+    };
+    debug!(
+        filename = %safe_name,
+        path = %target_path.display(),
+        size = bytes.len(),
+        mime = mime_label,
+        "attachment saved to disk",
+    );
+
+    Some(ContentBlock::Text {
+        text: format!(
+            "[Attachment received]\nFilename: {}\nType: {}\nSize: {} bytes\nSaved to: {}\nUse the appropriate skill to read or process this file.",
+            safe_name,
+            mime_label,
+            bytes.len(),
+            target_path.display(),
+        ),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -54,8 +54,6 @@ pub const PREFIX_TEMPLATE_MAX_LEN: usize = 200;
 pub struct RelayConfig {
     #[serde(default)]
     pub enabled: bool,
-    #[serde(default = "default_loop_guard_depth")]
-    pub loop_guard_max_depth: u8,
     #[serde(default = "default_prefix_template")]
     pub prefix_template: String,
     #[serde(default)]
@@ -66,15 +64,10 @@ impl Default for RelayConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            loop_guard_max_depth: default_loop_guard_depth(),
             prefix_template: default_prefix_template(),
             aliases: HashMap::new(),
         }
     }
-}
-
-fn default_loop_guard_depth() -> u8 {
-    1
 }
 
 fn default_prefix_template() -> String {

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -1,0 +1,658 @@
+//! Cross-channel relay marker support.
+//!
+//! Lets agents emit a block in their response that gets forwarded to a different
+//! platform's channel via a peer adapter. Spec: see
+//! `AI-Memory/shared/proposals/2026-05-26-openab-cross-channel-relay.md`.
+//!
+//! Marker grammar (block-only, line-anchored — same approach as
+//! `slack::extract_file_send_markers` post-2026-05-26):
+//!
+//! ```text
+//! <<openab-relay-to discord:swat-team>>
+//! body line 1
+//! body line 2
+//! <<openab-relay-end>>
+//! ```
+//!
+//! Two parsing entry points:
+//! - [`extract_relay_blocks`] — final-pass extractor. Returns residual text +
+//!   parsed directives + parse errors.
+//! - [`mask_streaming_relay_blocks`] — streaming-time mask. Hides in-progress
+//!   blocks from the placeholder edit loop so bare markers never appear to the
+//!   origin user.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{Arc, Weak};
+
+use serde::Deserialize;
+
+use crate::adapter::ChatAdapter;
+
+// --- Marker constants ---
+
+/// Opener prefix. Body of opener line is `<<openab-relay-to {platform}:{alias}>>`.
+pub(crate) const OPENER_PREFIX: &str = "<<openab-relay-to ";
+pub(crate) const OPENER_SUFFIX: &str = ">>";
+pub(crate) const CLOSER_LINE: &str = "<<openab-relay-end>>";
+
+/// File-send marker prefix — mirrored from `slack.rs:22`. Used by
+/// [`strip_file_send_markers`] to neutralize file-send markers inside relay
+/// bodies before peer dispatch (prevents Slack-targeted relay from triggering
+/// unintended file uploads).
+const FILE_SEND_MARKER_PREFIX: &str = "<<openab-send-file ";
+const FILE_SEND_MARKER_SUFFIX: &str = ">>";
+
+/// v4: max allowed prefix_template length. Well below smallest peer
+/// message_limit (Discord 2000, Slack 4000). Prevents format::split_message
+/// from char-by-char splitting an overlong template mid-string.
+pub const PREFIX_TEMPLATE_MAX_LEN: usize = 200;
+
+// --- Config types ---
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RelayConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_loop_guard_depth")]
+    pub loop_guard_max_depth: u8,
+    #[serde(default = "default_prefix_template")]
+    pub prefix_template: String,
+    #[serde(default)]
+    pub aliases: HashMap<String, RelayAlias>,
+}
+
+impl Default for RelayConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            loop_guard_max_depth: default_loop_guard_depth(),
+            prefix_template: default_prefix_template(),
+            aliases: HashMap::new(),
+        }
+    }
+}
+
+fn default_loop_guard_depth() -> u8 {
+    1
+}
+
+fn default_prefix_template() -> String {
+    "[via {sender_persona} from {sender_platform}]".to_string()
+}
+
+impl RelayConfig {
+    /// Validate config at load time. Called from main.rs after deserialization.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.prefix_template.len() > PREFIX_TEMPLATE_MAX_LEN {
+            return Err(format!(
+                "relay.prefix_template too long ({} > {} bytes)",
+                self.prefix_template.len(),
+                PREFIX_TEMPLATE_MAX_LEN,
+            ));
+        }
+        for key in self.aliases.keys() {
+            if !key.contains(':') {
+                return Err(format!(
+                    "relay.aliases key {key:?} missing 'platform:' prefix"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RelayAlias {
+    pub channel_id: String,
+}
+
+// --- Parse results ---
+
+#[derive(Clone, Debug)]
+pub struct RelayDirective {
+    pub target_platform: String,
+    pub target_alias: String,
+    pub body: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RelayParseError {
+    UnterminatedOpener { line: usize, target: String },
+    NestedOpener { line: usize, outer_target: String },
+    MalformedOpener { line: usize, raw: String },
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RelayExtractResult {
+    pub residual: String,
+    pub directives: Vec<RelayDirective>,
+    pub errors: Vec<RelayParseError>,
+}
+
+// --- Runtime context ---
+
+/// Built once in main.rs after both adapters are constructed. Peer refs are
+/// `Weak` to avoid cross-adapter Arc cycles.
+pub struct RelayContext {
+    pub config: Arc<RelayConfig>,
+    pub peers: HashMap<String, Weak<dyn ChatAdapter>>,
+}
+
+impl RelayContext {
+    pub fn peer(&self, platform: &str) -> Option<Arc<dyn ChatAdapter>> {
+        self.peers.get(platform).and_then(Weak::upgrade)
+    }
+}
+
+// --- Parser helpers ---
+
+/// Returns `Some((platform, alias))` if `trimmed_line` is a well-formed opener,
+/// `None` if it's not an opener at all, or returns an error variant signalling
+/// a malformed opener (prefix present but body doesn't parse).
+fn parse_opener_line(trimmed: &str) -> OpenerKind {
+    if !trimmed.starts_with(OPENER_PREFIX) || !trimmed.ends_with(OPENER_SUFFIX) {
+        return OpenerKind::NotOpener;
+    }
+    let inner = &trimmed[OPENER_PREFIX.len()..trimmed.len() - OPENER_SUFFIX.len()];
+    let inner = inner.trim();
+    match inner.split_once(':') {
+        Some((platform, alias)) => {
+            let platform = platform.trim();
+            let alias = alias.trim();
+            if platform.is_empty() || alias.is_empty() {
+                OpenerKind::Malformed(trimmed.to_string())
+            } else {
+                OpenerKind::Valid {
+                    platform: platform.to_string(),
+                    alias: alias.to_string(),
+                }
+            }
+        }
+        None => OpenerKind::Malformed(trimmed.to_string()),
+    }
+}
+
+enum OpenerKind {
+    NotOpener,
+    Valid { platform: String, alias: String },
+    Malformed(String),
+}
+
+fn is_closer_line(trimmed: &str) -> bool {
+    trimmed == CLOSER_LINE
+}
+
+// --- Public API ---
+
+/// Final-pass parser. Line-anchored block extraction.
+///
+/// Always returns `RelayExtractResult`. If `content` has no opener markers,
+/// `residual == content` and both vecs are empty.
+pub fn extract_relay_blocks(content: &str) -> RelayExtractResult {
+    if !content.contains(OPENER_PREFIX) {
+        return RelayExtractResult {
+            residual: content.to_string(),
+            directives: Vec::new(),
+            errors: Vec::new(),
+        };
+    }
+
+    let mut residual_lines: Vec<&str> = Vec::new();
+    let mut directives: Vec<RelayDirective> = Vec::new();
+    let mut errors: Vec<RelayParseError> = Vec::new();
+
+    let lines: Vec<&str> = content.split('\n').collect();
+    let mut i = 0usize;
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim();
+        match parse_opener_line(trimmed) {
+            OpenerKind::NotOpener => {
+                residual_lines.push(line);
+                i += 1;
+            }
+            OpenerKind::Malformed(raw) => {
+                errors.push(RelayParseError::MalformedOpener {
+                    line: i + 1,
+                    raw,
+                });
+                residual_lines.push(line);
+                i += 1;
+            }
+            OpenerKind::Valid { platform, alias } => {
+                let opener_line_no = i + 1;
+                let mut body_lines: Vec<&str> = Vec::new();
+                let mut j = i + 1;
+                let mut closed = false;
+                while j < lines.len() {
+                    let inner_line = lines[j];
+                    let inner_trimmed = inner_line.trim();
+                    if is_closer_line(inner_trimmed) {
+                        closed = true;
+                        break;
+                    }
+                    if let OpenerKind::Valid { .. } = parse_opener_line(inner_trimmed) {
+                        errors.push(RelayParseError::NestedOpener {
+                            line: j + 1,
+                            outer_target: format!("{platform}:{alias}"),
+                        });
+                        // Keep scanning until closer — body preserves the
+                        // nested opener line verbatim (no double-extraction).
+                    }
+                    body_lines.push(inner_line);
+                    j += 1;
+                }
+                if closed {
+                    directives.push(RelayDirective {
+                        target_platform: platform,
+                        target_alias: alias,
+                        body: body_lines.join("\n"),
+                    });
+                    i = j + 1; // skip past closer
+                } else {
+                    // Unterminated — preserve opener line as literal residual,
+                    // record error, do NOT consume body lines (they go back
+                    // into residual as normal text from i+1 onward).
+                    errors.push(RelayParseError::UnterminatedOpener {
+                        line: opener_line_no,
+                        target: format!("{platform}:{alias}"),
+                    });
+                    residual_lines.push(line);
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    RelayExtractResult {
+        residual: residual_lines.join("\n"),
+        directives,
+        errors,
+    }
+}
+
+/// Streaming-time mask. Hides in-progress relay blocks from the placeholder
+/// edit loop. Called on every stream tick from `adapter.rs`.
+///
+/// Behaviour:
+/// - No opener present → returns `Cow::Borrowed(content)` (fast path).
+/// - Complete opener+closer pair → replaced with `[relaying to platform:alias…]`.
+/// - Unterminated opener (still streaming) → truncated at opener line, status
+///   line appended. The final dispatch happens post-stream.
+///
+/// Idempotent: `mask(mask(x)) == mask(x)` because the status line `[relaying
+/// to ...]` does not start with `<<openab-relay-to ` so won't be re-parsed.
+pub fn mask_streaming_relay_blocks(content: &str) -> Cow<'_, str> {
+    if !content.contains(OPENER_PREFIX) {
+        return Cow::Borrowed(content);
+    }
+
+    let lines: Vec<&str> = content.split('\n').collect();
+    let mut out: Vec<String> = Vec::new();
+    let mut i = 0usize;
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim();
+        match parse_opener_line(trimmed) {
+            OpenerKind::Valid { platform, alias } => {
+                // Scan for closer.
+                let mut j = i + 1;
+                let mut closed = false;
+                while j < lines.len() {
+                    if is_closer_line(lines[j].trim()) {
+                        closed = true;
+                        break;
+                    }
+                    j += 1;
+                }
+                out.push(format!("[relaying to {platform}:{alias}…]"));
+                if closed {
+                    i = j + 1;
+                } else {
+                    // Unterminated — swallow everything after opener (it's
+                    // still streaming). Mask runs again on next tick.
+                    break;
+                }
+            }
+            _ => {
+                out.push(line.to_string());
+                i += 1;
+            }
+        }
+    }
+
+    Cow::Owned(out.join("\n"))
+}
+
+/// Loop-guard: rejects if body still contains an opener marker line.
+pub fn contains_relay_marker(body: &str) -> bool {
+    if !body.contains(OPENER_PREFIX) {
+        return false;
+    }
+    body.split('\n')
+        .any(|l| matches!(parse_opener_line(l.trim()), OpenerKind::Valid { .. }))
+}
+
+/// Apply prefix template — substitutes {sender_persona}, {sender_platform}.
+pub fn format_relay_body(template: &str, persona: &str, platform: &str, body: &str) -> String {
+    let prefix = template
+        .replace("{sender_persona}", persona)
+        .replace("{sender_platform}", platform);
+    if prefix.is_empty() {
+        body.to_string()
+    } else {
+        format!("{prefix}\n{body}")
+    }
+}
+
+/// Strip `<<openab-send-file PATH>>` marker lines from a relay body before
+/// peer dispatch. Same line-anchored rules as the file-send extractor itself.
+///
+/// Prevents Slack-targeted relay bodies from triggering unintended file
+/// uploads via `slack.rs:620` file-send extractor.
+pub fn strip_file_send_markers(body: &str) -> String {
+    if !body.contains(FILE_SEND_MARKER_PREFIX) {
+        return body.to_string();
+    }
+    body.split('\n')
+        .filter(|line| {
+            let trimmed = line.trim();
+            !(trimmed.starts_with(FILE_SEND_MARKER_PREFIX)
+                && trimmed.ends_with(FILE_SEND_MARKER_SUFFIX))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- extract_relay_blocks: final-pass parser ---
+
+    #[test]
+    fn no_markers_returns_empty_result_with_residual_intact() {
+        let input = "hello\nworld\n";
+        let r = extract_relay_blocks(input);
+        assert_eq!(r.residual, input);
+        assert!(r.directives.is_empty());
+        assert!(r.errors.is_empty());
+    }
+
+    #[test]
+    fn parse_single_block() {
+        let input = "before\n<<openab-relay-to discord:swat-team>>\nhello fern\n<<openab-relay-end>>\nafter";
+        let r = extract_relay_blocks(input);
+        assert_eq!(r.residual, "before\nafter");
+        assert_eq!(r.directives.len(), 1);
+        assert_eq!(r.directives[0].target_platform, "discord");
+        assert_eq!(r.directives[0].target_alias, "swat-team");
+        assert_eq!(r.directives[0].body, "hello fern");
+        assert!(r.errors.is_empty());
+    }
+
+    #[test]
+    fn parse_multiple_blocks() {
+        let input = "<<openab-relay-to discord:a>>\none\n<<openab-relay-end>>\nmiddle\n<<openab-relay-to slack:b>>\ntwo\n<<openab-relay-end>>";
+        let r = extract_relay_blocks(input);
+        assert_eq!(r.residual, "middle");
+        assert_eq!(r.directives.len(), 2);
+        assert_eq!(r.directives[0].target_alias, "a");
+        assert_eq!(r.directives[1].target_alias, "b");
+        assert!(r.errors.is_empty());
+    }
+
+    #[test]
+    fn parse_empty_body_block() {
+        let input = "<<openab-relay-to discord:x>>\n<<openab-relay-end>>";
+        let r = extract_relay_blocks(input);
+        assert_eq!(r.directives.len(), 1);
+        assert_eq!(r.directives[0].body, "");
+    }
+
+    #[test]
+    fn unterminated_opener_records_error_and_preserves_line() {
+        let input = "<<openab-relay-to discord:x>>\nstill streaming";
+        let r = extract_relay_blocks(input);
+        assert_eq!(r.directives.len(), 0);
+        assert_eq!(r.errors.len(), 1);
+        match &r.errors[0] {
+            RelayParseError::UnterminatedOpener { target, .. } => {
+                assert_eq!(target, "discord:x");
+            }
+            other => panic!("expected UnterminatedOpener, got {other:?}"),
+        }
+        assert!(r.residual.contains("<<openab-relay-to discord:x>>"));
+    }
+
+    #[test]
+    fn nested_opener_records_error_emits_outer_directive() {
+        let input = "<<openab-relay-to discord:a>>\n<<openab-relay-to slack:b>>\ninner\n<<openab-relay-end>>";
+        let r = extract_relay_blocks(input);
+        assert_eq!(r.directives.len(), 1);
+        assert_eq!(r.directives[0].target_platform, "discord");
+        assert_eq!(r.directives[0].target_alias, "a");
+        assert!(r.directives[0].body.contains("<<openab-relay-to slack:b>>"));
+        assert_eq!(r.errors.len(), 1);
+        assert!(matches!(r.errors[0], RelayParseError::NestedOpener { .. }));
+    }
+
+    #[test]
+    fn preserve_inline_marker_text() {
+        let input = "see the marker `<<openab-relay-to discord:x>>` inline here";
+        let r = extract_relay_blocks(input);
+        assert_eq!(r.residual, input);
+        assert!(r.directives.is_empty());
+        assert!(r.errors.is_empty());
+    }
+
+    #[test]
+    fn preserve_quoted_marker_in_code_fence() {
+        let input = "```\n<<openab-relay-to discord:x>>\nfoo\n<<openab-relay-end>>\n```";
+        let r = extract_relay_blocks(input);
+        // Line-anchored: opener occupies its own line (after trim), so this
+        // IS treated as a real block. Code fences don't protect content from
+        // the parser — agents need to use a different format if they want to
+        // demonstrate the marker without firing it (e.g. zero-width space).
+        assert_eq!(r.directives.len(), 1);
+    }
+
+    #[test]
+    fn body_preserves_blank_lines_verbatim() {
+        let input = "<<openab-relay-to discord:x>>\nline1\n\nline3\n<<openab-relay-end>>";
+        let r = extract_relay_blocks(input);
+        assert_eq!(r.directives[0].body, "line1\n\nline3");
+    }
+
+    #[test]
+    fn whitespace_trimmed_around_opener_and_closer() {
+        let input = "  <<openab-relay-to discord:x>>  \nbody\n  <<openab-relay-end>>  ";
+        let r = extract_relay_blocks(input);
+        assert_eq!(r.directives.len(), 1);
+        assert_eq!(r.directives[0].body, "body");
+    }
+
+    #[test]
+    fn malformed_opener_no_colon() {
+        let input = "<<openab-relay-to nocolon>>\nbody\n<<openab-relay-end>>";
+        let r = extract_relay_blocks(input);
+        assert_eq!(r.directives.len(), 0);
+        assert_eq!(r.errors.len(), 1);
+        assert!(matches!(r.errors[0], RelayParseError::MalformedOpener { .. }));
+    }
+
+    // --- mask_streaming_relay_blocks ---
+
+    #[test]
+    fn mask_no_marker_returns_borrowed_fast_path() {
+        let input = "hello world";
+        let r = mask_streaming_relay_blocks(input);
+        assert!(matches!(r, Cow::Borrowed(_)));
+        assert_eq!(r, "hello world");
+    }
+
+    #[test]
+    fn mask_complete_block_replaced_with_status_line() {
+        let input = "before\n<<openab-relay-to discord:x>>\nhello\n<<openab-relay-end>>\nafter";
+        let r = mask_streaming_relay_blocks(input);
+        assert!(!r.contains("<<openab-relay-to"));
+        assert!(!r.contains("<<openab-relay-end"));
+        assert!(!r.contains("hello"));
+        assert!(r.contains("[relaying to discord:x…]"));
+        assert!(r.contains("before"));
+        assert!(r.contains("after"));
+    }
+
+    #[test]
+    fn mask_unterminated_opener_truncates_at_opener() {
+        let input = "before\n<<openab-relay-to discord:x>>\npartial body still streaming";
+        let r = mask_streaming_relay_blocks(input);
+        assert!(!r.contains("<<openab-relay-to"));
+        assert!(!r.contains("partial body"));
+        assert!(r.contains("[relaying to discord:x…]"));
+        assert!(r.contains("before"));
+    }
+
+    #[test]
+    fn mask_idempotent() {
+        let input = "before\n<<openab-relay-to discord:x>>\nbody\n<<openab-relay-end>>\nafter";
+        let once = mask_streaming_relay_blocks(input).into_owned();
+        let twice = mask_streaming_relay_blocks(&once).into_owned();
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn mask_preserves_text_before_opener() {
+        let input = "important context\n<<openab-relay-to discord:x>>\nbody\n<<openab-relay-end>>";
+        let r = mask_streaming_relay_blocks(input);
+        assert!(r.starts_with("important context"));
+    }
+
+    #[test]
+    fn mask_multiple_complete_blocks_each_replaced() {
+        let input = "<<openab-relay-to discord:a>>\n1\n<<openab-relay-end>>\n<<openab-relay-to slack:b>>\n2\n<<openab-relay-end>>";
+        let r = mask_streaming_relay_blocks(input);
+        assert!(r.contains("[relaying to discord:a…]"));
+        assert!(r.contains("[relaying to slack:b…]"));
+        assert!(!r.contains("<<openab-relay"));
+    }
+
+    // --- contains_relay_marker (loop guard) ---
+
+    #[test]
+    fn loop_guard_detects_nested_marker_in_body() {
+        let body = "first paragraph\n<<openab-relay-to discord:x>>\nshould_not_relay";
+        assert!(contains_relay_marker(body));
+    }
+
+    #[test]
+    fn loop_guard_clean_body_passes() {
+        let body = "first paragraph\nno markers here at all";
+        assert!(!contains_relay_marker(body));
+    }
+
+    #[test]
+    fn loop_guard_inline_marker_does_not_trigger() {
+        let body = "see `<<openab-relay-to discord:x>>` example inline";
+        assert!(!contains_relay_marker(body));
+    }
+
+    // --- format_relay_body ---
+
+    #[test]
+    fn prefix_template_substitution() {
+        let formatted = format_relay_body(
+            "[via {sender_persona} from {sender_platform}]",
+            "tifa",
+            "slack",
+            "hello",
+        );
+        assert_eq!(formatted, "[via tifa from slack]\nhello");
+    }
+
+    #[test]
+    fn prefix_template_empty_omits_prefix() {
+        let formatted = format_relay_body("", "tifa", "slack", "hello");
+        assert_eq!(formatted, "hello");
+    }
+
+    // --- strip_file_send_markers ---
+
+    #[test]
+    fn strip_removes_file_send_marker_lines() {
+        let body = "hi\n<<openab-send-file /etc/passwd>>\nbye";
+        let r = strip_file_send_markers(body);
+        assert_eq!(r, "hi\nbye");
+    }
+
+    #[test]
+    fn strip_preserves_inline_marker_text() {
+        let body = "see `<<openab-send-file /x>>` inline";
+        let r = strip_file_send_markers(body);
+        assert_eq!(r, body);
+    }
+
+    #[test]
+    fn strip_fast_path_no_marker() {
+        let body = "plain text";
+        let r = strip_file_send_markers(body);
+        assert_eq!(r, body);
+    }
+
+    // --- RelayConfig::validate ---
+
+    #[test]
+    fn validate_rejects_overlong_prefix() {
+        let cfg = RelayConfig {
+            prefix_template: "x".repeat(PREFIX_TEMPLATE_MAX_LEN + 1),
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_alias_without_colon() {
+        let mut aliases = HashMap::new();
+        aliases.insert(
+            "bad-key".to_string(),
+            RelayAlias {
+                channel_id: "C1".into(),
+            },
+        );
+        let cfg = RelayConfig {
+            aliases,
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_default() {
+        let cfg = RelayConfig::default();
+        assert!(cfg.validate().is_ok());
+    }
+
+    // --- mask + extract drift property ---
+
+    #[test]
+    fn mask_then_extract_consistent_residual_subset() {
+        // For any text containing a complete relay block, the extractor's
+        // residual must NOT contain the original body text (it should have
+        // been routed to a directive). The mask MUST replace the body with
+        // a status line that the extractor doesn't recognize. This ensures
+        // the two passes can't drift on what counts as a marker.
+        let input = "before\n<<openab-relay-to discord:x>>\nsecret\n<<openab-relay-end>>\nafter";
+        let extracted = extract_relay_blocks(input);
+        assert!(!extracted.residual.contains("secret"));
+        assert_eq!(extracted.directives.len(), 1);
+
+        let masked = mask_streaming_relay_blocks(input);
+        assert!(!masked.contains("secret"));
+        // Mask output run back through extractor: zero directives (status
+        // line isn't a valid opener) and zero errors.
+        let re_extracted = extract_relay_blocks(&masked);
+        assert_eq!(re_extracted.directives.len(), 0);
+        assert_eq!(re_extracted.errors.len(), 0);
+    }
+}

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -517,49 +517,53 @@ impl SlackAdapter {
     }
 }
 
-/// Parse outbound text for file-send markers `<<openab:send-file:PATH>>`.
+/// Parse outbound text for file-send markers `<<openab-send-file PATH>>`.
 /// Returns `Some((text_without_markers, paths))` if at least one marker found,
-/// `None` if the text contains no markers (fast-path).
+/// `None` if no marker line is present (fast-path).
 ///
-/// Marker syntax is deliberately ugly/unambiguous so it never collides with
-/// natural language. Whitespace around markers is collapsed cleanly.
+/// **Line-anchored** (2026-05-26): the marker must occupy a line on its own
+/// (after trimming whitespace). Inline occurrences inside running text are
+/// preserved as literal — this prevents the agent from self-triggering when
+/// quoting its own source code or documentation that mentions the marker.
+///
+/// Lines containing other content alongside a marker are left untouched (no
+/// partial extraction); the agent must put the marker on its own line for it
+/// to fire. This trades a slightly stricter calling convention for immunity
+/// from natural-language and code-quote collisions.
 fn extract_file_send_markers(content: &str) -> Option<(String, Vec<String>)> {
     if !content.contains(FILE_SEND_MARKER_PREFIX) {
         return None;
     }
 
     let mut paths: Vec<String> = Vec::new();
-    let mut stripped = String::with_capacity(content.len());
-    let mut remaining = content;
+    let mut kept_lines: Vec<&str> = Vec::new();
 
-    while let Some(start) = remaining.find(FILE_SEND_MARKER_PREFIX) {
-        // Push everything before the marker into the stripped text.
-        stripped.push_str(&remaining[..start]);
-        let after_prefix = &remaining[start + FILE_SEND_MARKER_PREFIX.len()..];
-
-        match after_prefix.find(FILE_SEND_MARKER_SUFFIX) {
-            Some(end) => {
-                let path = after_prefix[..end].trim().to_string();
-                if !path.is_empty() {
-                    paths.push(path);
-                }
-                remaining = &after_prefix[end + FILE_SEND_MARKER_SUFFIX.len()..];
+    for line in content.split('\n') {
+        let trimmed = line.trim();
+        if trimmed.starts_with(FILE_SEND_MARKER_PREFIX) && trimmed.ends_with(FILE_SEND_MARKER_SUFFIX)
+        {
+            // Verified marker line: extract path between prefix and suffix.
+            let inner = &trimmed[FILE_SEND_MARKER_PREFIX.len()
+                ..trimmed.len() - FILE_SEND_MARKER_SUFFIX.len()];
+            let path = inner.trim();
+            if !path.is_empty() {
+                paths.push(path.to_string());
+                // Skip this line entirely from output.
+                continue;
             }
-            None => {
-                // Unterminated marker — treat as literal text, preserve.
-                stripped.push_str(FILE_SEND_MARKER_PREFIX);
-                stripped.push_str(after_prefix);
-                remaining = "";
-            }
+            // Empty path inside otherwise-valid marker — drop the line too
+            // (don't leak the empty `<<openab-send-file >>` to the user).
+            continue;
         }
+        // Not a marker line — preserve verbatim. Inline `<<openab-send-file ...>>`
+        // text is intentionally kept as literal content.
+        kept_lines.push(line);
     }
-    // Append any trailing text after the last marker.
-    stripped.push_str(remaining);
 
     if paths.is_empty() {
         return None;
     }
-    Some((stripped, paths))
+    Some((kept_lines.join("\n"), paths))
 }
 
 /// Pull the share message timestamp out of a `files.completeUploadExternal`
@@ -1952,5 +1956,80 @@ mod tests {
             !adapter.use_streaming(true),
             "should NOT stream when other bot present"
         );
+    }
+
+    // --- extract_file_send_markers tests (added 2026-05-26 with line-anchoring fix) ---
+
+    #[test]
+    fn marker_extracts_anchored_single_line() {
+        let input = "Here is the file:\n<<openab-send-file /tmp/report.pdf>>\nHope it helps.";
+        let (stripped, paths) = extract_file_send_markers(input).expect("marker should fire");
+        assert_eq!(paths, vec!["/tmp/report.pdf".to_string()]);
+        // Marker line is removed entirely; surrounding text joins directly.
+        assert_eq!(stripped, "Here is the file:\nHope it helps.");
+    }
+
+    #[test]
+    fn marker_extracts_multiple_anchored_lines() {
+        let input = "Files:\n<<openab-send-file /a.txt>>\n<<openab-send-file /b.txt>>\nDone.";
+        let (stripped, paths) = extract_file_send_markers(input).expect("markers should fire");
+        assert_eq!(paths, vec!["/a.txt".to_string(), "/b.txt".to_string()]);
+        assert_eq!(stripped, "Files:\nDone.");
+    }
+
+    #[test]
+    fn marker_inline_is_not_extracted() {
+        // Self-trigger regression: agent quotes the marker mid-sentence.
+        // Should be preserved verbatim; no upload attempted.
+        let input = "The marker syntax is `<<openab-send-file /abs/path>>` you write in chat.";
+        assert!(extract_file_send_markers(input).is_none());
+    }
+
+    #[test]
+    fn marker_indented_still_anchored() {
+        // Whitespace-only padding on the marker line should still anchor.
+        let input = "Result:\n    <<openab-send-file /tmp/x.png>>   \nDone.";
+        let (stripped, paths) = extract_file_send_markers(input).expect("marker should fire");
+        assert_eq!(paths, vec!["/tmp/x.png".to_string()]);
+        assert_eq!(stripped, "Result:\nDone.");
+    }
+
+    #[test]
+    fn marker_at_bof_and_eof() {
+        // Marker as very first / last line should still fire.
+        let bof = "<<openab-send-file /a>>\ntrailing";
+        let (s1, p1) = extract_file_send_markers(bof).expect("BOF marker should fire");
+        assert_eq!(p1, vec!["/a".to_string()]);
+        assert_eq!(s1, "trailing");
+
+        let eof = "leading\n<<openab-send-file /b>>";
+        let (s2, p2) = extract_file_send_markers(eof).expect("EOF marker should fire");
+        assert_eq!(p2, vec!["/b".to_string()]);
+        assert_eq!(s2, "leading");
+    }
+
+    #[test]
+    fn marker_with_trailing_text_on_same_line_is_ignored() {
+        // Marker followed by non-whitespace on the same line → not anchored,
+        // preserved as literal.
+        let input = "<<openab-send-file /a.txt>> caption text";
+        assert!(extract_file_send_markers(input).is_none());
+    }
+
+    #[test]
+    fn marker_self_trigger_regression_quoted_source_code() {
+        // Regression for 2026-05-26 incident: Tifa read slack.rs and quoted
+        // the marker prefix verbatim in a Slack reply. Old impl tried to
+        // upload garbage as a file. New impl preserves it as literal.
+        let input = "OpenAB marker syntax `<<openab-send-file ` and suffix `>>` plus other words like `<<openab-relay-to discord:swat-team>>` describe the design.";
+        assert!(extract_file_send_markers(input).is_none());
+    }
+
+    #[test]
+    fn marker_empty_path_drops_line_without_upload() {
+        // Defensive: anchored marker with no path between prefix/suffix
+        // shouldn't produce a phantom upload entry.
+        let input = "Before\n<<openab-send-file >>\nAfter";
+        assert!(extract_file_send_markers(input).is_none());
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -13,9 +13,13 @@ use tokio_tungstenite::tungstenite;
 use tracing::{debug, error, info, warn};
 
 /// Marker syntax for outbound file attachments in agent text output.
-/// Tifa writes `<<openab:send-file:/abs/path/to/file>>` in her response, OpenAB
+/// Tifa writes `<<openab-send-file /abs/path/to/file>>` in her response, OpenAB
 /// intercepts before posting and uploads the file via Slack's files API.
-const FILE_SEND_MARKER_PREFIX: &str = "<<openab:send-file:";
+///
+/// IMPORTANT: do NOT use colons in this marker (`:something:` would collide
+/// with Slack's emoji shortcode parser and get rendered as a gray-box
+/// placeholder even before our interceptor runs).
+const FILE_SEND_MARKER_PREFIX: &str = "<<openab-send-file ";
 const FILE_SEND_MARKER_SUFFIX: &str = ">>";
 /// Sanity cap so an agent typo doesn't try to upload /Users/jazlim or similar.
 /// Slack's own per-file limit is 1 GB by default; we cap at 100 MB.

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -12,6 +12,15 @@ use tokio::sync::watch;
 use tokio_tungstenite::tungstenite;
 use tracing::{debug, error, info, warn};
 
+/// Marker syntax for outbound file attachments in agent text output.
+/// Tifa writes `<<openab:send-file:/abs/path/to/file>>` in her response, OpenAB
+/// intercepts before posting and uploads the file via Slack's files API.
+const FILE_SEND_MARKER_PREFIX: &str = "<<openab:send-file:";
+const FILE_SEND_MARKER_SUFFIX: &str = ">>";
+/// Sanity cap so an agent typo doesn't try to upload /Users/jazlim or similar.
+/// Slack's own per-file limit is 1 GB by default; we cap at 100 MB.
+const FILE_SEND_MAX_BYTES: u64 = 100 * 1024 * 1024;
+
 const SLACK_API: &str = "https://slack.com/api";
 
 /// Map Unicode emoji to Slack short names for reactions API.
@@ -336,6 +345,232 @@ impl SlackAdapter {
         cache.insert(thread_ts.to_string(), tokio::time::Instant::now());
         enforce_cache_bounds(&mut cache, self.session_ttl);
     }
+
+    /// Post a plain text message — the original `send_message` path, extracted
+    /// so the marker-aware path can reuse it.
+    async fn send_plain_text(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
+        let mrkdwn = markdown_to_mrkdwn(content);
+        let mut body = serde_json::json!({
+            "channel": channel.channel_id,
+            "text": mrkdwn,
+        });
+        if let Some(thread_ts) = &channel.thread_id {
+            body["thread_ts"] = serde_json::Value::String(thread_ts.clone());
+        }
+        let resp = self.api_post("chat.postMessage", body).await?;
+        let ts = resp["ts"]
+            .as_str()
+            .ok_or_else(|| anyhow!("no ts in chat.postMessage response"))?;
+        Ok(MessageRef {
+            channel: ChannelRef {
+                platform: "slack".into(),
+                channel_id: channel.channel_id.clone(),
+                thread_id: channel.thread_id.clone(),
+                parent_id: None,
+                origin_event_id: None,
+            },
+            message_id: ts.to_string(),
+        })
+    }
+
+    /// Upload a file from disk and share it into the given channel/thread.
+    ///
+    /// Implements Slack's 3-step modern upload API:
+    ///   1. `files.getUploadURLExternal` → get an upload_url + file_id
+    ///   2. POST raw bytes to that upload_url (multipart/form-data, field name `file`)
+    ///   3. `files.completeUploadExternal` → publish into the channel
+    ///
+    /// Returns a MessageRef pointing at the share message ts. Failures bubble up
+    /// with the Slack error code in the message; caller is responsible for
+    /// surfacing to the user.
+    ///
+    /// Required Slack bot scopes: `files:write`. The file path must be readable
+    /// by the OpenAB process (host or container — whichever filesystem the
+    /// bridge runs in).
+    async fn send_file_to_slack(&self, channel: &ChannelRef, path: &str) -> Result<MessageRef> {
+        use tokio::io::AsyncReadExt;
+
+        // --- Validate the path ---
+        let path_buf = std::path::PathBuf::from(path);
+        if !path_buf.is_file() {
+            return Err(anyhow!("not a regular file: {path}"));
+        }
+        let metadata = tokio::fs::metadata(&path_buf).await?;
+        let size = metadata.len();
+        if size == 0 {
+            return Err(anyhow!("file is empty: {path}"));
+        }
+        if size > FILE_SEND_MAX_BYTES {
+            return Err(anyhow!(
+                "file too large ({size} bytes > {FILE_SEND_MAX_BYTES} cap): {path}"
+            ));
+        }
+        let filename = path_buf
+            .file_name()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| anyhow!("could not derive filename from path: {path}"))?
+            .to_string();
+
+        debug!(path = %path, filename = %filename, size, "slack: starting file upload");
+
+        // --- Step 1: getUploadURLExternal (form-encoded GET, per Slack docs) ---
+        let step1_resp = self
+            .client
+            .get(format!("{SLACK_API}/files.getUploadURLExternal"))
+            .header("Authorization", format!("Bearer {}", self.bot_token))
+            .query(&[
+                ("filename", filename.as_str()),
+                ("length", size.to_string().as_str()),
+            ])
+            .send()
+            .await?
+            .json::<serde_json::Value>()
+            .await?;
+
+        if step1_resp["ok"].as_bool() != Some(true) {
+            let err = step1_resp["error"]
+                .as_str()
+                .unwrap_or("unknown getUploadURLExternal error");
+            return Err(anyhow!("files.getUploadURLExternal: {err}"));
+        }
+        let upload_url = step1_resp["upload_url"]
+            .as_str()
+            .ok_or_else(|| anyhow!("no upload_url in getUploadURLExternal response"))?
+            .to_string();
+        let file_id = step1_resp["file_id"]
+            .as_str()
+            .ok_or_else(|| anyhow!("no file_id in getUploadURLExternal response"))?
+            .to_string();
+
+        // --- Step 2: PUT raw bytes to the signed URL ---
+        let mut file_bytes = Vec::with_capacity(size as usize);
+        tokio::fs::File::open(&path_buf)
+            .await?
+            .read_to_end(&mut file_bytes)
+            .await?;
+
+        let step2_resp = self
+            .client
+            .post(&upload_url)
+            .body(file_bytes)
+            .send()
+            .await?;
+
+        if !step2_resp.status().is_success() {
+            let status = step2_resp.status();
+            let body = step2_resp.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "upload PUT failed: HTTP {status} — body: {}",
+                body.chars().take(200).collect::<String>()
+            ));
+        }
+
+        // --- Step 3: completeUploadExternal — actually publish into the channel ---
+        let mut complete_body = serde_json::json!({
+            "files": [{ "id": file_id, "title": filename }],
+            "channel_id": channel.channel_id,
+        });
+        if let Some(thread_ts) = &channel.thread_id {
+            complete_body["thread_ts"] = serde_json::Value::String(thread_ts.clone());
+        }
+
+        let step3_resp = self.api_post("files.completeUploadExternal", complete_body).await?;
+
+        // Slack returns the file metadata; we want the share's message timestamp.
+        // It's available under `files[0].shares.public.<channel>[0].ts` or
+        // `files[0].shares.private.<channel>[0].ts`. Probe both.
+        let ts = extract_share_message_ts(&step3_resp, &channel.channel_id).unwrap_or_else(|| {
+            // No ts surfaced — use file_id as a stand-in. MessageRef is mostly
+            // used for reactions and edits, neither of which makes sense for a
+            // file share. So file_id is a reasonable degenerate identity.
+            file_id.clone()
+        });
+
+        info!(
+            file_id = %file_id,
+            filename = %filename,
+            size,
+            channel = %channel.channel_id,
+            "slack: file upload complete"
+        );
+
+        Ok(MessageRef {
+            channel: ChannelRef {
+                platform: "slack".into(),
+                channel_id: channel.channel_id.clone(),
+                thread_id: channel.thread_id.clone(),
+                parent_id: None,
+                origin_event_id: None,
+            },
+            message_id: ts,
+        })
+    }
+}
+
+/// Parse outbound text for file-send markers `<<openab:send-file:PATH>>`.
+/// Returns `Some((text_without_markers, paths))` if at least one marker found,
+/// `None` if the text contains no markers (fast-path).
+///
+/// Marker syntax is deliberately ugly/unambiguous so it never collides with
+/// natural language. Whitespace around markers is collapsed cleanly.
+fn extract_file_send_markers(content: &str) -> Option<(String, Vec<String>)> {
+    if !content.contains(FILE_SEND_MARKER_PREFIX) {
+        return None;
+    }
+
+    let mut paths: Vec<String> = Vec::new();
+    let mut stripped = String::with_capacity(content.len());
+    let mut remaining = content;
+
+    while let Some(start) = remaining.find(FILE_SEND_MARKER_PREFIX) {
+        // Push everything before the marker into the stripped text.
+        stripped.push_str(&remaining[..start]);
+        let after_prefix = &remaining[start + FILE_SEND_MARKER_PREFIX.len()..];
+
+        match after_prefix.find(FILE_SEND_MARKER_SUFFIX) {
+            Some(end) => {
+                let path = after_prefix[..end].trim().to_string();
+                if !path.is_empty() {
+                    paths.push(path);
+                }
+                remaining = &after_prefix[end + FILE_SEND_MARKER_SUFFIX.len()..];
+            }
+            None => {
+                // Unterminated marker — treat as literal text, preserve.
+                stripped.push_str(FILE_SEND_MARKER_PREFIX);
+                stripped.push_str(after_prefix);
+                remaining = "";
+            }
+        }
+    }
+    // Append any trailing text after the last marker.
+    stripped.push_str(remaining);
+
+    if paths.is_empty() {
+        return None;
+    }
+    Some((stripped, paths))
+}
+
+/// Pull the share message timestamp out of a `files.completeUploadExternal`
+/// response, probing both `public` and `private` share entries for the channel.
+/// Returns None if the response shape doesn't match (Slack may change this).
+fn extract_share_message_ts(resp: &serde_json::Value, channel_id: &str) -> Option<String> {
+    let files = resp.get("files")?.as_array()?;
+    let first = files.first()?;
+    let shares = first.get("shares")?;
+    for visibility in ["public", "private"] {
+        if let Some(share_map) = shares.get(visibility) {
+            if let Some(channel_shares) = share_map.get(channel_id) {
+                if let Some(first_share) = channel_shares.as_array().and_then(|a| a.first()) {
+                    if let Some(ts) = first_share.get("ts").and_then(|v| v.as_str()) {
+                        return Some(ts.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Shared eviction policy for positive-only caches.
@@ -369,28 +604,44 @@ impl ChatAdapter for SlackAdapter {
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
-        let mrkdwn = markdown_to_mrkdwn(content);
-        let mut body = serde_json::json!({
-            "channel": channel.channel_id,
-            "text": mrkdwn,
-        });
-        if let Some(thread_ts) = &channel.thread_id {
-            body["thread_ts"] = serde_json::Value::String(thread_ts.clone());
+        // Scan for file-send markers <<openab:send-file:PATH>>. If found, intercept:
+        // upload each file via Slack's files API, then send the remaining text (with
+        // markers stripped). Returns the MessageRef of the last action performed.
+        if let Some((stripped_text, file_paths)) = extract_file_send_markers(content) {
+            let mut last_msg: Option<MessageRef> = None;
+
+            // Post the residual text first (if non-empty), so the file appears AFTER
+            // any caption. Matches the natural reading order users expect.
+            let trimmed = stripped_text.trim();
+            if !trimmed.is_empty() {
+                last_msg = Some(self.send_plain_text(channel, trimmed).await?);
+            }
+
+            // Upload each file. Failure on one shouldn't block the rest — log & continue.
+            for path in &file_paths {
+                match self.send_file_to_slack(channel, path).await {
+                    Ok(msg_ref) => {
+                        info!(path = %path, "slack: file uploaded");
+                        last_msg = Some(msg_ref);
+                    }
+                    Err(e) => {
+                        error!(path = %path, error = %e, "slack: file upload failed");
+                        // Surface the failure to the user so they know it didn't go through.
+                        let err_text = format!(
+                            "⚠️ Failed to send file `{}`: {}\n(See OpenAB logs for details.)",
+                            path, e
+                        );
+                        last_msg = Some(self.send_plain_text(channel, &err_text).await?);
+                    }
+                }
+            }
+
+            // If we somehow had only markers and no surviving text, return a stub.
+            return last_msg.ok_or_else(|| anyhow!("no message sent (empty after marker strip)"));
         }
-        let resp = self.api_post("chat.postMessage", body).await?;
-        let ts = resp["ts"]
-            .as_str()
-            .ok_or_else(|| anyhow!("no ts in chat.postMessage response"))?;
-        Ok(MessageRef {
-            channel: ChannelRef {
-                platform: "slack".into(),
-                channel_id: channel.channel_id.clone(),
-                thread_id: channel.thread_id.clone(),
-                parent_id: None,
-                origin_event_id: None,
-            },
-            message_id: ts.to_string(),
-        })
+
+        // Standard path — no markers, just text.
+        self.send_plain_text(channel, content).await
     }
 
     async fn create_thread(

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -733,6 +733,13 @@ impl ChatAdapter for SlackAdapter {
 
             // Upload each file as a follow-up. Dedup via the cache so we don't
             // re-upload on each streaming edit chunk.
+            //
+            // Race-free check-and-claim: insert into cache FIRST under the lock,
+            // then upload. If insertion returns false (key already present),
+            // another edit_message call already claimed the slot — skip.
+            // The previous version did check-then-act with the lock released
+            // between check and insert, allowing duplicate uploads when two
+            // streaming edits fired within the upload latency window.
             for path in &file_paths {
                 let cache_key = format!(
                     "{}|{}|{}",
@@ -740,21 +747,24 @@ impl ChatAdapter for SlackAdapter {
                     msg.channel.thread_id.as_deref().unwrap_or(""),
                     path
                 );
-                {
-                    let cache = self.file_upload_cache.lock().await;
-                    if cache.contains(&cache_key) {
-                        debug!(path = %path, "skipping duplicate file upload (cached)");
-                        continue;
-                    }
+                let claimed = {
+                    let mut cache = self.file_upload_cache.lock().await;
+                    cache.insert(cache_key.clone()) // returns true if newly inserted
+                };
+                if !claimed {
+                    debug!(path = %path, "skipping duplicate file upload (already claimed)");
+                    continue;
                 }
                 match self.send_file_to_slack(&msg.channel, path).await {
                     Ok(_) => {
                         info!(path = %path, "slack: file uploaded via edit_message");
-                        let mut cache = self.file_upload_cache.lock().await;
-                        cache.insert(cache_key);
                     }
                     Err(e) => {
                         error!(path = %path, error = %e, "slack: file upload failed");
+                        // Roll back the claim so a future retry of the SAME path
+                        // (e.g. user re-asks after fixing the path) isn't blocked.
+                        let mut cache = self.file_upload_cache.lock().await;
+                        cache.remove(&cache_key);
                         let err_text = format!(
                             "⚠️ Failed to send file `{}`: {}\n(See OpenAB logs for details.)",
                             path, e

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1386,16 +1386,26 @@ async fn handle_message(
                     debug!(filename, "adding text file attachment");
                     extra_blocks.push(block);
                 }
-            } else if let Some(block) = media::download_and_encode_image(
+            } else if mimetype.starts_with("image/") {
+                if let Some(block) = media::download_and_encode_image(
+                    url,
+                    Some(mimetype),
+                    filename,
+                    size,
+                    Some(bot_token),
+                ).await {
+                    debug!(filename, "adding image attachment");
+                    extra_blocks.push(block);
+                }
+            } else if let Some(block) = media::download_to_disk(
                 url,
-                Some(mimetype),
                 filename,
+                mimetype,
                 size,
                 Some(bot_token),
-            )
-            .await
-            {
-                debug!(filename, "adding image attachment");
+                &ts,
+            ).await {
+                debug!(filename, "adding file attachment via disk path");
                 extra_blocks.push(block);
             } else {
                 // Fallback for unhandled file types (video, PDF, Office docs,

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -80,6 +80,11 @@ pub struct SlackAdapter {
     multibot_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
     /// TTL for participation cache entries (matches session_ttl_hours from config).
     session_ttl: std::time::Duration,
+    /// Dedup set for file uploads — keyed on `{channel}|{thread_ts}|{path}`.
+    /// Streaming edit_message can fire repeatedly during a single agent turn,
+    /// each potentially containing the file-send marker. Without dedup we'd
+    /// re-upload the same file dozens of times. Cleared once per session restart.
+    file_upload_cache: tokio::sync::Mutex<HashSet<String>>,
 }
 
 impl SlackAdapter {
@@ -97,6 +102,7 @@ impl SlackAdapter {
             participated_threads: tokio::sync::Mutex::new(HashMap::new()),
             multibot_threads: tokio::sync::Mutex::new(HashMap::new()),
             session_ttl,
+            file_upload_cache: tokio::sync::Mutex::new(HashSet::new()),
         }
     }
 
@@ -703,6 +709,63 @@ impl ChatAdapter for SlackAdapter {
     }
 
     async fn edit_message(&self, msg: &MessageRef, content: &str) -> Result<()> {
+        // Marker handling for the streaming path: OpenAB streams the final agent
+        // response via repeated edit_message calls against a placeholder. If the
+        // text contains file-send markers, we strip them from the edit (so the
+        // placeholder shows clean text) and trigger uploads as separate follow-up
+        // messages in the same channel/thread.
+        //
+        // Idempotency: we only want to upload each file ONCE per session, not on
+        // every streaming edit. We track this via the file_upload_cache keyed on
+        // (channel_id, thread_ts, path). The cache lives on the adapter struct.
+        if let Some((stripped_text, file_paths)) = extract_file_send_markers(content) {
+            // Edit the placeholder to the clean text (without markers).
+            let stripped_mrkdwn = markdown_to_mrkdwn(&stripped_text);
+            self.api_post(
+                "chat.update",
+                serde_json::json!({
+                    "channel": msg.channel.channel_id,
+                    "ts": msg.message_id,
+                    "text": stripped_mrkdwn,
+                }),
+            )
+            .await?;
+
+            // Upload each file as a follow-up. Dedup via the cache so we don't
+            // re-upload on each streaming edit chunk.
+            for path in &file_paths {
+                let cache_key = format!(
+                    "{}|{}|{}",
+                    msg.channel.channel_id,
+                    msg.channel.thread_id.as_deref().unwrap_or(""),
+                    path
+                );
+                {
+                    let cache = self.file_upload_cache.lock().await;
+                    if cache.contains(&cache_key) {
+                        debug!(path = %path, "skipping duplicate file upload (cached)");
+                        continue;
+                    }
+                }
+                match self.send_file_to_slack(&msg.channel, path).await {
+                    Ok(_) => {
+                        info!(path = %path, "slack: file uploaded via edit_message");
+                        let mut cache = self.file_upload_cache.lock().await;
+                        cache.insert(cache_key);
+                    }
+                    Err(e) => {
+                        error!(path = %path, error = %e, "slack: file upload failed");
+                        let err_text = format!(
+                            "⚠️ Failed to send file `{}`: {}\n(See OpenAB logs for details.)",
+                            path, e
+                        );
+                        let _ = self.send_plain_text(&msg.channel, &err_text).await;
+                    }
+                }
+            }
+            return Ok(());
+        }
+
         let mrkdwn = markdown_to_mrkdwn(content);
         self.api_post(
             "chat.update",

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1397,45 +1397,43 @@ async fn handle_message(
                     debug!(filename, "adding image attachment");
                     extra_blocks.push(block);
                 }
-            } else if let Some(block) = media::download_to_disk(
-                url,
-                filename,
-                mimetype,
-                size,
-                Some(bot_token),
-                &ts,
-            ).await {
-                debug!(filename, "adding file attachment via disk path");
-                extra_blocks.push(block);
             } else {
                 // Fallback for unhandled file types (video, PDF, Office docs,
-                // archives, generic binary). Without this, OpenAB silently
-                // drops the file — the agent never knows the user attached
-                // anything and reasons from incomplete context.
-                //
-                // Inject a small text ContentBlock with metadata so the agent
-                // can: (a) acknowledge the file exists, (b) optionally fetch
-                // it via a separate tool (Slack MCP's read_file, manual curl,
-                // etc.) if it has the capability and the content matters.
-                //
-                // Size-bound: only inject metadata, not contents — keeps the
-                // ACP message small regardless of file size.
-                let human_size = format_size_human(size);
-                let metadata = format!(
-                    "[Slack file attachment — not auto-loaded by OpenAB]\n\
-                     - filename: {filename}\n\
-                     - mimetype: {mimetype}\n\
-                     - size: {human_size}\n\
-                     - url: {url}\n\
-                     \n\
-                     This file type isn't auto-forwarded into your context. \
-                     If the contents matter to the user's request, fetch it \
-                     separately (Slack MCP's slack_read_file, or download via \
-                     curl with Bearer token if you have it). Otherwise just \
-                     acknowledge that the user shared the file."
-                );
-                debug!(filename, mimetype, size, "injecting unhandled-file metadata block");
-                extra_blocks.push(ContentBlock::Text { text: metadata });
+                // archives, generic binary): download to disk so the agent
+                // gets a local path it can hand to ffmpeg / pdftotext / etc.
+                // If the disk write fails, inject a failure-notice block so
+                // the agent still knows the file existed (fail loudly, don't
+                // silently drop).
+                match media::download_to_disk(
+                    url,
+                    filename,
+                    mimetype,
+                    size,
+                    Some(bot_token),
+                    &ts,
+                )
+                .await
+                {
+                    Some(block) => {
+                        debug!(filename, "adding file attachment via disk path");
+                        extra_blocks.push(block);
+                    }
+                    None => {
+                        let human_size = format_size_human(size);
+                        let notice = format!(
+                            "[Slack file attachment — download failed]\n\
+                             - filename: {filename}\n\
+                             - mimetype: {mimetype}\n\
+                             - size: {human_size}\n\
+                             \n\
+                             OpenAB tried to save this file locally but the download or write \
+                             failed (see logs). The user shared the file; acknowledge it but \
+                             note you couldn't access the contents."
+                        );
+                        warn!(filename, mimetype, size, "download_to_disk failed, emitting failure notice");
+                        extra_blocks.push(ContentBlock::Text { text: notice });
+                    }
+                }
             }
         }
     }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1069,6 +1069,35 @@ async fn handle_message(
             {
                 debug!(filename, "adding image attachment");
                 extra_blocks.push(block);
+            } else {
+                // Fallback for unhandled file types (video, PDF, Office docs,
+                // archives, generic binary). Without this, OpenAB silently
+                // drops the file — the agent never knows the user attached
+                // anything and reasons from incomplete context.
+                //
+                // Inject a small text ContentBlock with metadata so the agent
+                // can: (a) acknowledge the file exists, (b) optionally fetch
+                // it via a separate tool (Slack MCP's read_file, manual curl,
+                // etc.) if it has the capability and the content matters.
+                //
+                // Size-bound: only inject metadata, not contents — keeps the
+                // ACP message small regardless of file size.
+                let human_size = format_size_human(size);
+                let metadata = format!(
+                    "[Slack file attachment — not auto-loaded by OpenAB]\n\
+                     - filename: {filename}\n\
+                     - mimetype: {mimetype}\n\
+                     - size: {human_size}\n\
+                     - url: {url}\n\
+                     \n\
+                     This file type isn't auto-forwarded into your context. \
+                     If the contents matter to the user's request, fetch it \
+                     separately (Slack MCP's slack_read_file, or download via \
+                     curl with Bearer token if you have it). Otherwise just \
+                     acknowledge that the user shared the file."
+                );
+                debug!(filename, mimetype, size, "injecting unhandled-file metadata block");
+                extra_blocks.push(ContentBlock::Text { text: metadata });
             }
         }
     }
@@ -1219,6 +1248,25 @@ fn slack_file_download_url(file: &serde_json::Value) -> &str {
 /// Strip MIME parameters like `; charset=utf-8` so type-detection helpers see
 /// the bare media type. Slack occasionally sends mimetypes like
 /// `text/plain; charset=utf-8`; `media::is_text_file` expects the bare form.
+/// Format a byte count in a human-readable way (e.g. "2.2 MB", "456 KB").
+/// Used in the unhandled-file metadata block so the agent sees a friendly size.
+fn format_size_human(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else if bytes > 0 {
+        format!("{bytes} bytes")
+    } else {
+        "unknown size".to_string()
+    }
+}
+
 fn strip_mime_params(mimetype: &str) -> &str {
     mimetype.split(';').next().unwrap_or(mimetype).trim()
 }


### PR DESCRIPTION
## Summary

Adds the `<<openab-relay-to ...>>` / `<<openab-relay-end>>` marker pair from Tifa's 2026-05-26 proposal. Lets an agent emit a single message that posts a body to another platform's channel, alongside its normal reply on the origin channel.

Builds on the line-anchored marker design from `c39d451` (this morning's fix) and reuses that defensive pattern: relay markers must occupy their own line so the agent can quote them in docs/source code without self-triggering.

## Scope

- New `src/relay.rs` (651 lines): marker parser + dispatch logic
- `AdapterRouter`: optional `relay_ctx` field — `None` short-circuits everything (zero overhead for users who don't opt in)
- Streaming display mask: in-progress relay blocks hidden from placeholder edit loop across all 3 streaming sites (Text, ToolStart, ToolDone)
- Post-stream extraction runs **before** `compose_display` + `split_message`, so multi-line blocks aren't torn by the 4000/2000-char chunker
- Peer-side: looks up adapter via `Weak::upgrade`, applies prefix template, strips file-send markers (security: prevents Slack-targeted relay from triggering uploads), peer-side splits before sending
- `config.toml.example`: `[relay]` + `[relay.aliases]` documented, commented-out, disabled-by-default

## Config

```toml
[relay]
enabled = true
prefix_template = "[via {sender_persona} from {sender_platform}]"

[relay.aliases]
"discord:swat-team" = { channel_id = "1485156316480803018" }
"slack:tifa-dm"     = { channel_id = "D0B4JKKM9PD" }
```

Length-capped at 200 bytes; alias keys must contain `:` (platform:alias format). Validation at startup; invalid config bails before bridge serves traffic.

## Test plan

- [x] `cargo test` — all 409 tests pass (+29 from this branch)
- [x] `cargo build --release` clean, no warnings
- [ ] Manual smoke test in production:
  - Tifa says `<<openab-relay-to discord:swat-team>>body<<openab-relay-end>>` in Slack → body appears in Discord channel with `[via Tifa from slack]` prefix; origin Slack reply also sent
  - Bad alias → `⚠ relay to ...` notice appears in origin channel only, no relay
  - Bare `<<openab-relay-to ...` quoted inline (e.g. in code block) → preserved as literal, no dispatch

## Test plan — not done

- [ ] Real-world smoke test (requires runtime config alias + restart)
- [ ] Performance check under load (zero-overhead claim verified by inspection but not benchmarked)

## Backwards compatibility

Default config has no `[relay]` section → `relay_ctx` is `None` → every relay code path short-circuits. Bridges that don't opt in see zero behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)