### PR TITLE
docs: add OpenShell local Docker guide

### DIFF
--- a/.github/workflows/build-operator.yml
+++ b/.github/workflows/build-operator.yml
@@ -82,6 +82,7 @@ jobs:
           - { suffix: "-antigravity", dockerfile: "Dockerfile.antigravity", artifact: "antigravity" }
           - { suffix: "-pi", dockerfile: "Dockerfile.pi", artifact: "pi" }
           - { suffix: "-native", dockerfile: "Dockerfile.native", artifact: "native" }
+          - { suffix: "-native-sandbox", dockerfile: "openshell/Dockerfile", artifact: "native-sandbox" }
         platform:
           - { os: linux/amd64, runner: ubuntu-latest }
           - { os: linux/arm64, runner: ubuntu-24.04-arm }
@@ -150,6 +151,7 @@ jobs:
           - { suffix: "-antigravity", artifact: "antigravity" }
           - { suffix: "-pi", artifact: "pi" }
           - { suffix: "-native", artifact: "native" }
+          - { suffix: "-native-sandbox", artifact: "native-sandbox" }
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -24,6 +24,7 @@ jobs:
           - { dockerfile: Dockerfile.grok, suffix: "-grok", agent: "grok", agent_args: "agent stdio" }
           - { dockerfile: Dockerfile.antigravity, suffix: "-antigravity", agent: "agy-acp", agent_args: "" }
           - { dockerfile: Dockerfile.pi, suffix: "-pi", agent: "pi-acp", agent_args: "" }
