### PR TITLE
ci: add Dockerfile.native to build matrix

### DIFF
--- a/.github/workflows/build-operator.yml
+++ b/.github/workflows/build-operator.yml
@@ -76,6 +76,7 @@ jobs:
           - { suffix: "-grok", dockerfile: "Dockerfile.grok", artifact: "grok" }
           - { suffix: "-antigravity", dockerfile: "Dockerfile.antigravity", artifact: "antigravity" }
           - { suffix: "-pi", dockerfile: "Dockerfile.pi", artifact: "pi" }
+          - { suffix: "-native", dockerfile: "Dockerfile.native", artifact: "native" }
         platform:
           - { os: linux/amd64, runner: ubuntu-latest }
           - { os: linux/arm64, runner: ubuntu-24.04-arm }


### PR DESCRIPTION
Adds `openab-native` image variant to the Build Operator workflow matrix.

This enables `:beta` and versioned tags for the native Rust agent image (`Dockerfile.native`).