### PR TITLE
fix(gateway): ignore unsupported LINE reaction commands

### DIFF
--- a/gateway/src/adapters/line.rs
+++ b/gateway/src/adapters/line.rs
@@ -196,6 +196,14 @@ pub async fn dispatch_line_reply(
     reply: &GatewayReply,
     api_base: &str,
 ) -> bool {
+    if matches!(
+        reply.command.as_deref(),
+        Some("add_reaction") | Some("remove_reaction") | Some("create_topic")
+    ) {
+        info!(command = ?reply.command.as_deref(), "line: ignoring unsupported command");
+        return false;
+    }
+
     // Extract token from cache (drop lock before HTTP call)
     let cached_token = {
         let mut cache = reply_cache.lock().unwrap_or_else(|e| e.into_inner());

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -532,44 +532,48 @@ mod tests {
         assert!(used, "should report Reply API was used");
     }
 
-    /// Unsupported LINE commands should be ignored and must not consume the cached reply token.
+    /// All unsupported LINE commands should be ignored without consuming the cached reply token.
     #[tokio::test]
-    async fn line_ignores_reaction_commands_without_touching_cache() {
-        let server = MockServer::start().await;
-        let _reply = Mock::given(method("POST"))
-            .and(path("/v2/bot/message/reply"))
-            .respond_with(ResponseTemplate::new(200))
-            .expect(0)
-            .mount_as_scoped(&server)
+    async fn line_ignores_unsupported_commands_without_touching_cache() {
+        let unsupported = &["add_reaction", "remove_reaction", "create_topic"];
+
+        for cmd in unsupported {
+            let server = MockServer::start().await;
+            let _reply = Mock::given(method("POST"))
+                .and(path("/v2/bot/message/reply"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(0)
+                .mount_as_scoped(&server)
+                .await;
+            let _push = Mock::given(method("POST"))
+                .and(path("/v2/bot/message/push"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(0)
+                .mount_as_scoped(&server)
+                .await;
+
+            let cache = make_cache();
+            cache
+                .lock()
+                .unwrap()
+                .insert("evt_unsup".into(), ("tok_unsup".into(), Instant::now()));
+
+            let client = reqwest::Client::new();
+            let used = adapters::line::dispatch_line_reply(
+                &client,
+                "test_access_token",
+                &cache,
+                &make_reply_with_command("evt_unsup", cmd, "payload"),
+                &server.uri(),
+            )
             .await;
-        let _push = Mock::given(method("POST"))
-            .and(path("/v2/bot/message/push"))
-            .respond_with(ResponseTemplate::new(200))
-            .expect(0)
-            .mount_as_scoped(&server)
-            .await;
 
-        let cache = make_cache();
-        cache
-            .lock()
-            .unwrap()
-            .insert("evt_reaction".into(), ("tok_reaction".into(), Instant::now()));
-
-        let client = reqwest::Client::new();
-        let used = adapters::line::dispatch_line_reply(
-            &client,
-            "test_access_token",
-            &cache,
-            &make_reply_with_command("evt_reaction", "add_reaction", "👀"),
-            &server.uri(),
-        )
-        .await;
-
-        assert!(!used, "ignored LINE commands should not report reply usage");
-        assert!(
-            cache.lock().unwrap().contains_key("evt_reaction"),
-            "ignored LINE commands should not consume the cached reply token"
-        );
+            assert!(!used, "{cmd}: should not report reply usage");
+            assert!(
+                cache.lock().unwrap().contains_key("evt_unsup"),
+                "{cmd}: should not consume the cached reply token"
+            );
+        }
     }
 
     /// Cache miss: falls back to Push API with correct "to", bearer token, and message body.

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -466,6 +466,26 @@ mod tests {
         }
     }
 
+    fn make_reply_with_command(event_id: &str, command: &str, text: &str) -> schema::GatewayReply {
+        schema::GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: event_id.into(),
+            platform: "line".into(),
+            channel: schema::ReplyChannel {
+                id: "U1234".into(),
+                thread_id: None,
+            },
+            content: schema::Content {
+                content_type: "text".into(),
+                text: text.into(),
+                attachments: Vec::new(),
+            },
+            command: Some(command.into()),
+            request_id: None,
+            quote_message_id: None,
+        }
+    }
+
     fn make_cache() -> ReplyTokenCache {
         Arc::new(std::sync::Mutex::new(HashMap::new()))
     }
@@ -510,6 +530,46 @@ mod tests {
         .await;
 
         assert!(used, "should report Reply API was used");
+    }
+
+    /// Unsupported LINE commands should be ignored and must not consume the cached reply token.
+    #[tokio::test]
+    async fn line_ignores_reaction_commands_without_touching_cache() {
+        let server = MockServer::start().await;
+        let _reply = Mock::given(method("POST"))
+            .and(path("/v2/bot/message/reply"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount_as_scoped(&server)
+            .await;
+        let _push = Mock::given(method("POST"))
+            .and(path("/v2/bot/message/push"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount_as_scoped(&server)
+            .await;
+
+        let cache = make_cache();
+        cache
+            .lock()
+            .unwrap()
+            .insert("evt_reaction".into(), ("tok_reaction".into(), Instant::now()));
+
+        let client = reqwest::Client::new();
+        let used = adapters::line::dispatch_line_reply(
+            &client,
+            "test_access_token",
+            &cache,
+            &make_reply_with_command("evt_reaction", "add_reaction", "👀"),
+            &server.uri(),
+        )
+        .await;
+
+        assert!(!used, "ignored LINE commands should not report reply usage");
+        assert!(
+            cache.lock().unwrap().contains_key("evt_reaction"),
+            "ignored LINE commands should not consume the cached reply token"
+        );
     }
 
     /// Cache miss: falls back to Push API with correct "to", bearer token, and message body.


### PR DESCRIPTION
## What problem does this solve?

Closes #984

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1511661981508305027

LINE does not support message reactions, but the gateway currently forwards unsupported reaction commands like `add_reaction` as plain text replies. In practice that leaks reaction glyphs such as `👀` into LINE chats before the real assistant reply.

## At a Glance

```text
OpenAB core
  └─ sends GatewayReply(command="add_reaction", text="👀")
       └─ LINE gateway adapter
            ├─ before: sent "👀" as a normal LINE message
            └─ after: ignore unsupported command and keep reply token for the real reply
```

## Prior Art & Industry Research

Not applicable — this is a targeted gateway bug fix for one unsupported LINE behavior, not an architectural/runtime change. The existing OpenAB gateway adapters already establish the relevant local prior art: Google Chat and WeCom ignore unsupported reaction/topic commands, and Teams ignores unsupported reaction commands.

## Proposed Solution

Add an early command guard in `gateway/src/adapters/line.rs::dispatch_line_reply(...)` so LINE immediately ignores unsupported `add_reaction`, `remove_reaction`, and `create_topic` commands before touching the reply-token cache or calling the LINE API.

Add a regression test in `gateway/src/main.rs` that verifies:

- no Reply API request is sent
- no Push API request is sent
- the cached reply token remains available for the subsequent real reply

## Why this approach?

This keeps the fix local to the LINE gateway adapter, which is the layer that knows LINE cannot represent reactions or topics. It matches the existing adapter-specific pattern already used for unsupported commands on other gateway platforms and avoids broadening the scope into core reaction-policy changes.

Tradeoffs / limitations:

- this fixes the user-visible LINE bug without changing how core emits reaction commands
- a broader follow-up can still tighten `reactions.enabled = false` handling in core dispatch paths

## Alternatives Considered

1. Change core so it never emits reaction commands for LINE or when `reactions.enabled = false`.
   - Rejected for this PR because it is a broader P1 cleanup and not required to stop LINE from leaking reaction glyphs as messages.
2. Let LINE consume the reply token and silently no-op later.
   - Rejected because that risks degrading the real reply path; the adapter should bail out before token lookup.

## Validation

- [x] `cargo check` passes (`cd gateway && cargo check`)
- [x] `cargo test` passes (`cd gateway && cargo test`)
- [x] `cargo clippy` clean (`cd gateway && cargo clippy -- -D warnings`)
- [x] Manual testing — added a regression test that exercises an `add_reaction` gateway reply on LINE and confirms no LINE API call is made and the reply token stays cached
