### PR TITLE
docs(adr): Control Directives proposal

### DIFF
--- a/docs/adr/control-directives.md
+++ b/docs/adr/control-directives.md
@@ -83,7 +83,12 @@ The directive parser runs **before** the message enters the agent pipeline. It o
 - Resolves `~` to the bot's home directory
 - Loads `AGENTS.md`, `.kiro/steering/`, and skill definitions from the target path
 - If the path does not exist, session starts with default context (no error surfaced to user; logged at warn level)
-- Path must be absolute or start with `~`; relative paths are rejected
+- **Security boundary:** bot home subtree only. Enforcement:
+  1. Path must be absolute or start with `~` (relative paths rejected)
+  2. Resolve `~` → bot home, then `canonicalize()` (resolves symlinks, `..`, `.`)
+  3. Final canonical path MUST be a descendant of bot home directory
+  4. Symlinks that escape bot home are rejected after canonicalization
+  5. Violation → session fails with user-visible error, not silent fallback
 
 ### 3.2 `[[title:...]]` — Thread Title
 
@@ -94,7 +99,7 @@ The directive parser runs **before** the message enters the agent pipeline. It o
 ### 3.3 `[[model:...]]` — Model Selection
 
 - Value must match a configured model identifier
-- If the model is unavailable or unknown, the session falls back to the default model and logs a warning
+- If the model is unavailable or unknown, the session **fails with a user-visible error** — never silently falls back to default. Rationale: silent fallback can route an entire conversation through the wrong model without the user noticing
 - Does not persist beyond the session
 
 ---
@@ -135,9 +140,13 @@ Shared syntax reduces cognitive load. The direction is unambiguous from context 
 
 ### 4.4 Security Considerations
 
-- `[[ws:...]]` paths should be validated against an allowlist or restricted to the bot's home subtree to prevent directory traversal
-- `[[model:...]]` only selects from pre-configured models; cannot inject arbitrary API endpoints
+- `[[ws:...]]` enforces bot home subtree only — canonicalize, reject symlink escapes (see §3.1)
+- `[[model:...]]` only selects from pre-configured models; cannot inject arbitrary API endpoints; unknown model = hard fail
 - Directive values are sanitized (no newlines, no control characters beyond the value delimiter)
+
+### 4.5 No Mid-Session Reset
+
+Control directives are immutable once the session starts. There is no mechanism to change `ws`, `title`, or `model` mid-conversation. To change parameters, start a new session. This eliminates state mutation complexity and keeps the session contract predictable.
 
 ---
 
@@ -147,10 +156,12 @@ These are **not** in scope for Phase 1 but the design accommodates them:
 
 | Directive | Purpose |
 |-----------|---------|
-| `[[repo:owner/repo]]` | Bind GitHub repository context |
+| `[[repo:owner/repo]]` | Bind GitHub repository context (Phase 1 relies on `[[ws:...]]` steering to define repo context) |
 | `[[timeout:300]]` | Session timeout in seconds |
 | `[[skill:review]]` | Activate a specific skill set |
 | `[[label:bug]]` | Tag the session/thread with labels (multi-value: array semantics) |
+
+**Why `[[repo:...]]` is not in Phase 1:** Workspace steering files already define repository context (remote URL, branch conventions, etc.). A standalone `[[repo:...]]` directive would need to specify what "binding" means (clone? set remote? just metadata?) — that design is deferred until usage patterns emerge from `[[ws:...]]` adoption.
 
 For multi-value keys (e.g., `[[label:a]] [[label:b]]`), a future revision may introduce array semantics where repeated keys accumulate rather than overwrite. Phase 1 uses last-wins for all keys.
 
@@ -192,9 +203,10 @@ investigate the build failure
 - Naturally implies "session start" — aligns with first-message-only rule
 
 **Relationship to inline directives:**
