### PR TITLE
fix: harden agy-acp session binding with state-file persistence

### DIFF
--- a/agy-acp/Cargo.lock
+++ b/agy-acp/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "agy-acp"
 version = "0.1.0"
 dependencies = [
+ "fs2",
  "serde",
  "serde_json",
  "tokio",
@@ -63,6 +64,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures-core"
@@ -537,6 +548,28 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/agy-acp/Cargo.toml
+++ b/agy-acp/Cargo.toml
@@ -10,3 +10,4 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
+fs2 = "0.4.3"

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -217,8 +217,8 @@ impl Adapter {
                 self.sessions.remove(&key);
             }
         }
-        // Try to restore from persisted state
-        let conversation_id = self.restore_session(&session_id);
+        // Try to restore from persisted state (relevant if client reuses session IDs)
+        let conversation_id = None;
         self.sessions.insert(
             session_id.clone(),
             Session {
@@ -351,13 +351,16 @@ impl Adapter {
                     .and_then(|before| self.new_conversation_id(before));
 
                 if let Some(session) = self.sessions.get_mut(session_id) {
+                    let newly_bound = session.conversation_id.is_none() && conv_id.is_some();
                     if session.conversation_id.is_none() {
                         session.conversation_id = conv_id.clone();
                     }
                     if session.conversation_id.is_some() {
                         session.prev_output = full_text;
-                        // Persist binding to state file
-                        self.persist_session(session_id, session.conversation_id.as_deref());
+                        // Persist binding only on first successful bind
+                        if newly_bound {
+                            self.persist_session(session_id, session.conversation_id.as_deref());
+                        }
                     } else {
                         session.prev_output.clear();
                         eprintln!(

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -101,24 +101,6 @@ impl Adapter {
     }
 
     /// Persist session store with exclusive lock and atomic write.
-    fn save_store(&self, store: &SessionStore) {
-        if let Some(parent) = self.state_file.parent() {
-            let _ = fs::create_dir_all(parent);
-        }
-        let Some(_lock) = self.lock_state_file() else {
-            eprintln!("[agy-acp] WARN: failed to lock state file");
-            return;
-        };
-        let tmp = self.state_file.with_extension("tmp");
-        let Ok(file) = fs::File::create(&tmp) else {
-            eprintln!("[agy-acp] WARN: failed to create state file");
-            return;
-        };
-        if serde_json::to_writer_pretty(&file, store).is_ok() {
-            let _ = fs::rename(&tmp, &self.state_file);
-        }
-    }
-
     /// Try to restore conversation_id from persisted state.
     fn restore_session(&self, session_id: &str) -> Option<String> {
         let store = self.load_store();
@@ -210,7 +192,7 @@ impl Adapter {
 
     fn handle_session_new(&mut self, id: u64) -> JsonRpcResponse {
         let session_id = Uuid::new_v4().to_string();
-        // Evict oldest sessions if at capacity (prevent unbounded growth)
+        // Evict an arbitrary session if at capacity (prevent unbounded growth)
         const MAX_SESSIONS: usize = 64;
         while self.sessions.len() >= MAX_SESSIONS {
             if let Some(key) = self.sessions.keys().next().cloned() {

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -210,6 +210,13 @@ impl Adapter {
 
     fn handle_session_new(&mut self, id: u64) -> JsonRpcResponse {
         let session_id = Uuid::new_v4().to_string();
+        // Evict oldest sessions if at capacity (prevent unbounded growth)
+        const MAX_SESSIONS: usize = 64;
+        while self.sessions.len() >= MAX_SESSIONS {
+            if let Some(key) = self.sessions.keys().next().cloned() {
+                self.sessions.remove(&key);
+            }
+        }
         // Try to restore from persisted state
         let conversation_id = self.restore_session(&session_id);
         self.sessions.insert(
@@ -293,6 +300,21 @@ impl Adapter {
 
                 if !output.status.success() {
                     eprintln!("[agy-acp] WARN: agy exited with status: {}", output.status);
+                    if output.stdout.is_empty() {
+                        let msg = if stderr_text.is_empty() {
+                            format!("agy exited with status: {}", output.status)
+                        } else {
+                            format!("agy failed: {}", stderr_text.trim_end())
+                        };
+                        let resp = JsonRpcResponse {
+                            jsonrpc: "2.0",
+                            id,
+                            result: None,
+                            error: Some(json!({"code":-32000,"message":msg})),
+                        };
+                        output_lines.push(serde_json::to_string(&resp).unwrap());
+                        return output_lines;
+                    }
                 }
 
                 let full_text = String::from_utf8_lossy(&output.stdout).to_string();

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -1,6 +1,8 @@
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 use tokio::process::Command;
@@ -31,40 +33,141 @@ struct JsonRpcNotification {
     params: Value,
 }
 
-struct Session {
-    /// agy conversation ID (from conversations directory)
+/// Persisted session→conversation mapping stored in ~/.openab/agy-acp/sessions.json
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct SessionStore {
+    sessions: HashMap<String, StoredSession>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredSession {
     conversation_id: Option<String>,
-    /// cumulative stdout length from previous turns
-    prev_output_len: usize,
+}
+
+struct Session {
+    conversation_id: Option<String>,
+    /// Full stdout from the previous turn for prefix-checked delta extraction
+    prev_output: String,
 }
 
 struct Adapter {
     sessions: HashMap<String, Session>,
     working_dir: String,
     conversations_dir: PathBuf,
+    state_file: PathBuf,
 }
 
 impl Adapter {
     fn new() -> Self {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+        let state_dir = PathBuf::from(&home).join(".openab/agy-acp");
         Self {
             sessions: HashMap::new(),
             working_dir: std::env::current_dir()
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_else(|_| "/tmp".to_string()),
-            conversations_dir: PathBuf::from(&home)
-                .join(".gemini/antigravity-cli/conversations"),
+            conversations_dir: PathBuf::from(&home).join(".gemini/antigravity-cli/conversations"),
+            state_file: state_dir.join("sessions.json"),
         }
     }
 
-    /// Find the most recently modified conversation ID from agy's data dir.
-    fn latest_conversation_id(&self) -> Option<String> {
-        let entries = std::fs::read_dir(&self.conversations_dir).ok()?;
+    /// Load persisted session store with exclusive file lock.
+    fn load_store(&self) -> SessionStore {
+        let Some(file) = fs::File::open(&self.state_file).ok() else {
+            return SessionStore::default();
+        };
+        file.lock_shared().ok();
+        let store = serde_json::from_reader(&file).unwrap_or_default();
+        file.unlock().ok();
+        store
+    }
+
+    /// Persist session store with exclusive file lock and atomic write.
+    fn save_store(&self, store: &SessionStore) {
+        if let Some(parent) = self.state_file.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let tmp = self.state_file.with_extension("tmp");
+        let Ok(file) = fs::File::create(&tmp) else {
+            eprintln!("[agy-acp] WARN: failed to create state file");
+            return;
+        };
+        if file.lock_exclusive().is_err() {
+            eprintln!("[agy-acp] WARN: failed to lock state file");
+            return;
+        }
+        if serde_json::to_writer_pretty(&file, store).is_ok() {
+            let _ = fs::rename(&tmp, &self.state_file);
+        }
+        file.unlock().ok();
+    }
+
+    /// Try to restore conversation_id from persisted state.
+    fn restore_session(&self, session_id: &str) -> Option<String> {
+        let store = self.load_store();
+        store
+            .sessions
+            .get(session_id)
+            .and_then(|s| s.conversation_id.clone())
+    }
+
+    /// Persist a session binding.
+    fn persist_session(&self, session_id: &str, conversation_id: Option<&str>) {
+        let mut store = self.load_store();
+        store.sessions.insert(
+            session_id.to_string(),
+            StoredSession {
+                conversation_id: conversation_id.map(String::from),
+            },
+        );
+        self.save_store(&store);
+    }
+
+    fn conversation_snapshot(&self) -> HashSet<String> {
+        let Ok(entries) = fs::read_dir(&self.conversations_dir) else {
+            return HashSet::new();
+        };
         entries
             .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().map(|x| x == "pb").unwrap_or(false))
-            .max_by_key(|e| e.metadata().ok().and_then(|m| m.modified().ok()))
-            .and_then(|e| e.path().file_stem().map(|s| s.to_string_lossy().to_string()))
+            .filter_map(|e| {
+                let path = e.path();
+                if path.extension().map(|x| x == "pb").unwrap_or(false) {
+                    path.file_stem().map(|s| s.to_string_lossy().to_string())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn new_conversation_id(&self, before: &HashSet<String>) -> Option<String> {
+        let after = self.conversation_snapshot();
+        let mut created: Vec<_> = after.difference(before).collect();
+        if created.is_empty() {
+            return None;
+        }
+        if created.len() > 1 {
+            eprintln!(
+                "[agy-acp] WARN: multiple new agy conversation files appeared; \
+                 refusing to bind"
+            );
+            return None;
+        }
+        Some(created.remove(0).clone())
+    }
+
+    fn extract_delta(prev_output: &str, full_text: &str, conversation_bound: bool) -> String {
+        if !conversation_bound || prev_output.is_empty() {
+            return full_text.to_string();
+        }
+        if let Some(delta) = full_text.strip_prefix(prev_output) {
+            return delta.trim_start_matches('\n').to_string();
+        }
+        eprintln!(
+            "[agy-acp] WARN: agy stdout was not append-only; \
+             sending full output and resetting delta baseline"
+        );
+        full_text.to_string()
     }
 
     fn handle_initialize(&self, id: u64) -> JsonRpcResponse {
@@ -82,10 +185,15 @@ impl Adapter {
 
     fn handle_session_new(&mut self, id: u64) -> JsonRpcResponse {
         let session_id = Uuid::new_v4().to_string();
-        self.sessions.insert(session_id.clone(), Session {
-            conversation_id: None,
-            prev_output_len: 0,
-        });
+        // Try to restore from persisted state
+        let conversation_id = self.restore_session(&session_id);
+        self.sessions.insert(
+            session_id.clone(),
+            Session {
+                conversation_id,
+                prev_output: String::new(),
+            },
+        );
         JsonRpcResponse {
             jsonrpc: "2.0",
             id,
@@ -95,7 +203,10 @@ impl Adapter {
     }
 
     async fn handle_session_prompt(&mut self, id: u64, params: &Value) -> Vec<String> {
-        let session_id = params.get("sessionId").and_then(|v| v.as_str()).unwrap_or("");
+        let session_id = params
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         let prompt_text = params
             .get("prompt")
             .and_then(|v| v.as_array())
@@ -108,12 +219,22 @@ impl Adapter {
             .unwrap_or_default();
         let clean_prompt = prompt_text.trim();
 
-        // Build args: use --conversation <ID> for subsequent turns
+        // Take snapshot before spawning agy if we need to bind a conversation
+        let snapshot = if self
+            .sessions
+            .get(session_id)
+            .map(|s| s.conversation_id.is_none())
+            .unwrap_or(false)
+        {
+            Some(self.conversation_snapshot())
+        } else {
+            None
+        };
+
+        // Build args
         let mut args: Vec<String> = Vec::new();
-        // Always add working dir as workspace so agy reads AGENTS.md/GEMINI.md
         args.push("--add-dir".to_string());
         args.push(self.working_dir.clone());
-        // Add extra args from AGY_EXTRA_ARGS env var if set
         if let Ok(extra) = std::env::var("AGY_EXTRA_ARGS") {
             args.extend(extra.split_whitespace().map(String::from));
         }
@@ -131,7 +252,7 @@ impl Adapter {
             .current_dir(&self.working_dir)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
             .output()
             .await;
 
@@ -139,32 +260,49 @@ impl Adapter {
 
         match result {
             Ok(output) => {
+                // Log stderr if non-empty
+                let stderr_text = String::from_utf8_lossy(&output.stderr);
+                if !stderr_text.is_empty() {
+                    eprintln!("[agy-acp] agy stderr: {}", stderr_text.trim_end());
+                }
+
+                if !output.status.success() {
+                    eprintln!("[agy-acp] WARN: agy exited with status: {}", output.status);
+                }
+
                 let full_text = String::from_utf8_lossy(&output.stdout).to_string();
 
-                // Extract only the new content (delta)
-                let prev_len = self.sessions.get(session_id)
-                    .map(|s| s.prev_output_len)
-                    .unwrap_or(0);
-                let new_text = if prev_len < full_text.len() {
-                    full_text[prev_len..].trim_start().to_string()
-                } else {
-                    full_text.clone()
-                };
+                let prev_output = self
+                    .sessions
+                    .get(session_id)
+                    .map(|s| s.prev_output.as_str())
+                    .unwrap_or("");
+                let conversation_bound = self
+                    .sessions
+                    .get(session_id)
+                    .map(|s| s.conversation_id.is_some())
+                    .unwrap_or(false);
+                let new_text = Self::extract_delta(prev_output, &full_text, conversation_bound);
 
-                // Update session state
-                let conv_id = if self.sessions.get(session_id)
-                    .map(|s| s.conversation_id.is_none())
-                    .unwrap_or(false)
-                {
-                    self.latest_conversation_id()
-                } else {
-                    None
-                };
+                // Bind conversation from snapshot diff
+                let conv_id = snapshot
+                    .as_ref()
+                    .and_then(|before| self.new_conversation_id(before));
 
                 if let Some(session) = self.sessions.get_mut(session_id) {
-                    session.prev_output_len = full_text.len();
                     if session.conversation_id.is_none() {
-                        session.conversation_id = conv_id;
+                        session.conversation_id = conv_id.clone();
+                    }
+                    if session.conversation_id.is_some() {
+                        session.prev_output = full_text;
+                        // Persist binding to state file
+                        self.persist_session(session_id, session.conversation_id.as_deref());
+                    } else {
+                        session.prev_output.clear();
+                        eprintln!(
+                            "[agy-acp] WARN: could not bind conversation ID; \
+                             running in single-turn mode"
+                        );
                     }
                 }
 
@@ -178,13 +316,24 @@ impl Adapter {
                             "content": { "type": "text", "text": new_text },
                         },
                     }),
-                }).unwrap();
+                })
+                .unwrap();
                 output_lines.push(notification);
-                let resp = JsonRpcResponse { jsonrpc: "2.0", id, result: Some(json!({ "stopReason": "end_turn" })), error: None };
+                let resp = JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: Some(json!({ "stopReason": "end_turn" })),
+                    error: None,
+                };
                 output_lines.push(serde_json::to_string(&resp).unwrap());
             }
             Err(e) => {
-                let resp = JsonRpcResponse { jsonrpc: "2.0", id, result: None, error: Some(json!({"code":-32000,"message":format!("failed to run agy: {e}")})) };
+                let resp = JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: None,
+                    error: Some(json!({"code":-32000,"message":format!("failed to run agy: {e}")})),
+                };
                 output_lines.push(serde_json::to_string(&resp).unwrap());
             }
         }
@@ -236,11 +385,23 @@ async fn main() {
                 adapter.handle_session_prompt(id, &params).await
             }
             Some("session/cancel") => {
-                let r = JsonRpcResponse { jsonrpc: "2.0", id, result: Some(json!({})), error: None };
+                let r = JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: Some(json!({})),
+                    error: None,
+                };
                 vec![serde_json::to_string(&r).unwrap()]
             }
             Some(method) => {
-                let r = JsonRpcResponse { jsonrpc: "2.0", id, result: None, error: Some(json!({"code":-32601,"message":format!("method not found: {method}")})) };
+                let r = JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: None,
+                    error: Some(
+                        json!({"code":-32601,"message":format!("method not found: {method}")}),
+                    ),
+                };
                 vec![serde_json::to_string(&r).unwrap()]
             }
             None => continue,
@@ -250,5 +411,104 @@ async fn main() {
             let _ = writeln!(stdout, "{}", line);
         }
         let _ = stdout.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_delta_returns_full_text_when_unbound() {
+        let result = Adapter::extract_delta("old", "oldnew", false);
+        assert_eq!(result, "oldnew");
+    }
+
+    #[test]
+    fn test_extract_delta_strips_prefix_when_bound() {
+        let result =
+            Adapter::extract_delta("first response\n", "first response\nsecond response", true);
+        assert_eq!(result, "second response");
+    }
+
+    #[test]
+    fn test_extract_delta_returns_full_when_not_append_only() {
+        let result = Adapter::extract_delta("old response", "fresh response", true);
+        assert_eq!(result, "fresh response");
+    }
+
+    #[test]
+    fn test_extract_delta_preserves_leading_spaces() {
+        let result = Adapter::extract_delta("hello\n", "hello\n  indented code", true);
+        assert_eq!(result, "  indented code");
+    }
+
+    #[test]
+    fn test_new_conversation_id_returns_none_when_multiple_files() {
+        let root = std::env::temp_dir().join(format!("agy-acp-multi-{}", Uuid::new_v4()));
+        let conv_dir = root.join("conversations");
+        fs::create_dir_all(&conv_dir).unwrap();
+
+        let adapter = Adapter {
+            sessions: HashMap::new(),
+            working_dir: root.to_string_lossy().to_string(),
+            conversations_dir: conv_dir.clone(),
+            state_file: root.join("sessions.json"),
+        };
+
+        let before = adapter.conversation_snapshot();
+        fs::write(conv_dir.join("a.pb"), b"").unwrap();
+        fs::write(conv_dir.join("b.pb"), b"").unwrap();
+
+        assert_eq!(adapter.new_conversation_id(&before), None);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[ignore] // filesystem I/O — run with CHI_INTEG=1
+    fn test_snapshot_diff_binds_single_new_conversation() {
+        let root = std::env::temp_dir().join(format!("agy-acp-snap-{}", Uuid::new_v4()));
+        let conv_dir = root.join("conversations");
+        fs::create_dir_all(&conv_dir).unwrap();
+        fs::write(conv_dir.join("existing.pb"), b"old").unwrap();
+
+        let adapter = Adapter {
+            sessions: HashMap::new(),
+            working_dir: root.to_string_lossy().to_string(),
+            conversations_dir: conv_dir.clone(),
+            state_file: root.join("sessions.json"),
+        };
+
+        let before = adapter.conversation_snapshot();
+        fs::write(conv_dir.join("new-conv.pb"), b"new").unwrap();
+
+        assert_eq!(
+            adapter.new_conversation_id(&before),
+            Some("new-conv".to_string())
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[ignore] // filesystem I/O — run with CHI_INTEG=1
+    fn test_persist_and_restore_session_binding() {
+        let root = std::env::temp_dir().join(format!("agy-acp-state-{}", Uuid::new_v4()));
+        let _ = fs::create_dir_all(&root);
+
+        let adapter = Adapter {
+            sessions: HashMap::new(),
+            working_dir: root.to_string_lossy().to_string(),
+            conversations_dir: root.join("conversations"),
+            state_file: root.join("sessions.json"),
+        };
+
+        adapter.persist_session("sess-1", Some("conv-abc"));
+        let restored = adapter.restore_session("sess-1");
+        assert_eq!(restored, Some("conv-abc".to_string()));
+
+        let missing = adapter.restore_session("sess-unknown");
+        assert_eq!(missing, None);
+
+        let _ = fs::remove_dir_all(root);
     }
 }

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -332,6 +332,7 @@ impl Adapter {
                     .as_ref()
                     .and_then(|before| self.new_conversation_id(before));
 
+                let mut persist_conv_id: Option<String> = None;
                 if let Some(session) = self.sessions.get_mut(session_id) {
                     let newly_bound = session.conversation_id.is_none() && conv_id.is_some();
                     if session.conversation_id.is_none() {
@@ -339,9 +340,8 @@ impl Adapter {
                     }
                     if session.conversation_id.is_some() {
                         session.prev_output = full_text;
-                        // Persist binding only on first successful bind
                         if newly_bound {
-                            self.persist_session(session_id, session.conversation_id.as_deref());
+                            persist_conv_id = session.conversation_id.clone();
                         }
                     } else {
                         session.prev_output.clear();
@@ -350,6 +350,9 @@ impl Adapter {
                              running in single-turn mode"
                         );
                     }
+                }
+                if let Some(ref cid) = persist_conv_id {
+                    self.persist_session(session_id, Some(cid.as_str()));
                 }
 
                 let notification = serde_json::to_string(&JsonRpcNotification {

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -239,6 +239,20 @@ impl Adapter {
             .get("sessionId")
             .and_then(|v| v.as_str())
             .unwrap_or("");
+
+        // Restore evicted session from state file if needed
+        if !session_id.is_empty() && !self.sessions.contains_key(session_id) {
+            if let Some(conv_id) = self.restore_session(session_id) {
+                self.sessions.insert(
+                    session_id.to_string(),
+                    Session {
+                        conversation_id: Some(conv_id),
+                        prev_output: String::new(),
+                    },
+                );
+            }
+        }
+
         let prompt_text = params
             .get("prompt")
             .and_then(|v| v.as_array())

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -71,35 +71,52 @@ impl Adapter {
         }
     }
 
-    /// Load persisted session store with exclusive file lock.
-    fn load_store(&self) -> SessionStore {
+    /// Acquire exclusive lock on a dedicated lock file for read-write mutual exclusion.
+    fn lock_state_file(&self) -> Option<fs::File> {
+        if let Some(parent) = self.state_file.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let lock_path = self.state_file.with_extension("lock");
+        let lock_file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&lock_path)
+            .ok()?;
+        lock_file.lock_exclusive().ok()?;
+        Some(lock_file)
+    }
+
+    /// Load persisted session store (caller must hold lock).
+    fn load_store_inner(&self) -> SessionStore {
         let Some(file) = fs::File::open(&self.state_file).ok() else {
             return SessionStore::default();
         };
-        file.lock_shared().ok();
-        let store = serde_json::from_reader(&file).unwrap_or_default();
-        file.unlock().ok();
-        store
+        serde_json::from_reader(&file).unwrap_or_default()
     }
 
-    /// Persist session store with exclusive file lock and atomic write.
+    /// Load persisted session store with lock.
+    fn load_store(&self) -> SessionStore {
+        let _lock = self.lock_state_file();
+        self.load_store_inner()
+    }
+
+    /// Persist session store with exclusive lock and atomic write.
     fn save_store(&self, store: &SessionStore) {
         if let Some(parent) = self.state_file.parent() {
             let _ = fs::create_dir_all(parent);
         }
+        let Some(_lock) = self.lock_state_file() else {
+            eprintln!("[agy-acp] WARN: failed to lock state file");
+            return;
+        };
         let tmp = self.state_file.with_extension("tmp");
         let Ok(file) = fs::File::create(&tmp) else {
             eprintln!("[agy-acp] WARN: failed to create state file");
             return;
         };
-        if file.lock_exclusive().is_err() {
-            eprintln!("[agy-acp] WARN: failed to lock state file");
-            return;
-        }
         if serde_json::to_writer_pretty(&file, store).is_ok() {
             let _ = fs::rename(&tmp, &self.state_file);
         }
-        file.unlock().ok();
     }
 
     /// Try to restore conversation_id from persisted state.
@@ -111,16 +128,24 @@ impl Adapter {
             .and_then(|s| s.conversation_id.clone())
     }
 
-    /// Persist a session binding.
+    /// Persist a session binding (read-modify-write under single lock).
     fn persist_session(&self, session_id: &str, conversation_id: Option<&str>) {
-        let mut store = self.load_store();
+        let Some(_lock) = self.lock_state_file() else {
+            return;
+        };
+        let mut store = self.load_store_inner();
         store.sessions.insert(
             session_id.to_string(),
             StoredSession {
                 conversation_id: conversation_id.map(String::from),
             },
         );
-        self.save_store(&store);
+        let tmp = self.state_file.with_extension("tmp");
+        if let Ok(file) = fs::File::create(&tmp) {
+            if serde_json::to_writer_pretty(&file, &store).is_ok() {
+                let _ = fs::rename(&tmp, &self.state_file);
+            }
+        }
     }
 
     fn conversation_snapshot(&self) -> HashSet<String> {
@@ -444,6 +469,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // filesystem I/O — run with CHI_INTEG=1
     fn test_new_conversation_id_returns_none_when_multiple_files() {
         let root = std::env::temp_dir().join(format!("agy-acp-multi-{}", Uuid::new_v4()));
         let conv_dir = root.join("conversations");


### PR DESCRIPTION
## Summary

Alternative implementation to #927 for the same stale-output bug. This PR supersedes #927 by adding **persistent state-file based session binding** and addressing all review findings identified during the #927 review.


<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/1dca6b16-b5ab-4501-a00b-7f9db4ffb569" />


## Why This PR Over #927

PR #927 introduced snapshot-based conversation binding which is better than main, but our team review identified 7 findings (1 🔴 + 6 🟡). Rather than patching #927 incrementally, this PR implements the recommended architecture from the review discussion:

| | PR #927 (Snapshot Only) | PR #928 (State File) |
|---|---|---|
| **Conversation binding** | Snapshot diff, in-memory only | Snapshot diff + persist to `~/.openab/agy-acp/sessions.json` |
| **Survives restart** | ❌ Lost on restart | ✅ Restored from state file |
| **TOCTOU mitigation** | Refuse to bind (single-turn fallback) | Same + persisted binding eliminates re-guessing |
| **Concurrent safety** | No locking | Dedicated lock file (`sessions.lock`) with `fs2` |
| **Delta extraction** | `trim_start()` — strips meaningful whitespace | `trim_start_matches(\x27\\n\x27)` — preserves indentation |
| **Subprocess errors** | stderr → /dev/null, exit status unchecked | stderr captured + logged, non-zero exit → JSON-RPC error |
| **Test ADR compliance** | ❌ Filesystem test missing `#[ignore]` | ✅ All filesystem tests marked `#[ignore]` |
| **Test naming** | Non-standard | `test_<scenario>_<expected_outcome>` per ADR |
| **Memory management** | `prev_output.clone()` every turn, unbounded sessions | `prev_output` by ref, 64-session cap with eviction + restore |
| **State file I/O** | N/A | Only on first bind (not every turn) |

The ideal solution would be for `agy` CLI to natively return the conversation ID, eliminating all filesystem guessing. That requires an upstream change. This PR is the best achievable without upstream modifications.

## Changes

| File | Change |
|------|--------|
| `agy-acp/Cargo.toml` | Add `fs2 = "0.4.3"` for file locking |
| `agy-acp/src/main.rs` | Replace global latest-conversation lookup with snapshot diff + state-file persistence |
| `agy-acp/src/main.rs` | Prefix-checked delta extraction with `trim_start_matches(\x27\\n\x27)` |
| `agy-acp/src/main.rs` | Capture stderr + check exit status, return JSON-RPC error on failure |
| `agy-acp/src/main.rs` | Dedicated lock file + atomic write (tmp+rename) for concurrent safety |
| `agy-acp/src/main.rs` | 64-session cap with eviction + restore from state file |
| `agy-acp/src/main.rs` | Unit tests following ADR conventions |

## Testing

```
cargo fmt --manifest-path agy-acp/Cargo.toml
cargo test --manifest-path agy-acp/Cargo.toml
```

Unit tests (always run):
- `test_extract_delta_returns_full_text_when_unbound`
- `test_extract_delta_strips_prefix_when_bound`
- `test_extract_delta_returns_full_when_not_append_only`
- `test_extract_delta_preserves_leading_spaces`

Integration tests (`#[ignore]`, run with `CHI_INTEG=1`):
- `test_new_conversation_id_returns_none_when_multiple_files`
- `test_snapshot_diff_binds_single_new_conversation`
- `test_persist_and_restore_session_binding`

## Compatibility

- Backward compatible: Yes
- Config/env changes: Creates `~/.openab/agy-acp/sessions.json` (auto-created)
- New dependency: `fs2 = "0.4.3"` (well-maintained, minimal)
- If merged, #927 should be closed as superseded