+          - { dockerfile: openshell/Dockerfile, suffix: "-native-sandbox", agent: "openab-agent", agent_args: "" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -69,12 +69,21 @@ openshell provider create --name discord --type generic \
   --credential "DISCORD_BOT_TOKEN=your-token-here"
 ```
 
-### 2. Build and create sandbox
+### 2. Create sandbox
+
+Using the pre-built image:
 
 ```bash
-# From the repo root
-docker build -t oab-sandbox openshell/
+openshell sandbox create --name oab \
+  --from ghcr.io/openabdev/openab-native-sandbox:latest \
+  --provider discord \
+  -- bash
+```
 
+Or build locally from `openshell/Dockerfile`:
+
+```bash
+docker build -t oab-sandbox openshell/
 openshell sandbox create --name oab \
   --from oab-sandbox:latest \
   --provider discord \

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -1,0 +1,147 @@
+# OpenShell
+
+Run OAB inside an [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandbox for isolated, policy-enforced execution with credential injection.
+
+## Prerequisites
+
+- Docker running on the host
+- [OpenShell CLI](https://github.com/NVIDIA/OpenShell#install) installed
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
+```
+
+## Quick Start (Local Docker)
+
+### 1. Create a sandbox
+
+```bash
+openshell sandbox create --name oab -- bash
+```
+
+### 2. Connect and install OAB
+
+```bash
+openshell sandbox connect oab
+```
+
+Inside the sandbox:
+
+```bash
+git clone https://github.com/openabdev/openab.git
+cd openab
+cargo build --release
+```
+
+### 3. Configure credentials
+
+On the host, create providers for the tokens OAB needs:
+
+```bash
+# Discord bot token
+export DISCORD_BOT_TOKEN="your-token"
+openshell provider create --name discord --env DISCORD_BOT_TOKEN
+
+# GitHub token
+export GITHUB_TOKEN="your-token"
+openshell provider create --name github --env GITHUB_TOKEN
+
+# LLM provider (pick one)
+export ANTHROPIC_API_KEY="your-key"
+openshell provider create --name anthropic --env ANTHROPIC_API_KEY
+```
+
+Then recreate the sandbox with providers attached:
+
+```bash
+openshell sandbox delete oab
+openshell sandbox create --name oab \
+  --provider discord \
+  --provider github \
+  --provider anthropic \
+  -- bash
+```
+
+### 4. Apply network policy
+
+Create `oab-policy.yaml`:
+
+```yaml
+network:
+  egress:
+    - destination: "discord.com"
+      ports: [443]
+    - destination: "gateway.discord.gg"
+      ports: [443]
+    - destination: "api.github.com"
+      ports: [443]
+    - destination: "github.com"
+      ports: [443]
+    - destination: "api.anthropic.com"
+      ports: [443]
+```
+
+Apply it:
+
+```bash
+openshell policy set oab --policy oab-policy.yaml
+```
+
+### 5. Run OAB
+
+Inside the sandbox:
+
+```bash
+cd openab
+./target/release/openab serve --config config.toml
+```
+
+## Port Forwarding
+
+If OAB exposes a webhook endpoint (e.g., for GitHub webhooks):
+
+```bash
+openshell sandbox create --name oab \
+  --forward 3000 \
+  --provider discord \
+  --provider github \
+  -- bash
+```
+
+`localhost:3000` on the host reaches port 3000 inside the sandbox.
+
+## BYOC (Custom Image)
+
+For a pre-built OAB sandbox image, create a `Dockerfile`:
+
+```dockerfile
+FROM ubuntu:24.04
+
+RUN groupadd -g 1000660000 sandbox && \
+    useradd -u 1000660000 -g sandbox -m sandbox
+
+RUN apt-get update && apt-get install -y \
+    curl git iproute2 ca-certificates build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    su sandbox -c 'sh -s -- -y'
+
+WORKDIR /home/sandbox
+USER sandbox
+```
+
+```bash
+openshell sandbox create --name oab \
+  --from ./Dockerfile \
+  --provider discord \
+  --provider github \
+  -- bash
+```
+
+## Cleanup
+
+```bash
+openshell sandbox delete oab
+```

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -43,8 +43,9 @@ At this point you are **inside the sandbox** (prompt changes). To return to the 
 
 ```bash
 # 3. (Inside sandbox) Download and install OAB
-sandbox$ curl -LO https://github.com/openabdev/openab/releases/latest/download/openab-linux-x64.tar.gz
-sandbox$ tar xzf openab-linux-x64.tar.gz
+sandbox$ TAG=$(curl -sI https://github.com/openabdev/openab/releases/latest | grep -i location | sed 's|.*/||' | tr -d '\r')
+sandbox$ curl -LO "https://github.com/openabdev/openab/releases/download/${TAG}/${TAG}-linux-x64.tar.gz"
+sandbox$ tar xzf ${TAG}-linux-x64.tar.gz
 sandbox$ chmod +x openab
 
 # 4. (Inside sandbox) Create config.toml
@@ -124,7 +125,8 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 # Download pre-built OAB binary
-RUN curl -L https://github.com/openabdev/openab/releases/latest/download/openab-linux-x64.tar.gz | \
+ARG OAB_VERSION=openab-0.8.4-beta.10
+RUN curl -L "https://github.com/openabdev/openab/releases/download/${OAB_VERSION}/${OAB_VERSION}-linux-x64.tar.gz" | \
     tar xz -C /usr/local/bin/
 
 USER sandbox

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -13,7 +13,7 @@ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | 
 
 ## Quick Start (Local Docker)
 
-The following is a single copy-pasteable sequence. Run all commands on the host unless noted otherwise.
+The following is a single copy-pasteable sequence. All commands run **on the host** unless prefixed with `sandbox$`.
 
 ```bash
 # 1. Create credential providers
@@ -29,14 +29,42 @@ openshell provider create --name github --env GITHUB_TOKEN
 openshell provider create --name anthropic --env ANTHROPIC_API_KEY
 
 # 2. Create sandbox with providers and port forwarding
+#    This starts an isolated container and drops you into a bash shell inside it.
+#    The sandbox runs until you `exit` or delete it from the host.
 openshell sandbox create --name oab \
   --provider discord \
   --provider github \
   --provider anthropic \
   --forward 3000 \
   -- bash
+```
 
-# 3. Apply network policy (all unlisted egress is denied by default)
+At this point you are **inside the sandbox** (prompt changes). To return to the host, type `exit`. To reconnect later: `openshell sandbox connect oab`.
+
+```bash
+# 3. (Inside sandbox) Clone and build OAB
+sandbox$ git clone https://github.com/openabdev/openab.git
+sandbox$ cd openab
+sandbox$ cargo build --release
+
+# 4. (Inside sandbox) Create config.toml
+sandbox$ cp config.toml.example config.toml
+sandbox$ sed -i 's/allowed_channels = \["1234567890"\]/allowed_channels = ["YOUR_CHANNEL_ID"]/' config.toml
+```
+
+Edit `config.toml` to set your Discord channel ID. The env vars (`DISCORD_BOT_TOKEN`, etc.) are already injected by the provider — no need to set them manually.
+
+```bash
+# 5. (Inside sandbox) Run OAB
+sandbox$ ./target/release/openab serve --config config.toml
+```
+
+### Applying network policy (from a separate host terminal)
+
+Open a new terminal on the host while OAB is running:
+
+```bash
+# All unlisted egress is denied by default.
 cat > /tmp/oab-policy.yaml <<'EOF'
 network:
   egress:
@@ -52,21 +80,9 @@ network:
       ports: [443]
 EOF
 openshell policy set oab --policy /tmp/oab-policy.yaml --wait
-
-# 4. Connect to the sandbox
-openshell sandbox connect oab
 ```
 
-Inside the sandbox:
-
-```bash
-git clone https://github.com/openabdev/openab.git
-cd openab
-cargo build --release
-./target/release/openab serve --config config.toml
-```
-
-At this point `localhost:3000` on the host reaches port 3000 inside the sandbox (useful for GitHub webhook delivery via grok/ngrok).
+> **DNS note:** OpenShell resolves hostnames in `destination` via the sandbox's DNS at policy evaluation time. Wildcard subdomains (e.g., `*.discord.com`) are not supported — list each hostname explicitly. If a service uses multiple domains, check its docs for the full list.
 
 ## Credential Management
 
@@ -109,7 +125,6 @@ RUN apt-get update && apt-get install -y \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     su sandbox -c 'sh -s -- -y'
 
-# Pre-clone and build OAB
 USER sandbox
 WORKDIR /home/sandbox
 RUN . /home/sandbox/.cargo/env && \
@@ -137,7 +152,9 @@ openshell sandbox connect oab
 Inside the sandbox, OAB is already built:
 
 ```bash
-./target/release/openab serve --config config.toml
+sandbox$ cp config.toml.example config.toml
+# Edit config.toml with your channel ID
+sandbox$ ./target/release/openab serve --config config.toml
 ```
 
 ## Cleanup

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -13,29 +13,9 @@ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | 
 
 ## Quick Start (Local Docker)
 
-### 1. Create a sandbox
+### 1. Create credential providers
 
-```bash
-openshell sandbox create --name oab -- bash
-```
-
-### 2. Connect and install OAB
-
-```bash
-openshell sandbox connect oab
-```
-
-Inside the sandbox:
-
-```bash
-git clone https://github.com/openabdev/openab.git
-cd openab
-cargo build --release
-```
-
-### 3. Configure credentials
-
-On the host, create providers for the tokens OAB needs:
+OpenShell injects credentials as environment variables at sandbox runtime — they never touch the sandbox filesystem. Providers persist across sandbox restarts until explicitly deleted.
 
 ```bash
 # Discord bot token
@@ -51,10 +31,11 @@ export ANTHROPIC_API_KEY="your-key"
 openshell provider create --name anthropic --env ANTHROPIC_API_KEY
 ```
 
-Then recreate the sandbox with providers attached:
+> Providers are stored in the OpenShell gateway's local state. The host env vars are only read at `provider create` time and are not needed afterwards.
+
+### 2. Create a sandbox with providers
 
 ```bash
-openshell sandbox delete oab
 openshell sandbox create --name oab \
   --provider discord \
   --provider github \
@@ -62,9 +43,9 @@ openshell sandbox create --name oab \
   -- bash
 ```
 
-### 4. Apply network policy
+### 3. Apply network policy
 
-Create `oab-policy.yaml`:
+Create `oab-policy.yaml` on the host:
 
 ```yaml
 network:
@@ -81,30 +62,39 @@ network:
       ports: [443]
 ```
 
-Apply it:
+Apply to the running sandbox:
 
 ```bash
-openshell policy set oab --policy oab-policy.yaml
+openshell policy set oab --policy oab-policy.yaml --wait
 ```
 
-### 5. Run OAB
+The `--wait` flag blocks until the policy is enforced. All egress not listed above is denied by default.
+
+### 4. Connect and run OAB
+
+```bash
+openshell sandbox connect oab
+```
 
 Inside the sandbox:
 
 ```bash
+git clone https://github.com/openabdev/openab.git
 cd openab
+cargo build --release
 ./target/release/openab serve --config config.toml
 ```
 
 ## Port Forwarding
 
-If OAB exposes a webhook endpoint (e.g., for GitHub webhooks):
+If OAB exposes a webhook endpoint (e.g., for GitHub webhooks), add `--forward` at creation:
 
 ```bash
 openshell sandbox create --name oab \
   --forward 3000 \
   --provider discord \
   --provider github \
+  --provider anthropic \
   -- bash
 ```
 
@@ -137,6 +127,7 @@ openshell sandbox create --name oab \
   --from ./Dockerfile \
   --provider discord \
   --provider github \
+  --provider anthropic \
   -- bash
 ```
 

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -218,31 +218,21 @@ Each forwarded port creates a tunnel: `localhost:<port>` on the host → `127.0.
 
 ## BYOC (Custom Image)
 
-Build a custom sandbox image with OAB pre-installed:
-
-```dockerfile
-FROM ubuntu:24.04
-
-RUN groupadd -g 1000660000 sandbox && \
-    useradd -u 1000660000 -g sandbox -m sandbox
-
-RUN apt-get update && apt-get install -y \
-    curl git ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-
-ARG OAB_VERSION=openab-0.8.4-beta.10
-RUN curl -L "https://github.com/openabdev/openab/releases/download/${OAB_VERSION}/${OAB_VERSION}-linux-x64.tar.gz" | \
-    tar xz -C /usr/local/bin/
-
-USER sandbox
-WORKDIR /home/sandbox
-```
-
-Run it:
+A pre-built Dockerfile is provided at [`openshell/Dockerfile`](../openshell/Dockerfile) with OAB and the native agent pre-installed:
 
 ```bash
 openshell sandbox create --name oab \
-  --from ./Dockerfile \
+  --from openshell/Dockerfile \
+  --provider discord \
+  -- bash
+```
+
+To customize the OAB version:
+
+```bash
+docker build --build-arg OAB_VERSION=openab-0.8.4-beta.10 -t oab-sandbox openshell/
+openshell sandbox create --name oab \
+  --from oab-sandbox \
   --provider discord \
   -- bash
 ```

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -1,21 +1,6 @@
 # OpenShell
 
-Run OAB inside an [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandbox for isolated, policy-enforced execution with credential injection.
-
-## Prerequisites
-
-- Docker running on the host (user must be in the `docker` group)
-- [OpenShell CLI](https://github.com/NVIDIA/OpenShell#install) installed
-
-```bash
-curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
-```
-
-> **Note:** The installer starts `openshell-gateway` as a systemd user service. If the gateway fails with "failed to query Docker daemon version", add your user to the `docker` group and restart the session:
-> ```bash
-> sudo usermod -aG docker $USER
-> # Log out and back in (or: loginctl terminate-user $USER)
-> ```
+Run OAB inside an [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandbox for isolated, policy-enforced execution.
 
 ## Architecture
 
@@ -34,11 +19,8 @@ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | 
 │  ┌───────────────────────────────────────────────────────────────┐  │
 │  │  Docker Container (sandbox: "oab")                            │  │
 │  │                                                               │  │
-│  │  /sandbox/                                                    │  │
-│  │  ├── openab              ← ACP broker binary                  │  │
-│  │  ├── openab-agent        ← native Rust coding agent           │  │
-│  │  ├── config.toml         ← bot token + agent config           │  │
-│  │  └── .openab/agent/auth.json  ← codex OAuth token             │  │
+│  │  /home/sandbox/                                               │  │
+│  │  └── config.toml         ← bot token + agent config           │  │
 │  │                                                               │  │
 │  │  openab run ──stdio JSON-RPC──► openab-agent                  │  │
 │  │       │                              │                        │  │
@@ -63,89 +45,43 @@ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | 
 └──────────────────┘         └──────────────────┘
 ```
 
-## Quick Start (Local Docker)
+## Prerequisites
 
-All commands run **on the host** unless prefixed with `sandbox$`.
+- Docker running on the host (user must be in the `docker` group)
+- [OpenShell CLI](https://github.com/NVIDIA/OpenShell#install) installed
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
+```
+
+> **Note:** If the gateway fails with "failed to query Docker daemon version", add your user to the `docker` group and re-login:
+> ```bash
+> sudo usermod -aG docker $USER
+> # Log out and back in (or: loginctl terminate-user $USER)
+> ```
+
+## Quick Start
 
 ### 1. Create credential provider
 
 ```bash
-export DISCORD_BOT_TOKEN="your-token"
-
 openshell provider create --name discord --type generic \
-  --credential "DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN}"
+  --credential "DISCORD_BOT_TOKEN=your-token-here"
 ```
 
-### 2. Create sandbox
+### 2. Build and create sandbox
 
 ```bash
+# From the repo root
+docker build -t oab-sandbox openshell/
+
 openshell sandbox create --name oab \
+  --from oab-sandbox:latest \
   --provider discord \
   -- bash
 ```
 
-At this point you are **inside the sandbox** (prompt changes). To return to the host, type `exit`. To reconnect later: `openshell sandbox connect oab`.
-
-### 3. Install OAB + Native Agent (from host)
-
-The sandbox has **default-deny egress**, so download binaries on the host and copy them in:
-
-```bash
-# On the host (separate terminal)
-TAG=$(curl -sI https://github.com/openabdev/openab/releases/latest | grep -i location | sed 's|.*/||' | tr -d '\r')
-
-# Download OAB
-curl -LO "https://github.com/openabdev/openab/releases/download/${TAG}/${TAG}-linux-x64.tar.gz"
-tar xzf ${TAG}-linux-x64.tar.gz
-
-# Extract openab-agent from the native image
-docker pull ghcr.io/openabdev/openab-native:beta
-CID=$(docker create ghcr.io/openabdev/openab-native:beta)
-docker cp $CID:/usr/local/bin/openab-agent ./openab-agent
-docker rm $CID
-
-# Copy into sandbox
-CONTAINER=$(docker ps --filter name=openshell-oab -q)
-docker cp openab $CONTAINER:/sandbox/
-docker cp openab-agent $CONTAINER:/sandbox/
-docker exec $CONTAINER chmod +x /sandbox/openab /sandbox/openab-agent
-```
-
-### 4. Authenticate openab-agent (codex OAuth — headless)
-
-```bash
-# On the host
-docker exec -it $CONTAINER /sandbox/openab-agent auth codex-oauth --no-browser
-```
-
-This prints an authorization URL. Open it in your browser, approve, then paste the `localhost:1455/auth/callback?...` URL back into the terminal.
-
-### 5. Create config.toml
-
-```bash
-cat > /tmp/oab-config.toml <<'EOF'
-[discord]
-bot_token = "${DISCORD_BOT_TOKEN}"
-allow_all_channels = true
-
-[agent]
-command = "/sandbox/openab-agent"
-working_dir = "/sandbox"
-env = { OPENAB_AGENT_OPENAI_MODEL = "gpt-5.4-mini" }
-
-[pool]
-max_sessions = 3
-session_ttl_hours = 1
-
-[reactions]
-enabled = true
-EOF
-docker cp /tmp/oab-config.toml $CONTAINER:/sandbox/config.toml
-```
-
-> **Note:** The `${DISCORD_BOT_TOKEN}` env var expansion works only if the raw token is available in the sandbox environment. If using OpenShell providers (which inject reference tokens), hardcode the bot token directly in the config instead.
-
-### 6. Set network policy
+### 3. Set network policy (from host)
 
 ```bash
 openshell policy update oab \
@@ -156,44 +92,41 @@ openshell policy update oab \
   --add-endpoint "auth0.openai.com:443:read-write:rest:enforce"
 ```
 
-### 7. Run OAB
+### 4. Authenticate (inside sandbox)
 
 ```bash
-# Inside sandbox (openshell sandbox connect oab)
-sandbox$ cd /sandbox && ./openab run --config config.toml
+sandbox$ openab-agent auth codex-oauth --no-browser
 ```
 
-Or from the host:
+Open the printed URL in your browser, approve, then paste the `localhost:1455/auth/callback?...` URL back.
+
+### 5. Create config and run
 
 ```bash
-docker exec -d $CONTAINER bash -c "cd /sandbox && ./openab run --config config.toml"
+sandbox$ cat > config.toml <<'EOF'
+[discord]
+bot_token = "your-bot-token"
+allow_all_channels = true
+
+[agent]
+command = "openab-agent"
+working_dir = "/home/sandbox"
+env = { OPENAB_AGENT_OPENAI_MODEL = "gpt-5.4-mini" }
+
+[pool]
+max_sessions = 3
+session_ttl_hours = 1
+
+[reactions]
+enabled = true
+EOF
+
+sandbox$ openab run --config config.toml
 ```
-
-## Credential Management
-
-| Operation | Command |
-|-----------|---------|
-| List providers | `openshell provider list` |
-| Delete a provider | `openshell provider delete discord` |
-| Rotate a credential | Delete + recreate with new value |
-
-Providers use `--type generic --credential KEY=VALUE` format. Credentials are injected as env vars at sandbox runtime.
 
 ## Network Policy
 
-OpenShell sandboxes have **default-deny egress**. Use `openshell policy update` to allow specific endpoints:
-
-```bash
-# Add an endpoint
-openshell policy update oab --add-endpoint "api.example.com:443:read-write:rest:enforce"
-
-# View current policy
-openshell policy get oab
-```
-
-Endpoint format: `host:port:access:protocol:mode`
-
-### Required endpoints by agent backend
+OpenShell sandboxes have **default-deny egress**. Required endpoints by backend:
 
 | Backend | Endpoints |
 |---------|-----------|
@@ -202,39 +135,10 @@ Endpoint format: `host:port:access:protocol:mode`
 | Native Agent (anthropic) | `api.anthropic.com:443` |
 | GitHub access | `api.github.com:443`, `github.com:443` |
 
-## Port Forwarding
-
-Add `--forward <port>` at sandbox creation:
+## Reconnecting
 
 ```bash
-openshell sandbox create --name oab \
-  --provider discord \
-  --forward 3000 \
-  --forward 8080 \
-  -- bash
-```
-
-Each forwarded port creates a tunnel: `localhost:<port>` on the host → `127.0.0.1:<port>` inside the sandbox.
-
-## BYOC (Custom Image)
-
-A pre-built Dockerfile is provided at [`openshell/Dockerfile`](../openshell/Dockerfile) with OAB and the native agent pre-installed:
-
-```bash
-openshell sandbox create --name oab \
-  --from openshell/Dockerfile \
-  --provider discord \
-  -- bash
-```
-
-To customize the OAB version:
-
-```bash
-docker build --build-arg OAB_VERSION=openab-0.8.4-beta.10 -t oab-sandbox openshell/
-openshell sandbox create --name oab \
-  --from oab-sandbox \
-  --provider discord \
-  -- bash
+openshell sandbox connect oab
 ```
 
 ## Cleanup

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -4,87 +4,124 @@ Run OAB inside an [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandbo
 
 ## Prerequisites
 
-- Docker running on the host
+- Docker running on the host (user must be in the `docker` group)
 - [OpenShell CLI](https://github.com/NVIDIA/OpenShell#install) installed
 
 ```bash
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
 ```
 
+> **Note:** The installer starts `openshell-gateway` as a systemd user service. If the gateway fails with "failed to query Docker daemon version", add your user to the `docker` group and restart the session:
+> ```bash
+> sudo usermod -aG docker $USER
+> # Log out and back in (or: loginctl terminate-user $USER)
+> ```
+
 ## Quick Start (Local Docker)
 
-The following is a single copy-pasteable sequence. All commands run **on the host** unless prefixed with `sandbox$`.
+All commands run **on the host** unless prefixed with `sandbox$`.
+
+### 1. Create credential provider
 
 ```bash
-# 1. Create credential providers
-#    Providers are stored in the OpenShell gateway's local state.
-#    Host env vars are read only at creation time and not retained.
-#    Providers persist until explicitly removed with `openshell provider delete <name>`.
 export DISCORD_BOT_TOKEN="your-token"
-export GITHUB_TOKEN="your-token"
-export ANTHROPIC_API_KEY="your-key"
 
-openshell provider create --name discord --env DISCORD_BOT_TOKEN
-openshell provider create --name github --env GITHUB_TOKEN
-openshell provider create --name anthropic --env ANTHROPIC_API_KEY
+openshell provider create --name discord --type generic \
+  --credential "DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN}"
+```
 
-# 2. Create sandbox with providers and port forwarding
-#    This starts an isolated container and drops you into a bash shell inside it.
-#    The sandbox runs until you `exit` or delete it from the host.
+### 2. Create sandbox
+
+```bash
 openshell sandbox create --name oab \
   --provider discord \
-  --provider github \
-  --provider anthropic \
-  --forward 3000 \
   -- bash
 ```
 
 At this point you are **inside the sandbox** (prompt changes). To return to the host, type `exit`. To reconnect later: `openshell sandbox connect oab`.
 
-```bash
-# 3. (Inside sandbox) Download and install OAB
-sandbox$ TAG=$(curl -sI https://github.com/openabdev/openab/releases/latest | grep -i location | sed 's|.*/||' | tr -d '\r')
-sandbox$ curl -LO "https://github.com/openabdev/openab/releases/download/${TAG}/${TAG}-linux-x64.tar.gz"
-sandbox$ tar xzf ${TAG}-linux-x64.tar.gz
-sandbox$ chmod +x openab
+### 3. Install OAB + Native Agent (from host)
 
-# 4. (Inside sandbox) Create config.toml
-sandbox$ curl -LO https://raw.githubusercontent.com/openabdev/openab/main/config.toml.example
-sandbox$ cp config.toml.example config.toml
-sandbox$ sed -i 's/allowed_channels = \["1234567890"\]/allowed_channels = ["YOUR_CHANNEL_ID"]/' config.toml
+The sandbox has **default-deny egress**, so download binaries on the host and copy them in:
+
+```bash
+# On the host (separate terminal)
+TAG=$(curl -sI https://github.com/openabdev/openab/releases/latest | grep -i location | sed 's|.*/||' | tr -d '\r')
+
+# Download OAB
+curl -LO "https://github.com/openabdev/openab/releases/download/${TAG}/${TAG}-linux-x64.tar.gz"
+tar xzf ${TAG}-linux-x64.tar.gz
+
+# Extract openab-agent from the native image
+docker pull ghcr.io/openabdev/openab-native:beta
+CID=$(docker create ghcr.io/openabdev/openab-native:beta)
+docker cp $CID:/usr/local/bin/openab-agent ./openab-agent
+docker rm $CID
+
+# Copy into sandbox
+CONTAINER=$(docker ps --filter name=openshell-oab -q)
+docker cp openab $CONTAINER:/sandbox/
+docker cp openab-agent $CONTAINER:/sandbox/
+docker exec $CONTAINER chmod +x /sandbox/openab /sandbox/openab-agent
 ```
 
-Edit `config.toml` to set your Discord channel ID. The env vars (`DISCORD_BOT_TOKEN`, etc.) are already injected by the provider — no need to set them manually.
+### 4. Authenticate openab-agent (codex OAuth — headless)
 
 ```bash
-# 5. (Inside sandbox) Run OAB
-sandbox$ ./openab serve --config config.toml
+# On the host
+docker exec -it $CONTAINER /sandbox/openab-agent auth codex-oauth --no-browser
 ```
 
-### Applying network policy (from a separate host terminal)
+This prints an authorization URL. Open it in your browser, approve, then paste the `localhost:1455/auth/callback?...` URL back into the terminal.
 
-Open a new terminal on the host while OAB is running:
+### 5. Create config.toml
 
 ```bash
-# All unlisted egress is denied by default.
-cat > /tmp/oab-policy.yaml <<'EOF'
-network:
-  egress:
-    - destination: "discord.com"
-      ports: [443]
-    - destination: "gateway.discord.gg"
-      ports: [443]
-    - destination: "api.github.com"
-      ports: [443]
-    - destination: "github.com"
-      ports: [443]
-    - destination: "api.anthropic.com"
-      ports: [443]
+cat > /tmp/oab-config.toml <<'EOF'
+[discord]
+bot_token = "${DISCORD_BOT_TOKEN}"
+allow_all_channels = true
+
+[agent]
+command = "/sandbox/openab-agent"
+working_dir = "/sandbox"
+env = { OPENAB_AGENT_OPENAI_MODEL = "gpt-5.4-mini" }
+
+[pool]
+max_sessions = 3
+session_ttl_hours = 1
+
+[reactions]
+enabled = true
 EOF
-openshell policy set oab --policy /tmp/oab-policy.yaml --wait
+docker cp /tmp/oab-config.toml $CONTAINER:/sandbox/config.toml
 ```
 
-> **DNS note:** OpenShell resolves hostnames in `destination` via the sandbox's DNS at policy evaluation time. Wildcard subdomains (e.g., `*.discord.com`) are not supported — list each hostname explicitly. If a service uses multiple domains, check its docs for the full list.
+> **Note:** The `${DISCORD_BOT_TOKEN}` env var expansion works only if the raw token is available in the sandbox environment. If using OpenShell providers (which inject reference tokens), hardcode the bot token directly in the config instead.
+
+### 6. Set network policy
+
+```bash
+openshell policy update oab \
+  --add-endpoint "discord.com:443:read-write:rest:enforce" \
+  --add-endpoint "gateway.discord.gg:443:read-write:websocket:enforce" \
+  --add-endpoint "cdn.discordapp.com:443:read-write:rest:enforce" \
+  --add-endpoint "chatgpt.com:443:read-write:rest:enforce" \
+  --add-endpoint "auth0.openai.com:443:read-write:rest:enforce"
+```
+
+### 7. Run OAB
+
+```bash
+# Inside sandbox (openshell sandbox connect oab)
+sandbox$ cd /sandbox && ./openab run --config config.toml
+```
+
+Or from the host:
+
+```bash
+docker exec -d $CONTAINER bash -c "cd /sandbox && ./openab run --config config.toml"
+```
 
 ## Credential Management
 
@@ -94,11 +131,34 @@ openshell policy set oab --policy /tmp/oab-policy.yaml --wait
 | Delete a provider | `openshell provider delete discord` |
 | Rotate a credential | Delete + recreate with new value |
 
-Credentials are injected as env vars at sandbox runtime. They are **not** written to the sandbox filesystem. Removing a provider immediately revokes access on the next sandbox restart.
+Providers use `--type generic --credential KEY=VALUE` format. Credentials are injected as env vars at sandbox runtime.
+
+## Network Policy
+
+OpenShell sandboxes have **default-deny egress**. Use `openshell policy update` to allow specific endpoints:
+
+```bash
+# Add an endpoint
+openshell policy update oab --add-endpoint "api.example.com:443:read-write:rest:enforce"
+
+# View current policy
+openshell policy get oab
+```
+
+Endpoint format: `host:port:access:protocol:mode`
+
+### Required endpoints by agent backend
+
+| Backend | Endpoints |
+|---------|-----------|
+| All | `discord.com:443`, `gateway.discord.gg:443`, `cdn.discordapp.com:443` |
+| Native Agent (codex) | `chatgpt.com:443`, `auth0.openai.com:443` |
+| Native Agent (anthropic) | `api.anthropic.com:443` |
+| GitHub access | `api.github.com:443`, `github.com:443` |
 
 ## Port Forwarding
 
-Add `--forward <port>` at sandbox creation. Multiple ports are supported:
+Add `--forward <port>` at sandbox creation:
 
 ```bash
 openshell sandbox create --name oab \
@@ -108,7 +168,7 @@ openshell sandbox create --name oab \
   -- bash
 ```
 
-Each forwarded port creates an SSH tunnel: `localhost:<port>` on the host → `127.0.0.1:<port>` inside the sandbox. Tunnels are torn down when the sandbox is deleted.
+Each forwarded port creates a tunnel: `localhost:<port>` on the host → `127.0.0.1:<port>` inside the sandbox.
 
 ## BYOC (Custom Image)
 
@@ -121,18 +181,15 @@ RUN groupadd -g 1000660000 sandbox && \
     useradd -u 1000660000 -g sandbox -m sandbox
 
 RUN apt-get update && apt-get install -y \
-    curl git iproute2 ca-certificates && \
+    curl git ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-# Download pre-built OAB binary
 ARG OAB_VERSION=openab-0.8.4-beta.10
 RUN curl -L "https://github.com/openabdev/openab/releases/download/${OAB_VERSION}/${OAB_VERSION}-linux-x64.tar.gz" | \
     tar xz -C /usr/local/bin/
 
 USER sandbox
 WORKDIR /home/sandbox
-RUN curl -LO https://raw.githubusercontent.com/openabdev/openab/main/config.toml.example && \
-    cp config.toml.example config.toml
 ```
 
 Run it:
@@ -141,28 +198,12 @@ Run it:
 openshell sandbox create --name oab \
   --from ./Dockerfile \
   --provider discord \
-  --provider github \
-  --provider anthropic \
-  --forward 3000 \
   -- bash
-
-openshell policy set oab --policy /tmp/oab-policy.yaml --wait
-openshell sandbox connect oab
-```
-
-Inside the sandbox, OAB is already installed:
-
-```bash
-sandbox$ sed -i 's/allowed_channels = \["1234567890"\]/allowed_channels = ["YOUR_CHANNEL_ID"]/' config.toml
-sandbox$ openab serve --config config.toml
 ```
 
 ## Cleanup
 
 ```bash
 openshell sandbox delete oab
-# Optionally remove providers
 openshell provider delete discord
-openshell provider delete github
-openshell provider delete anthropic
 ```

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -42,12 +42,13 @@ openshell sandbox create --name oab \
 At this point you are **inside the sandbox** (prompt changes). To return to the host, type `exit`. To reconnect later: `openshell sandbox connect oab`.
 
 ```bash
-# 3. (Inside sandbox) Clone and build OAB
-sandbox$ git clone https://github.com/openabdev/openab.git
-sandbox$ cd openab
-sandbox$ cargo build --release
+# 3. (Inside sandbox) Download and install OAB
+sandbox$ curl -LO https://github.com/openabdev/openab/releases/latest/download/openab-linux-x64.tar.gz
+sandbox$ tar xzf openab-linux-x64.tar.gz
+sandbox$ chmod +x openab
 
 # 4. (Inside sandbox) Create config.toml
+sandbox$ curl -LO https://raw.githubusercontent.com/openabdev/openab/main/config.toml.example
 sandbox$ cp config.toml.example config.toml
 sandbox$ sed -i 's/allowed_channels = \["1234567890"\]/allowed_channels = ["YOUR_CHANNEL_ID"]/' config.toml
 ```
@@ -56,7 +57,7 @@ Edit `config.toml` to set your Discord channel ID. The env vars (`DISCORD_BOT_TO
 
 ```bash
 # 5. (Inside sandbox) Run OAB
-sandbox$ ./target/release/openab serve --config config.toml
+sandbox$ ./openab serve --config config.toml
 ```
 
 ### Applying network policy (from a separate host terminal)
@@ -119,19 +120,17 @@ RUN groupadd -g 1000660000 sandbox && \
     useradd -u 1000660000 -g sandbox -m sandbox
 
 RUN apt-get update && apt-get install -y \
-    curl git iproute2 ca-certificates build-essential && \
+    curl git iproute2 ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-    su sandbox -c 'sh -s -- -y'
+# Download pre-built OAB binary
+RUN curl -L https://github.com/openabdev/openab/releases/latest/download/openab-linux-x64.tar.gz | \
+    tar xz -C /usr/local/bin/
 
 USER sandbox
 WORKDIR /home/sandbox
-RUN . /home/sandbox/.cargo/env && \
-    git clone https://github.com/openabdev/openab.git && \
-    cd openab && cargo build --release
-
-WORKDIR /home/sandbox/openab
+RUN curl -LO https://raw.githubusercontent.com/openabdev/openab/main/config.toml.example && \
+    cp config.toml.example config.toml
 ```
 
 Run it:
@@ -149,12 +148,11 @@ openshell policy set oab --policy /tmp/oab-policy.yaml --wait
 openshell sandbox connect oab
 ```
 
-Inside the sandbox, OAB is already built:
+Inside the sandbox, OAB is already installed:
 
 ```bash
-sandbox$ cp config.toml.example config.toml
-# Edit config.toml with your channel ID
-sandbox$ ./target/release/openab serve --config config.toml
+sandbox$ sed -i 's/allowed_channels = \["1234567890"\]/allowed_channels = ["YOUR_CHANNEL_ID"]/' config.toml
+sandbox$ openab serve --config config.toml
 ```
 
 ## Cleanup

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -17,6 +17,52 @@ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | 
 > # Log out and back in (or: loginctl terminate-user $USER)
 > ```
 
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Host (Linux with Docker)                                           │
+│                                                                     │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │  OpenShell Gateway (systemd user service :17670)              │  │
+│  │  • manages sandbox lifecycle                                  │  │
+│  │  • enforces network policy (default-deny egress)              │  │
+│  │  • injects provider credentials into sandbox env              │  │
+│  └──────────────────────────┬────────────────────────────────────┘  │
+│                             │ creates & policies                     │
+│                             ▼                                        │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │  Docker Container (sandbox: "oab")                            │  │
+│  │                                                               │  │
+│  │  /sandbox/                                                    │  │
+│  │  ├── openab              ← ACP broker binary                  │  │
+│  │  ├── openab-agent        ← native Rust coding agent           │  │
+│  │  ├── config.toml         ← bot token + agent config           │  │
+│  │  └── .openab/agent/auth.json  ← codex OAuth token             │  │
+│  │                                                               │  │
+│  │  openab run ──stdio JSON-RPC──► openab-agent                  │  │
+│  │       │                              │                        │  │
+│  │       │ Discord WS                   │ ChatGPT API            │  │
+│  └───────┼──────────────────────────────┼────────────────────────┘  │
+│           │                              │                           │
+│  ┌────────┼──────────────────────────────┼────────────────────┐     │
+│  │ Network Policy (egress allowlist)     │                    │     │
+│  │  ✓ discord.com:443                    │                    │     │
+│  │  ✓ gateway.discord.gg:443            │                    │     │
+│  │  ✓ cdn.discordapp.com:443            │                    │     │
+│  │  ✓ chatgpt.com:443  ◄────────────────┘                    │     │
+│  │  ✓ auth0.openai.com:443                                   │     │
+│  │  ✗ everything else DENIED                                  │     │
+│  └────────┼───────────────────────────────────────────────────┘     │
+└───────────┼─────────────────────────────────────────────────────────┘
+            │
+            ▼
+┌──────────────────┐         ┌──────────────────┐
+│  Discord API     │         │  ChatGPT API     │
+│  (bot gateway)   │         │  (chatgpt.com)   │
+└──────────────────┘         └──────────────────┘
+```
+
 ## Quick Start (Local Docker)
 
 All commands run **on the host** unless prefixed with `sandbox$`.

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -13,41 +13,31 @@ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | 
 
 ## Quick Start (Local Docker)
 
-### 1. Create credential providers
-
-OpenShell injects credentials as environment variables at sandbox runtime — they never touch the sandbox filesystem. Providers persist across sandbox restarts until explicitly deleted.
+The following is a single copy-pasteable sequence. Run all commands on the host unless noted otherwise.
 
 ```bash
-# Discord bot token
+# 1. Create credential providers
+#    Providers are stored in the OpenShell gateway's local state.
+#    Host env vars are read only at creation time and not retained.
+#    Providers persist until explicitly removed with `openshell provider delete <name>`.
 export DISCORD_BOT_TOKEN="your-token"
-openshell provider create --name discord --env DISCORD_BOT_TOKEN
-
-# GitHub token
 export GITHUB_TOKEN="your-token"
-openshell provider create --name github --env GITHUB_TOKEN
-
-# LLM provider (pick one)
 export ANTHROPIC_API_KEY="your-key"
+
+openshell provider create --name discord --env DISCORD_BOT_TOKEN
+openshell provider create --name github --env GITHUB_TOKEN
 openshell provider create --name anthropic --env ANTHROPIC_API_KEY
-```
 
-> Providers are stored in the OpenShell gateway's local state. The host env vars are only read at `provider create` time and are not needed afterwards.
-
-### 2. Create a sandbox with providers
-
-```bash
+# 2. Create sandbox with providers and port forwarding
 openshell sandbox create --name oab \
   --provider discord \
   --provider github \
   --provider anthropic \
+  --forward 3000 \
   -- bash
-```
 
-### 3. Apply network policy
-
-Create `oab-policy.yaml` on the host:
-
-```yaml
+# 3. Apply network policy (all unlisted egress is denied by default)
+cat > /tmp/oab-policy.yaml <<'EOF'
 network:
   egress:
     - destination: "discord.com"
@@ -60,19 +50,10 @@ network:
       ports: [443]
     - destination: "api.anthropic.com"
       ports: [443]
-```
+EOF
+openshell policy set oab --policy /tmp/oab-policy.yaml --wait
 
-Apply to the running sandbox:
-
-```bash
-openshell policy set oab --policy oab-policy.yaml --wait
-```
-
-The `--wait` flag blocks until the policy is enforced. All egress not listed above is denied by default.
-
-### 4. Connect and run OAB
-
-```bash
+# 4. Connect to the sandbox
 openshell sandbox connect oab
 ```
 
@@ -85,24 +66,35 @@ cargo build --release
 ./target/release/openab serve --config config.toml
 ```
 
+At this point `localhost:3000` on the host reaches port 3000 inside the sandbox (useful for GitHub webhook delivery via grok/ngrok).
+
+## Credential Management
+
+| Operation | Command |
+|-----------|---------|
+| List providers | `openshell provider list` |
+| Delete a provider | `openshell provider delete discord` |
+| Rotate a credential | Delete + recreate with new value |
+
+Credentials are injected as env vars at sandbox runtime. They are **not** written to the sandbox filesystem. Removing a provider immediately revokes access on the next sandbox restart.
+
 ## Port Forwarding
 
-If OAB exposes a webhook endpoint (e.g., for GitHub webhooks), add `--forward` at creation:
+Add `--forward <port>` at sandbox creation. Multiple ports are supported:
 
 ```bash
 openshell sandbox create --name oab \
-  --forward 3000 \
   --provider discord \
-  --provider github \
-  --provider anthropic \
+  --forward 3000 \
+  --forward 8080 \
   -- bash
 ```
 
-`localhost:3000` on the host reaches port 3000 inside the sandbox.
+Each forwarded port creates an SSH tunnel: `localhost:<port>` on the host → `127.0.0.1:<port>` inside the sandbox. Tunnels are torn down when the sandbox is deleted.
 
 ## BYOC (Custom Image)
 
-For a pre-built OAB sandbox image, create a `Dockerfile`:
+Build a custom sandbox image with OAB pre-installed:
 
 ```dockerfile
 FROM ubuntu:24.04
@@ -114,13 +106,20 @@ RUN apt-get update && apt-get install -y \
     curl git iproute2 ca-certificates build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     su sandbox -c 'sh -s -- -y'
 
-WORKDIR /home/sandbox
+# Pre-clone and build OAB
 USER sandbox
+WORKDIR /home/sandbox
+RUN . /home/sandbox/.cargo/env && \
+    git clone https://github.com/openabdev/openab.git && \
+    cd openab && cargo build --release
+
+WORKDIR /home/sandbox/openab
 ```
+
+Run it:
 
 ```bash
 openshell sandbox create --name oab \
@@ -128,11 +127,25 @@ openshell sandbox create --name oab \
   --provider discord \
   --provider github \
   --provider anthropic \
+  --forward 3000 \
   -- bash
+
+openshell policy set oab --policy /tmp/oab-policy.yaml --wait
+openshell sandbox connect oab
+```
+
+Inside the sandbox, OAB is already built:
+
+```bash
+./target/release/openab serve --config config.toml
 ```
 
 ## Cleanup
 
 ```bash
 openshell sandbox delete oab
+# Optionally remove providers
+openshell provider delete discord
+openshell provider delete github
+openshell provider delete anthropic
 ```

--- a/openshell/Dockerfile
+++ b/openshell/Dockerfile
@@ -3,9 +3,7 @@ FROM ghcr.io/openabdev/openab-native:beta
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends iproute2 && rm -rf /var/lib/apt/lists/*
 RUN groupadd -g 1000660000 sandbox && \
-    useradd -u 1000660000 -g sandbox -m -s /bin/bash sandbox && \
-    cp -a /home/agent/.openab /home/sandbox/.openab 2>/dev/null || true && \
-    chown -R sandbox:sandbox /home/sandbox
+    useradd -u 1000660000 -g sandbox -m -s /bin/bash sandbox
 
 USER sandbox
 WORKDIR /home/sandbox

--- a/openshell/Dockerfile
+++ b/openshell/Dockerfile
@@ -1,8 +1,11 @@
 FROM ghcr.io/openabdev/openab-native:beta
 
 USER root
-RUN groupadd -g 1000660000 sandbox 2>/dev/null || true && \
-    usermod -u 1000660000 -g 1000660000 agent 2>/dev/null || true
+RUN apt-get update && apt-get install -y --no-install-recommends iproute2 && rm -rf /var/lib/apt/lists/*
+RUN groupadd -g 1000660000 sandbox && \
+    useradd -u 1000660000 -g sandbox -m -s /bin/bash sandbox && \
+    cp -a /home/agent/.openab /home/sandbox/.openab 2>/dev/null || true && \
+    chown -R sandbox:sandbox /home/sandbox
 
-USER agent
-WORKDIR /home/agent
+USER sandbox
+WORKDIR /home/sandbox

--- a/openshell/Dockerfile
+++ b/openshell/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:24.04
+
+RUN groupadd -g 1000660000 sandbox && \
+    useradd -u 1000660000 -g sandbox -m sandbox
+
+RUN apt-get update && apt-get install -y \
+    curl git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download OAB + native agent
+ARG OAB_VERSION=openab-0.8.4-beta.10
+RUN curl -L "https://github.com/openabdev/openab/releases/download/${OAB_VERSION}/${OAB_VERSION}-linux-x64.tar.gz" | \
+    tar xz -C /usr/local/bin/ && \
+    curl -L "https://github.com/openabdev/openab/releases/download/${OAB_VERSION}/${OAB_VERSION}-native-linux-x64.tar.gz" | \
+    tar xz -C /usr/local/bin/
+
+USER sandbox
+WORKDIR /home/sandbox

--- a/openshell/Dockerfile
+++ b/openshell/Dockerfile
@@ -1,18 +1,8 @@
-FROM ubuntu:24.04
+FROM ghcr.io/openabdev/openab-native:beta
 
-RUN groupadd -g 1000660000 sandbox && \
-    useradd -u 1000660000 -g sandbox -m sandbox
+USER root
+RUN groupadd -g 1000660000 sandbox 2>/dev/null || true && \
+    usermod -u 1000660000 -g 1000660000 agent 2>/dev/null || true
 
-RUN apt-get update && apt-get install -y \
-    curl git ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-
-# Download OAB + native agent
-ARG OAB_VERSION=openab-0.8.4-beta.10
-RUN curl -L "https://github.com/openabdev/openab/releases/download/${OAB_VERSION}/${OAB_VERSION}-linux-x64.tar.gz" | \
-    tar xz -C /usr/local/bin/ && \
-    curl -L "https://github.com/openabdev/openab/releases/download/${OAB_VERSION}/${OAB_VERSION}-native-linux-x64.tar.gz" | \
-    tar xz -C /usr/local/bin/
-
-USER sandbox
-WORKDIR /home/sandbox
+USER agent
+WORKDIR /home/agent


### PR DESCRIPTION
Add OpenShell sandbox support for running OAB in an isolated, policy-enforced container via [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell).

## Changes

- `docs/openshell.md` — full guide: prerequisites, quick start, network policy, cleanup
- `openshell/Dockerfile` — sandbox-ready image based on `openab-native` (adds `sandbox` user + `iproute2`)
- `.github/workflows/build-operator.yml` — adds `openab-native-sandbox` to Docker build matrix
- `.github/workflows/docker-smoke-test.yml` — adds smoke test for the sandbox image

## Image

```
ghcr.io/openabdev/openab-native-sandbox:latest
```

Built from `openshell/Dockerfile`, extends `openab-native:beta` with OpenShell requirements:
- `sandbox` user/group (uid/gid 1000660000)
- `iproute2` for network namespace creation

## Usage

```bash
openshell provider create --name discord --type generic --credential "DISCORD_BOT_TOKEN=your-token"

openshell sandbox create --name oab \
  --from ghcr.io/openabdev/openab-native-sandbox:latest \
  --provider discord -- bash

openshell policy update oab \
  --add-endpoint "discord.com:443:read-write:rest:enforce" \
  --add-endpoint "gateway.discord.gg:443:read-write:websocket:enforce" \
  --add-endpoint "chatgpt.com:443:read-write:rest:enforce"

# Inside sandbox
openab-agent auth codex-oauth --no-browser
openab run --config config.toml
```

## Tested

Verified end-to-end on zf (Ubuntu 24.04 x86_64) with OpenShell v0.0.53 — bot connected to Discord and responded to messages.

Thread: 1511138789836456127