### PR TITLE
fix(openab-agent): escape XML special chars in skills prompt

### DIFF
--- a/openab-agent/src/skills.rs
+++ b/openab-agent/src/skills.rs
@@ -99,6 +99,11 @@ fn parse_frontmatter(content: &str) -> Option<(String, String)> {
     Some((name, description))
 }
 
+/// Escape XML special characters in user-controlled strings to preserve prompt structure.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+}
+
 /// Format skills as a system prompt section listing available skills.
 pub fn format_skills_prompt(skills: &[Skill]) -> String {
     if skills.is_empty() {
@@ -113,8 +118,8 @@ pub fn format_skills_prompt(skills: &[Skill]) -> String {
     for skill in skills {
         out.push_str(&format!(
             "  <skill>\n    <name>{}</name>\n    <description>{}</description>\n    <location>{}</location>\n  </skill>\n",
-            skill.name,
-            skill.description,
+            xml_escape(&skill.name),
+            xml_escape(&skill.description),
             skill.path.join("SKILL.md").display(),
         ));
     }
@@ -229,5 +234,17 @@ mod tests {
         assert!(prompt.contains("<location>/home/agent/.openab/skills/test/SKILL.md</location>"));
         assert!(prompt.contains("</available_skills>"));
         assert!(prompt.contains("Before replying, scan the skills below"));
+    }
+
+    #[test]
+    fn format_skills_prompt_escapes_xml_chars() {
+        let skills = vec![Skill {
+            name: "a<b".to_string(),
+            description: "Use <tag> & \"quotes\"".to_string(),
+            path: PathBuf::from("/skills/test"),
+        }];
+        let prompt = format_skills_prompt(&skills);
+        assert!(prompt.contains("<name>a&lt;b</name>"));
+        assert!(prompt.contains("<description>Use &lt;tag&gt; &amp; \"quotes\"</description>"));
     }
 }

--- a/openab-agent/src/skills.rs
+++ b/openab-agent/src/skills.rs
@@ -109,13 +109,18 @@ pub fn format_skills_prompt(skills: &[Skill]) -> String {
     if skills.is_empty() {
         return String::new();
     }
+
+    // Sort skills by name to ensure deterministic output
+    let mut sorted_skills = skills.to_vec();
+    sorted_skills.sort_by(|a, b| a.name.cmp(&b.name));
+
     let mut out = String::from(concat!(
         "\n\n## Skills\n\n",
         "Before replying, scan the skills below. If one matches or may be relevant to the user's task, ",
         "use the `read` tool to load the full SKILL.md at the listed location and follow its instructions.\n\n",
         "<available_skills>\n",
     ));
-    for skill in skills {
+    for skill in sorted_skills {
         out.push_str(&format!(
             "  <skill>\n    <name>{}</name>\n    <description>{}</description>\n    <location>{}</location>\n  </skill>\n",
             xml_escape(&skill.name),
@@ -246,5 +251,25 @@ mod tests {
         let prompt = format_skills_prompt(&skills);
         assert!(prompt.contains("<name>a&lt;b</name>"));
         assert!(prompt.contains("<description>Use &lt;tag&gt; &amp; \"quotes\"</description>"));
+    }
+
+    #[test]
+    fn format_skills_prompt_is_deterministic() {
+        let skills = vec![
+            Skill {
+                name: "zoo".to_string(),
+                description: "Zoo skill".to_string(),
+                path: PathBuf::from("/skills/zoo"),
+            },
+            Skill {
+                name: "apple".to_string(),
+                description: "Apple skill".to_string(),
+                path: PathBuf::from("/skills/apple"),
+            },
+        ];
+        let prompt = format_skills_prompt(&skills);
+        let apple_idx = prompt.find("<name>apple</name>").unwrap();
+        let zoo_idx = prompt.find("<name>zoo</name>").unwrap();
+        assert!(apple_idx < zoo_idx);
     }
 }

--- a/openab-agent/src/skills.rs
+++ b/openab-agent/src/skills.rs
@@ -127,7 +127,7 @@ pub fn format_skills_prompt(skills: &[Skill]) -> String {
             "  <skill>\n    <name>{}</name>\n    <description>{}</description>\n    <location>{}</location>\n  </skill>\n",
             xml_escape(&skill.name),
             xml_escape(&skill.description),
-            skill.path.join("SKILL.md").display(),
+            xml_escape(&skill.path.join("SKILL.md").to_string_lossy()),
         ));
     }
     out.push_str("</available_skills>\n");
@@ -247,12 +247,13 @@ mod tests {
     fn format_skills_prompt_escapes_xml_chars() {
         let skills = vec![Skill {
             name: "a<b".to_string(),
-            description: "Use <tag> & \"quotes\"".to_string(),
-            path: PathBuf::from("/skills/test"),
+            description: "Use <tag> & \"quotes\" </description> injection test".to_string(),
+            path: PathBuf::from("/skills/test&cool"),
         }];
         let prompt = format_skills_prompt(&skills);
         assert!(prompt.contains("<name>a&lt;b</name>"));
-        assert!(prompt.contains("<description>Use &lt;tag&gt; &amp; \"quotes\"</description>"));
+        assert!(prompt.contains("<description>Use &lt;tag&gt; &amp; \"quotes\" &lt;/description&gt; injection test</description>"));
+        assert!(prompt.contains("<location>/skills/test&amp;cool/SKILL.md</location>"));
     }
 
     #[test]

--- a/openab-agent/src/skills.rs
+++ b/openab-agent/src/skills.rs
@@ -101,7 +101,9 @@ fn parse_frontmatter(content: &str) -> Option<(String, String)> {
 
 /// Escape XML special characters in user-controlled strings to preserve prompt structure.
 fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 /// Format skills as a system prompt section listing available skills.


### PR DESCRIPTION
## Summary

Builds on #958. Adds XML escaping for user-controlled `name` and `description` fields in the skills prompt.

## Problem

Skill names and descriptions come from SKILL.md frontmatter (user-controlled). Characters like `<`, `>`, `&` would break the XML structure introduced in #958, causing LLMs to misparse skill boundaries.

## Fix

- Add `xml_escape()` helper (`&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`)
- Apply to `skill.name` and `skill.description` in `format_skills_prompt`
- Path left unescaped (filesystem paths don't contain XML specials in practice)
- Added test: `format_skills_prompt_escapes_xml_chars`

## Note

Could not run `cargo test` in CI-less environment (no C linker available), but the logic is trivial and the test assertions are straightforward. CI on this PR will confirm.

cc @chaodu-agent — this is a follow-up fix for your PR.