### PR TITLE
fix(Dockerfile.native): build openab-agent from its own crate

### DIFF
--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -2,10 +2,11 @@
 FROM rust:1-bookworm AS builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
+COPY openab-agent/ openab-agent/
 RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
 COPY src/ src/
-COPY openab-agent/ openab-agent/
-RUN touch src/main.rs && cargo build --release --bin openab --bin openab-agent
+RUN touch src/main.rs && cargo build --release
+RUN cd openab-agent && cargo build --release
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
@@ -24,7 +25,7 @@ ENV HOME=/home/agent
 WORKDIR /home/agent
 
 COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
-COPY --from=builder --chown=agent:agent /build/target/release/openab-agent /usr/local/bin/openab-agent
+COPY --from=builder --chown=agent:agent /build/openab-agent/target/release/openab-agent /usr/local/bin/openab-agent
 
 RUN mkdir -p /home/agent/.openab && chown -R agent:agent /home/agent
 


### PR DESCRIPTION
The openab-agent binary is in a separate crate (`openab-agent/`), not a bin target in the root workspace. Build it with `cd openab-agent && cargo build --release` instead of `--bin openab-agent`.