### PR TITLE
ci: fix agy-acp binary artifact collision with source directory

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -15,9 +15,10 @@ jobs:
 
       - name: Build openab binary (once)
         run: |
+          mkdir -p .binaries
           DOCKER_BUILDKIT=1 docker build --target builder -t openab-builder -f Dockerfile .
           CID=$(docker create openab-builder)
-          docker cp "$CID:/build/target/release/openab" openab
+          docker cp "$CID:/build/target/release/openab" .binaries/openab
           docker rm "$CID"
 
       - name: Build agy-acp adapter (for Dockerfile.antigravity)
@@ -25,7 +26,7 @@ jobs:
           if [ -f Dockerfile.antigravity ]; then
             DOCKER_BUILDKIT=1 docker build --target adapter-builder -t agy-acp-builder -f Dockerfile.antigravity .
             CID=$(docker create agy-acp-builder)
-            docker cp "$CID:/build/target/release/agy-acp" agy-acp
+            docker cp "$CID:/build/target/release/agy-acp" .binaries/agy-acp
             docker rm "$CID"
           fi
 
@@ -33,9 +34,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: openab-binary
-          path: |
-            openab
-            agy-acp
+          path: .binaries/
           retention-days: 1
 
   smoke-test:


### PR DESCRIPTION
## Problem

The `build-binary` job does:
```bash
docker cp "$CID:/build/target/release/agy-acp" agy-acp
```

But `agy-acp/` already exists as a **source directory** in the repo checkout. When `docker cp` targets a path that's already a directory, it copies the file *into* it as `agy-acp/agy-acp` rather than creating a file at that path.

Then `upload-artifact` with `path: agy-acp` uploads the entire directory (source code + nested binary). On download to `.pre-built/`, `agy-acp` is a directory — not a binary. The `COPY --from=adapter-builder` succeeds (copies a directory) but `which agy-acp` fails because it's not an executable file.

This is why the antigravity smoke test fails with:
```
docker run --rm --entrypoint which openab-test-antigravity agy-acp
Process completed with exit code 1
```

## Fix

Stage all binaries into a dedicated `.binaries/` directory before uploading, avoiding name collisions with any repo directories.

## Related

- Failing run: https://github.com/openabdev/openab/actions/runs/26877770169/job/79270216936
- PR #985 (triggered the failing CI)