### PR TITLE
ci: replace dorny/paths-filter with native git diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,18 +22,16 @@ jobs:
       operator: ${{ steps.filter.outputs.operator }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            core:
-              - 'src/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-            gateway:
-              - 'gateway/**'
-            operator:
-              - 'operator/**'
+          fetch-depth: 0
+      - id: filter
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
+          echo "core=$(echo "$CHANGED" | grep -qE '^(src/|Cargo\.(toml|lock))' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "gateway=$(echo "$CHANGED" | grep -q '^gateway/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "operator=$(echo "$CHANGED" | grep -q '^operator/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
   check:
     needs: changes


### PR DESCRIPTION
## Problem

`dorny/paths-filter@v3` action is broken because the author's GitHub account has been suspended. This affects all PRs in this repo.

## Solution

Replace with a native `git diff --name-only` + `grep` approach. Zero third-party dependencies, functionally equivalent.

## Changes

- Remove `dorny/paths-filter@v3` dependency
- Add `fetch-depth: 0` to checkout (needed for diff)
- Use shell script to detect changed paths and set outputs

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365150664560881/1508657918445359115