### PR TITLE
feat(hooks): pass OPENAB_AGENT_NAME and OPENAB_BACKEND_AGENT to hook scripts

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -80,6 +80,10 @@ Scripts run with a sanitized environment:
 - `BOOTSTRAP_URI`, `BOOTSTRAP_BASE_URI`, `BOOTSTRAP_PERSONAL_URI`
 - `STATE_BUCKET`, `TASK_FAMILY`
 
+**OpenAB identity (passed if set):**
+- `OPENAB_AGENT_NAME` — the agent's configured name
+- `OPENAB_BACKEND_AGENT` — the backend agent type (e.g. `claude`, `codex`)
+
 > **Note:** `DISCORD_BOT_TOKEN` and other openab secrets are NOT exposed to hook scripts.
 
 ## Security

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -195,7 +195,9 @@ async fn execute(path: &PathBuf, timeout_secs: u64) -> anyhow::Result<()> {
             || key == "BOOTSTRAP_BASE_URI"
             || key == "BOOTSTRAP_PERSONAL_URI"
             || key == "STATE_BUCKET"
-            || key == "TASK_FAMILY";
+            || key == "TASK_FAMILY"
+            || key == "OPENAB_AGENT_NAME"
+            || key == "OPENAB_BACKEND_AGENT";
         if pass {
             cmd.env(&key, &val);
         }


### PR DESCRIPTION
## Summary

Pass `OPENAB_AGENT_NAME` and `OPENAB_BACKEND_AGENT` through to hook scripts so they can identify which agent and backend they are running under.

## Changes

- `src/hooks.rs`: add two exact-match entries to the env allow-list
- `docs/hooks.md`: document the new vars under a new "OpenAB identity" section

## Use Cases

- Per-agent S3 backup paths: `s3://$STATE_BUCKET/$OPENAB_AGENT_NAME/`
- Conditional logic based on backend type
- Observability / logging context

## Testing

- Minimal change (two `||` conditions added to existing boolean expression)
- CI will validate compilation and existing hook tests