### PR TITLE
feat(openab-agent): support /models for model switching

### DIFF
--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -35,6 +35,7 @@ When the user picks an option, OpenAB sends `session/set_config_option` to the A
 
 | Agent | `/models` | `/agents` |
 |-------|-----------|-----------|
+| openab-agent | ✅ Returns available models via `configOptions` in `session/new` response | ❌ |
 | kiro-cli | ✅ Returns available models via `models` fallback | ✅ Returns modes (`kiro_default`, `kiro_planner`) via `modes` fallback |
 | claude-code | ❌ No `configOptions` emitted | ❌ |
 | codex | ❌ | ❌ |
@@ -43,6 +44,8 @@ When the user picks an option, OpenAB sends `session/set_config_option` to the A
 | copilot | ❌ (tracking: #496) | ❌ |
 
 If the agent doesn't expose options, the user sees: `⚠️ No model options available. Start a conversation first by @mentioning the bot.`
+
+> **Backward compatibility:** `openab-agent` returns `configOptions` in the `session/new` response (alongside `sessionId`). ACP clients that only read `sessionId` will continue to work — `configOptions` is additive. Clients that support `/models` should read `configOptions[].options` to populate the model picker. Each model option includes a `provider` field (`"anthropic"` or `"openai"`) for routing.
 
 > **Note:** Discord Select Menus are limited to 25 items. If the agent returns more, only the first 25 are shown with a count of how many were truncated.
 

--- a/openab-agent/Cargo.lock
+++ b/openab-agent/Cargo.lock
@@ -86,6 +86,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +173,41 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -353,6 +397,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +592,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,19 +733,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openab-agent"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
+ "getrandom 0.4.2",
  "libc",
+ "open",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
+ "urlencoding",
  "uuid",
 ]
 
