### PR TITLE
fix(gateway): bound teams webhook body size, document deserialization safety

### DIFF
--- a/gateway/src/adapters/teams.rs
+++ b/gateway/src/adapters/teams.rs
@@ -664,6 +664,7 @@ mod tests {
             ws_token: None,
             event_tx,
             reply_token_cache: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            client: reqwest::Client::new(),
         })
     }
 

--- a/gateway/src/adapters/teams.rs
+++ b/gateway/src/adapters/teams.rs
@@ -648,6 +648,25 @@ mod tests {
         }
     }
 
+    fn make_test_state() -> Arc<crate::AppState> {
+        let (event_tx, _rx) = tokio::sync::broadcast::channel(16);
+
+        Arc::new(crate::AppState {
+            telegram_bot_token: None,
+            telegram_secret_token: None,
+            line_channel_secret: None,
+            line_access_token: None,
+            teams: Some(TeamsAdapter::new(make_config(vec![]))),
+            teams_service_urls: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            feishu: None,
+            google_chat: None,
+            wecom: None,
+            ws_token: None,
+            event_tx,
+            reply_token_cache: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        })
+    }
+
     fn make_activity_with_tenant(tenant_id: Option<&str>) -> Activity {
         Activity {
             activity_type: "message".into(),
@@ -663,6 +682,32 @@ mod tests {
             }),
             channel_data: None,
         }
