### PR TITLE
ci: replace sed/awk Dockerfile rewriting with --build-context overrides

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -72,29 +72,26 @@ jobs:
           DF="${{ matrix.variant.dockerfile }}"
 
           if grep -q "FROM rust" "$DF"; then
-            # Remove ALL 'FROM rust' stages, keep only the final runtime stage
-            awk '
-              /^FROM rust/ { skip=1; next }
-              /^FROM / && !/^FROM rust/ { skip=0 }
-              !skip { print }
-            ' "$DF" > Dockerfile.ci
+            # Create fake builder context with pre-built binary at the expected path
+            mkdir -p .fake-builder/build/target/release
+            cp .pre-built/openab .fake-builder/build/target/release/openab
 
-            # Prepend stub builder stages that just provide the pre-built binaries
-            {
-              echo "FROM debian:bookworm-slim AS builder"
-              echo "RUN mkdir -p /build/target/release"
-              echo "COPY .pre-built/openab /build/target/release/openab"
-              # Handle additional build stages (e.g. adapter-builder)
-              grep -i '^FROM rust' "$DF" | grep -oE 'AS [a-zA-Z0-9_-]+' | awk '{print $2}' | grep -v '^builder$' | while read stage; do
-                echo "FROM debian:bookworm-slim AS $stage"
-                echo "RUN mkdir -p /build/target/release"
-                echo "COPY .pre-built/* /build/target/release/"
-              done
-              cat Dockerfile.ci
-            } > Dockerfile.final
-            docker build -t openab-test${{ matrix.variant.suffix }} -f Dockerfile.final .
+            BUILD_CONTEXTS="--build-context builder=.fake-builder"
+
+            # Handle additional named Rust stages (e.g. adapter-builder)
+            grep -i '^FROM rust' "$DF" | sed -n 's/.*AS \([a-zA-Z0-9_-]*\).*/\1/p' | grep -v '^builder$' | while read stage; do
+              mkdir -p ".fake-${stage}/build/target/release"
+              cp .pre-built/* ".fake-${stage}/build/target/release/"
+              echo "--build-context ${stage}=.fake-${stage}"
+            done > /tmp/extra-contexts.txt
+
+            if [ -s /tmp/extra-contexts.txt ]; then
+              BUILD_CONTEXTS="$BUILD_CONTEXTS $(cat /tmp/extra-contexts.txt | tr '\n' ' ')"
+            fi
+
+            docker buildx build $BUILD_CONTEXTS -t openab-test${{ matrix.variant.suffix }} -f "$DF" .
           else
-            docker build -t openab-test${{ matrix.variant.suffix }} -f "$DF" .
+            docker buildx build -t openab-test${{ matrix.variant.suffix }} -f "$DF" .
           fi
 
       - name: Verify openab CMD does not crash


### PR DESCRIPTION
## Summary

Replace the fragile sed/awk-based Dockerfile rewriting in `docker-smoke-test.yml` with Docker BuildKit `--build-context` overrides.

## What changed

The "Build image (skip Rust compilation)" step now:
1. Creates `.fake-builder/build/target/release/openab` with the pre-built binary
2. Passes `--build-context builder=.fake-builder` to `docker buildx build`
3. Automatically detects additional named Rust stages (e.g. `adapter-builder` in `Dockerfile.antigravity`) and overrides them too

Docker BuildKit completely skips the original `FROM rust` stages when a `--build-context` override is provided, using our fake directory as the stage context instead.

## Before (sed/awk rewriting)
- `awk` strips all `FROM rust` stages from the Dockerfile
- Stub stages are prepended manually
- Broke on multi-stage builds (antigravity)
- Generates temp Dockerfile.ci / Dockerfile.final

## After (--build-context)
- Zero Dockerfile modifications
- Multi-stage builds work natively
- BuildKit fully skips Rust stages
- 19 lines vs 22 lines, simpler logic

## Testing

CI will validate this on all 12 Dockerfile variants in the matrix.

Fixes #986