### PR TITLE
ci: add native, grok, pi variants to pr-preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -19,8 +19,11 @@ on:
           - copilot
           - cursor
           - gemini
+          - grok
           - hermes
+          - native
           - opencode
+          - pi
         default: 'default'
 
 env:


### PR DESCRIPTION
These Dockerfiles exist but were missing from the variant dropdown:
- `Dockerfile.native`
- `Dockerfile.grok`
- `Dockerfile.pi`