### PR TITLE
fix(antigravity): add unzip to runtime image

### DIFF
--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -16,7 +16,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install agy (Google Antigravity CLI)
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini bubblewrap socat && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini bubblewrap socat unzip && rm -rf /var/lib/apt/lists/*
 
 # Install claude-agent-acp adapter and Claude Code CLI.
 # Without CLAUDE_CODE_EXECUTABLE the adapter uses its own bundled SDK cli.js,

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini bubblewrap && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini bubblewrap unzip && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
 ARG CODEX_ACP_VERSION=0.14.0

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
 ARG COPILOT_VERSION=1.0.51

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install Cursor Agent CLI (pinned version)
 # Tarball source: https://downloads.cursor.com/lab/<version>/linux/<arch>/agent-cli-package.tar.gz

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
 ARG GEMINI_CLI_VERSION=0.42.0

--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -13,7 +13,7 @@ FROM debian:bookworm-slim
 RUN useradd -m -u 1000 agent
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl procps ripgrep tini git && \
+      ca-certificates curl procps ripgrep tini git unzip && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Grok Build CLI — pinned version with SHA256 checksum verification.

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -13,7 +13,7 @@ FROM python:3.12-slim-bookworm
 RUN useradd -m -u 1000 agent
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl procps ripgrep tini git ffmpeg xz-utils && \
+      ca-certificates curl procps ripgrep tini git ffmpeg unzip xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Hermes Agent — pinned to known commit with checksum verification

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -23,7 +23,7 @@ RUN touch src/main.rs && cargo build --release
 # Note: opencode does not publish SHA256 checksums for its releases,
 # so checksum verification is not possible at this time.
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install opencode
 ARG OPENCODE_VERSION=1.15.7

--- a/Dockerfile.pi
+++ b/Dockerfile.pi
@@ -8,7 +8,7 @@ RUN touch src/main.rs && cargo build --release
 
 # --- Runtime stage ---
 FROM node:22-bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git procps ripgrep tini bubblewrap socat && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git procps ripgrep tini bubblewrap socat unzip && rm -rf /var/lib/apt/lists/*
 
 # Install pi-acp adapter and Pi coding agent CLI.
 # The Pi coding agent npm package was renamed from @mariozechner/pi-coding-agent to @earendil-works/pi-coding-agent.


### PR DESCRIPTION
Same as #938 for native — `Dockerfile.antigravity` needs `unzip` for the hooks AWS CLI self-bootstrap pattern.