### PR TITLE
fix(openab-agent): use XML format for skills prompt

### DIFF
--- a/openab-agent/src/skills.rs
+++ b/openab-agent/src/skills.rs
@@ -106,7 +106,7 @@ pub fn format_skills_prompt(skills: &[Skill]) -> String {
     }
     let mut out = String::from(concat!(
         "\n\n## Skills\n\n",
-        "Before replying, scan the skills below. If one clearly matches the user's task, ",
+        "Before replying, scan the skills below. If one matches or may be relevant to the user's task, ",
         "use the `read` tool to load the full SKILL.md at the listed location and follow its instructions.\n\n",
         "<available_skills>\n",
     ));

--- a/openab-agent/src/skills.rs
+++ b/openab-agent/src/skills.rs
@@ -104,15 +104,21 @@ pub fn format_skills_prompt(skills: &[Skill]) -> String {
     if skills.is_empty() {
         return String::new();
     }
-    let mut out = String::from("\n\n## Available Skills\n\nThe following skills are available. Use the `read` tool to load the full SKILL.md when you need a skill's instructions.\n\n");
+    let mut out = String::from(concat!(
+        "\n\n## Skills\n\n",
+        "Before replying, scan the skills below. If one clearly matches the user's task, ",
+        "use the `read` tool to load the full SKILL.md at the listed location and follow its instructions.\n\n",
+        "<available_skills>\n",
+    ));
     for skill in skills {
         out.push_str(&format!(
-            "- **{}** ({}): {}\n",
+            "  <skill>\n    <name>{}</name>\n    <description>{}</description>\n    <location>{}</location>\n  </skill>\n",
             skill.name,
+            skill.description,
             skill.path.join("SKILL.md").display(),
-            skill.description
         ));
     }
+    out.push_str("</available_skills>\n");
     out
 }
 
@@ -210,15 +216,18 @@ mod tests {
     }
 
     #[test]
-    fn format_skills_prompt_includes_path() {
+    fn format_skills_prompt_uses_xml_format() {
         let skills = vec![Skill {
             name: "test".to_string(),
             description: "A test skill".to_string(),
             path: PathBuf::from("/home/agent/.openab/skills/test"),
         }];
         let prompt = format_skills_prompt(&skills);
-        assert!(prompt.contains("test"));
-        assert!(prompt.contains("A test skill"));
-        assert!(prompt.contains("SKILL.md"));
+        assert!(prompt.contains("<available_skills>"));
+        assert!(prompt.contains("<name>test</name>"));
+        assert!(prompt.contains("<description>A test skill</description>"));
+        assert!(prompt.contains("<location>/home/agent/.openab/skills/test/SKILL.md</location>"));
+        assert!(prompt.contains("</available_skills>"));
+        assert!(prompt.contains("Before replying, scan the skills below"));
     }
 }

--- a/openab-agent/src/skills.rs
+++ b/openab-agent/src/skills.rs
@@ -99,23 +99,35 @@ fn parse_frontmatter(content: &str) -> Option<(String, String)> {
     Some((name, description))
 }
 