@@ -699,6 +788,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -1066,6 +1161,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1519,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -141,30 +141,55 @@ impl AcpServer {
             .clone()
             .or_else(|| std::env::var("OPENAB_AGENT_PROVIDER").ok())
             .unwrap_or_default();
+        let model_override = self.active_model.as_deref();
         let (provider, active_provider): (Box<dyn crate::llm::LlmProvider>, &str) =
             match provider_choice.as_str() {
-                "anthropic" => match AnthropicProvider::from_env() {
-                    Ok(p) => (Box::new(p), "anthropic"),
-                    Err(e) => return self.error_response(id, -32000, &e),
-                },
-                "openai" | "codex" => match crate::llm::OpenAiProvider::from_auth_store() {
-                    Ok(p) => (Box::new(p), "openai"),
-                    Err(e) => return self.error_response(id, -32000, &e),
-                },
+                "anthropic" => {
+                    let res = match model_override {
+                        Some(m) => AnthropicProvider::from_env_with_model(m),
+                        None => AnthropicProvider::from_env(),
+                    };
+                    match res {
+                        Ok(p) => (Box::new(p), "anthropic"),
+                        Err(e) => return self.error_response(id, -32000, &e),
+                    }
+                }
+                "openai" | "codex" => {
+                    let res = match model_override {
+                        Some(m) => crate::llm::OpenAiProvider::from_auth_store_with_model(m),
+                        None => crate::llm::OpenAiProvider::from_auth_store(),
+                    };
+                    match res {
+                        Ok(p) => (Box::new(p), "openai"),
+                        Err(e) => return self.error_response(id, -32000, &e),
+                    }
+                }
                 _ => {
                     // Auto-detect: try API key first, then OAuth token
-                    match AnthropicProvider::from_env() {
+                    let anthropic_res = match model_override {
+                        Some(m) => AnthropicProvider::from_env_with_model(m),
+                        None => AnthropicProvider::from_env(),
+                    };
+                    match anthropic_res {
                         Ok(p) => (Box::new(p), "anthropic"),
-                        Err(_) => match crate::llm::OpenAiProvider::from_auth_store() {
-                            Ok(p) => (Box::new(p), "openai"),
-                            Err(e) => {
-                                return self.error_response(
-                                    id,
-                                    -32000,
-                                    &format!("No credentials: set ANTHROPIC_API_KEY or run `openab-agent auth codex-oauth`. {e}"),
-                                )
+                        Err(_) => {
+                            let openai_res = match model_override {
+                                Some(m) => {
+                                    crate::llm::OpenAiProvider::from_auth_store_with_model(m)
+                                }
+                                None => crate::llm::OpenAiProvider::from_auth_store(),
+                            };
+                            match openai_res {
+                                Ok(p) => (Box::new(p), "openai"),
+                                Err(e) => {
+                                    return self.error_response(
+                                        id,
+                                        -32000,
+                                        &format!("No credentials: set ANTHROPIC_API_KEY or run `openab-agent auth codex-oauth`. {e}"),
+                                    )
+                                }
                             }
-                        },
+                        }
                     }
                 }
             };
@@ -317,18 +342,28 @@ impl AcpServer {
         self.active_provider = Some(provider_name.to_string());
 
         // Rebuild the current session's provider so the switch takes effect immediately
-        if !session_id.is_empty() {
-            if let Some(_agent) = self.sessions.remove(session_id) {
-                let new_provider: Result<Box<dyn crate::llm::LlmProvider>, String> =
-                    match provider_name {
-                        "anthropic" => AnthropicProvider::from_env().map(|p| Box::new(p) as _),
-                        _ => {
-                            crate::llm::OpenAiProvider::from_auth_store().map(|p| Box::new(p) as _)
-                        }
-                    };
-                if let Ok(p) = new_provider {
+        if !session_id.is_empty() && self.sessions.contains_key(session_id) {
+            let new_provider: Result<Box<dyn crate::llm::LlmProvider>, String> = match provider_name
+            {
+                "anthropic" => {
+                    AnthropicProvider::from_env_with_model(value).map(|p| Box::new(p) as _)
+                }
+                _ => crate::llm::OpenAiProvider::from_auth_store_with_model(value)
+                    .map(|p| Box::new(p) as _),
+            };
+            match new_provider {
+                Ok(p) => {
+                    // Atomic: only remove old session after new provider succeeds
+                    self.sessions.remove(session_id);
                     let agent = Agent::new_boxed(p, self.working_dir.clone());
                     self.sessions.insert(session_id.to_string(), agent);
+                }
+                Err(e) => {
+                    return self.error_response(
+                        id,
+                        -32000,
+                        &format!("failed to switch provider: {e}"),
+                    );
                 }
             }
         }

--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -4,8 +4,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use uuid::Uuid;
+
+const MODEL_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Deserialize)]
 pub struct JsonRpcRequest {
@@ -31,6 +34,23 @@ pub struct JsonRpcNotification {
     pub params: Value,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ModelOption {
+    value: String,
+    name: String,
+    provider: String,
+}
+
+impl ModelOption {
+    fn new(value: &str, name: &str, provider: &str) -> Self {
+        Self {
+            value: value.to_string(),
+            name: name.to_string(),
+            provider: provider.to_string(),
+        }
+    }
+}
+
 pub struct AcpServer {
     // TODO(v0.2): add session TTL and periodic cleanup to prevent OOM
     sessions: HashMap<String, Agent>,
@@ -39,6 +59,8 @@ pub struct AcpServer {
     active_model: Option<String>,
     /// Active provider name: "anthropic" or "openai" (safe alternative to env mutation)
     active_provider: Option<String>,
+    /// Last model list exposed to the ACP client; used to validate model switches.
+    model_options: Vec<ModelOption>,
 }
 
 impl AcpServer {
@@ -50,6 +72,7 @@ impl AcpServer {
                 .unwrap_or_else(|_| "/tmp".to_string()),
             active_model: None,
             active_provider: None,
+            model_options: Vec::new(),
         }
     }
 
@@ -208,6 +231,7 @@ impl AcpServer {
                     "gpt-4.1-nano".to_string()
                 }
             });
+        self.model_options = Self::available_models().await;
 
         let resp = JsonRpcResponse {
             jsonrpc: "2.0",
@@ -220,7 +244,7 @@ impl AcpServer {
                     "category": "model",
                     "type": "enum",
                     "currentValue": model_name,
-                    "options": Self::available_models().await
+                    "options": self.model_options
                 }]
             })),
             error: None,
@@ -230,18 +254,14 @@ impl AcpServer {
 
     /// List available models based on configured credentials.
     /// Queries provider APIs when possible, falls back to known defaults.
-    async fn available_models() -> Vec<Value> {
+    async fn available_models() -> Vec<ModelOption> {
         let mut models = Vec::new();
 
         // Query Anthropic models if credentials are available
         if std::env::var("ANTHROPIC_API_KEY").is_ok() {
             match Self::fetch_anthropic_models().await {
                 Ok(fetched) => models.extend(fetched),
-                Err(_) => {
-                    // Fallback to known defaults if API unreachable
-                    models.push(json!({"value": "claude-sonnet-4-20250514", "name": "Claude Sonnet 4", "provider": "anthropic"}));
-                    models.push(json!({"value": "claude-haiku-4-20250514", "name": "Claude Haiku 4", "provider": "anthropic"}));
-                }
+                Err(_) => models.extend(Self::fallback_anthropic_models()),
             }
         }
 
@@ -249,25 +269,27 @@ impl AcpServer {
         if crate::auth::load_tokens().is_ok() {
             match Self::fetch_openai_models().await {
                 Ok(fetched) => models.extend(fetched),
-                Err(_) => {
-                    // Fallback to known defaults if API unreachable
-                    models.push(json!({"value": "gpt-4.1-nano", "name": "GPT-4.1 Nano", "provider": "openai"}));
-                    models.push(json!({"value": "gpt-4.1-mini", "name": "GPT-4.1 Mini", "provider": "openai"}));
-                    models.push(json!({"value": "o4-mini", "name": "o4-mini", "provider": "openai"}));
-                }
+                Err(_) => models.extend(Self::fallback_openai_models()),
             }
         }
 
         if models.is_empty() {
-            models.push(json!({"value": "none", "name": "No credentials configured", "provider": "none"}));
+            models.push(ModelOption::new(
+                "none",
+                "No credentials configured",
+                "none",
+            ));
         }
         models
     }
 
     /// Fetch models from Anthropic /v1/models API.
-    async fn fetch_anthropic_models() -> Result<Vec<Value>, String> {
+    async fn fetch_anthropic_models() -> Result<Vec<ModelOption>, String> {
         let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|e| e.to_string())?;
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(MODEL_DISCOVERY_TIMEOUT)
+            .build()
+            .map_err(|e| e.to_string())?;
         let resp = client
             .get("https://api.anthropic.com/v1/models")
             .header("x-api-key", &api_key)
@@ -287,11 +309,8 @@ impl AcpServer {
                 if let Some(id) = m.get("id").and_then(|v| v.as_str()) {
                     // Only include chat models (claude-*)
                     if id.starts_with("claude") {
-                        let display = m
-                            .get("display_name")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(id);
-                        models.push(json!({"value": id, "name": display, "provider": "anthropic"}));
+                        let display = m.get("display_name").and_then(|v| v.as_str()).unwrap_or(id);
+                        models.push(ModelOption::new(id, display, "anthropic"));
                     }
                 }
             }
@@ -303,11 +322,14 @@ impl AcpServer {
     }
 
     /// Fetch models from OpenAI-compatible /models endpoint.
-    async fn fetch_openai_models() -> Result<Vec<Value>, String> {
+    async fn fetch_openai_models() -> Result<Vec<ModelOption>, String> {
         let tokens = crate::auth::load_tokens().map_err(|e| e.to_string())?;
         let base_url = std::env::var("OPENAB_AGENT_OPENAI_BASE_URL")
             .unwrap_or_else(|_| "https://chatgpt.com/backend-api".to_string());
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(MODEL_DISCOVERY_TIMEOUT)
+            .build()
+            .map_err(|e| e.to_string())?;
         let resp = client
             .get(format!("{}/models", base_url))
             .bearer_auth(&tokens.access_token)
@@ -334,7 +356,7 @@ impl AcpServer {
                         .or_else(|| m.get("id"))
                         .and_then(|v| v.as_str())
                         .unwrap_or(id);
-                    models.push(json!({"value": id, "name": name, "provider": "openai"}));
+                    models.push(ModelOption::new(id, name, "openai"));
                 }
             }
         }
@@ -344,23 +366,37 @@ impl AcpServer {
         Ok(models)
     }
 
-    /// Sync version for use in non-async contexts (e.g. set_config_option validation).
-    /// Uses credential detection with known defaults — the async version queries APIs.
-    fn available_models_sync() -> Vec<Value> {
+    fn fallback_available_models() -> Vec<ModelOption> {
         let mut models = Vec::new();
         if std::env::var("ANTHROPIC_API_KEY").is_ok() {
-            models.push(json!({"value": "claude-sonnet-4-20250514", "name": "Claude Sonnet 4", "provider": "anthropic"}));
-            models.push(json!({"value": "claude-haiku-4-20250514", "name": "Claude Haiku 4", "provider": "anthropic"}));
+            models.extend(Self::fallback_anthropic_models());
         }
         if crate::auth::load_tokens().is_ok() {
-            models.push(json!({"value": "gpt-4.1-nano", "name": "GPT-4.1 Nano", "provider": "openai"}));
-            models.push(json!({"value": "gpt-4.1-mini", "name": "GPT-4.1 Mini", "provider": "openai"}));
-            models.push(json!({"value": "o4-mini", "name": "o4-mini", "provider": "openai"}));
+            models.extend(Self::fallback_openai_models());
         }
         if models.is_empty() {
-            models.push(json!({"value": "none", "name": "No credentials configured", "provider": "none"}));
+            models.push(ModelOption::new(
+                "none",
+                "No credentials configured",
+                "none",
+            ));
         }
         models
+    }
+
+    fn fallback_anthropic_models() -> Vec<ModelOption> {
+        vec![
+            ModelOption::new("claude-sonnet-4-20250514", "Claude Sonnet 4", "anthropic"),
+            ModelOption::new("claude-haiku-4-20250514", "Claude Haiku 4", "anthropic"),
+        ]
+    }
+
+    fn fallback_openai_models() -> Vec<ModelOption> {
+        vec![
+            ModelOption::new("gpt-4.1-nano", "GPT-4.1 Nano", "openai"),
+            ModelOption::new("gpt-4.1-mini", "GPT-4.1 Mini", "openai"),
+            ModelOption::new("o4-mini", "o4-mini", "openai"),
+        ]
     }
 
     async fn handle_session_prompt(&mut self, id: u64, params: &Value) -> Vec<String> {
@@ -434,29 +470,25 @@ impl AcpServer {
             return self.error_response(id, -32602, "unsupported configId or empty value");
         }
 
-        // We need the cached model list; use sync fallback for validation
-        let models = Self::available_models_sync();
+        let models = if self.model_options.is_empty() {
+            Self::fallback_available_models()
+        } else {
+            self.model_options.clone()
+        };
         let matched = models
             .iter()
-            .find(|m| m.get("value").and_then(|v| v.as_str()) == Some(value));
-        if matched.is_none() {
-            return self.error_response(
-                id,
-                -32602,
-                &format!("unknown model: {value}. Use one from available_models."),
-            );
-        }
-
-        // Determine provider from model metadata (not name prefix)
-        let provider_name = matched
-            .unwrap()
-            .get("provider")
-            .and_then(|v| v.as_str())
-            .unwrap_or("openai");
+            .find(|m| m.value == value)
+            .cloned()
+            .ok_or_else(|| format!("unknown model: {value}. Use one from available_models."));
+        let matched = match matched {
+            Ok(m) => m,
+            Err(e) => return self.error_response(id, -32602, &e),
+        };
+        let provider_name = matched.provider.as_str();
 
         // Store in struct (safe — no env mutation)
         self.active_model = Some(value.to_string());
-        self.active_provider = Some(provider_name.to_string());
+        self.active_provider = Some(matched.provider.clone());
 
         // Rebuild the current session's provider so the switch takes effect immediately
         if !session_id.is_empty() && self.sessions.contains_key(session_id) {
@@ -570,5 +602,60 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("ANTHROPIC_API_KEY"));
+    }
+
+    #[test]
+    fn test_set_config_option_accepts_cached_dynamic_model() {
+        let mut server = AcpServer::new();
+        server.model_options = vec![ModelOption::new(
+            "claude-opus-4-20250514",
+            "Claude Opus 4",
+            "anthropic",
+        )];
+
+        let resp_str = server.handle_set_config_option(
+            4,
+            &json!({
+                "configId": "model",
+                "value": "claude-opus-4-20250514",
+            }),
+        );
+        let resp: Value = serde_json::from_str(&resp_str).unwrap();
+
+        assert!(resp["error"].is_null());
+        assert_eq!(
+            resp["result"]["configOptions"][0]["currentValue"],
+            "claude-opus-4-20250514"
+        );
+        assert_eq!(
+            server.active_model.as_deref(),
+            Some("claude-opus-4-20250514")
+        );
+        assert_eq!(server.active_provider.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn test_set_config_option_rejects_unknown_model() {
+        let mut server = AcpServer::new();
+        server.model_options = vec![ModelOption::new(
+            "claude-opus-4-20250514",
+            "Claude Opus 4",
+            "anthropic",
+        )];
+
+        let resp_str = server.handle_set_config_option(
+            5,
+            &json!({
+                "configId": "model",
+                "value": "not-in-menu",
+            }),
+        );
+        let resp: Value = serde_json::from_str(&resp_str).unwrap();
+
+        assert_eq!(resp["error"]["code"], -32602);
+        assert!(resp["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("unknown model"));
     }
 }

--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -35,6 +35,10 @@ pub struct AcpServer {
     // TODO(v0.2): add session TTL and periodic cleanup to prevent OOM
     sessions: HashMap<String, Agent>,
     working_dir: String,
+    /// Active model name (safe alternative to env mutation)
+    active_model: Option<String>,
+    /// Active provider name: "anthropic" or "openai" (safe alternative to env mutation)
+    active_provider: Option<String>,
 }
 
 impl AcpServer {
@@ -44,6 +48,8 @@ impl AcpServer {
             working_dir: std::env::current_dir()
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_else(|_| "/tmp".to_string()),
+            active_model: None,
+            active_provider: None,
         }
     }
 
@@ -129,8 +135,12 @@ impl AcpServer {
     fn handle_session_new(&mut self, id: u64) -> String {
         let session_id = Uuid::new_v4().to_string();
 
-        // Respect OPENAB_AGENT_PROVIDER if set, otherwise auto-detect
-        let provider_choice = std::env::var("OPENAB_AGENT_PROVIDER").unwrap_or_default();
+        // Use struct config if set, then env, then auto-detect
+        let provider_choice = self
+            .active_provider
+            .clone()
+            .or_else(|| std::env::var("OPENAB_AGENT_PROVIDER").ok())
+            .unwrap_or_default();
         let (provider, active_provider): (Box<dyn crate::llm::LlmProvider>, &str) =
             match provider_choice.as_str() {
                 "anthropic" => match AnthropicProvider::from_env() {
@@ -162,13 +172,17 @@ impl AcpServer {
         let agent = Agent::new_boxed(provider, self.working_dir.clone());
         self.sessions.insert(session_id.clone(), agent);
 
-        let model_name = std::env::var("OPENAB_AGENT_MODEL").unwrap_or_else(|_| {
-            if active_provider == "anthropic" {
-                "claude-sonnet-4-20250514".to_string()
-            } else {
-                "gpt-4.1-nano".to_string()
-            }
-        });
+        let model_name = self
+            .active_model
+            .clone()
+            .or_else(|| std::env::var("OPENAB_AGENT_MODEL").ok())
+            .unwrap_or_else(|| {
+                if active_provider == "anthropic" {
+                    "claude-sonnet-4-20250514".to_string()
+                } else {
+                    "gpt-4.1-nano".to_string()
+                }
+            });
 
         let resp = JsonRpcResponse {
             jsonrpc: "2.0",
@@ -264,24 +278,60 @@ impl AcpServer {
     }
 
     fn handle_set_config_option(&mut self, id: u64, params: &Value) -> String {
-        let config_id = params.get("configId").and_then(|v| v.as_str()).unwrap_or("");
+        let config_id = params
+            .get("configId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         let value = params.get("value").and_then(|v| v.as_str()).unwrap_or("");
+        let session_id = params
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
 
         if config_id != "model" || value.is_empty() {
             return self.error_response(id, -32602, "unsupported configId or empty value");
         }
 
-        // Set the model env var so next session picks it up
-        // SAFETY: openab-agent is single-threaded for config changes
-        unsafe { std::env::set_var("OPENAB_AGENT_MODEL", value) };
+        // Validate model against available options
+        let models = Self::available_models();
+        let valid = models
+            .iter()
+            .any(|m| m.get("value").and_then(|v| v.as_str()) == Some(value));
+        if !valid {
+            return self.error_response(
+                id,
+                -32602,
+                &format!("unknown model: {value}. Use one from available_models."),
+            );
+        }
 
         // Determine provider from model name
-        let provider = if value.starts_with("claude") {
+        let provider_name = if value.starts_with("claude") {
             "anthropic"
         } else {
             "openai"
         };
-        unsafe { std::env::set_var("OPENAB_AGENT_PROVIDER", provider) };
+
+        // Store in struct (safe — no env mutation)
+        self.active_model = Some(value.to_string());
+        self.active_provider = Some(provider_name.to_string());
+
+        // Rebuild the current session's provider so the switch takes effect immediately
+        if !session_id.is_empty() {
+            if let Some(_agent) = self.sessions.remove(session_id) {
+                let new_provider: Result<Box<dyn crate::llm::LlmProvider>, String> =
+                    match provider_name {
+                        "anthropic" => AnthropicProvider::from_env().map(|p| Box::new(p) as _),
+                        _ => {
+                            crate::llm::OpenAiProvider::from_auth_store().map(|p| Box::new(p) as _)
+                        }
+                    };
+                if let Ok(p) = new_provider {
+                    let agent = Agent::new_boxed(p, self.working_dir.clone());
+                    self.sessions.insert(session_id.to_string(), agent);
+                }
+            }
+        }
 
         self.ok_response(
             id,
@@ -292,7 +342,7 @@ impl AcpServer {
                     "category": "model",
                     "type": "enum",
                     "currentValue": value,
-                    "options": Self::available_models()
+                    "options": models
                 }]
             }),
         )

--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -86,7 +86,7 @@ impl AcpServer {
 
             let output = match req.method.as_deref() {
                 Some("initialize") => vec![self.handle_initialize(id)],
-                Some("session/new") => vec![self.handle_session_new(id)],
+                Some("session/new") => vec![self.handle_session_new(id).await],
                 Some("session/prompt") => {
                     let params = req.params.unwrap_or(json!({}));
                     self.handle_session_prompt(id, &params).await
@@ -132,7 +132,7 @@ impl AcpServer {
         serde_json::to_string(&resp).unwrap()
     }
 
-    fn handle_session_new(&mut self, id: u64) -> String {
+    async fn handle_session_new(&mut self, id: u64) -> String {
         let session_id = Uuid::new_v4().to_string();
 
         // Use struct config if set, then env, then auto-detect
@@ -220,7 +220,7 @@ impl AcpServer {
                     "category": "model",
                     "type": "enum",
                     "currentValue": model_name,
-                    "options": Self::available_models()
+                    "options": Self::available_models().await
                 }]
             })),
             error: None,
@@ -229,19 +229,136 @@ impl AcpServer {
     }
 
     /// List available models based on configured credentials.
-    fn available_models() -> Vec<Value> {
+    /// Queries provider APIs when possible, falls back to known defaults.
+    async fn available_models() -> Vec<Value> {
         let mut models = Vec::new();
+
+        // Query Anthropic models if credentials are available
         if std::env::var("ANTHROPIC_API_KEY").is_ok() {
-            models.push(json!({"value": "claude-sonnet-4-20250514", "name": "Claude Sonnet 4"}));
-            models.push(json!({"value": "claude-haiku-4-20250514", "name": "Claude Haiku 4"}));
+            match Self::fetch_anthropic_models().await {
+                Ok(fetched) => models.extend(fetched),
+                Err(_) => {
+                    // Fallback to known defaults if API unreachable
+                    models.push(json!({"value": "claude-sonnet-4-20250514", "name": "Claude Sonnet 4", "provider": "anthropic"}));
+                    models.push(json!({"value": "claude-haiku-4-20250514", "name": "Claude Haiku 4", "provider": "anthropic"}));
+                }
+            }
         }
+
+        // Query OpenAI models if credentials are available
         if crate::auth::load_tokens().is_ok() {
-            models.push(json!({"value": "gpt-4.1-nano", "name": "GPT-4.1 Nano"}));
-            models.push(json!({"value": "gpt-4.1-mini", "name": "GPT-4.1 Mini"}));
-            models.push(json!({"value": "o4-mini", "name": "o4-mini"}));
+            match Self::fetch_openai_models().await {
+                Ok(fetched) => models.extend(fetched),
+                Err(_) => {
+                    // Fallback to known defaults if API unreachable
+                    models.push(json!({"value": "gpt-4.1-nano", "name": "GPT-4.1 Nano", "provider": "openai"}));
+                    models.push(json!({"value": "gpt-4.1-mini", "name": "GPT-4.1 Mini", "provider": "openai"}));
+                    models.push(json!({"value": "o4-mini", "name": "o4-mini", "provider": "openai"}));
+                }
+            }
+        }
+
+        if models.is_empty() {
+            models.push(json!({"value": "none", "name": "No credentials configured", "provider": "none"}));
+        }
+        models
+    }
+
+    /// Fetch models from Anthropic /v1/models API.
+    async fn fetch_anthropic_models() -> Result<Vec<Value>, String> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|e| e.to_string())?;
+        let client = reqwest::Client::new();
+        let resp = client
+            .get("https://api.anthropic.com/v1/models")
+            .header("x-api-key", &api_key)
+            .header("anthropic-version", "2023-06-01")
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        if !resp.status().is_success() {
+            return Err(format!("Anthropic API returned {}", resp.status()));
+        }
+
+        let body: Value = resp.json().await.map_err(|e| e.to_string())?;
+        let mut models = Vec::new();
+        if let Some(data) = body.get("data").and_then(|d| d.as_array()) {
+            for m in data {
+                if let Some(id) = m.get("id").and_then(|v| v.as_str()) {
+                    // Only include chat models (claude-*)
+                    if id.starts_with("claude") {
+                        let display = m
+                            .get("display_name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(id);
+                        models.push(json!({"value": id, "name": display, "provider": "anthropic"}));
+                    }
+                }
+            }
         }
         if models.is_empty() {
-            models.push(json!({"value": "none", "name": "No credentials configured"}));
+            return Err("No models returned from Anthropic API".to_string());
+        }
+        Ok(models)
+    }
+
+    /// Fetch models from OpenAI-compatible /models endpoint.
+    async fn fetch_openai_models() -> Result<Vec<Value>, String> {
+        let tokens = crate::auth::load_tokens().map_err(|e| e.to_string())?;
+        let base_url = std::env::var("OPENAB_AGENT_OPENAI_BASE_URL")
+            .unwrap_or_else(|_| "https://chatgpt.com/backend-api".to_string());
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("{}/models", base_url))
+            .bearer_auth(&tokens.access_token)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        if !resp.status().is_success() {
+            return Err(format!("OpenAI API returned {}", resp.status()));
+        }
+
+        let body: Value = resp.json().await.map_err(|e| e.to_string())?;
+        let mut models = Vec::new();
+        // Handle both { "data": [...] } and [...] shapes
+        let items = body
+            .get("data")
+            .and_then(|d| d.as_array())
+            .or_else(|| body.as_array());
+        if let Some(data) = items {
+            for m in data {
+                if let Some(id) = m.get("id").and_then(|v| v.as_str()) {
+                    let name = m
+                        .get("name")
+                        .or_else(|| m.get("id"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(id);
+                    models.push(json!({"value": id, "name": name, "provider": "openai"}));
+                }
+            }
+        }
+        if models.is_empty() {
+            return Err("No models returned from OpenAI API".to_string());
+        }
+        Ok(models)
+    }
+
+    /// Sync version for use in non-async contexts (e.g. set_config_option validation).
+    /// Uses credential detection with known defaults — the async version queries APIs.
+    fn available_models_sync() -> Vec<Value> {
+        let mut models = Vec::new();
+        if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+            models.push(json!({"value": "claude-sonnet-4-20250514", "name": "Claude Sonnet 4", "provider": "anthropic"}));
+            models.push(json!({"value": "claude-haiku-4-20250514", "name": "Claude Haiku 4", "provider": "anthropic"}));
+        }
+        if crate::auth::load_tokens().is_ok() {
+            models.push(json!({"value": "gpt-4.1-nano", "name": "GPT-4.1 Nano", "provider": "openai"}));
+            models.push(json!({"value": "gpt-4.1-mini", "name": "GPT-4.1 Mini", "provider": "openai"}));
+            models.push(json!({"value": "o4-mini", "name": "o4-mini", "provider": "openai"}));
+        }
+        if models.is_empty() {
+            models.push(json!({"value": "none", "name": "No credentials configured", "provider": "none"}));
         }
         models
     }
@@ -317,12 +434,12 @@ impl AcpServer {
             return self.error_response(id, -32602, "unsupported configId or empty value");
         }
 
-        // Validate model against available options
-        let models = Self::available_models();
-        let valid = models
+        // We need the cached model list; use sync fallback for validation
+        let models = Self::available_models_sync();
+        let matched = models
             .iter()
-            .any(|m| m.get("value").and_then(|v| v.as_str()) == Some(value));
-        if !valid {
+            .find(|m| m.get("value").and_then(|v| v.as_str()) == Some(value));
+        if matched.is_none() {
             return self.error_response(
                 id,
                 -32602,
@@ -330,12 +447,12 @@ impl AcpServer {
             );
         }
 
-        // Determine provider from model name
-        let provider_name = if value.starts_with("claude") {
-            "anthropic"
-        } else {
-            "openai"
-        };
+        // Determine provider from model metadata (not name prefix)
+        let provider_name = matched
+            .unwrap()
+            .get("provider")
+            .and_then(|v| v.as_str())
+            .unwrap_or("openai");
 
         // Store in struct (safe — no env mutation)
         self.active_model = Some(value.to_string());
@@ -419,12 +536,12 @@ mod tests {
         assert_eq!(resp["result"]["agentCapabilities"]["streaming"], false);
     }
 
-    #[test]
-    fn test_session_new() {
+    #[tokio::test]
+    async fn test_session_new() {
         // Set a fake key so from_env() succeeds in CI
         unsafe { std::env::set_var("ANTHROPIC_API_KEY", "test-key") };
         let mut server = AcpServer::new();
-        let resp_str = server.handle_session_new(2);
+        let resp_str = server.handle_session_new(2).await;
         let resp: Value = serde_json::from_str(&resp_str).unwrap();
         assert_eq!(resp["jsonrpc"], "2.0");
         assert_eq!(resp["id"], 2);
@@ -437,8 +554,8 @@ mod tests {
         assert!(!config_options[0]["options"].as_array().unwrap().is_empty());
     }
 
-    #[test]
-    fn test_session_new_missing_key() {
+    #[tokio::test]
+    async fn test_session_new_missing_key() {
         // Ensure no OAuth token exists either
         let auth_path =
             std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string()))
@@ -446,7 +563,7 @@ mod tests {
         let _ = std::fs::remove_file(&auth_path);
         unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
         let mut server = AcpServer::new();
-        let resp_str = server.handle_session_new(3);
+        let resp_str = server.handle_session_new(3).await;
         let resp: Value = serde_json::from_str(&resp_str).unwrap();
         assert!(resp["error"].is_object());
         assert!(resp["error"]["message"]

--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -661,4 +661,111 @@ mod tests {
             .unwrap()
             .contains("unknown model"));
     }
+
+    #[tokio::test]
+    async fn test_model_switch_preserves_session_history() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("ANTHROPIC_API_KEY", "test-key") };
+        let mut server = AcpServer::new();
+
+        // Create a session
+        let resp_str = server.handle_session_new(10).await;
+        let resp: Value = serde_json::from_str(&resp_str).unwrap();
+        let session_id = resp["result"]["sessionId"].as_str().unwrap().to_string();
+
+        // Simulate conversation history by pushing a message into the agent
+        let agent = server.sessions.get_mut(&session_id).unwrap();
+        agent.messages.push(crate::llm::Message {
+            role: "user".to_string(),
+            content: vec![crate::llm::ContentBlock::Text {
+                text: "hello".to_string(),
+            }],
+        });
+        assert_eq!(agent.message_count(), 1);
+
+        // Switch model (same provider — should succeed with test-key)
+        server.model_options = vec![
+            ModelOption::new("claude-sonnet-4-20250514", "Claude Sonnet 4", "anthropic"),
+            ModelOption::new("claude-haiku-4-20250514", "Claude Haiku 4", "anthropic"),
+        ];
+        let resp_str = server.handle_set_config_option(
+            11,
+            &json!({
+                "configId": "model",
+                "value": "claude-haiku-4-20250514",
+                "sessionId": session_id,
+            }),
+        );
+        let resp: Value = serde_json::from_str(&resp_str).unwrap();
+        assert!(resp["error"].is_null(), "switch should succeed");
+
+        // Verify conversation history is preserved
+        let agent = server.sessions.get(&session_id).unwrap();
+        assert_eq!(
+            agent.message_count(),
+            1,
+            "messages must survive model switch"
+        );
+    }
+
+    #[test]
+    fn test_failed_switch_does_not_update_state() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let mut server = AcpServer::new();
+        server.model_options = vec![ModelOption::new("gpt-4.1-nano", "GPT-4.1 Nano", "openai")];
+
+        // No OpenAI credentials → rebuild will fail
+        let resp_str = server.handle_set_config_option(
+            12,
+            &json!({
+                "configId": "model",
+                "value": "gpt-4.1-nano",
+                "sessionId": "nonexistent-session",
+            }),
+        );
+        let resp: Value = serde_json::from_str(&resp_str).unwrap();
+
+        // No session exists so it skips rebuild, state still updates
+        // (the guard only fires when session exists)
+        assert!(resp["error"].is_null());
+
+        // Now test with a real session that will fail on rebuild
+        // Reset state
+        server.active_model = None;
+        server.active_provider = None;
+
+        // Insert a dummy session using anthropic key
+        unsafe { std::env::set_var("ANTHROPIC_API_KEY", "test-key") };
+        let provider = AnthropicProvider::from_env_with_model("claude-sonnet-4-20250514").unwrap();
+        let agent = Agent::new_boxed(Box::new(provider), "/tmp".to_string());
+        server.sessions.insert("test-session".to_string(), agent);
+
+        // Remove anthropic key and try to switch to anthropic model → should fail
+        unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
+        server.model_options = vec![ModelOption::new(
+            "claude-opus-4-20250514",
+            "Claude Opus 4",
+            "anthropic",
+        )];
+        let resp_str = server.handle_set_config_option(
+            13,
+            &json!({
+                "configId": "model",
+                "value": "claude-opus-4-20250514",
+                "sessionId": "test-session",
+            }),
+        );
+        let resp: Value = serde_json::from_str(&resp_str).unwrap();
+
+        assert!(resp["error"].is_object(), "rebuild should fail");
+        // State should NOT have been updated
+        assert_eq!(
+            server.active_model, None,
+            "active_model must not change on failure"
+        );
+        assert_eq!(
+            server.active_provider, None,
+            "active_provider must not change on failure"
+        );
+    }
 }

--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -556,6 +556,9 @@ impl AcpServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_initialize_response() {
@@ -570,6 +573,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_new() {
+        let _guard = ENV_LOCK.lock().unwrap();
         // Set a fake key so from_env() succeeds in CI
         unsafe { std::env::set_var("ANTHROPIC_API_KEY", "test-key") };
         let mut server = AcpServer::new();
@@ -588,6 +592,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_new_missing_key() {
+        let _guard = ENV_LOCK.lock().unwrap();
         // Ensure no OAuth token exists either
         let auth_path =
             std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string()))

--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -223,6 +223,13 @@ impl AcpServer {
         let model_name = self
             .active_model
             .clone()
+            .or_else(|| {
+                if active_provider == "openai" {
+                    std::env::var("OPENAB_AGENT_OPENAI_MODEL").ok()
+                } else {
+                    None
+                }
+            })
             .or_else(|| std::env::var("OPENAB_AGENT_MODEL").ok())
             .unwrap_or_else(|| {
                 if active_provider == "anthropic" {
@@ -255,23 +262,32 @@ impl AcpServer {
     /// List available models based on configured credentials.
     /// Queries provider APIs when possible, falls back to known defaults.
     async fn available_models() -> Vec<ModelOption> {
-        let mut models = Vec::new();
+        let has_anthropic = std::env::var("ANTHROPIC_API_KEY").is_ok();
+        let has_openai = crate::auth::load_tokens().is_ok();
 
-        // Query Anthropic models if credentials are available
-        if std::env::var("ANTHROPIC_API_KEY").is_ok() {
-            match Self::fetch_anthropic_models().await {
-                Ok(fetched) => models.extend(fetched),
-                Err(_) => models.extend(Self::fallback_anthropic_models()),
-            }
-        }
+        let (anthropic_models, openai_models) = tokio::join!(
+            async {
+                if has_anthropic {
+                    Self::fetch_anthropic_models()
+                        .await
+                        .unwrap_or_else(|_| Self::fallback_anthropic_models())
+                } else {
+                    Vec::new()
+                }
+            },
+            async {
+                if has_openai {
+                    Self::fetch_openai_models()
+                        .await
+                        .unwrap_or_else(|_| Self::fallback_openai_models())
+                } else {
+                    Vec::new()
+                }
+            },
+        );
 
-        // Query OpenAI models if credentials are available
-        if crate::auth::load_tokens().is_ok() {
-            match Self::fetch_openai_models().await {
-                Ok(fetched) => models.extend(fetched),
-                Err(_) => models.extend(Self::fallback_openai_models()),
-            }
-        }
+        let mut models = anthropic_models;
+        models.extend(openai_models);
 
         if models.is_empty() {
             models.push(ModelOption::new(
@@ -675,7 +691,7 @@ mod tests {
 
         // Simulate conversation history by pushing a message into the agent
         let agent = server.sessions.get_mut(&session_id).unwrap();
-        agent.messages.push(crate::llm::Message {
+        agent.push_message(crate::llm::Message {
             role: "user".to_string(),
             content: vec![crate::llm::ContentBlock::Text {
                 text: "hello".to_string(),

--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -486,10 +486,6 @@ impl AcpServer {
         };
         let provider_name = matched.provider.as_str();
 
-        // Store in struct (safe — no env mutation)
-        self.active_model = Some(value.to_string());
-        self.active_provider = Some(matched.provider.clone());
-
         // Rebuild the current session's provider so the switch takes effect immediately
         if !session_id.is_empty() && self.sessions.contains_key(session_id) {
             let new_provider: Result<Box<dyn crate::llm::LlmProvider>, String> = match provider_name
@@ -502,10 +498,8 @@ impl AcpServer {
             };
             match new_provider {
                 Ok(p) => {
-                    // Atomic: only remove old session after new provider succeeds
-                    self.sessions.remove(session_id);
-                    let agent = Agent::new_boxed(p, self.working_dir.clone());
-                    self.sessions.insert(session_id.to_string(), agent);
+                    // Swap provider in-place, preserving conversation history
+                    self.sessions.get_mut(session_id).unwrap().swap_provider(p);
                 }
                 Err(e) => {
                     return self.error_response(
@@ -516,6 +510,10 @@ impl AcpServer {
                 }
             }
         }
+
+        // Update state only after successful rebuild (avoids stale state on failure)
+        self.active_model = Some(value.to_string());
+        self.active_provider = Some(matched.provider.clone());
 
         self.ok_response(
             id,

--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -89,6 +89,10 @@ impl AcpServer {
                     // TODO(v0.2): implement cancellation token to abort in-progress agent.run()
                     vec![self.ok_response(id, json!({}))]
                 }
+                Some("session/set_config_option") => {
+                    let params = req.params.unwrap_or(json!({}));
+                    vec![self.handle_set_config_option(id, &params)]
+                }
                 Some(method) => {
                     vec![self.error_response(id, -32601, &format!("method not found: {method}"))]
                 }
@@ -127,42 +131,80 @@ impl AcpServer {
 
         // Respect OPENAB_AGENT_PROVIDER if set, otherwise auto-detect
         let provider_choice = std::env::var("OPENAB_AGENT_PROVIDER").unwrap_or_default();
-        let provider: Box<dyn crate::llm::LlmProvider> = match provider_choice.as_str() {
-            "anthropic" => match AnthropicProvider::from_env() {
-                Ok(p) => Box::new(p),
-                Err(e) => return self.error_response(id, -32000, &e),
-            },
-            "openai" | "codex" => match crate::llm::OpenAiProvider::from_auth_store() {
-                Ok(p) => Box::new(p),
-                Err(e) => return self.error_response(id, -32000, &e),
-            },
-            _ => {
-                // Auto-detect: try API key first, then OAuth token
-                match AnthropicProvider::from_env() {
-                    Ok(p) => Box::new(p),
-                    Err(_) => match crate::llm::OpenAiProvider::from_auth_store() {
-                        Ok(p) => Box::new(p),
-                        Err(e) => {
-                            return self.error_response(
-                                id,
-                                -32000,
-                                &format!("No credentials: set ANTHROPIC_API_KEY or run `openab-agent auth codex-oauth`. {e}"),
-                            )
-                        }
-                    },
+        let (provider, active_provider): (Box<dyn crate::llm::LlmProvider>, &str) =
+            match provider_choice.as_str() {
+                "anthropic" => match AnthropicProvider::from_env() {
+                    Ok(p) => (Box::new(p), "anthropic"),
+                    Err(e) => return self.error_response(id, -32000, &e),
+                },
+                "openai" | "codex" => match crate::llm::OpenAiProvider::from_auth_store() {
+                    Ok(p) => (Box::new(p), "openai"),
+                    Err(e) => return self.error_response(id, -32000, &e),
+                },
+                _ => {
+                    // Auto-detect: try API key first, then OAuth token
+                    match AnthropicProvider::from_env() {
+                        Ok(p) => (Box::new(p), "anthropic"),
+                        Err(_) => match crate::llm::OpenAiProvider::from_auth_store() {
+                            Ok(p) => (Box::new(p), "openai"),
+                            Err(e) => {
+                                return self.error_response(
+                                    id,
+                                    -32000,
+                                    &format!("No credentials: set ANTHROPIC_API_KEY or run `openab-agent auth codex-oauth`. {e}"),
+                                )
+                            }
+                        },
+                    }
                 }
-            }
-        };
+            };
 
         let agent = Agent::new_boxed(provider, self.working_dir.clone());
         self.sessions.insert(session_id.clone(), agent);
+
+        let model_name = std::env::var("OPENAB_AGENT_MODEL").unwrap_or_else(|_| {
+            if active_provider == "anthropic" {
+                "claude-sonnet-4-20250514".to_string()
+            } else {
+                "gpt-4.1-nano".to_string()
+            }
+        });
+
         let resp = JsonRpcResponse {
             jsonrpc: "2.0",
             id,
-            result: Some(json!({ "sessionId": session_id })),
+            result: Some(json!({
+                "sessionId": session_id,
+                "configOptions": [{
+                    "id": "model",
+                    "name": "Model",
+                    "category": "model",
+                    "type": "enum",
+                    "currentValue": model_name,
+                    "options": Self::available_models()
+                }]
+            })),
             error: None,
         };
         serde_json::to_string(&resp).unwrap()
+    }
+
+    /// List available models based on configured credentials.
+    fn available_models() -> Vec<Value> {
+        let mut models = Vec::new();
+        if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+            models.push(json!({"value": "claude-sonnet-4-20250514", "name": "Claude Sonnet 4"}));
+            models.push(json!({"value": "claude-haiku-4-20250514", "name": "Claude Haiku 4"}));
+        }
+        if crate::auth::load_tokens().is_ok() {
+            models.push(json!({"value": "gpt-4.1-nano", "name": "GPT-4.1 Nano"}));
+            models.push(json!({"value": "gpt-4.1-mini", "name": "GPT-4.1 Mini"}));
+            models.push(json!({"value": "o4-mini", "name": "o4-mini"}));
+        }
+        if models.is_empty() {
+            models.push(json!({"value": "none", "name": "No credentials configured"}));
+        }
+        models
     }
 
     async fn handle_session_prompt(&mut self, id: u64, params: &Value) -> Vec<String> {
@@ -221,6 +263,41 @@ impl AcpServer {
         output_lines
     }
 
+    fn handle_set_config_option(&mut self, id: u64, params: &Value) -> String {
+        let config_id = params.get("configId").and_then(|v| v.as_str()).unwrap_or("");
+        let value = params.get("value").and_then(|v| v.as_str()).unwrap_or("");
+
+        if config_id != "model" || value.is_empty() {
+            return self.error_response(id, -32602, "unsupported configId or empty value");
+        }
+
+        // Set the model env var so next session picks it up
+        // SAFETY: openab-agent is single-threaded for config changes
+        unsafe { std::env::set_var("OPENAB_AGENT_MODEL", value) };
+
+        // Determine provider from model name
+        let provider = if value.starts_with("claude") {
+            "anthropic"
+        } else {
+            "openai"
+        };
+        unsafe { std::env::set_var("OPENAB_AGENT_PROVIDER", provider) };
+
+        self.ok_response(
+            id,
+            json!({
+                "configOptions": [{
+                    "id": "model",
+                    "name": "Model",
+                    "category": "model",
+                    "type": "enum",
+                    "currentValue": value,
+                    "options": Self::available_models()
+                }]
+            }),
+        )
+    }
+
     fn ok_response(&self, id: u64, result: Value) -> String {
         serde_json::to_string(&JsonRpcResponse {
             jsonrpc: "2.0",
@@ -267,6 +344,12 @@ mod tests {
         assert_eq!(resp["jsonrpc"], "2.0");
         assert_eq!(resp["id"], 2);
         assert!(resp["result"]["sessionId"].as_str().unwrap().len() > 0);
+        // Verify configOptions are returned for /models support
+        let config_options = resp["result"]["configOptions"].as_array().unwrap();
+        assert!(!config_options.is_empty());
+        assert_eq!(config_options[0]["id"], "model");
+        assert_eq!(config_options[0]["category"], "model");
+        assert!(!config_options[0]["options"].as_array().unwrap().is_empty());
     }
 
     #[test]

--- a/openab-agent/src/agent.rs
+++ b/openab-agent/src/agent.rs
@@ -23,7 +23,7 @@ const MAX_CONTEXT_MESSAGES: usize = 100;
 
 pub struct Agent {
     provider: Box<dyn LlmProvider>,
-    messages: Vec<Message>,
+    pub(crate) messages: Vec<Message>,
     working_dir: PathBuf,
     system_prompt: String,
     tools: Vec<ToolDef>,
@@ -56,6 +56,12 @@ impl Agent {
     /// Replace the LLM provider while preserving conversation history.
     pub fn swap_provider(&mut self, provider: Box<dyn LlmProvider>) {
         self.provider = provider;
+    }
+
+    /// Number of messages in the conversation (test helper).
+    #[cfg(test)]
+    pub fn message_count(&self) -> usize {
+        self.messages.len()
     }
 
     /// Run the agent with a user prompt, executing tool calls until completion.

--- a/openab-agent/src/agent.rs
+++ b/openab-agent/src/agent.rs
@@ -23,7 +23,7 @@ const MAX_CONTEXT_MESSAGES: usize = 100;
 
 pub struct Agent {
     provider: Box<dyn LlmProvider>,
-    pub(crate) messages: Vec<Message>,
+    messages: Vec<Message>,
     working_dir: PathBuf,
     system_prompt: String,
     tools: Vec<ToolDef>,
@@ -62,6 +62,12 @@ impl Agent {
     #[cfg(test)]
     pub fn message_count(&self) -> usize {
         self.messages.len()
+    }
+
+    /// Push a message into the conversation (test helper).
+    #[cfg(test)]
+    pub fn push_message(&mut self, msg: Message) {
+        self.messages.push(msg);
     }
 
     /// Run the agent with a user prompt, executing tool calls until completion.

--- a/openab-agent/src/agent.rs
+++ b/openab-agent/src/agent.rs
@@ -53,6 +53,11 @@ impl Agent {
         }
     }
 
+    /// Replace the LLM provider while preserving conversation history.
+    pub fn swap_provider(&mut self, provider: Box<dyn LlmProvider>) {
+        self.provider = provider;
+    }
+
     /// Run the agent with a user prompt, executing tool calls until completion.
     /// Returns the final text response.
     fn build_system_prompt(working_dir: &str) -> String {

--- a/openab-agent/src/llm.rs
+++ b/openab-agent/src/llm.rs
@@ -92,6 +92,13 @@ impl AnthropicProvider {
         })
     }
 
+    /// Create provider with a specific model override.
+    pub fn from_env_with_model(model: &str) -> Result<Self, String> {
+        let mut p = Self::from_env()?;
+        p.model = model.to_string();
+        Ok(p)
+    }
+
     fn build_request_body(&self, system: &str, messages: &[Message], tools: &[ToolDef]) -> Value {
         let msgs: Vec<Value> = messages
             .iter()
@@ -272,6 +279,13 @@ impl OpenAiProvider {
                 .unwrap_or(8192),
             client: reqwest::Client::new(),
         })
+    }
+
+    /// Create provider with a specific model override.
+    pub fn from_auth_store_with_model(model: &str) -> Result<Self, String> {
+        let mut p = Self::from_auth_store()?;
+        p.model = model.to_string();
+        Ok(p)
     }
 }
 


### PR DESCRIPTION
## 0. Discord Discussion URL

Thread: 1511138789836456127

## 1. What Problem Does This Solve?

`openab-agent` did not expose ACP `configOptions`, so OpenAB's Discord `/models` command could not list or switch models for native openab-agent sessions.

## 2. At A Glance

```text
Discord /models
  -> OpenAB reads cached ACP configOptions
  -> user selects a model
  -> session/set_config_option
  -> openab-agent validates the selected cached option
  -> rebuilds the session provider with the selected model
```

## 3. Prior Art & Industry Research

- OpenClaw: reviewed for comparable runtime model switching behavior. The relevant pattern is exposing model selection as session-level agent configuration rather than requiring users to restart the gateway.
- Hermes Agent: reviewed for self-hosted agent configuration behavior. The relevant pattern is keeping provider/model selection explicit in agent runtime configuration and avoiding implicit provider inference where possible.

Neither project maps exactly to OpenAB's ACP `configOptions` flow, so this PR follows the existing OpenAB `/models` integration used by ACP-compatible agents.

## 4. Proposed Solution

- Return a `model` config option from `session/new`.
- Discover available models from configured Anthropic/OpenAI credentials, with bounded provider API calls and fallback defaults.
- Cache the model options returned to the ACP client and validate `session/set_config_option` against that same list.
- Store the active model/provider on `AcpServer` instead of mutating process environment at runtime.
- Rebuild the current session provider atomically after a successful model switch.

## 5. Why This Approach

This keeps the `/models` UI and `set_config_option` validation on the same source of truth. It also avoids brittle name-prefix routing by carrying provider metadata with each option, and bounds model discovery so session creation does not hang on a slow provider endpoint.

Tradeoff: model discovery is cached per openab-agent process/session lifecycle, so newly released provider models may require a new session to appear.

## 6. Alternatives Considered

- Hardcoded model list only: simpler, but stale quickly and hides models available to the configured account.
- Prefix-based provider inference: fragile for future model names and custom OpenAI-compatible backends.
- Live validation during every model switch: more current, but can reject a model after it was displayed if provider discovery changes or the network flakes.

## 7. Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`

## Summary

`openab-agent` now returns `configOptions` in the `session/new` ACP response, enabling Discord `/models` to list and switch between available models.

## Changes

- `session/new` response includes `configOptions` with category `model`.
- New `session/set_config_option` handler for runtime model switching.
- Model discovery queries provider APIs with a short timeout and falls back to defaults.
- Model options carry provider metadata for routing.
- Model switch validation uses the same cached options shown to the user.

## Usage

```text
/models              -> list available models
/model set 2         -> switch to model #2
/model set o4-mini   -> switch by name
```
