### PR TITLE
fix: chown full home dir in all Dockerfiles

### DIFF
--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -46,7 +46,7 @@ WORKDIR /home/agent
 COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
 COPY --from=adapter-builder --chown=agent:agent /build/target/release/agy-acp /usr/local/bin/agy-acp
 
-RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent/.gemini
+RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent
 
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -31,7 +31,7 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
-RUN mkdir -p /home/node/.claude && chown -R node:node /home/node/.claude
+RUN mkdir -p /home/node/.claude && chown -R node:node /home/node
 
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -28,7 +28,7 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
-RUN mkdir -p /home/node/.codex && chown -R node:node /home/node/.codex
+RUN mkdir -p /home/node/.codex && chown -R node:node /home/node
 
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -27,7 +27,7 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
-RUN mkdir -p /home/node/.copilot && chown -R node:node /home/node/.copilot
+RUN mkdir -p /home/node/.copilot && chown -R node:node /home/node
 
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -39,7 +39,7 @@ WORKDIR /home/agent
 
 COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
 
-RUN mkdir -p /home/agent/.cursor && chown -R agent:agent /home/agent/.cursor
+RUN mkdir -p /home/agent/.cursor && chown -R agent:agent /home/agent
 
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -27,7 +27,7 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
-RUN mkdir -p /home/node/.gemini && chown -R node:node /home/node/.gemini
+RUN mkdir -p /home/node/.gemini && chown -R node:node /home/node
 
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -42,7 +42,7 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
-RUN mkdir -p /home/node/.opencode && chown -R node:node /home/node/.opencode
+RUN mkdir -p /home/node/.opencode && chown -R node:node /home/node
 
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/Dockerfile.pi
+++ b/Dockerfile.pi
@@ -29,7 +29,7 @@ WORKDIR /home/node
 
 COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
 
-RUN mkdir -p /home/node/.pi && chown -R node:node /home/node/.pi
+RUN mkdir -p /home/node/.pi && chown -R node:node /home/node
 
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \


### PR DESCRIPTION
Hooks need write access to `$HOME` for AWS CLI install and S3 sync. Several Dockerfiles only chowned the agent-specific subdir (e.g. `.gemini`, `.codex`) but not the home dir itself, causing `Permission denied` on `mkdir $HOME/aws-cli`.