### PR TITLE
fix(openab-agent): default OpenAI model to gpt-5.4-mini

### DIFF
--- a/docs/native-agent.md
+++ b/docs/native-agent.md
@@ -31,7 +31,7 @@ env = { OPENAB_AGENT_OPENAI_MODEL = "gpt-5.4-mini" }
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENAB_AGENT_OPENAI_MODEL` | `gpt-4.1-nano` | Model to use |
+| `OPENAB_AGENT_OPENAI_MODEL` | `gpt-5.4-mini` | Model to use (must be supported by your ChatGPT plan — see [Supported Models](#supported-models-chatgpt-subscription)) |
 | `OPENAB_AGENT_OPENAI_BASE_URL` | `https://chatgpt.com/backend-api` | API base URL |
 | `OPENAB_AGENT_PROVIDER` | auto-detect | Force provider (`anthropic`, `openai`, `codex`) |
 | `OPENAB_AGENT_MAX_TOKENS` | `8192` | Max output tokens |

--- a/openab-agent/src/llm.rs
+++ b/openab-agent/src/llm.rs
@@ -265,7 +265,7 @@ impl OpenAiProvider {
                 .unwrap_or_else(|_| "https://chatgpt.com/backend-api".to_string()),
             model: std::env::var("OPENAB_AGENT_OPENAI_MODEL")
                 .or_else(|_| std::env::var("OPENAB_AGENT_MODEL"))
-                .unwrap_or_else(|_| "gpt-4.1-nano".to_string()),
+                .unwrap_or_else(|_| "gpt-5.4-mini".to_string()),
             max_tokens: std::env::var("OPENAB_AGENT_MAX_TOKENS")
                 .ok()
                 .and_then(|v| v.parse().ok())


### PR DESCRIPTION
## Summary

- `OpenAiProvider::from_auth_store()` falls back to `gpt-4.1-nano` when neither `OPENAB_AGENT_OPENAI_MODEL` nor `OPENAB_AGENT_MODEL` is set. That model is not in the ChatGPT subscription supported list documented in `docs/native-agent.md` (`gpt-5.2`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`), so on Plus/Pro accounts the request fails inside the codex backend and the user sees a generic JSON-RPC `-32603 Internal error` in Discord — exactly the symptom that #885 was already trying to expose.
- Change the fallback to `gpt-5.4-mini`. It is supported on both Plus and Pro plans, and it is already the example value shown in `docs/native-agent.md` (`env = { OPENAB_AGENT_OPENAI_MODEL = \"gpt-5.4-mini\" }`), so the default now matches the documented happy path. Anthropic provider default is untouched.
- Updated the env-var table in `docs/native-agent.md` to reflect the new default and to point at the Supported Models section so users don't accidentally pick an unsupported model.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1511790012620865666

### Context

Triaged in a Discord thread today: a Plus user removed `OPENAB_AGENT_OPENAI_MODEL` from their config to simplify setup and started hitting `-32603` again. Even with #885 merged, the codex backend returned no `error.data.message`, so the bridge had nothing to surface. Root cause is the default itself rather than the error-surfacing path.

## Test plan

- [x] `cargo build` in `openab-agent/` — clean
- [x] `cargo test llm::` in `openab-agent/` — 6/6 pass
- [x] Confirmed the unrelated `acp::tests::test_session_new` failure also reproduces on `origin/main` — pre-existing, not introduced here
- [ ] Manual: run `openab-agent` with no model env var on a Plus account and verify it does not return `-32603`