### PR TITLE
fix(adapter): cut turn early after tool failure instead of hanging

### DIFF
--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -120,6 +120,9 @@ pub struct AcpConnection {
     pub config_options: Vec<ConfigOption>,
     pub last_active: Instant,
     pub session_reset: bool,
+    /// Set to true when the recv loop hard-timeout fires. Signals get_or_create
+    /// to kill this process and start a fresh session rather than reusing it.
+    pub force_recreate: bool,
     _reader_handle: JoinHandle<()>,
     _stderr_handle: Option<JoinHandle<()>>,
 }
@@ -411,6 +414,7 @@ impl AcpConnection {
             config_options: Vec::new(),
             last_active: Instant::now(),
             session_reset: false,
+            force_recreate: false,
             _reader_handle: reader_handle,
             _stderr_handle: stderr_handle,
         })

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -128,10 +128,15 @@ impl SessionPool {
         let mut saved_session_id = saved_session_id;
         if let Some(conn) = existing.clone() {
             let conn = conn.lock().await;
-            if conn.alive() {
+            if conn.alive() && !conn.force_recreate {
                 return Ok(());
             }
-            if saved_session_id.is_none() {
+            if conn.force_recreate {
+                // Hard timeout fired: kill this process and start a completely
+                // fresh session. Don't load the old session_id — it may have
+                // pending background work that caused the timeout in the first place.
+                warn!(thread_id, "force_recreate set after hard timeout, discarding stuck session");
+            } else if saved_session_id.is_none() {
                 saved_session_id = conn.acp_session_id.clone();
             }
         }
@@ -220,7 +225,7 @@ impl SessionPool {
             let Ok(existing) = existing.try_lock() else {
                 return Ok(());
             };
-            if existing.alive() {
+            if existing.alive() && !existing.force_recreate {
                 return Ok(());
             }
             warn!(thread_id, "stale connection, rebuilding");

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -214,6 +214,8 @@ pub enum AcpEvent {
         id: String,
         title: String,
         status: String,
+        /// Captured from rawOutput.aggregated_output (codex-acp) on failure.
+        output: Option<String>,
     },
     ConfigUpdate {
         options: Vec<ConfigOption>,
@@ -265,10 +267,21 @@ pub fn classify_notification(msg: &JsonRpcMessage) -> Option<AcpEvent> {
                 .unwrap_or("")
                 .to_string();
             if status == "completed" || status == "failed" {
+                let output = if status == "failed" {
+                    update
+                        .get("rawOutput")
+                        .and_then(|r| r.get("aggregated_output"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                } else {
+                    None
+                };
                 Some(AcpEvent::ToolDone {
                     id: tool_id,
                     title,
                     status,
+                    output,
                 })
             } else {
                 Some(AcpEvent::ToolStart { id: tool_id, title })

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -529,6 +529,9 @@ impl AdapterRouter {
                     // messages and abandons cleanly on dead agent / hard ceiling
                     // so late responses cannot leak into the next prompt.
                     let mut response_error: Option<String> = None;
+                    let mut last_tool_failure: Option<(String, String)> = None; // (title, output)
+                    let mut tool_failure_deadline: Option<tokio::time::Instant> = None;
+                    let tool_failure_grace = std::time::Duration::from_secs(90);
                     let prompt_start = tokio::time::Instant::now();
                     loop {
                         let notification = tokio::select! {
@@ -543,11 +546,38 @@ impl AdapterRouter {
                                     conn.abandon_request(request_id).await;
                                     break;
                                 }
+                                // If a tool failed and the agent hasn't streamed any
+                                // text within the grace window, cut early instead of
+                                // waiting the full hard timeout.
+                                if let Some(deadline) = tool_failure_deadline {
+                                    if tokio::time::Instant::now() >= deadline {
+                                        let (title, output) = last_tool_failure.as_ref().unwrap();
+                                        response_error = Some(if output.is_empty() {
+                                            format!("Tool failed: `{title}`")
+                                        } else {
+                                            format!(
+                                                "Tool failed: `{title}`\n```\n{}\n```",
+                                                output.chars().take(400).collect::<String>()
+                                            )
+                                        });
+                                        conn.force_recreate = true;
+                                        conn.abandon_request(request_id).await;
+                                        break;
+                                    }
+                                }
                                 if prompt_start.elapsed() > prompt_hard_timeout {
-                                    response_error = Some(format!(
+                                    let base = format!(
                                         "Agent exceeded hard timeout ({}s)",
                                         prompt_hard_timeout.as_secs(),
-                                    ));
+                                    );
+                                    response_error = Some(match &last_tool_failure {
+                                        Some((title, output)) => format!(
+                                            "{base}\nLast failed tool: `{title}`\n```\n{}\n```",
+                                            output.chars().take(400).collect::<String>()
+                                        ),
+                                        None => base,
+                                    });
+                                    conn.force_recreate = true;
                                     conn.abandon_request(request_id).await;
                                     break;
                                 }
@@ -572,6 +602,8 @@ impl AdapterRouter {
                         if let Some(event) = classify_notification(&notification) {
                             match event {
                                 AcpEvent::Text(t) => {
+                                    // Agent is responding — cancel any tool-failure early-exit deadline.
+                                    tool_failure_deadline = None;
                                     text_buf.push_str(&t);
                                     if let Some(tx) = &buf_tx {
                                         let _ = tx.send(compose_display(
@@ -607,11 +639,16 @@ impl AdapterRouter {
                                         ));
                                     }
                                 }
-                                AcpEvent::ToolDone { id, title, status } => {
+                                AcpEvent::ToolDone { id, title, status, output } => {
                                     reactions.set_thinking().await;
                                     let new_state = if status == "completed" {
                                         ToolState::Completed
                                     } else {
+                                        let out = output.unwrap_or_default();
+                                        last_tool_failure = Some((title.clone(), out));
+                                        tool_failure_deadline = Some(
+                                            tokio::time::Instant::now() + tool_failure_grace
+                                        );
                                         ToolState::Failed
                                     };
                                     if let Some(slot) = tool_lines.iter_mut().find(|e| e.id == id) {
@@ -669,6 +706,7 @@ impl AdapterRouter {
                     };
 
                     let final_content = markdown::convert_tables(&final_content, table_mode);
+                    tracing::debug!(content_len = final_content.len(), content_preview = &final_content[..final_content.len().min(80)], "final content before chunking");
                     let chunks = format::split_message(&final_content, message_limit);
                     if let Some(msg) = placeholder_msg {
                         if let Some(ref reply_id) = directives.reply_to {
@@ -701,10 +739,16 @@ impl AdapterRouter {
                         } else {
                             // Normal streaming: edit first chunk into placeholder, send rest
                             if let Some(first) = chunks.first() {
-                                let _ = adapter.edit_message(&msg, first).await;
+                                if let Err(e) = adapter.edit_message(&msg, first).await {
+                                    tracing::warn!(error = ?e, content_len = first.len(), "final edit_message failed");
+                                }
+                            } else {
+                                tracing::warn!("final chunks empty, nothing to edit into placeholder");
                             }
                             for chunk in chunks.iter().skip(1) {
-                                let _ = adapter.send_message(&thread_channel, chunk).await;
+                                if let Err(e) = adapter.send_message(&thread_channel, chunk).await {
+                                    tracing::warn!(error = ?e, "overflow chunk send_message failed");
+                                }
                             }
                         }
                     } else {


### PR DESCRIPTION
## Problem

When a tool call fails (e.g. DNS error, auth error), the agent makes an OpenAI API call to generate an error explanation. If the session has **large context** (loaded via `session/load` from a previous run), this API call can take **5+ minutes**, and during this time **all subsequent messages in the thread are silently dropped**.

### Root Cause

The recv loop in `stream_prompt_blocks` holds `with_connection`'s mutex for the entire prompt duration. A hung OpenAI call means no subsequent `get_or_create` can acquire the lock for that thread — messages queue up but never get dispatched.

### How to Reproduce

1. Start openab with `session/load` enabled (default) so the agent resumes a previous session with conversation history
2. In a Discord thread, send a command that runs a tool which will fail due to network/auth issues (e.g. `gmail triage` without `gws auth login`, or `ping -c 1 wrongdns.com`)
3. The bot shows the tool running (🔥 reaction) then the tool fails (✗ in display)
4. Send any follow-up message — **no response, ever**, even after 30 minutes

The larger the loaded session context, the slower the agent's OpenAI error-handling call, making the hang more likely to exceed the old 30-minute hard timeout.

## Fix

### 1. 90-second grace period after tool failure (`src/adapter.rs`)

When a `tool_call_update` with `status: "failed"` arrives, start a 90-second deadline. If no agent text chunk arrives within that window, cut the turn early and surface the raw tool error to the user instead of waiting for the hard timeout.

The deadline is cleared if the agent starts streaming text — allowing normal completion when the agent responds quickly (as it does with small context).

### 2. `force_recreate` flag (`src/acp/connection.rs`, `src/acp/pool.rs`)

When cutting early (grace period or hard timeout), mark the connection `force_recreate = true`. The next `get_or_create` for that thread will spawn a fresh agent process and call `session/new` instead of reusing the stuck process or resuming the same session via `session/load` (which would likely re-trigger the same hang).

### 3. Capture `rawOutput.aggregated_output` (`src/acp/protocol.rs`)

Extended `AcpEvent::ToolDone` to include the tool's raw output on failure (from `rawOutput.aggregated_output` in `tool_call_update`). This makes the error message shown to users actionable:

```
Tool failed: `ping -c 1 wrongdns.com`
\`\`\`
ping: wrongdns.com: Temporary failure in name resolution
\`\`\`
```

### 4. Reduce default `prompt_hard_timeout` from 30min → 5min (`src/config.rs`)

As a safety net for cases where no tool failed but the agent hangs (e.g. very long thinking). Still configurable via `[pool] prompt_hard_timeout_secs`.

## Behavior After Fix

| Scenario | Before | After |
|---|---|---|
| Tool fails, agent responds quickly | ✅ Works | ✅ Works (grace period cleared by text) |
| Tool fails, agent hangs (large context) | ❌ Silent for 30min | ✅ Error shown in ~90s |
| Follow-up message after hang | ❌ Never delivered | ✅ Fresh session, responds normally |