### PR TITLE
ci: add native to merge-manifests matrix

### DIFF
--- a/.github/workflows/build-operator.yml
+++ b/.github/workflows/build-operator.yml
@@ -144,6 +144,7 @@ jobs:
           - { suffix: "-grok", artifact: "grok" }
           - { suffix: "-antigravity", artifact: "antigravity" }
           - { suffix: "-pi", artifact: "pi" }
+          - { suffix: "-native", artifact: "native" }
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The native image was building but never pushed — it was missing from the `merge-manifests` job matrix. This adds it so `openab-native:beta` gets pushed to GHCR.