-- `/new` is a convenience layer; control directives remain the canonical spec
+- `/new` is **transport sugar only** — it MUST NOT introduce semantics beyond what `[[key:value]]` provides
 - Users who prefer text-only (or are on platforms without slash commands) use `@Bot [[...]]` directly
 - Both paths produce identical `SessionMetadata`
+- `/new` and inline `[[...]]` cannot co-exist in the same message (a `/new` invocation IS the session's first message; there is no separate text body to embed inline directives)
 
 ---
 

--- a/docs/adr/control-directives.md
+++ b/docs/adr/control-directives.md
@@ -1,0 +1,198 @@
+# ADR: Control Directives
+
+- **Status:** Proposed
+- **Date:** 2026-06-02
+- **Author:** @pAhudSern (proposed by Pahud, authored by chaodu-agent)
+- **Related:** [Output Directives](../output-directives.md)
+
+---
+
+## 1. Context
+
+### 1.1 Problem
+
+A single OAB bot instance may serve multiple projects, each with its own steering files, skills, and workspace context. Today, there is no mechanism for a user to specify session-level parameters (working directory, model, language) when initiating a conversation. The bot always starts with its default configuration, requiring manual reconfiguration or separate bot instances per project.
+
+### 1.2 Existing Pattern
+
+OAB already has **output directives** — `[[key:value]]` syntax that agents prepend to their responses to control delivery behavior (e.g., `[[reply_to:...]]`). This pattern is well-understood, parsed reliably, and invisible to end users after processing.
+
+### 1.3 Opportunity
+
+Extend the `[[key:value]]` convention to **input** (user → bot) messages, creating **control directives** that configure the session at creation time. This unifies the directive syntax across both directions and gives users declarative control over session initialization without requiring new slash commands or config files.
+
+---
+
+## 2. Decision
+
+Introduce **Control Directives** — `[[key:value]]` patterns in user messages that configure session parameters. They share the double-bracket syntax with output directives but flow in the opposite direction (user → broker → agent runtime).
+
+### 2.1 Syntax
+
+```
+@Bot [[ws:~/workdir/foo]] [[title:PR review]] investigate this build failure
+```
+
+### 2.2 Core Rules
+
+| Rule | Behavior |
+|------|----------|
+| **Scope** | Processed only on the session's first message (the one that mentions/triggers the bot) |
+| **Parsing** | Extract all `[[key:value]]` matches from the message body |
+| **Stripping** | Directives are removed from the message; remaining text becomes the prompt |
+| **Duplicate keys** | Last value wins |
+| **Unknown keys** | Silently ignored (forward compatible) |
+| **Placement** | Inline or on separate lines — parser handles both |
+| **Empty value** | `[[key:]]` is valid; treated as explicit empty/reset |
+
+### 2.3 Architecture Position
+
+```
+User message
+     │
+     ▼
+┌─────────────────────┐
+│  Directive Parser    │  ← extracts [[key:value]], strips from message
+│  (middleware)        │
+└─────────────────────┘
+     │
+     ├── structured SessionMetadata
+     │
+     ▼
+┌─────────────────────┐
+│  Agent Runtime       │  ← receives clean prompt + metadata
+└─────────────────────┘
+```
+
+The directive parser runs **before** the message enters the agent pipeline. It outputs:
+- `prompt: String` — the message with directives stripped
+- `metadata: SessionMetadata` — parsed key-value pairs for runtime configuration
+
+---
+
+## 3. Supported Directives (Phase 1)
+
+| Directive | Purpose | Example |
+|-----------|---------|---------|
+| `[[ws:/path]]` | Set session working directory; loads steering/skills from that path | `[[ws:~/projects/myapp]]` |
+| `[[title:...]]` | Set initial thread title | `[[title:Bug triage #42]]` |
+| `[[model:...]]` | Specify model for this session | `[[model:claude-sonnet-4-20250514]]` |
+| `[[lang:...]]` | Force response language | `[[lang:en]]` |
+
+### 3.1 `[[ws:/path]]` — Workspace
+
+- Resolves `~` to the bot's home directory
+- Loads `AGENTS.md`, `.kiro/steering/`, and skill definitions from the target path
+- If the path does not exist, session starts with default context (no error surfaced to user; logged at warn level)
+- Path must be absolute or start with `~`; relative paths are rejected
+
+### 3.2 `[[title:...]]` — Thread Title
+
+- Sets the initial thread/channel title
+- Agent may override this later per its own SOP (e.g., status-based title updates)
+- Max length: 100 characters (truncated silently)
+
+### 3.3 `[[model:...]]` — Model Selection
+
+- Value must match a configured model identifier
+- If the model is unavailable or unknown, the session falls back to the default model and logs a warning
+- Does not persist beyond the session
+
+### 3.4 `[[lang:...]]` — Response Language
+
+- IETF language tag (e.g., `en`, `zh-TW`, `ja`)
+- Applied as a system-level instruction to the agent
+- Does not affect directive parsing or log language
+
+---
+
+## 4. Design Decisions
+
+### 4.1 Why Session-First Only
+
+Processing directives only on the first message keeps the mental model simple:
+- No mid-conversation state mutations
+- No need for "directive acknowledged" confirmation messages
+- Session parameters are immutable once established
+- Easier to reason about for both users and agents
+
+### 4.2 Why Not Slash Commands
+
+| Aspect | Slash Commands | Control Directives |
+|--------|---------------|-------------------|
+| Discovery | Platform UI autocomplete | Docs / muscle memory |
+| Composability | One command at a time | Multiple directives in one message |
+| Platform dependency | Requires registration per platform | Platform-agnostic (just text) |
+| Works with mention | Awkward (`/command @bot`) | Natural (`@bot [[...]] prompt`) |
+
+Control directives are platform-agnostic text — they work on Discord, Slack, Telegram, or any adapter without platform-specific command registration.
+
+### 4.3 Relationship to Output Directives
+
+| Aspect | Output Directives | Control Directives |
+|--------|-------------------|-------------------|
+| Direction | Agent → Platform | User → Broker |
+| Processing layer | Response post-processor | Message pre-processor |
+| Timing | Every response | Session first message only |
+| Syntax | `[[key:value]]` | `[[key:value]]` |
+| Unknown keys | Ignored | Ignored |
+| Duplicate keys | Last wins | Last wins |
+
+Shared syntax reduces cognitive load. The direction is unambiguous from context (who authored the message).
+
+### 4.4 Security Considerations
+
+- `[[ws:...]]` paths should be validated against an allowlist or restricted to the bot's home subtree to prevent directory traversal
+- `[[model:...]]` only selects from pre-configured models; cannot inject arbitrary API endpoints
+- Directive values are sanitized (no newlines, no control characters beyond the value delimiter)
+
+---
+
+## 5. Future Extensions
+
+These are **not** in scope for Phase 1 but the design accommodates them:
+
+| Directive | Purpose |
+|-----------|---------|
+| `[[repo:owner/repo]]` | Bind GitHub repository context |
+| `[[timeout:300]]` | Session timeout in seconds |
+| `[[skill:review]]` | Activate a specific skill set |
+| `[[label:bug]]` | Tag the session/thread with labels (multi-value: array semantics) |
+
+For multi-value keys (e.g., `[[label:a]] [[label:b]]`), a future revision may introduce array semantics where repeated keys accumulate rather than overwrite. Phase 1 uses last-wins for all keys.
+
+---
+
+## 6. Implementation Plan
+
+### Phase 1: Parser + `ws` + `title`
+
+1. Implement directive parser as a middleware in the message ingestion pipeline
+2. Define `SessionMetadata` struct
+3. Wire `[[ws:...]]` to workspace/context loading
+4. Wire `[[title:...]]` to thread title initialization
+5. Unit tests for parser edge cases (nested brackets, escaped content, empty values)
+
+### Phase 2: `model` + `lang`
+
+1. Wire `[[model:...]]` to model selection in agent runtime
+2. Wire `[[lang:...]]` to system prompt language instruction
+3. Validation and fallback logic
+
+---
+
+## 7. Alternatives Considered
+
+| Alternative | Rejected Because |
+|-------------|-----------------|
+| YAML front-matter in messages | Visually heavy; unfamiliar to chat users |
+| Separate `/config` command before conversation | Extra round-trip; breaks single-message session start |
+| Per-channel bot configuration | Doesn't scale to ad-hoc project switching |
+| Environment variables per bot instance | Requires multiple bot deployments |
+
+---
+
+## 8. References
+
+- [Output Directives](../output-directives.md) — existing `[[key:value]]` pattern for agent → platform
+- [Steering Design Guide](../steering-design-guide.md) — how workspace steering files are structured

--- a/docs/adr/control-directives.md
+++ b/docs/adr/control-directives.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed
 - **Date:** 2026-06-02
-- **Author:** @pAhudSern (proposed by Pahud, authored by chaodu-agent)
+- **Author:** chaodu-agent
 - **Related:** [Output Directives](../output-directives.md)
 
 ---

--- a/docs/adr/control-directives.md
+++ b/docs/adr/control-directives.md
@@ -179,6 +179,31 @@ For multi-value keys (e.g., `[[label:a]] [[label:b]]`), a future revision may in
 2. Wire `[[lang:...]]` to system prompt language instruction
 3. Validation and fallback logic
 
+### Phase 3: `/new` Slash Command
+
+Platform-specific UX sugar that translates to control directives internally.
+
+```
+/new ws:~/projects/myapp model:claude-sonnet-4-20250514
+investigate the build failure
+```
+
+1. Register `/new` slash command on supported platforms (Discord, Slack)
+2. Command handler parses arguments into `[[key:value]]` directives
+3. Feeds through the same directive parser pipeline as inline directives
+4. Creates a new thread with the parsed session metadata
+
+**Why `/new`:**
+- Short, intuitive — matches "new session/thread" mental model
+- Platform autocomplete provides discoverability
+- Does not conflict with other bots' commands
+- Naturally implies "session start" — aligns with first-message-only rule
+
+**Relationship to inline directives:**
+- `/new` is a convenience layer; control directives remain the canonical spec
+- Users who prefer text-only (or are on platforms without slash commands) use `@Bot [[...]]` directly
+- Both paths produce identical `SessionMetadata`
+
 ---
 
 ## 7. Alternatives Considered

--- a/docs/adr/control-directives.md
+++ b/docs/adr/control-directives.md
@@ -30,7 +30,8 @@ Introduce **Control Directives** — `[[key:value]]` patterns in user messages t
 ### 2.1 Syntax
 
 ```
-@Bot [[ws:~/workdir/foo]] [[title:PR review]] investigate this build failure
+@Bot [[ws:~/workdir/foo]] [[title:PR review]]
+investigate this build failure
 ```
 
 ### 2.2 Core Rules
@@ -38,12 +39,13 @@ Introduce **Control Directives** — `[[key:value]]` patterns in user messages t
 | Rule | Behavior |
 |------|----------|
 | **Scope** | Processed only on the session's first message (the one that mentions/triggers the bot) |
-| **Parsing** | Extract all `[[key:value]]` matches from the message body |
-| **Stripping** | Directives are removed from the message; remaining text becomes the prompt |
+| **Parsing** | Extract a leading control header only: directives immediately after the trigger/mention and before normal prompt text |
+| **Stop condition** | The first non-directive token or line starts prompt content; later `[[key:value]]` text is preserved verbatim |
+| **Stripping** | Header directives are removed from the message; remaining text becomes the prompt |
 | **Duplicate keys** | Last value wins |
 | **Unknown keys** | Silently ignored (forward compatible) |
-| **Placement** | Inline or on separate lines — parser handles both |
-| **Empty value** | `[[key:]]` is valid; treated as explicit empty/reset |
+| **Placement** | Directives may be adjacent on the trigger line or on following header lines before prompt content begins |
+| **Empty value** | Behavior is directive-specific: empty `ws` and `model` are invalid; empty `title` means "use generated title" |
 
 ### 2.3 Architecture Position
 
@@ -52,7 +54,7 @@ User message
      │
      ▼
 ┌─────────────────────┐
-│  Directive Parser    │  ← extracts [[key:value]], strips from message
+│  Directive Parser    │  ← extracts leading [[key:value]] header, strips it
 │  (middleware)        │
 └─────────────────────┘
      │
@@ -76,7 +78,6 @@ The directive parser runs **before** the message enters the agent pipeline. It o
 |-----------|---------|---------|
 | `[[ws:/path]]` | Set session working directory; loads steering/skills from that path | `[[ws:~/projects/myapp]]` |
 | `[[title:...]]` | Set initial thread title | `[[title:Bug triage #42]]` |
-| `[[model:...]]` | Specify model for this session | `[[model:claude-sonnet-4-20250514]]` |
 
 ### 3.1 `[[ws:/path]]` — Workspace
 
@@ -85,9 +86,10 @@ The directive parser runs **before** the message enters the agent pipeline. It o
 - **Security boundary — bot home subtree only.** Enforcement order:
   1. Reject if path is relative (does not start with `~` or `/`)
   2. Expand `~` → bot home directory
-  3. Canonicalize (resolve symlinks, `..`, `.`) via `std::fs::canonicalize()` or equivalent
+  3. Canonicalize both the bot home root and target path (resolve symlinks, `..`, `.`) via `std::fs::canonicalize()` or equivalent
   4. Verify canonical path starts with bot home root (`canonical.starts_with(bot_home)`)
   5. **Reject** if outside bot home — session does not start, user-visible error returned
+- The canonical workspace is stored in `SessionMetadata` and reused for session creation, session load/resume, eviction rebuilds, and any persisted session mapping. A `[[ws:...]]` session must never resume in the configured default working directory unless that was the resolved workspace.
 - Workspace steering defines repo context (remote URL, branch, etc.) — no separate repo binding needed in Phase 1
 
 ### 3.2 `[[title:...]]` — Thread Title
@@ -98,8 +100,10 @@ The directive parser runs **before** the message enters the agent pipeline. It o
 
 ### 3.3 `[[model:...]]` — Model Selection
 
+Phase 2 adds `[[model:...]]` after the parser, workspace, and title path are implemented.
+
 - Value must match a configured model identifier
-- If the model is unavailable or unknown, the session is **rejected before any agent/runtime initialization** — user receives an error, no partial state is created
+- If the model is unavailable or unknown, the session is rejected after runtime config discovery but before the user's first prompt is sent. The user receives an error and no user task is executed in the wrong model.
 - Does not persist beyond the session
 
 ---
@@ -138,6 +142,8 @@ Control directives are platform-agnostic text — they work on Discord, Slack, T
 
 Shared syntax reduces cognitive load. The direction is unambiguous from context (who authored the message).
 
+Control directives intentionally do **not** scan the entire message body. This mirrors the output directive header concept and avoids corrupting normal prompts that quote code, issue templates, or examples containing `[[key:value]]`.
+
 ### 4.4 Security Considerations
 
 - `[[ws:...]]` enforces bot home subtree only — canonicalize, reject symlink escapes (see §3.1)
@@ -173,14 +179,15 @@ For multi-value keys (e.g., `[[label:a]] [[label:b]]`), a future revision may in
 
 1. Implement directive parser as a middleware in the message ingestion pipeline
 2. Define `SessionMetadata` struct
-3. Wire `[[ws:...]]` to workspace/context loading
-4. Wire `[[title:...]]` to thread title initialization
-5. Unit tests for parser edge cases (nested brackets, escaped content, empty values)
+3. Persist `SessionMetadata` per session key so workspace survives reconnect, resume, and eviction rebuilds
+4. Wire `[[ws:...]]` to workspace/context loading
+5. Wire `[[title:...]]` to thread title initialization
+6. Unit tests for parser edge cases (nested brackets, escaped content, empty values, body text that contains directive-like literals)
 
 ### Phase 2: `model`
 
 1. Wire `[[model:...]]` to model selection in agent runtime
-2. Validation and fallback logic
+2. Validate against runtime config options before the first user prompt is sent; reject unknown values instead of falling back silently
 
 ### Phase 3: `/new` Slash Command
 

--- a/docs/adr/control-directives.md
+++ b/docs/adr/control-directives.md
@@ -80,15 +80,15 @@ The directive parser runs **before** the message enters the agent pipeline. It o
 
 ### 3.1 `[[ws:/path]]` — Workspace
 
-- Resolves `~` to the bot's home directory
 - Loads `AGENTS.md`, `.kiro/steering/`, and skill definitions from the target path
-- If the path does not exist, session starts with default context (no error surfaced to user; logged at warn level)
-- **Security boundary:** bot home subtree only. Enforcement:
-  1. Path must be absolute or start with `~` (relative paths rejected)
-  2. Resolve `~` → bot home, then `canonicalize()` (resolves symlinks, `..`, `.`)
-  3. Final canonical path MUST be a descendant of bot home directory
-  4. Symlinks that escape bot home are rejected after canonicalization
-  5. Violation → session fails with user-visible error, not silent fallback
+- If the path does not exist, session fails with user-visible error
+- **Security boundary — bot home subtree only.** Enforcement order:
+  1. Reject if path is relative (does not start with `~` or `/`)
+  2. Expand `~` → bot home directory
+  3. Canonicalize (resolve symlinks, `..`, `.`) via `std::fs::canonicalize()` or equivalent
+  4. Verify canonical path starts with bot home root (`canonical.starts_with(bot_home)`)
+  5. **Reject** if outside bot home — session does not start, user-visible error returned
+- Workspace steering defines repo context (remote URL, branch, etc.) — no separate repo binding needed in Phase 1
 
 ### 3.2 `[[title:...]]` — Thread Title
 
@@ -99,7 +99,7 @@ The directive parser runs **before** the message enters the agent pipeline. It o
 ### 3.3 `[[model:...]]` — Model Selection
 
 - Value must match a configured model identifier
-- If the model is unavailable or unknown, the session **fails with a user-visible error** — never silently falls back to default. Rationale: silent fallback can route an entire conversation through the wrong model without the user noticing
+- If the model is unavailable or unknown, the session is **rejected before any agent/runtime initialization** — user receives an error, no partial state is created
 - Does not persist beyond the session
 
 ---

--- a/docs/adr/control-directives.md
+++ b/docs/adr/control-directives.md
@@ -11,7 +11,7 @@
 
 ### 1.1 Problem
 
-A single OAB bot instance may serve multiple projects, each with its own steering files, skills, and workspace context. Today, there is no mechanism for a user to specify session-level parameters (working directory, model, language) when initiating a conversation. The bot always starts with its default configuration, requiring manual reconfiguration or separate bot instances per project.
+A single OAB bot instance may serve multiple projects, each with its own steering files, skills, and workspace context. Today, there is no mechanism for a user to specify session-level parameters (working directory, model) when initiating a conversation. The bot always starts with its default configuration, requiring manual reconfiguration or separate bot instances per project.
 
 ### 1.2 Existing Pattern
 
@@ -77,7 +77,6 @@ The directive parser runs **before** the message enters the agent pipeline. It o
 | `[[ws:/path]]` | Set session working directory; loads steering/skills from that path | `[[ws:~/projects/myapp]]` |
 | `[[title:...]]` | Set initial thread title | `[[title:Bug triage #42]]` |
 | `[[model:...]]` | Specify model for this session | `[[model:claude-sonnet-4-20250514]]` |
-| `[[lang:...]]` | Force response language | `[[lang:en]]` |
 
 ### 3.1 `[[ws:/path]]` — Workspace
 
@@ -97,12 +96,6 @@ The directive parser runs **before** the message enters the agent pipeline. It o
 - Value must match a configured model identifier
 - If the model is unavailable or unknown, the session falls back to the default model and logs a warning
 - Does not persist beyond the session
-
-### 3.4 `[[lang:...]]` — Response Language
-
-- IETF language tag (e.g., `en`, `zh-TW`, `ja`)
-- Applied as a system-level instruction to the agent
-- Does not affect directive parsing or log language
 
 ---
 
@@ -173,11 +166,10 @@ For multi-value keys (e.g., `[[label:a]] [[label:b]]`), a future revision may in
 4. Wire `[[title:...]]` to thread title initialization
 5. Unit tests for parser edge cases (nested brackets, escaped content, empty values)
 
-### Phase 2: `model` + `lang`
+### Phase 2: `model`
 
 1. Wire `[[model:...]]` to model selection in agent runtime
-2. Wire `[[lang:...]]` to system prompt language instruction
-3. Validation and fallback logic
+2. Validation and fallback logic
 
 ### Phase 3: `/new` Slash Command
 

--- a/docs/adr/control-directives.md
+++ b/docs/adr/control-directives.md
@@ -13,11 +13,23 @@
 
 A single OAB bot instance may serve multiple projects, each with its own steering files, skills, and workspace context. Today, there is no mechanism for a user to specify session-level parameters (working directory, model) when initiating a conversation. The bot always starts with its default configuration, requiring manual reconfiguration or separate bot instances per project.
 
-### 1.2 Existing Pattern
+### 1.2 Why Workspace Selection Matters
+
+Specifying a workspace at session start eliminates the manual warm-up cost. Without it, users spend the first several messages orienting the agent. With `[[ws:...]]`, the agent gains full project context immediately:
+
+- **Steering rules** — `AGENTS.md` and `.kiro/steering/` load automatically (coding style, architecture decisions, naming conventions). The agent knows how this project does things.
+- **Skills** — `.kiro/skills/` activate project-specific capabilities (e.g., review workflows, deployment helpers).
+- **File scope** — the agent's working directory is the project root; reads, searches, and writes target the correct codebase.
+- **Git context** — branch, remote, and commit history are correct for PR review, diff, and blame operations.
+- **Session isolation** — multiple projects served by one bot instance never leak context between sessions.
+
+In short: one directive replaces 3–5 round trips of "here's the repo, here's how we work, here's what I need."
+
+### 1.3 Existing Pattern
 
 OAB already has **output directives** — `[[key:value]]` syntax that agents prepend to their responses to control delivery behavior (e.g., `[[reply_to:...]]`). This pattern is well-understood, parsed reliably, and invisible to end users after processing.
 
-### 1.3 Opportunity
+### 1.4 Opportunity
 
 Extend the `[[key:value]]` convention to **input** (user → bot) messages, creating **control directives** that configure the session at creation time. This unifies the directive syntax across both directions and gives users declarative control over session initialization without requiring new slash commands or config files.
 

--- a/docs/adr/control-directives.md
+++ b/docs/adr/control-directives.md
@@ -195,7 +195,7 @@ investigate the build failure
 
 **Why `/new`:**
 - Short, intuitive — matches "new session/thread" mental model
-- Platform autocomplete provides discoverability
+- **Typed arguments with platform UI** — autocomplete for workspaces, dropdown for models, validation before submit. Users don't need to memorize exact model names or path syntax
 - Does not conflict with other bots' commands
 - Naturally implies "session start" — aligns with first-message-only rule
 

--- a/docs/adr/control-directives.md
+++ b/docs/adr/control-directives.md
@@ -92,6 +92,31 @@ The directive parser runs **before** the message enters the agent pipeline. It o
 - The canonical workspace is stored in `SessionMetadata` and reused for session creation, session load/resume, eviction rebuilds, and any persisted session mapping. A `[[ws:...]]` session must never resume in the configured default working directory unless that was the resolved workspace.
 - Workspace steering defines repo context (remote URL, branch, etc.) — no separate repo binding needed in Phase 1
 
+#### Workspace Aliases
+
+Full paths are verbose for frequent use. The operator may define workspace aliases in `config.toml`:
+
+```toml
+[workspace.aliases]
+openab = "~/projects/openab"
+infra  = "~/projects/infra-cdk"
+web    = "~/projects/frontend"
+```
+
+Users reference aliases with an `@` prefix:
+
+```
+@Bot [[ws:@openab]] [[title:Fix CI]]
+help me debug the smoke test
+```
+
+Resolution order:
+1. If value starts with `@`, look up alias in `workspace.aliases`
+2. If alias not found → reject with user-visible error listing available aliases
+3. If found → substitute the full path, then apply the same canonicalize + security check as raw paths
+
+Aliases are syntactic sugar — they resolve before any security validation and produce identical `SessionMetadata` to raw paths.
+
 ### 3.2 `[[title:...]]` — Thread Title
 
 - Sets the initial thread/channel title
@@ -175,14 +200,15 @@ For multi-value keys (e.g., `[[label:a]] [[label:b]]`), a future revision may in
 
 ## 6. Implementation Plan
 
-### Phase 1: Parser + `ws` + `title`
+### Phase 1: Parser + `ws` (with aliases) + `title`
 
 1. Implement directive parser as a middleware in the message ingestion pipeline
 2. Define `SessionMetadata` struct
 3. Persist `SessionMetadata` per session key so workspace survives reconnect, resume, and eviction rebuilds
-4. Wire `[[ws:...]]` to workspace/context loading
-5. Wire `[[title:...]]` to thread title initialization
-6. Unit tests for parser edge cases (nested brackets, escaped content, empty values, body text that contains directive-like literals)
+4. Add `[workspace.aliases]` table to `config.toml` schema
+5. Wire `[[ws:...]]` to workspace/context loading (raw paths and `@alias` resolution)
+6. Wire `[[title:...]]` to thread title initialization
+7. Unit tests for parser edge cases (nested brackets, escaped content, empty values, body text that contains directive-like literals, unknown alias error)
 
 ### Phase 2: `model`
 


### PR DESCRIPTION
## 0. Discord Discussion URL

https://discord.com/channels/1491295327620169908/1491365150664560881/1511386032237711481

## 1. What problem does this solve?

A single OAB bot instance may serve multiple projects, each with its own steering files, skills, and workspace context. Today, users cannot specify session-level parameters such as working directory or initial title when starting a conversation.

## 2. At a Glance

```
@Bot [[ws:~/projects/myapp]] [[title:Bug triage]]
investigate this build failure
          |
          v
leading control header parser
          |
          +--> clean prompt
          +--> SessionMetadata { workspace, title }
          |
          v
ACP session creation
```

## 3. Prior Art & Industry Research

Not applicable for this PR: this is an ADR proposal only. The implementation PR for runtime session mutation should include the required OpenClaw and Hermes Agent research before changing broker behavior.

## 4. Proposed Solution

Add an ADR for Control Directives: a leading `[[key:value]]` header in the first user message that can initialize session metadata.

Phase 1 covers:

- `[[ws:...]]` for workspace selection
- `[[title:...]]` for initial thread title
- parser and `SessionMetadata` persistence requirements

Phase 2 covers:

- `[[model:...]]` after runtime config discovery can validate the model before sending the first user prompt

## 5. Why This Approach

The syntax reuses the existing output directive shape while keeping parsing bounded to a leading header so normal prompt text, code snippets, and examples containing `[[key:value]]` remain intact.

## 6. Alternatives Considered

- YAML front matter: too heavy for chat.
- Separate `/config` command: adds a round trip before every new session.
- Per-channel bot config: poor fit for ad-hoc project switching.
- Multiple bot deployments: operationally heavier than per-session metadata.

## 7. Validation

Docs-only ADR change:

- Reviewed against `docs/output-directives.md`
- Reviewed against current ACP session creation/resume behavior
- No runtime tests required