+/// Escape XML special characters in user-controlled strings to preserve prompt structure.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 /// Format skills as a system prompt section listing available skills.
 pub fn format_skills_prompt(skills: &[Skill]) -> String {
     if skills.is_empty() {
         return String::new();
     }
+
+    // Sort skills by name to ensure deterministic output
+    let mut sorted_skills = skills.to_vec();
+    sorted_skills.sort_by(|a, b| a.name.cmp(&b.name));
+
     let mut out = String::from(concat!(
         "\n\n## Skills\n\n",
         "Before replying, scan the skills below. If one matches or may be relevant to the user's task, ",
         "use the `read` tool to load the full SKILL.md at the listed location and follow its instructions.\n\n",
         "<available_skills>\n",
     ));
-    for skill in skills {
+    for skill in sorted_skills {
         out.push_str(&format!(
             "  <skill>\n    <name>{}</name>\n    <description>{}</description>\n    <location>{}</location>\n  </skill>\n",
-            skill.name,
-            skill.description,
-            skill.path.join("SKILL.md").display(),
+            xml_escape(&skill.name),
+            xml_escape(&skill.description),
+            xml_escape(&skill.path.join("SKILL.md").to_string_lossy()),
         ));
     }
     out.push_str("</available_skills>\n");
@@ -229,5 +241,38 @@ mod tests {
         assert!(prompt.contains("<location>/home/agent/.openab/skills/test/SKILL.md</location>"));
         assert!(prompt.contains("</available_skills>"));
         assert!(prompt.contains("Before replying, scan the skills below"));
+    }
+
+    #[test]
+    fn format_skills_prompt_escapes_xml_chars() {
+        let skills = vec![Skill {
+            name: "a<b".to_string(),
+            description: "Use <tag> & \"quotes\" </description> injection test".to_string(),
+            path: PathBuf::from("/skills/test&cool"),
+        }];
+        let prompt = format_skills_prompt(&skills);
+        assert!(prompt.contains("<name>a&lt;b</name>"));
+        assert!(prompt.contains("<description>Use &lt;tag&gt; &amp; \"quotes\" &lt;/description&gt; injection test</description>"));
+        assert!(prompt.contains("<location>/skills/test&amp;cool/SKILL.md</location>"));
+    }
+
+    #[test]
+    fn format_skills_prompt_is_deterministic() {
+        let skills = vec![
+            Skill {
+                name: "zoo".to_string(),
+                description: "Zoo skill".to_string(),
+                path: PathBuf::from("/skills/zoo"),
+            },
+            Skill {
+                name: "apple".to_string(),
+                description: "Apple skill".to_string(),
+                path: PathBuf::from("/skills/apple"),
+            },
+        ];
+        let prompt = format_skills_prompt(&skills);
+        let apple_idx = prompt.find("<name>apple</name>").unwrap();
+        let zoo_idx = prompt.find("<name>zoo</name>").unwrap();
+        assert!(apple_idx < zoo_idx);
     }
 }


### PR DESCRIPTION
## Summary

The current `format_skills_prompt` uses a markdown bullet list format that LLMs struggle to parse reliably. The agent does not know when or how to load skills because the instruction text is too vague ("when you need") and the path is buried in markdown formatting.

This PR aligns our skills prompt with the industry-standard XML format used by all major coding agents.

Discord Discussion URL: https://discord.com/channels/1490282656913559673/1510656502283767819

## Changes

- Switch from markdown bullet list to structured XML `<available_skills>` format
- Add explicit `<name>`, `<description>`, `<location>` elements per skill
- Strengthen instruction text: "Before replying, scan the skills below. If one matches or may be relevant to the user's task, use the `read` tool to load the full SKILL.md at the listed location and follow its instructions."
- Update test to verify XML format output

## Prior Art

Researched how 4 major agents handle skill prompt injection:

| Agent | Prompt Format | Loading Mechanism | Key Instruction |
|-------|--------------|-------------------|-----------------|
| **[Pi](https://github.com/badlogic/pi-mono)** | XML `<available_skills>` with `<location>` | Agent uses `read` tool on path | "Use the read tool to load a skill's file when the task matches its description" |
| **[OpenCode](https://opencode.ai/docs/skills/)** | XML `<available_skills>` in skill tool description | Dedicated `skill({ name })` tool | Implicit in tool schema |
| **[OpenClaw](https://docs2.openclaw.ai)** | XML `<available_skills>` with `<location>` | Agent uses `read` tool on path | "use `read` to load the SKILL.md at the listed location" |
| **[Hermes](https://hermes-agent.nousresearch.com/docs/developer-guide/prompt-assembly/)** | YAML-like list + `skill_view` tool | Dedicated `skill_view(name)` tool | "Before replying, scan the skills below. If one clearly matches your task, load it with skill_view(name) and follow its instructions." |

All four use structured formats (XML or dedicated tools) rather than markdown. All include explicit trigger conditions and action instructions. Our previous implementation had neither.

## Before (markdown, weak instruction)

```
## Available Skills

The following skills are available. Use the `read` tool to load the full SKILL.md when you need a skill's instructions.

- **brave-search** (/path/to/SKILL.md): Web search via Brave Search API
```

## After (XML, strong instruction)

```xml
## Skills

Before replying, scan the skills below. If one matches or may be relevant to the user's task, use the `read` tool to load the full SKILL.md at the listed location and follow its instructions.

<available_skills>
  <skill>
    <name>brave-search</name>
    <description>Web search via Brave Search API</description>
    <location>/path/to/brave-search/SKILL.md</location>
  </skill>
</available_skills>
```

## Testing

- Unit test updated to verify XML structure
- CI validates compilation and test pass (all 3 checks ✅)