+    }
+
+    // --- webhook body limit ---
+
+    #[tokio::test]
+    async fn webhook_rejects_oversized_body_before_auth() {
+        let status = webhook(
+            State(make_test_state()),
+            HeaderMap::new(),
+            "x".repeat(WEBHOOK_BODY_LIMIT + 1),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn webhook_allows_body_at_limit_to_reach_auth() {
+        let status = webhook(
+            State(make_test_state()),
+            HeaderMap::new(),
+            "x".repeat(WEBHOOK_BODY_LIMIT),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
     }
 
     #[test]

--- a/gateway/src/adapters/teams.rs
+++ b/gateway/src/adapters/teams.rs
@@ -417,6 +417,12 @@ fn ensure_trailing_slash(url: &str) -> String {
 
 // --- Webhook handler ---
 
+/// Max webhook body size: 256 KB. Real Teams activities are a few KB; the
+/// activity is parsed *before* JWT auth (Bot Framework requires serviceUrl /
+/// channelId from the body to validate the token), so this caps the
+/// unauthenticated parse attack surface. Mirrors the feishu adapter's limit.
+const WEBHOOK_BODY_LIMIT: usize = 256 * 1024;
+
 pub async fn webhook(
     State(state): State<Arc<crate::AppState>>,
     headers: HeaderMap,
@@ -427,6 +433,12 @@ pub async fn webhook(
         None => return StatusCode::NOT_FOUND,
     };
 
+    // Defense-in-depth: bound the pre-auth body size (axum's default limit is 2 MB).
+    if body.len() > WEBHOOK_BODY_LIMIT {
+        warn!(size = body.len(), "teams webhook body too large");
+        return StatusCode::PAYLOAD_TOO_LARGE;
+    }
+
     // Extract auth header early (before parsing activity)
     let auth_header = match headers.get("authorization").and_then(|v| v.to_str().ok()) {
         Some(h) => h.to_string(),
@@ -436,7 +448,16 @@ pub async fn webhook(
         }
     };
 
-    // Parse activity first (needed for JWT serviceUrl + endorsements validation)
+    // Parse activity first (needed for JWT serviceUrl + endorsements validation).
+    //
+    // SECURITY NOTE (OX untrusted-deserialization finding — false positive):
+    // `Activity` is a strict, derive-only DTO (String / Option<_> / nested
+    // structs) with no custom Deserialize, no side-effectful Drop, and no enum
+    // variant dispatch. serde_json's data model cannot instantiate arbitrary
+    // types (unlike bincode/serde_yaml/rmp-serde), so object-injection / RCE
+    // does not apply. The recommended "strict DTO + validate after" pattern is
+    // already in place: JWT, activity-type, and tenant-allowlist checks below.
+    // DoS is bounded by serde_json's recursion limit (128) and the body cap above.
     let activity: Activity = match serde_json::from_str(&body) {
         Ok(a) => a,
         Err(e) => {


### PR DESCRIPTION
## What problem does this solve?

An OX security scan flagged `serde_json::from_str(&body)` into `Activity` in the Teams adapter ([teams.rs](gateway/src/adapters/teams.rs)) as untrusted deserialization (object-injection / RCE). On review this is a **false positive** for this code, but it surfaced one genuine, already-bounded risk worth hardening: the Bot Framework `Activity` JSON is parsed **before** JWT auth (the token can't be validated without `serviceUrl`/`channelId` from the body), so the parse is reachable unauthenticated.

This PR documents the deserialization-safety rationale at the call site and adds a defense-in-depth pre-auth body-size cap.

Closes #<!-- no linked issue; raised via OX scan + Discord -->

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365157010542652/1509845175579705414

## At a Glance

```
inbound POST /webhook/teams
        |
        v
[ body.len() > 256 KB ? ] --yes--> 413 PAYLOAD_TOO_LARGE   <-- NEW pre-auth guard
        | no
        v
serde_json::from_str -> Activity (strict derive-only DTO)
        |  (parse happens before auth: Bot Framework needs serviceUrl/channelId)
        v
JWT validation -> activity-type gate -> tenant allowlist -> dispatch
```

## Prior Art & Industry Research

Not applicable — this is a trivial, self-contained security hardening (input size bound) plus an inline code comment. The pattern is already established **within this repo**: the feishu adapter uses the same `WEBHOOK_BODY_LIMIT` + `body.len()` check returning `413` ([feishu.rs:2112](gateway/src/adapters/feishu.rs#L2112), [feishu.rs:2214](gateway/src/adapters/feishu.rs#L2214)).

## Proposed Solution

1. **Pre-auth body-size guard** — add `const WEBHOOK_BODY_LIMIT: usize = 256 * 1024;` and reject oversized bodies with `413 PAYLOAD_TOO_LARGE` before parsing/auth. Mirrors the feishu adapter (which uses 1 MB); 256 KB is more conservative and still far above any real activity (a few KB).
2. **Inline suppression rationale** — document why `serde_json::from_str` into `Activity` is safe: `Activity` is a derive-only strict DTO (`String` / `Option<_>` / nested structs) with no custom `Deserialize`, no side-effectful `Drop`, and no enum dispatch; serde_json's data model cannot instantiate arbitrary types (unlike bincode/serde_yaml/rmp-serde); and the recommended "strict DTO + validate after" pattern is already in place (JWT → activity-type → tenant allowlist). DoS is bounded by serde_json's recursion limit (128) and the new body cap.

## Why this approach?

The OX finding's threat class (object injection / RCE) does not apply to `serde_json` + a derive-only DTO, so no behavioral change to deserialization is warranted — changing the target type or adding `#[serde(deny_unknown_fields)]` would only risk breaking valid Teams traffic when Microsoft adds Activity fields. The only real residual is unauthenticated resource use, which a body cap addresses at near-zero cost and zero impact on valid traffic.

## Alternatives Considered

- **`route_layer(DefaultBodyLimit::max(..))` in main.rs** — works, but the explicit in-handler `body.len()` check is consistent with the existing feishu adapter, doesn't depend on middleware ordering, and keeps the limit visible next to the parse it protects.
- **`#[serde(deny_unknown_fields)]` on `Activity`** — rejected: Microsoft adds fields to Bot Framework activities over time; this would break inbound messages for no security gain.
- **Just suppress the OX finding, no code change** — the suppression is correct, but the pre-auth body cap is cheap defense-in-depth worth landing alongside the documentation.

## Validation

Rust changes:
- [x] `cargo check` passes
- [x] `cargo test` passes (existing 20 teams tests pass; no behavior change to valid traffic)
- [x] `cargo clippy` clean

All PRs:
- [x] Manual testing — verified the gateway crate builds; confirmed the new guard returns `413` for bodies over 256 KB and is a no-op for normal-sized activities (real activities are a few KB, well under the cap). No change to the parse/auth/dispatch path for valid traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

