### PR TITLE
docs: wire gh auth to raw git

### DIFF
--- a/docs/gh-auth-device-flow.md
+++ b/docs/gh-auth-device-flow.md
@@ -65,6 +65,43 @@ How it works:
 gh auth status
 ```
 
+## Enable raw `git` operations
+
+`gh auth status` only proves that GitHub CLI can call the GitHub API. It does
+not guarantee that raw Git commands can clone or fetch private repositories.
+Many coding agents call `git clone`, `git fetch`, or `git ls-remote` directly.
+In a headless pod, raw Git cannot prompt for a username/password, so private
+repo access can fail with:
+
+```text
+fatal: could not read Username for 'https://github.com': No such device or address
+```
+
+After `gh auth login` succeeds, wire Git to use the GitHub CLI credential
+helper:
+
+```bash
+gh auth setup-git --hostname github.com
+```
+
+Then verify both layers:
+
+```bash
+gh auth status --hostname github.com
+git config --global --get-all credential.https://github.com.helper
+git ls-remote https://github.com/OWNER/PRIVATE_REPO HEAD
+```
+
+Expected signal:
+
+- `gh auth status` shows an active GitHub account.
+- `git config` includes `gh auth git-credential`.
+- `git ls-remote` returns a commit hash for `HEAD`.
+
+If `gh auth status` passes but `git ls-remote` fails, run
+`gh auth setup-git --hostname github.com` again. This is especially important
+for Codex/ACP review workflows that need to fetch private forks or branches.
+
 ## Steering / prompt snippet (Kiro CLI only)
 
 > **Note:** This section applies only to [Kiro CLI](https://kiro.dev) agents. Other agent backends (Claude Code, Codex, Gemini) have their own prompt/config mechanisms.


### PR DESCRIPTION
## Summary

- Problem: In headless agent pods, `gh auth status` can pass while raw `git clone` / `git fetch` still fails for private repositories.
- Why it matters: Coding agents often use raw Git during review workflows. If Git is not wired to the GitHub CLI credential helper, private fork/branch fetches fail with `fatal: could not read Username for 'https://github.com': No such device or address`.
- What changed: Added a `gh auth setup-git --hostname github.com` step and a raw `git ls-remote` verification probe to the GitHub CLI auth guide.
- What did NOT change: Docs only. No runtime, chart, image, or auth behavior changed.

## Prior Research

- Existing issues checked: none found for `gh auth setup-git git clone private repo`.
- Existing PRs checked: none found for `gh auth setup-git git clone private repo`.
- Existing docs checked: `docs/gh-auth-device-flow.md`, `docs/github-token-setup.md`, `docs/copilot.md`.

## Before / After

```text
BEFORE:
The guide verified `gh auth status`, but did not explain that raw Git needs a
credential helper too. A pod could be authenticated for `gh` API calls while
private `git clone` still failed non-interactively.

AFTER:
The guide tells operators to run:
  gh auth setup-git --hostname github.com
and verify raw private-repo access with:
  git ls-remote https://github.com/OWNER/PRIVATE_REPO HEAD
```

## Changes

| File | Change |
|------|--------|
| `docs/gh-auth-device-flow.md` | Add raw Git credential-helper setup and verification section. |

## Testing

- Docs-only change; no automated tests run.
- Runtime verification in a local Codex/OpenAB pod:

```text
Before:
git ls-remote https://github.com/shaun-agent/biosight-openab-handoff HEAD
fatal: could not read Username for 'https://github.com': No such device or address

Fix:
gh auth setup-git --hostname github.com

After:
git ls-remote https://github.com/shaun-agent/biosight-openab-handoff HEAD
afd12d2ab20d5de19fa54e5b2b80655445ed9223 HEAD
```

## Risks and Mitigations

- Risk: Users may assume `gh auth status` is sufficient for all GitHub access.
  - Mitigation: The new section explicitly separates GitHub CLI API auth from raw Git credential-helper setup.
- Risk: The raw Git probe requires a private repo URL.
  - Mitigation: The guide uses a placeholder `OWNER/PRIVATE_REPO`.

## Compatibility / Migration

- Backward compatible: Yes.
- Config/env changes: No.
- Migration needed: No.
