### PR TITLE
fix: harden agy-acp session binding

### DIFF
--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 use tokio::process::Command;
@@ -34,8 +34,8 @@ struct JsonRpcNotification {
 struct Session {
     /// agy conversation ID (from conversations directory)
     conversation_id: Option<String>,
-    /// cumulative stdout length from previous turns
-    prev_output_len: usize,
+    /// full stdout from the previous turn for prefix-checked delta extraction
+    prev_output: String,
 }
 
 struct Adapter {
@@ -52,19 +52,56 @@ impl Adapter {
             working_dir: std::env::current_dir()
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_else(|_| "/tmp".to_string()),
-            conversations_dir: PathBuf::from(&home)
-                .join(".gemini/antigravity-cli/conversations"),
+            conversations_dir: PathBuf::from(&home).join(".gemini/antigravity-cli/conversations"),
         }
     }
 
-    /// Find the most recently modified conversation ID from agy's data dir.
-    fn latest_conversation_id(&self) -> Option<String> {
-        let entries = std::fs::read_dir(&self.conversations_dir).ok()?;
+    fn conversation_snapshot(&self) -> HashSet<String> {
+        let Ok(entries) = std::fs::read_dir(&self.conversations_dir) else {
+            return HashSet::new();
+        };
+
         entries
             .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().map(|x| x == "pb").unwrap_or(false))
-            .max_by_key(|e| e.metadata().ok().and_then(|m| m.modified().ok()))
-            .and_then(|e| e.path().file_stem().map(|s| s.to_string_lossy().to_string()))
+            .filter_map(|e| {
+                let path = e.path();
+                if path.extension().map(|x| x == "pb").unwrap_or(false) {
+                    path.file_stem().map(|s| s.to_string_lossy().to_string())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn new_conversation_id(&self, before: &HashSet<String>) -> Option<String> {
+        let after = self.conversation_snapshot();
+        let mut created = after.difference(before);
+        let first = created.next()?.to_string();
+        if created.next().is_some() {
+            eprintln!(
+                "[agy-acp] WARN: multiple new agy conversation files appeared; \
+                 refusing to bind this ACP session by global heuristic"
+            );
+            return None;
+        }
+        Some(first)
+    }
+
+    fn extract_delta(prev_output: &str, full_text: &str, conversation_bound: bool) -> String {
+        if !conversation_bound || prev_output.is_empty() {
+            return full_text.to_string();
+        }
+
+        if let Some(delta) = full_text.strip_prefix(prev_output) {
+            return delta.trim_start().to_string();
+        }
+
+        eprintln!(
+            "[agy-acp] WARN: agy stdout was not append-only for the bound conversation; \
+             sending full output for this turn and resetting delta baseline"
+        );
+        full_text.to_string()
     }
 
     fn handle_initialize(&self, id: u64) -> JsonRpcResponse {
@@ -82,10 +119,13 @@ impl Adapter {
 
     fn handle_session_new(&mut self, id: u64) -> JsonRpcResponse {
         let session_id = Uuid::new_v4().to_string();
-        self.sessions.insert(session_id.clone(), Session {
-            conversation_id: None,
-            prev_output_len: 0,
-        });
+        self.sessions.insert(
+            session_id.clone(),
+            Session {
+                conversation_id: None,
+                prev_output: String::new(),
+            },
+        );
         JsonRpcResponse {
             jsonrpc: "2.0",
             id,
@@ -95,7 +135,10 @@ impl Adapter {
     }
 
     async fn handle_session_prompt(&mut self, id: u64, params: &Value) -> Vec<String> {
-        let session_id = params.get("sessionId").and_then(|v| v.as_str()).unwrap_or("");
+        let session_id = params
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         let prompt_text = params
             .get("prompt")
             .and_then(|v| v.as_array())
@@ -107,6 +150,17 @@ impl Adapter {
             })
             .unwrap_or_default();
         let clean_prompt = prompt_text.trim();
+
+        let conversation_snapshot = if self
+            .sessions
+            .get(session_id)
+            .map(|s| s.conversation_id.is_none())
+            .unwrap_or(false)
+        {
+            Some(self.conversation_snapshot())
+        } else {
+            None
+        };
 
         // Build args: use --conversation <ID> for subsequent turns
         let mut args: Vec<String> = Vec::new();
@@ -141,30 +195,35 @@ impl Adapter {
             Ok(output) => {
                 let full_text = String::from_utf8_lossy(&output.stdout).to_string();
 
-                // Extract only the new content (delta)
-                let prev_len = self.sessions.get(session_id)
-                    .map(|s| s.prev_output_len)
-                    .unwrap_or(0);
-                let new_text = if prev_len < full_text.len() {
-                    full_text[prev_len..].trim_start().to_string()
-                } else {
-                    full_text.clone()
-                };
+                let prev_output = self
+                    .sessions
+                    .get(session_id)
+                    .map(|s| s.prev_output.clone())
+                    .unwrap_or_default();
+                let conversation_bound = self
+                    .sessions
+                    .get(session_id)
+                    .map(|s| s.conversation_id.is_some())
+                    .unwrap_or(false);
+                let new_text = Self::extract_delta(&prev_output, &full_text, conversation_bound);
 
-                // Update session state
-                let conv_id = if self.sessions.get(session_id)
-                    .map(|s| s.conversation_id.is_none())
-                    .unwrap_or(false)
-                {
-                    self.latest_conversation_id()
-                } else {
-                    None
-                };
+                let conv_id = conversation_snapshot
+                    .as_ref()
+                    .and_then(|before| self.new_conversation_id(before));
 
                 if let Some(session) = self.sessions.get_mut(session_id) {
-                    session.prev_output_len = full_text.len();
                     if session.conversation_id.is_none() {
                         session.conversation_id = conv_id;
+                    }
+                    if session.conversation_id.is_some() {
+                        session.prev_output = full_text;
+                    } else {
+                        session.prev_output.clear();
+                        eprintln!(
+                            "[agy-acp] WARN: could not bind an agy conversation ID; \
+                             this ACP session will run in single-turn mode until a \
+                             conversation can be bound"
+                        );
                     }
                 }
 
@@ -178,13 +237,24 @@ impl Adapter {
                             "content": { "type": "text", "text": new_text },
                         },
                     }),
-                }).unwrap();
+                })
+                .unwrap();
                 output_lines.push(notification);
-                let resp = JsonRpcResponse { jsonrpc: "2.0", id, result: Some(json!({ "stopReason": "end_turn" })), error: None };
+                let resp = JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: Some(json!({ "stopReason": "end_turn" })),
+                    error: None,
+                };
                 output_lines.push(serde_json::to_string(&resp).unwrap());
             }
             Err(e) => {
-                let resp = JsonRpcResponse { jsonrpc: "2.0", id, result: None, error: Some(json!({"code":-32000,"message":format!("failed to run agy: {e}")})) };
+                let resp = JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: None,
+                    error: Some(json!({"code":-32000,"message":format!("failed to run agy: {e}")})),
+                };
                 output_lines.push(serde_json::to_string(&resp).unwrap());
             }
         }
@@ -236,11 +306,23 @@ async fn main() {
                 adapter.handle_session_prompt(id, &params).await
             }
             Some("session/cancel") => {
-                let r = JsonRpcResponse { jsonrpc: "2.0", id, result: Some(json!({})), error: None };
+                let r = JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: Some(json!({})),
+                    error: None,
+                };
                 vec![serde_json::to_string(&r).unwrap()]
             }
             Some(method) => {
-                let r = JsonRpcResponse { jsonrpc: "2.0", id, result: None, error: Some(json!({"code":-32601,"message":format!("method not found: {method}")})) };
+                let r = JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: None,
+                    error: Some(
+                        json!({"code":-32601,"message":format!("method not found: {method}")}),
+                    ),
+                };
                 vec![serde_json::to_string(&r).unwrap()]
             }
             None => continue,
