### PR TITLE
feat(discord): trusted bot @mention bypasses involvement gate

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -37,7 +37,7 @@ Discord adapter. Requires a Discord bot token.
 | `allow_all_users` | bool \| omit | auto-detect | `true` = any user; `false` = only `allowed_users`. Omitted = inferred from list. |
 | `allowed_users` | string[] | `[]` | User IDs to allow. Only checked when `allow_all_users` resolves to false. |
 | `allow_bot_messages` | string | `"off"` | `"off"` — ignore all bot messages. `"mentions"` — only process bot messages that @mention this bot. `"all"` — process all bot messages (capped by `max_bot_turns`). |
-| `trusted_bot_ids` | string[] | `[]` | When non-empty, only these bot IDs pass the bot gate. Empty = any bot (mode permitting). Ignored when `allow_bot_messages = "off"`. |
+| `trusted_bot_ids` | string[] | `[]` | When non-empty, only these bot IDs pass the bot gate. Empty = any bot (mode permitting). **Admission override:** a trusted bot that @mentions this bot bypasses `allow_bot_messages` mode entirely (treated as human @mention, can pull bot into threads). |
 | `allow_user_messages` | string | `"involved"` | `"involved"` — reply in threads bot has participated in without @mention; channel messages require @mention; DMs always process. `"mentions"` — always require @mention. `"multibot-mentions"` — like `"involved"`, but require @mention once another bot has posted in the thread. |
 | `allow_dm` | bool | `false` | `true` = respond to Discord DMs; `false` = ignore DMs. `allowed_users` still applies in DMs. Each DM user consumes one session slot. |
 | `max_bot_turns` | u32 | `100` | Max consecutive bot turns per thread before throttling (soft limit). Human message resets the counter. A compiled-in hard cap of 1000 consecutive bot messages is always enforced. |

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -134,6 +134,8 @@ trusted_bot_ids = ["123456789012345678"]  # only this bot's messages pass throug
 
 Empty (default) = any bot can pass through (subject to the mode check).
 
+**Admission override:** A trusted bot that explicitly @mentions this bot bypasses the `allow_bot_messages` mode entirely — the mention is treated the same as a human @mention. This allows trusted bots to pull this bot into threads even when `allow_bot_messages = "off"`. Messages from trusted bots *without* @mention still follow normal gating.
+
 ### `allowed_role_ids`
 
 Role IDs that trigger the bot, same as a direct @mention. This enables users to invoke multiple bots simultaneously with a single role mention (e.g. `@AllBots review this`).
@@ -282,19 +284,23 @@ In a multi-bot setup, every bot enforces an **involvement gate** before processi
 
 **Rule:** A bot must be **involved** (thread owner or has previously replied) before it will process any message in that thread.
 
-**Key constraint:** Only a human @mention can pull a bot into a thread for the first time. A bot @mentioning another bot that is not yet involved will be **silently dropped**.
+**Key constraint:** Only a human @mention — or a @mention from a bot in `trusted_bot_ids` — can pull a bot into a thread for the first time. A @mention from an untrusted bot will be **silently dropped**.
 
 ```
-Bot A's thread (Bot B not yet involved):
+Bot A's thread (Bot B not yet involved, Bot A NOT in Bot B's trusted_bot_ids):
 
-  Bot A: "@Bot_B please review this"     → ❌ dropped (Bot B not involved)
+  Bot A: "@Bot_B please review this"     → ❌ dropped (Bot B not involved, Bot A untrusted)
   Human: "@Bot_B please review this"     → ✅ Bot B replies, now involved
   Bot A: "@Bot_B any updates?"           → ✅ processed (Bot B is involved)
+
+Bot A's thread (Bot B not yet involved, Bot A IS in Bot B's trusted_bot_ids):
+
+  Bot A: "@Bot_B please review this"     → ✅ treated as human @mention, Bot B becomes involved
 ```
 
-**Why:** This prevents bots from pulling other bots into arbitrary threads without human consent, protects session pool resources, and eliminates cross-thread chain reactions.
+**Why:** This prevents untrusted bots from pulling other bots into arbitrary threads without human consent, protects session pool resources, and eliminates cross-thread chain reactions. Trusted bots are explicitly authorized by the admin.
 
