### PR TITLE
fix(native): add unzip to runtime image

### DIFF
--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -10,7 +10,7 @@ RUN cd openab-agent && cargo build --release
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git procps ripgrep tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
The `openab-native` image is missing `unzip`, which is needed for the `[hooks.pre_boot]` AWS CLI self-bootstrap pattern documented in `docs/adr/hooks.md`.

The main `Dockerfile` already includes it — this aligns `Dockerfile.native`.