### PR TITLE
fix(gateway/telegram): fallback to plain text on Markdown parse failure

### DIFF
--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -346,11 +346,16 @@ pub async fn handle_reply(
         Ok(resp) => {
             let body: serde_json::Value = resp.json().await.unwrap_or_default();
             if body["ok"].as_bool() != Some(true) {
-                warn!(
-                    desc = %body["description"].as_str().unwrap_or("unknown"),
-                    "telegram Markdown send failed, retrying as plain text"
-                );
-                true
+                let desc = body["description"].as_str().unwrap_or("unknown");
+                // Only retry as plain text for parse-related errors; other failures
+                // (rate limit, forbidden, etc.) should not trigger a second request.
+                if desc.contains("parse") || desc.contains("entities") {
+                    warn!(desc = %desc, "telegram Markdown parse failed, retrying as plain text");
+                    true
+                } else {
+                    error!(desc = %desc, "telegram send failed (non-parse error)");
+                    false
+                }
             } else {
                 false
             }
@@ -362,7 +367,7 @@ pub async fn handle_reply(
     };
 
     if retry_plain {
-        let _ = client
+        match client
             .post(&url)
             .json(&serde_json::json!({
                 "chat_id": reply.channel.id,
@@ -371,7 +376,18 @@ pub async fn handle_reply(
             }))
             .send()
             .await
-            .map_err(|e| error!("telegram plain text send error: {e}"));
+        {
+            Ok(resp) => {
+                let body: serde_json::Value = resp.json().await.unwrap_or_default();
+                if body["ok"].as_bool() != Some(true) {
+                    error!(
+                        desc = %body["description"].as_str().unwrap_or("unknown"),
+                        "telegram plain text fallback also failed"
+                    );
+                }
+            }
+            Err(e) => error!("telegram plain text send error: {e}"),
+        }
     }
 }
 

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -332,7 +332,7 @@ pub async fn handle_reply(
         "gateway → telegram"
     );
     let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage");
-    let _ = client
+    let retry_plain = match client
         .post(&url)
         .json(&serde_json::json!({
             "chat_id": reply.channel.id,
@@ -342,7 +342,37 @@ pub async fn handle_reply(
         }))
         .send()
         .await
-        .map_err(|e| error!("telegram send error: {e}"));
+    {
+        Ok(resp) => {
+            let body: serde_json::Value = resp.json().await.unwrap_or_default();
+            if body["ok"].as_bool() != Some(true) {
+                warn!(
+                    desc = %body["description"].as_str().unwrap_or("unknown"),
+                    "telegram Markdown send failed, retrying as plain text"
+                );
+                true
+            } else {
+                false
+            }
+        }
+        Err(e) => {
+            error!("telegram send error: {e}");
+            false
+        }
+    };
+
+    if retry_plain {
+        let _ = client
+            .post(&url)
+            .json(&serde_json::json!({
+                "chat_id": reply.channel.id,
+                "text": reply.content.text,
+                "message_thread_id": reply.channel.thread_id,
+            }))
+            .send()
+            .await
+            .map_err(|e| error!("telegram plain text send error: {e}"));
+    }
 }
 
 /// Download media from Telegram via getFile → store to filesystem (colocate mode).

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -344,20 +344,25 @@ pub async fn handle_reply(
         .await
     {
         Ok(resp) => {
-            let body: serde_json::Value = resp.json().await.unwrap_or_default();
-            if body["ok"].as_bool() != Some(true) {
-                let desc = body["description"].as_str().unwrap_or("unknown");
-                // Only retry as plain text for parse-related errors; other failures
-                // (rate limit, forbidden, etc.) should not trigger a second request.
-                if desc.contains("parse") || desc.contains("entities") {
-                    warn!(desc = %desc, "telegram Markdown parse failed, retrying as plain text");
-                    true
-                } else {
-                    error!(desc = %desc, "telegram send failed (non-parse error)");
-                    false
+            match resp.json::<serde_json::Value>().await {
+                Ok(body) if body["ok"].as_bool() != Some(true) => {
+                    let desc = body["description"].as_str().unwrap_or("unknown");
+                    let code = body["error_code"].as_u64().unwrap_or(0);
+                    // Retry as plain text only for 400 Bad Request (parse/entity errors).
+                    // Other failures (429 rate limit, 403 forbidden) should not retry.
+                    if code == 400 {
+                        warn!(desc = %desc, "telegram Markdown send rejected (400), retrying as plain text");
+                        true
+                    } else {
+                        error!(code, desc = %desc, "telegram send failed");
+                        false
+                    }
                 }
-            } else {
-                false
+                Ok(_) => false,
+                Err(e) => {
+                    warn!("telegram response not valid JSON, retrying as plain text: {e}");
+                    true
+                }
             }
         }
         Err(e) => {
@@ -378,12 +383,15 @@ pub async fn handle_reply(
             .await
         {
             Ok(resp) => {
-                let body: serde_json::Value = resp.json().await.unwrap_or_default();
-                if body["ok"].as_bool() != Some(true) {
-                    error!(
-                        desc = %body["description"].as_str().unwrap_or("unknown"),
-                        "telegram plain text fallback also failed"
-                    );
+                match resp.json::<serde_json::Value>().await {
+                    Ok(body) if body["ok"].as_bool() != Some(true) => {
+                        error!(
+                            desc = %body["description"].as_str().unwrap_or("unknown"),
+                            "telegram plain text fallback also failed"
+                        );
+                    }
+                    Err(e) => warn!("telegram plain text fallback response not valid JSON: {e}"),
+                    _ => {}
                 }
             }
             Err(e) => error!("telegram plain text send error: {e}"),

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -348,10 +348,8 @@ pub async fn handle_reply(
                 Ok(body) if body["ok"].as_bool() != Some(true) => {
                     let desc = body["description"].as_str().unwrap_or("unknown");
                     let code = body["error_code"].as_u64().unwrap_or(0);
-                    // Retry as plain text only for 400 Bad Request (parse/entity errors).
-                    // Other failures (429 rate limit, 403 forbidden) should not retry.
-                    if code == 400 {
-                        warn!(desc = %desc, "telegram Markdown send rejected (400), retrying as plain text");
+                    if should_retry_plain_text_fallback(code, desc) {
+                        warn!(code, desc = %desc, "telegram Markdown parse failed, retrying as plain text");
                         true
                     } else {
                         error!(code, desc = %desc, "telegram send failed");
@@ -360,8 +358,8 @@ pub async fn handle_reply(
                 }
                 Ok(_) => false,
                 Err(e) => {
-                    warn!("telegram response not valid JSON, retrying as plain text: {e}");
-                    true
+                    warn!("telegram response not valid JSON: {e}");
+                    false
                 }
             }
         }
@@ -397,6 +395,15 @@ pub async fn handle_reply(
             Err(e) => error!("telegram plain text send error: {e}"),
         }
     }
+}
+
+fn should_retry_plain_text_fallback(code: u64, description: &str) -> bool {
+    if code != 400 {
+        return false;
+    }
+
+    let description = description.to_ascii_lowercase();
+    description.contains("parse") || description.contains("entities")
 }
 
 /// Download media from Telegram via getFile → store to filesystem (colocate mode).
@@ -536,4 +543,41 @@ async fn download_telegram_document(
         size: bytes.len() as u64,
         path: Some(path),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_retry_plain_text_fallback;
+
+    #[test]
+    fn retries_markdown_parse_errors() {
+        assert!(should_retry_plain_text_fallback(
+            400,
+            "Bad Request: can't parse entities: Can't find end of the entity"
+        ));
+    }
+
+    #[test]
+    fn retries_entity_errors() {
+        assert!(should_retry_plain_text_fallback(
+            400,
+            "Bad Request: unsupported start tag in entities"
+        ));
+    }
+
+    #[test]
+    fn does_not_retry_unrelated_bad_requests() {
+        assert!(!should_retry_plain_text_fallback(
+            400,
+            "Bad Request: message text is empty"
+        ));
+    }
+
+    #[test]
+    fn does_not_retry_non_bad_request_errors() {
+        assert!(!should_retry_plain_text_fallback(
+            429,
+            "Too Many Requests: retry after 10"
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #871.

When Telegram rejects a message due to Markdown parse errors (unescaped special characters in URLs, Chinese text, code snippets), the adapter now detects the API-level failure (`ok: false`) and retries without `parse_mode`.

## Problem

```
Agent response (contains _ * [ ] `)
        │
        ▼
telegram.rs: let _ = client.post(sendMessage)
  parse_mode: "Markdown"
        │
        ▼
Telegram API: {"ok": false, "description": "can't parse entities"}
        │
        ▼
Message silently dropped — user sees ✅ reaction but no text
```

Two issues:
1. `let _ =` discarded the HTTP response — Telegram API errors (`ok: false`) were never checked
2. `parse_mode: "Markdown"` is strict — unescaped `_`, `*`, `[`, `]`, `\`` cause rejection

## Fix

Try with Markdown first. If Telegram returns `ok: false`, log a warning and retry as plain text (no `parse_mode`). Network errors are still logged without retry.

## Changes

| File | Change |
|------|--------|
| `gateway/src/adapters/telegram.rs` | Check sendMessage response body; retry without parse_mode on failure |

## Validation

- [ ] `cargo check` — no C linker in agent environment; CI will verify
- [x] Code review: pattern matches existing gateway error handling style
- [x] Minimal change: +32/-2 lines, single file

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1504195583676780605