### PR TITLE
fix(acp): surface nested JSON-RPC error details

### DIFF
--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -72,12 +72,41 @@ impl JsonRpcError {
             .and_then(|d| d.get("message"))
             .and_then(|m| m.as_str())
     }
+
+    /// Extract the most useful user-facing detail from `error.data`.
+    ///
+    /// codex-acp may put a JSON-encoded upstream error inside
+    /// `error.data.message`. When that shape is present, prefer the nested
+    /// `error.message`; if parsing fails, fall back to the original string.
+    pub fn user_detail(&self) -> Option<String> {
+        let data = self.data.as_ref()?;
+
+        if let Some(message) = self.data_message() {
+            return Some(extract_nested_error_message(message).unwrap_or_else(|| message.into()));
+        }
+
+        data.get("details")
+            .and_then(|d| d.as_str())
+            .map(str::to_owned)
+    }
+}
+
+fn extract_nested_error_message(message: &str) -> Option<String> {
+    let parsed: Value = serde_json::from_str(message).ok()?;
+
+    parsed
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(|m| m.as_str())
+        .or_else(|| parsed.get("message").and_then(|m| m.as_str()))
+        .filter(|m| !m.is_empty())
+        .map(str::to_owned)
 }
 
 impl std::fmt::Display for JsonRpcError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "JSON-RPC error {}: {}", self.code, self.message)?;
-        if let Some(detail) = self.data_message() {
+        if let Some(detail) = self.user_detail() {
             write!(f, " — {detail}")?;
         }
         Ok(())
@@ -402,5 +431,45 @@ mod tests {
         let opts = parse_config_options(&result);
         assert_eq!(opts.len(), 1);
         assert_eq!(opts[0].id, "model");
+    }
+
+    #[test]
+    fn user_detail_extracts_codex_nested_error_message() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({
+                "message": "{\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"model not supported\"}}",
+                "codex_error_info": "other"
+            })),
+        };
+
+        assert_eq!(err.user_detail().as_deref(), Some("model not supported"));
+    }
+
+    #[test]
+    fn user_detail_falls_back_to_raw_message_when_nested_json_parse_fails() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({
+                "message": "plain upstream error"
+            })),
+        };
+
+        assert_eq!(err.user_detail().as_deref(), Some("plain upstream error"));
+    }
+
+    #[test]
+    fn user_detail_uses_details_when_message_is_absent() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({
+                "details": "gateway disconnected"
+            })),
+        };
+
+        assert_eq!(err.user_detail().as_deref(), Some("gateway disconnected"));
     }
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -39,7 +39,12 @@ pub fn parse_output_directives(content: &str) -> (OutputDirectives, String) {
                         "reply_to" => {
                             let v = value.trim();
                             // Validate: non-empty, reasonable length, no whitespace/control chars
-                            if !v.is_empty() && v.len() <= 64 && v.chars().all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_') {
+                            if !v.is_empty()
+                                && v.len() <= 64
+                                && v.chars().all(|c| {
+                                    c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_'
+                                })
+                            {
                                 directives.reply_to = Some(v.to_string());
                             }
                         }
@@ -564,7 +569,12 @@ impl AdapterRouter {
                                 continue;
                             }
                             if let Some(ref err) = notification.error {
-                                response_error = Some(format_coded_error(err.code, &err.message, err.data_message()));
+                                let detail = err.user_detail();
+                                response_error = Some(format_coded_error(
+                                    err.code,
+                                    &err.message,
+                                    detail.as_deref(),
+                                ));
                             }
                             break;
                         }


### PR DESCRIPTION
## What problem does this solve?

Closes #998
Related #1000

When codex-acp returns JSON-RPC `-32603`, OpenAB currently surfaces the top-level `error.message`, which is often only `Internal error`. In Codex failures, the actionable upstream message can be nested inside `error.data.message` as a JSON-encoded string, so users cannot see the real cause without DEBUG `acp_recv` logs.

Discord Discussion URL: https://discordapp.com/channels/1491295327620169908/1511790012620865666

## At a Glance

```text
ACP response
  error.code = -32603
  error.message = "Internal error"
  error.data.message = "{\"error\":{\"message\":\"real cause\"}}"
        |
        v
JsonRpcError::user_detail()
        |
        v
format_coded_error(...)
        |
        v
User sees the real upstream message when available
```

## Prior Art & Industry Research

Not applicable - targeted bug fix to existing error-display behavior. This does not change architecture, runtime model, agent lifecycle, scheduling, delivery, or persistence.

**OpenClaw:**
Not applicable for this small parser/display fix. #1000 notes similar `-32603` UX issues in OpenClaw, but this PR only preserves OpenAB's existing JSON-RPC flow and extracts already-received structured data.

**Hermes Agent:**
Not applicable for this small parser/display fix. No gateway architecture or message-delivery behavior changes are introduced.

**Other references:**
- #885 added `error.data` capture and display support.
- #998 provides the Codex nested JSON error shape.
- #1000 discusses broader classification for `-32603` errors.

## Proposed Solution

Add `JsonRpcError::user_detail()` to extract the most useful user-facing detail from `error.data`.

The method:
- prefers `error.data.message`
- if that message is JSON-encoded, extracts nested `error.message`
- falls back to the original `data.message` when parsing fails
- falls back to `data.details` when `message` is absent

`adapter.rs` now passes this extracted detail into `format_coded_error()`.

## Why this approach?

This keeps the fix at the ACP error boundary where the structured JSON-RPC payload is still available. It is backward-compatible: unknown formats and parse failures fall back to the existing raw `data.message` behavior.

It also keeps #1000's future classifier possible, because the classifier can operate on the real upstream message instead of only `Internal error`.

## Alternatives Considered

1. Change codex-acp to emit a different JSON-RPC code.
   Not practical; OpenAB should handle agent SDK output defensively.

2. Only classify `-32603` by top-level message text.
   Insufficient for #998 because the top-level message is only `Internal error`.

3. Display the full raw `error.data` object.
   More noisy and more likely to leak implementation details. Extracting the human-facing nested message is cleaner.

## Validation

Rust changes:
- [x] `cargo check` passes
- [x] `cargo test` passes, including new tests
- [x] `cargo clippy` clean

Manual testing:
- [x] Ran Docker-based validation in `rust:1-bookworm`
- [x] `cargo check` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `cargo test` passed: 428 passed
- [x] Docker runs used `--rm`; verified no `rust:1-bookworm` containers remained

Note: full `cargo fmt --check` is currently blocked by pre-existing formatting drift outside this PR. The modified files were checked with `rustfmt --edition 2021 --check`.