-**Workaround:** Pre-involve all needed bots at thread creation by @mentioning them (or using a shared role via `allowed_role_ids`).
+**Workaround (without trusted_bot_ids):** Pre-involve all needed bots at thread creation by @mentioning them (or using a shared role via `allowed_role_ids`).
 
 > 📖 Full design details: [docs/messaging.md — Involvement Gate](messaging.md#involvement-gate)
 

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -187,7 +187,7 @@ BotA in thread: here's my analysis
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `allow_bot_messages` | string | `"off"` | `"off"` — ignore bot messages. `"mentions"` — only process bot messages that @mention this bot. `"all"` — process all bot messages (capped by `max_bot_turns`). |
-| `trusted_bot_ids` | string[] | `[]` | Whitelist of bot IDs. For Slack, entries may be Bot User IDs (`U...`) or Bot IDs (`B...`); `U...` matching requires `users:read` so OpenAB can call `bots.info`. Empty = any bot (mode permitting). Ignored when `allow_bot_messages = "off"`. |
+| `trusted_bot_ids` | string[] | `[]` | Whitelist of bot IDs. For Slack, entries may be Bot User IDs (`U...`) or Bot IDs (`B...`); `U...` matching requires `users:read` so OpenAB can call `bots.info`. Empty = any bot (mode permitting). **Admission override:** a trusted bot that @mentions this bot bypasses `allow_bot_messages` mode entirely (treated as human @mention). |
 | `max_bot_turns` | u32 | `20` | Max consecutive bot turns per thread before throttling. A human message resets the counter. |
 
 > **Safety:** When `allow_bot_messages = "all"`, a separate hardcoded cap of 10 consecutive bot turns applies regardless of `max_bot_turns`.
@@ -267,7 +267,7 @@ All message routing in OpenAB is guarded by the **involvement gate** — a pre-d
 
 ### Design principle
 
-**Humans are the gatekeepers.** A bot cannot participate in a thread until a human explicitly pulls it in via @mention. Bots cannot pull other bots into threads — only humans can.
+**Humans are the gatekeepers.** A bot cannot participate in a thread until a human explicitly pulls it in via @mention. Bots cannot pull other bots into threads — only humans can, **unless** the sending bot is in the target bot's `trusted_bot_ids` (see [Trusted bot admission override](#trusted-bot-admission-override) below).
 
 ### How a bot becomes involved
 
@@ -297,7 +297,11 @@ Inbound message in thread
   │               │
   │               ├─ From a human → pass (bot will reply and become involved)
   │               │
-  │               └─ From another bot → ❌ DROP (bot-to-bot cannot break the gate)
+  │               └─ From another bot:
+  │                     │
+  │                     ├─ Sender in trusted_bot_ids → pass (same as human @mention)
+  │                     │
+  │                     └─ Otherwise → ❌ DROP (bot-to-bot cannot break the gate)
   │
   └─ Message dropped — never reaches Dispatcher or SessionPool
 ```
@@ -318,8 +322,26 @@ This is an intentional safety constraint:
 | Bot A @mentions Bot B (Bot B not yet involved) | ❌ Silently dropped |
 | Bot A @mentions Bot B (Bot B already involved) | ✅ Processed per `allow_bot_messages` mode |
 | Human @mentions Bot B, then Bot A @mentions Bot B | ✅ Works — Bot B is already involved |
+| **Trusted** Bot A @mentions Bot B (Bot A in Bot B's `trusted_bot_ids`) | ✅ Treated as human @mention — Bot B becomes involved |
 
-### Workaround for bot-to-bot handoff
+### Trusted bot admission override
+
+When a bot is listed in another bot's `trusted_bot_ids` and explicitly @mentions that bot, the mention is treated identically to a human @mention:
+
+- The target bot becomes **involved** in the thread
+- The `allow_bot_messages` mode check is **bypassed** entirely
+- The message is dispatched to the session
+
+This enables bot-to-bot coordination (e.g. a coordinator bot pulling reviewer bots into threads) without requiring human intervention for every thread.
+
+**Requirements:**
+- The sending bot must be in the target bot's `trusted_bot_ids` config
+- The sending bot must explicitly @mention the target bot
+- Messages from trusted bots **without** @mention still follow normal `allow_bot_messages` gating
+
+**Safety:** `trusted_bot_ids` defaults to empty — this feature is entirely opt-in. The `max_bot_turns` cap still applies after involvement to prevent runaway loops.
+
+### Workaround for bot-to-bot handoff (without trusted_bot_ids)
 
 If you need Bot A to hand off to Bot B in a thread where Bot B is not yet involved:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,6 +203,10 @@ pub struct DiscordConfig {
     /// the allowlist filters further. Empty = allow any bot (mode permitting).
     /// Only relevant when `allow_bot_messages` is `"mentions"` or `"all"`;
     /// ignored when `"off"` since all bot messages are rejected before this check.
+    ///
+    /// **Admission override**: a trusted bot that explicitly @mentions this bot
+    /// bypasses the `allow_bot_messages` mode entirely (treated as human @mention).
+    /// This allows trusted bots to pull this bot into threads regardless of mode.
     #[serde(default)]
     pub trusted_bot_ids: Vec<String>,
     #[serde(default)]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -457,68 +457,75 @@ impl EventHandler for Handler {
 
         // Bot message gating (from upstream #321)
         if msg.author.bot {
-            match self.allow_bot_messages {
-                AllowBots::Off => return,
-                AllowBots::Mentions => {
-                    if !is_mentioned {
-                        return;
-                    }
-                }
-                AllowBots::All => {
-                    let cap = MAX_CONSECUTIVE_BOT_TURNS as usize;
-                    let limit = std::cmp::min(MAX_CONSECUTIVE_BOT_TURNS, 100) as u8;
-                    let history = ctx
-                        .cache
-                        .channel_messages(msg.channel_id)
-                        .map(|msgs| {
-                            let mut recent: Vec<_> = msgs
-                                .iter()
-                                .filter(|(mid, _)| **mid < msg.id)
-                                .map(|(_, m)| m.clone())
-                                .collect();
-                            recent.sort_unstable_by_key(|m| std::cmp::Reverse(m.id));
-                            recent.truncate(cap);
-                            recent
-                        })
-                        .filter(|msgs| !msgs.is_empty());
+            // Trusted bot @mention bypass: treat as human mention, skip mode check.
+            let trusted_mention = is_mentioned
+                && !self.trusted_bot_ids.is_empty()
+                && self.trusted_bot_ids.contains(&msg.author.id.get());
 
-                    let recent = if let Some(cached) = history {
-                        cached
-                    } else {
-                        match msg
-                            .channel_id
-                            .messages(
-                                &ctx.http,
-                                serenity::builder::GetMessages::new()
-                                    .before(msg.id)
-                                    .limit(limit),
-                            )
-                            .await
-                        {
-                            Ok(msgs) => msgs,
-                            Err(e) => {
-                                tracing::warn!(channel_id = %msg.channel_id, error = %e, "failed to fetch history for bot turn cap, rejecting (fail-closed)");
-                                return;
-                            }
+            if !trusted_mention {
+                match self.allow_bot_messages {
+                    AllowBots::Off => return,
+                    AllowBots::Mentions => {
+                        if !is_mentioned {
+                            return;
                         }
-                    };
+                    }
+                    AllowBots::All => {
+                        let cap = MAX_CONSECUTIVE_BOT_TURNS as usize;
+                        let limit = std::cmp::min(MAX_CONSECUTIVE_BOT_TURNS, 100) as u8;
+                        let history = ctx
+                            .cache
+                            .channel_messages(msg.channel_id)
+                            .map(|msgs| {
+                                let mut recent: Vec<_> = msgs
+                                    .iter()
+                                    .filter(|(mid, _)| **mid < msg.id)
+                                    .map(|(_, m)| m.clone())
+                                    .collect();
+                                recent.sort_unstable_by_key(|m| std::cmp::Reverse(m.id));
+                                recent.truncate(cap);
+                                recent
+                            })
+                            .filter(|msgs| !msgs.is_empty());
 
-                    let consecutive_bot = recent
-                        .iter()
-                        .take_while(|m| m.author.bot && m.author.id != bot_id)
-                        .count();
-                    if consecutive_bot >= cap {
-                        tracing::warn!(channel_id = %msg.channel_id, cap, "bot turn cap reached, ignoring");
-                        return;
+                        let recent = if let Some(cached) = history {
+                            cached
+                        } else {
+                            match msg
+                                .channel_id
+                                .messages(
+                                    &ctx.http,
+                                    serenity::builder::GetMessages::new()
+                                        .before(msg.id)
+                                        .limit(limit),
+                                )
+                                .await
+                            {
+                                Ok(msgs) => msgs,
+                                Err(e) => {
+                                    tracing::warn!(channel_id = %msg.channel_id, error = %e, "failed to fetch history for bot turn cap, rejecting (fail-closed)");
+                                    return;
+                                }
+                            }
+                        };
+
+                        let consecutive_bot = recent
+                            .iter()
+                            .take_while(|m| m.author.bot && m.author.id != bot_id)
+                            .count();
+                        if consecutive_bot >= cap {
+                            tracing::warn!(channel_id = %msg.channel_id, cap, "bot turn cap reached, ignoring");
+                            return;
+                        }
                     }
                 }
-            }
 
-            if !self.trusted_bot_ids.is_empty()
-                && !self.trusted_bot_ids.contains(&msg.author.id.get())
-            {
-                tracing::debug!(bot_id = %msg.author.id, "bot not in trusted_bot_ids, ignoring");
-                return;
+                if !self.trusted_bot_ids.is_empty()
+                    && !self.trusted_bot_ids.contains(&msg.author.id.get())
+                {
+                    tracing::debug!(bot_id = %msg.author.id, "bot not in trusted_bot_ids, ignoring");
+                    return;
+                }
             }
         }
 
@@ -2170,6 +2177,18 @@ fn is_denied_user(
     !is_bot && !allow_all_users && !allowed_users.contains(&user_id)
 }
 
+/// Returns `true` if a bot message should bypass the `allow_bot_messages` mode check.
+/// A trusted bot that @mentions this bot is treated the same as a human @mention —
+/// it can pull the bot into a thread regardless of the `allow_bot_messages` setting.
+#[cfg(test)]
+fn is_trusted_bot_mention(
+    is_mentioned: bool,
+    trusted_bot_ids: &HashSet<u64>,
+    author_id: u64,
+) -> bool {
+    is_mentioned && !trusted_bot_ids.is_empty() && trusted_bot_ids.contains(&author_id)
+}
+
 /// Pure decision function: should a DM be processed?
 /// Returns `true` if the DM should be processed (bot responds).
 /// Mirrors the DM gating logic in EventHandler::message:
@@ -2937,6 +2956,42 @@ mod tests {
     fn denied_user_bot_skips_allowlist() {
         let allowed = HashSet::from([100]);
         assert!(!is_denied_user(true, false, &allowed, 999));
+    }
+
+    // --- Trusted bot mention bypass tests ---
+    // A trusted bot @mentioning this bot bypasses allow_bot_messages mode,
+    // treating the mention the same as a human @mention.
+
+    /// GIVEN: trusted bot @mentions this bot
+    /// THEN:  bypass is granted (treated as human mention)
+    #[test]
+    fn trusted_bot_mention_bypasses_gate() {
+        let trusted = HashSet::from([42]);
+        assert!(is_trusted_bot_mention(true, &trusted, 42));
+    }
+
+    /// GIVEN: untrusted bot @mentions this bot
+    /// THEN:  no bypass (normal bot gating applies)
+    #[test]
+    fn untrusted_bot_mention_no_bypass() {
+        let trusted = HashSet::from([42]);
+        assert!(!is_trusted_bot_mention(true, &trusted, 99));
+    }
+
+    /// GIVEN: trusted bot sends message WITHOUT @mention
+    /// THEN:  no bypass (must explicitly @mention)
+    #[test]
+    fn trusted_bot_no_mention_no_bypass() {
+        let trusted = HashSet::from([42]);
+        assert!(!is_trusted_bot_mention(false, &trusted, 42));
+    }
+
+    /// GIVEN: empty trusted_bot_ids (feature not configured)
+    /// THEN:  no bypass regardless of mention
+    #[test]
+    fn empty_trusted_ids_no_bypass() {
+        let trusted: HashSet<u64> = HashSet::new();
+        assert!(!is_trusted_bot_mention(true, &trusted, 42));
     }
 
     // --- DM gating tests (#656) ---

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -457,7 +457,20 @@ impl EventHandler for Handler {
 
         // Bot message gating (from upstream #321)
         if msg.author.bot {
-            // Trusted bot @mention bypass: treat as human mention, skip mode check.
+            // Trusted bot admission override: when a bot listed in `trusted_bot_ids`
+            // explicitly @mentions this bot, bypass the entire `allow_bot_messages`
+            // mode check. This treats the trusted bot's @mention identically to a
+            // human @mention — the bot becomes involved in the thread and the message
+            // is dispatched regardless of the `allow_bot_messages` setting.
+            //
+            // Rationale: `trusted_bot_ids` expresses admin-level trust. A trusted bot
+            // that @mentions this bot is performing a deliberate handoff/coordination
+            // action, equivalent to a human pulling the bot into a conversation.
+            //
+            // Safety: requires both (1) explicit @mention AND (2) sender in
+            // trusted_bot_ids. Messages from trusted bots without @mention still
+            // follow normal gating. Empty trusted_bot_ids (default) disables this
+            // entirely — no behavioral change for existing deployments.
             let trusted_mention = is_mentioned
                 && !self.trusted_bot_ids.is_empty()
                 && self.trusted_bot_ids.contains(&msg.author.id.get());
@@ -2992,6 +3005,89 @@ mod tests {
     fn empty_trusted_ids_no_bypass() {
         let trusted: HashSet<u64> = HashSet::new();
         assert!(!is_trusted_bot_mention(true, &trusted, 42));
+    }
+
+    // --- Trusted bot admission integration tests ---
+    // These test the full bot gating decision path: allow_bot_messages mode +
+    // trusted_bot_ids + trusted mention bypass, mirroring the actual logic in
+    // EventHandler::message.
+
+    /// Simulates the bot admission decision from EventHandler::message.
+    /// Returns `true` if the bot message would be processed (not dropped).
+    fn should_admit_bot_message(
+        allow_bot_messages: AllowBots,
+        is_mentioned: bool,
+        trusted_bot_ids: &HashSet<u64>,
+        author_id: u64,
+    ) -> bool {
+        let trusted_mention = is_mentioned
+            && !trusted_bot_ids.is_empty()
+            && trusted_bot_ids.contains(&author_id);
+
+        if !trusted_mention {
+            match allow_bot_messages {
+                AllowBots::Off => return false,
+                AllowBots::Mentions => {
+                    if !is_mentioned {
+                        return false;
+                    }
+                }
+                AllowBots::All => {} // would check consecutive cap, skip for unit test
+            }
+
+            if !trusted_bot_ids.is_empty() && !trusted_bot_ids.contains(&author_id) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// GIVEN: allow_bot_messages=Off, trusted bot @mentions this bot
+    /// THEN:  admitted (trusted mention overrides Off mode)
+    #[test]
+    fn bot_admission_trusted_mention_overrides_off() {
+        let trusted = HashSet::from([42]);
+        assert!(should_admit_bot_message(AllowBots::Off, true, &trusted, 42));
+    }
+
+    /// GIVEN: allow_bot_messages=Off, untrusted bot @mentions this bot
+    /// THEN:  rejected (Off mode blocks)
+    #[test]
+    fn bot_admission_untrusted_mention_blocked_by_off() {
+        let trusted = HashSet::from([42]);
+        assert!(!should_admit_bot_message(AllowBots::Off, true, &trusted, 99));
+    }
+
+    /// GIVEN: allow_bot_messages=Off, trusted bot without @mention
+    /// THEN:  rejected (no mention = no bypass)
+    #[test]
+    fn bot_admission_trusted_no_mention_blocked_by_off() {
+        let trusted = HashSet::from([42]);
+        assert!(!should_admit_bot_message(AllowBots::Off, false, &trusted, 42));
+    }
+
+    /// GIVEN: allow_bot_messages=Off, empty trusted_bot_ids, bot @mentions
+    /// THEN:  rejected (feature not configured)
+    #[test]
+    fn bot_admission_empty_trusted_ids_off_mode() {
+        let trusted: HashSet<u64> = HashSet::new();
+        assert!(!should_admit_bot_message(AllowBots::Off, true, &trusted, 42));
+    }
+
+    /// GIVEN: allow_bot_messages=Mentions, trusted bot @mentions
+    /// THEN:  admitted (would pass anyway, but bypass also works)
+    #[test]
+    fn bot_admission_mentions_mode_trusted_mention() {
+        let trusted = HashSet::from([42]);
+        assert!(should_admit_bot_message(AllowBots::Mentions, true, &trusted, 42));
+    }
+
+    /// GIVEN: allow_bot_messages=All, untrusted bot (not in trusted_bot_ids)
+    /// THEN:  rejected by trusted_bot_ids filter
+    #[test]
+    fn bot_admission_all_mode_untrusted_bot_rejected() {
+        let trusted = HashSet::from([42]);
+        assert!(!should_admit_bot_message(AllowBots::All, false, &trusted, 99));
     }
 
     // --- DM gating tests (#656) ---


### PR DESCRIPTION
## What

Allow trusted bots to @mention other bots into threads — treating the mention identically to a human @mention. The target bot becomes **involved** in the thread and will process the message.

## Why

The current involvement gate (documented in #950) enforces "humans are gatekeepers" — only humans can pull a bot into a thread via @mention. Bot-to-bot @mention of a non-involved bot is silently dropped because `allow_bot_messages` defaults to `Off`, which rejects all bot messages before any other check runs.

This creates friction for legitimate bot-to-bot coordination:
- A coordinator bot (e.g. 超渡) cannot pull reviewer bots into a thread
- Multi-agent workflows require a human to manually @mention every bot
- The `trusted_bot_ids` config already expresses trust, but that trust is gated behind the mode check

## How

In the bot message gating block (`src/discord.rs`), added a `trusted_mention` check **before** the `allow_bot_messages` mode switch:

```rust
let trusted_mention = is_mentioned
    && !self.trusted_bot_ids.is_empty()
    && self.trusted_bot_ids.contains(&msg.author.id.get());

if !trusted_mention {
    match self.allow_bot_messages { ... }
    // trusted_bot_ids filter also here
}
```

If a trusted bot explicitly @mentions this bot, the entire mode check and trusted filter are skipped — the message proceeds as if it came from a human.

## Behavior change

| Scenario | Before | After |
|----------|--------|-------|
| Trusted bot @mentions this bot (mode=Off) | ❌ Dropped | ✅ Processed (same as human) |
| Trusted bot @mentions this bot (mode=Mentions) | ✅ Already worked | ✅ Still works |
| Untrusted bot @mentions this bot | ❌ Dropped | ❌ Still dropped |
| Trusted bot message without @mention | ❌ Dropped (mode=Off) | ❌ Still dropped |

## Opt-in only — no surprise for existing users

This feature is **strictly opt-in**:
- `trusted_bot_ids` defaults to empty → behavior is identical to before
- Only admins who explicitly configure `trusted_bot_ids` get the new capability
- No new config flag needed — `trusted_bot_ids = []` (default) is the opt-out
- Enterprise users who have not configured `trusted_bot_ids` are completely unaffected

If a future need arises to allow `trusted_bot_ids` for other purposes without granting involvement bypass, we can add a dedicated flag at that point. For now, configuring `trusted_bot_ids` implies trust for thread involvement.

## Safety

- **No new config** — uses existing `trusted_bot_ids` field
- **Explicit trust only** — admin must configure which bots are trusted
- **Requires @mention** — trusted bots without explicit @mention still follow normal gating
- **Loop prevention** — `max_bot_turns` and `bot_turns` tracker still apply after involvement
- **Backward compatible** — empty `trusted_bot_ids` (default) preserves current behavior exactly

## Testing

Added 4 unit tests for the pure `is_trusted_bot_mention` decision function:
- Trusted bot with @mention → bypass ✅
- Untrusted bot with @mention → no bypass
- Trusted bot without @mention → no bypass
- Empty trusted_bot_ids → no bypass

Refs #949, #950