@@ -250,5 +332,54 @@ async fn main() {
             let _ = writeln!(stdout, "{}", line);
         }
         let _ = stdout.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn extract_delta_returns_full_text_without_bound_conversation() {
+        let output = Adapter::extract_delta("old", "oldnew", false);
+        assert_eq!(output, "oldnew");
+    }
+
+    #[test]
+    fn extract_delta_returns_only_appended_output_for_bound_conversation() {
+        let output =
+            Adapter::extract_delta("first response\n", "first response\nsecond response", true);
+        assert_eq!(output, "second response");
+    }
+
+    #[test]
+    fn extract_delta_falls_back_when_output_is_not_append_only() {
+        let output = Adapter::extract_delta("old response", "fresh response", true);
+        assert_eq!(output, "fresh response");
+    }
+
+    #[test]
+    fn new_conversation_id_uses_snapshot_diff_instead_of_latest_file() {
+        let root = std::env::temp_dir().join(format!("agy-acp-test-{}", Uuid::new_v4()));
+        let conversations_dir = root.join("conversations");
+        fs::create_dir_all(&conversations_dir).unwrap();
+        fs::write(conversations_dir.join("old.pb"), b"old").unwrap();
+
+        let adapter = Adapter {
+            sessions: HashMap::new(),
+            working_dir: root.to_string_lossy().to_string(),
+            conversations_dir: conversations_dir.clone(),
+        };
+
+        let before = adapter.conversation_snapshot();
+        fs::write(conversations_dir.join("new.pb"), b"new").unwrap();
+
+        assert_eq!(
+            adapter.new_conversation_id(&before),
+            Some("new".to_string())
+        );
+
+        let _ = fs::remove_dir_all(root);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #905 and #906.

We saw `agy-acp` still return stale Antigravity output in a live Discord/OpenAB deployment after the OpenAB session had been reset. A prompt like `stat?` could receive unrelated prior content such as an old transcription/auth-flow response. That makes Antigravity unsafe as a peer worker in multi-bot Discord loops because the adapter may send old conversation state as if it were the current assistant reply.

This PR tightens the adapter in two places:

1. Bind the `agy` conversation ID by taking a pre/post snapshot of the conversation directory around the first prompt, instead of selecting the globally newest conversation file.
2. Replace raw byte-offset delta extraction with prefix-checked delta extraction, and only apply deltas after the ACP session is actually bound to a specific `agy` conversation.

## Before / After

```text
BEFORE:
ACP session A first turn
  -> agy writes/updates conversation files
  -> adapter picks globally newest *.pb file
  -> later turns slice stdout by byte length
  -> wrong conversation or non-append-only stdout can leak stale output

AFTER:
ACP session A first turn
  -> adapter snapshots conversations before invoking agy
  -> agy runs
  -> adapter binds only the single newly-created conversation ID
  -> later turns use --conversation <ID>
  -> delta is extracted only if current stdout starts with the previous stdout
  -> otherwise full output is sent and the delta baseline is reset
```

## Data Flow (ASCII)

```text
Discord thread
  -> OpenAB session/prompt
  -> agy-acp session_id
  -> snapshot ~/.gemini/antigravity-cli/conversations/*.pb
  -> agy -p "<prompt>"
  -> snapshot again
  -> bind exactly one new conversation ID
  -> next prompt uses agy --conversation <ID> -p "<prompt>"
  -> strip previous stdout prefix only when it matches
  -> send current turn text to Discord
```

## Investigation

### Related Issue: #905

- #905 documents the original bug where `agy --continue -p` emitted cumulative conversation output and `agy-acp` forwarded it verbatim.
- The key lesson is that the adapter must not assume CLI stdout is already the current assistant turn.

### Related PR: #906

- #906 moved toward `--conversation <ID>` plus delta extraction.
- The current `main` implementation still uses a global `latest_conversation_id()` heuristic and byte-index slicing.
- In live usage, this can still bind the wrong conversation under shared-home or multi-session activity and can still treat stale output as current output.


### Discord Discussion

- Discussion thread: https://discord.com/channels/1491295327620169908/1491365158868619404/1508850210506281182

### Live Operator Observation

- In a local OpenAB deployment, `/reset` removed the active OpenAB session.
- A fresh `agy-acp` session was then created for a new mention.
- The bot still returned unrelated stale content, which strongly suggests adapter/CLI conversation binding or output extraction is still not robust enough for Discord-visible multi-agent use.

### Key Takeaway

`agy-acp` should fail soft into single-turn mode when it cannot safely bind the exact conversation, rather than relying on global "latest conversation" state. Once bound, it should only emit deltas when the previous stdout is an actual prefix of the current stdout.

## Changes

| File | Change |
|------|--------|
| `agy-acp/src/main.rs` | Replace global latest-conversation lookup with pre/post snapshot diff. |
| `agy-acp/src/main.rs` | Store previous full stdout instead of raw byte length. |
| `agy-acp/src/main.rs` | Extract deltas with `strip_prefix()` instead of slicing by byte offset. |
| `agy-acp/src/main.rs` | Only apply delta extraction once a conversation ID is bound. |
| `agy-acp/src/main.rs` | Add warnings when binding is ambiguous or unavailable. |
| `agy-acp/src/main.rs` | Add unit tests for delta behavior and snapshot-based conversation binding. |

## Testing

- `cargo fmt --manifest-path agy-acp/Cargo.toml`
- `cargo test --manifest-path agy-acp/Cargo.toml`

Test result:

```text
running 4 tests
test tests::extract_delta_falls_back_when_output_is_not_append_only ... ok
test tests::extract_delta_returns_only_appended_output_for_bound_conversation ... ok
test tests::extract_delta_returns_full_text_without_bound_conversation ... ok
test tests::new_conversation_id_uses_snapshot_diff_instead_of_latest_file ... ok
```

Not yet verified:

- End-to-end Discord deployment with the patched image. The fix is based on the observed live failure mode plus unit coverage around the unsafe adapter logic.

## Risks and Mitigations

- Risk: If `agy` does not create a detectable new conversation file on first turn, the ACP session will not get multi-turn native `agy` context.
  - Mitigation: The adapter logs a warning and avoids binding to a potentially wrong global conversation. This is safer than leaking stale output.

- Risk: If `agy --conversation <ID>` stops returning append-only stdout, delta extraction will not strip anything.
  - Mitigation: The adapter checks `strip_prefix()` and sends full output rather than panicking or slicing incorrectly.

- Risk: This does not fix all possible `agy` CLI output-quality issues.
  - Mitigation: This PR is scoped to adapter session binding and output isolation only.

## Compatibility / Migration

- Backward compatible: Yes.
- Config/env changes: No.
- Migration needed: No.

