### PR TITLE
fix(acp): capture missing error diagnostics

### DIFF
--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -3,14 +3,17 @@ use crate::acp::protocol::{
 };
 use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin};
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
+
+const DIAGNOSTIC_LINE_LIMIT: usize = 8;
+const DIAGNOSTIC_LINE_MAX_CHARS: usize = 2_000;
 
 /// Pick the most permissive selectable permission option from ACP options.
 fn pick_best_option(options: &[Value]) -> Option<String> {
@@ -115,6 +118,7 @@ pub struct AcpConnection {
     next_id: AtomicU64,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<JsonRpcMessage>>>>,
     notify_tx: Arc<Mutex<Option<mpsc::UnboundedSender<JsonRpcMessage>>>>,
+    diagnostics: Arc<Mutex<AgentDiagnostics>>,
     pub acp_session_id: Option<String>,
     pub supports_load_session: bool,
     pub config_options: Vec<ConfigOption>,
@@ -122,6 +126,62 @@ pub struct AcpConnection {
     pub session_reset: bool,
     _reader_handle: JoinHandle<()>,
     _stderr_handle: Option<JoinHandle<()>>,
+}
+
+#[derive(Default)]
+pub(crate) struct AgentDiagnostics {
+    stderr: VecDeque<String>,
+    malformed_stdout: VecDeque<String>,
+}
+
+#[derive(Default)]
+struct AgentDiagnosticSnapshot {
+    stderr: Vec<String>,
+    malformed_stdout: Vec<String>,
+}
+
+impl AgentDiagnostics {
+    fn push_stderr(&mut self, line: String) {
+        push_limited(&mut self.stderr, line);
+    }
+
+    fn push_malformed_stdout(&mut self, line: String) {
+        push_limited(&mut self.malformed_stdout, line);
+    }
+
+    fn snapshot(&self) -> AgentDiagnosticSnapshot {
+        AgentDiagnosticSnapshot {
+            stderr: self.stderr.iter().cloned().collect(),
+            malformed_stdout: self.malformed_stdout.iter().cloned().collect(),
+        }
+    }
+}
+
+impl AgentDiagnosticSnapshot {
+    fn is_empty(&self) -> bool {
+        self.stderr.is_empty() && self.malformed_stdout.is_empty()
+    }
+}
+
+fn push_limited(lines: &mut VecDeque<String>, line: String) {
+    if lines.len() == DIAGNOSTIC_LINE_LIMIT {
+        lines.pop_front();
+    }
+    lines.push_back(line);
+}
+
+fn sanitize_diagnostic_line(line: &str) -> String {
+    let mut out = String::new();
+    for ch in line.trim().chars() {
+        if out.len() >= DIAGNOSTIC_LINE_MAX_CHARS {
+            out.push_str("...");
+            break;
+        }
+        if !ch.is_control() || ch == '\t' {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 /// Build the final set of env vars for the agent subprocess.
@@ -160,6 +220,7 @@ pub(crate) async fn run_reader_loop<R, W>(
     writer: Arc<Mutex<W>>,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<JsonRpcMessage>>>>,
     notify_tx: Arc<Mutex<Option<mpsc::UnboundedSender<JsonRpcMessage>>>>,
+    diagnostics: Arc<Mutex<AgentDiagnostics>>,
 ) where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
@@ -178,7 +239,18 @@ pub(crate) async fn run_reader_loop<R, W>(
         }
         let msg: JsonRpcMessage = match serde_json::from_str(line.trim()) {
             Ok(m) => m,
-            Err(_) => continue,
+            Err(e) => {
+                let sanitized = sanitize_diagnostic_line(&line);
+                if !sanitized.is_empty() {
+                    warn!(
+                        parse_error = %e,
+                        line = %sanitized,
+                        "agent stdout was not valid JSON-RPC"
+                    );
+                    diagnostics.lock().await.push_malformed_stdout(sanitized);
+                }
+                continue;
+            }
         };
         debug!(line = line.trim(), "acp_recv");
 
@@ -356,11 +428,13 @@ impl AcpConnection {
         let stdout = proc.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
         let stdin = proc.stdin.take().ok_or_else(|| anyhow!("no stdin"))?;
         let stdin = Arc::new(Mutex::new(stdin));
+        let diagnostics = Arc::new(Mutex::new(AgentDiagnostics::default()));
 
         // Capture agent stderr and log it (ACP spec: agents MAY write to stderr
         // for logging; clients MAY capture or ignore it).
         let stderr_handle = if let Some(stderr) = proc.stderr.take() {
             let cmd_name = command.to_string();
+            let diagnostics = diagnostics.clone();
             Some(tokio::spawn(async move {
                 let mut reader = BufReader::new(stderr);
                 let mut line = String::new();
@@ -369,14 +443,10 @@ impl AcpConnection {
                     match reader.read_line(&mut line).await {
                         Ok(0) => break,
                         Ok(_) => {
-                            let trimmed = line.trim();
-                            if !trimmed.is_empty() {
-                                let sanitized: String = trimmed.chars()
-                                    .filter(|c| !c.is_control() || *c == '\t')
-                                    .collect();
-                                if !sanitized.is_empty() {
-                                    tracing::warn!(agent = %cmd_name, "{sanitized}");
-                                }
+                            let sanitized = sanitize_diagnostic_line(&line);
+                            if !sanitized.is_empty() {
+                                tracing::warn!(agent = %cmd_name, "{sanitized}");
+                                diagnostics.lock().await.push_stderr(sanitized);
                             }
                         }
                         Err(_) => break,
@@ -397,6 +467,7 @@ impl AcpConnection {
             stdin.clone(),
             pending.clone(),
             notify_tx.clone(),
+            diagnostics.clone(),
         ));
 
         Ok(Self {
@@ -406,6 +477,7 @@ impl AcpConnection {
             next_id: AtomicU64::new(1),
             pending,
             notify_tx,
+            diagnostics,
             acp_session_id: None,
             supports_load_session: false,
             config_options: Vec::new(),
@@ -638,6 +710,26 @@ impl AcpConnection {
         !self._reader_handle.is_finished()
     }
 
+    pub async fn log_diagnostics(&self, reason: &str, request_id: Option<u64>) {
+        let snapshot = self.diagnostics.lock().await.snapshot();
+        if snapshot.is_empty() {
+            error!(
+                reason,
+                ?request_id,
+                "agent request failed without JSON-RPC error"
+            );
+            return;
+        }
+
+        error!(
+            reason,
+            ?request_id,
+            recent_stderr = ?snapshot.stderr,
+            recent_malformed_stdout = ?snapshot.malformed_stdout,
+            "agent request failed without JSON-RPC error"
+        );
+    }
+
     /// Resume a previous session by ID. Returns Ok(()) if the agent accepted
     /// the load, or an error if it failed (caller should fall back to session/new).
     pub async fn session_load(&mut self, session_id: &str, cwd: &str) -> Result<()> {
@@ -856,6 +948,7 @@ mod reader_loop_tests {
             Arc::new(Mutex::new(HashMap::new()));
         let notify_tx: Arc<Mutex<Option<mpsc::UnboundedSender<JsonRpcMessage>>>> =
             Arc::new(Mutex::new(None));
+        let diagnostics = Arc::new(Mutex::new(AgentDiagnostics::default()));
 
         let (sub_tx, mut sub_rx) = mpsc::unbounded_channel();
         *notify_tx.lock().await = Some(sub_tx);
@@ -866,19 +959,17 @@ mod reader_loop_tests {
             writer,
             pending.clone(),
             notify_tx.clone(),
+            diagnostics,
         ));
 
         let stale = b"{\"jsonrpc\":\"2.0\",\"id\":42,\"result\":{\"stopReason\":\"ok\"}}\n";
         agent_stdout_writer.write_all(stale).await.unwrap();
         agent_stdout_writer.flush().await.unwrap();
 
-        let forwarded = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            sub_rx.recv(),
-        )
-        .await
-        .expect("subscriber should receive stale message before timeout")
-        .expect("subscriber channel should not be closed");
+        let forwarded = tokio::time::timeout(std::time::Duration::from_secs(2), sub_rx.recv())
+            .await
+            .expect("subscriber should receive stale message before timeout")
+            .expect("subscriber channel should not be closed");
         assert_eq!(forwarded.id, Some(42));
         assert!(pending.lock().await.is_empty());
 
@@ -899,6 +990,7 @@ mod reader_loop_tests {
             Arc::new(Mutex::new(HashMap::new()));
         let notify_tx: Arc<Mutex<Option<mpsc::UnboundedSender<JsonRpcMessage>>>> =
             Arc::new(Mutex::new(None));
+        let diagnostics = Arc::new(Mutex::new(AgentDiagnostics::default()));
 
         let (resp_tx, resp_rx) = oneshot::channel();
         pending.lock().await.insert(7, resp_tx);
@@ -912,6 +1004,7 @@ mod reader_loop_tests {
             writer,
             pending.clone(),
             notify_tx.clone(),
+            diagnostics,
         ));
 
         let payload = b"{\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{\"stopReason\":\"end_turn\"}}\n";
@@ -933,5 +1026,38 @@ mod reader_loop_tests {
 
         drop(agent_stdout_writer);
         handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn malformed_stdout_is_recorded_in_diagnostics() {
+        let (mut agent_stdout_writer, agent_stdout_reader) = duplex(8 * 1024);
+        let (agent_stdin_writer, _agent_stdin_reader) = duplex(8 * 1024);
+
+        let pending: Arc<Mutex<HashMap<u64, oneshot::Sender<JsonRpcMessage>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let notify_tx: Arc<Mutex<Option<mpsc::UnboundedSender<JsonRpcMessage>>>> =
+            Arc::new(Mutex::new(None));
+        let diagnostics = Arc::new(Mutex::new(AgentDiagnostics::default()));
+
+        let writer = Arc::new(Mutex::new(agent_stdin_writer));
+        let handle = tokio::spawn(run_reader_loop(
+            agent_stdout_reader,
+            writer,
+            pending,
+            notify_tx,
+            diagnostics.clone(),
+        ));
+
+        agent_stdout_writer
+            .write_all(b"provider rejected request\n")
+            .await
+            .unwrap();
+        agent_stdout_writer.flush().await.unwrap();
+
+        drop(agent_stdout_writer);
+        handle.await.unwrap();
+
+        let snapshot = diagnostics.lock().await.snapshot();
+        assert_eq!(snapshot.malformed_stdout, vec!["provider rejected request"]);
     }
 }

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+const INTERNAL_ERROR_CHECK_LOGS: &str = "Internal error. Check OpenAB logs for details.";
+
 // --- Outgoing ---
 
 #[derive(Debug, Serialize)]
@@ -72,12 +74,76 @@ impl JsonRpcError {
             .and_then(|d| d.get("message"))
             .and_then(|m| m.as_str())
     }
+
+    /// Extract the most useful user-facing detail from `error.data`.
+    ///
+    /// Agents may put a JSON-encoded upstream error inside `error.data.message`.
+    /// When that shape is present, prefer the nested `error.message`. If the
+    /// nested payload cannot be parsed, log the raw value at ERROR level so the
+    /// details are not only visible in DEBUG `acp_recv` logs.
+    pub fn user_detail(&self) -> Option<String> {
+        let data = self.data.as_ref()?;
+
+        if let Some(message) = self.data_message() {
+            return Some(self.extract_message_detail(message));
+        }
+
+        data.get("details")
+            .and_then(|d| d.as_str())
+            .map(str::to_owned)
+    }
+
+    fn extract_message_detail(&self, message: &str) -> String {
+        if !looks_like_json(message) {
+            return message.into();
+        }
+
+        match extract_nested_error_message(message) {
+            Ok(Some(detail)) => detail,
+            Ok(None) => {
+                tracing::error!(
+                    code = self.code,
+                    error_message = %self.message,
+                    data_message = %message,
+                    "JSON-RPC error data.message contained JSON without a user-facing message"
+                );
+                INTERNAL_ERROR_CHECK_LOGS.into()
+            }
+            Err(err) => {
+                tracing::error!(
+                    code = self.code,
+                    error_message = %self.message,
+                    data_message = %message,
+                    parse_error = %err,
+                    "failed to parse JSON-RPC error data.message"
+                );
+                INTERNAL_ERROR_CHECK_LOGS.into()
+            }
+        }
+    }
+}
+
+fn looks_like_json(message: &str) -> bool {
+    let trimmed = message.trim_start();
+    trimmed.starts_with('{') || trimmed.starts_with('[')
+}
+
+fn extract_nested_error_message(message: &str) -> Result<Option<String>, serde_json::Error> {
+    let parsed: Value = serde_json::from_str(message)?;
+
+    Ok(parsed
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(|m| m.as_str())
+        .or_else(|| parsed.get("message").and_then(|m| m.as_str()))
+        .filter(|m| !m.is_empty())
+        .map(str::to_owned))
 }
 
 impl std::fmt::Display for JsonRpcError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "JSON-RPC error {}: {}", self.code, self.message)?;
-        if let Some(detail) = self.data_message() {
+        if let Some(detail) = self.user_detail() {
             write!(f, " — {detail}")?;
         }
         Ok(())
@@ -402,5 +468,63 @@ mod tests {
         let opts = parse_config_options(&result);
         assert_eq!(opts.len(), 1);
         assert_eq!(opts[0].id, "model");
+    }
+
+    #[test]
+    fn user_detail_extracts_nested_json_error_message() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({
+                "message": "{\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"model not supported\"}}"
+            })),
+        };
+
+        assert_eq!(err.user_detail().as_deref(), Some("model not supported"));
+    }
+
+    #[test]
+    fn user_detail_uses_raw_message_when_it_is_not_json() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({
+                "message": "plain upstream error"
+            })),
+        };
+
+        assert_eq!(err.user_detail().as_deref(), Some("plain upstream error"));
+    }
+
+    #[test]
+    fn user_detail_logs_json_parse_failure_and_shows_check_logs_message() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({
+                "message": "{\"error\":{\"message\":"
+            })),
+        };
+
+        assert_eq!(
+            err.user_detail().as_deref(),
+            Some(INTERNAL_ERROR_CHECK_LOGS)
+        );
+    }
+
+    #[test]
+    fn user_detail_logs_json_without_nested_message_and_shows_check_logs_message() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({
+                "message": "{\"error\":{\"type\":\"invalid_request_error\"}}"
+            })),
+        };
+
+        assert_eq!(
+            err.user_detail().as_deref(),
+            Some(INTERNAL_ERROR_CHECK_LOGS)
+        );
     }
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -11,6 +11,8 @@ use crate::format;
 use crate::markdown::{self, TableMode};
 use crate::reactions::StatusReactionController;
 
+const INTERNAL_ERROR_CHECK_LOGS: &str = "Internal error. Check OpenAB logs for details.";
+
 // --- Output directive parsing ---
 
 /// Parsed directives from agent output header block.
@@ -39,7 +41,12 @@ pub fn parse_output_directives(content: &str) -> (OutputDirectives, String) {
                         "reply_to" => {
                             let v = value.trim();
                             // Validate: non-empty, reasonable length, no whitespace/control chars
-                            if !v.is_empty() && v.len() <= 64 && v.chars().all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_') {
+                            if !v.is_empty()
+                                && v.len() <= 64
+                                && v.chars().all(|c| {
+                                    c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_'
+                                })
+                            {
                                 directives.reply_to = Some(v.to_string());
                             }
                         }
@@ -529,24 +536,34 @@ impl AdapterRouter {
                     // messages and abandons cleanly on dead agent / hard ceiling
                     // so late responses cannot leak into the next prompt.
                     let mut response_error: Option<String> = None;
+                    let mut failure_without_json_rpc: Option<String> = None;
                     let prompt_start = tokio::time::Instant::now();
                     loop {
                         let notification = tokio::select! {
                             msg = rx.recv() => match msg {
                                 Some(n) => n,
-                                // Reader saw EOF and already drained pending; nothing to abandon.
-                                None => break,
+                                None => {
+                                    // Reader saw EOF and already drained pending; no JSON-RPC
+                                    // error reached the adapter, so diagnostics are in logs.
+                                    response_error = Some(INTERNAL_ERROR_CHECK_LOGS.into());
+                                    failure_without_json_rpc = Some(
+                                        "agent connection closed before JSON-RPC response".into(),
+                                    );
+                                    break;
+                                }
                             },
                             _ = tokio::time::sleep(liveness_check_interval) => {
                                 if !conn.alive() {
-                                    response_error = Some("Agent process died".into());
+                                    response_error = Some(INTERNAL_ERROR_CHECK_LOGS.into());
+                                    failure_without_json_rpc = Some("agent process died".into());
                                     conn.abandon_request(request_id).await;
                                     break;
                                 }
                                 if prompt_start.elapsed() > prompt_hard_timeout {
-                                    response_error = Some(format!(
-                                        "Agent exceeded hard timeout ({}s)",
-                                        prompt_hard_timeout.as_secs(),
+                                    response_error = Some(INTERNAL_ERROR_CHECK_LOGS.into());
+                                    failure_without_json_rpc = Some(format!(
+                                        "agent exceeded hard timeout ({}s) without JSON-RPC response",
+                                        prompt_hard_timeout.as_secs()
                                     ));
                                     conn.abandon_request(request_id).await;
                                     break;
@@ -564,7 +581,12 @@ impl AdapterRouter {
                                 continue;
                             }
                             if let Some(ref err) = notification.error {
-                                response_error = Some(format_coded_error(err.code, &err.message, err.data_message()));
+                                let detail = err.user_detail();
+                                response_error = Some(format_coded_error(
+                                    err.code,
+                                    &err.message,
+                                    detail.as_deref(),
+                                ));
                             }
                             break;
                         }
@@ -641,6 +663,10 @@ impl AdapterRouter {
                                 _ => {}
                             }
                         }
+                    }
+
+                    if let Some(reason) = failure_without_json_rpc.as_deref() {
+                        conn.log_diagnostics(reason, Some(request_id)).await;
                     }
 
                     conn.prompt_done().await;


### PR DESCRIPTION
## What problem does this solve?

Closes #998
Related #1000

Discord Discussion URL: https://discordapp.com/channels/1491295327620169908/1511790012620865666

Some ACP agents return useful upstream failures as JSON-RPC errors, but others can fail before returning a structured JSON-RPC error at all. In those cases OpenAB may only see stderr, malformed stdout, EOF, process death, or a prompt timeout. Previously those clues were either only visible in DEBUG `acp_recv` logs, logged as isolated stderr lines, or silently ignored when stdout could not be parsed as JSON-RPC.

This makes production troubleshooting difficult because users in Discord/Slack see a generic failure without a request-level diagnostic summary in normal WARN/ERROR logs.

## At a Glance

```text
Agent stdout JSON-RPC error
  -> extract safe user-facing detail from error.data
  -> chat shows structured error/detail

Agent stderr / malformed stdout / EOF / process died / timeout
  -> capture recent diagnostics in AcpConnection
  -> ERROR log summarizes request failure and recent diagnostics
  -> chat shows "Internal error. Check OpenAB logs for details."
```

## Prior Art & Industry Research

Not applicable - targeted bug fix to existing ACP error handling. This does not change architecture, runtime model, agent lifecycle, scheduling, delivery, or persistence.

**OpenClaw:**
Not applicable for this parser/diagnostics fix. #1000 discusses broader `-32603` classification concerns, but this PR intentionally avoids assigning agent-specific meaning to JSON-RPC codes.

**Hermes Agent:**
Not applicable for this small ACP client-side error handling fix. No gateway or delivery semantics are changed.

**Other references:**
- #885 captured `error.data` from JSON-RPC errors.
- #998 shows a nested Codex upstream error inside `error.data.message`.
- #1000 raises the broader concern that `-32603` means different things across coding agents.

## Proposed Solution

Add a small rolling diagnostic buffer to `AcpConnection` for recent agent stderr and malformed stdout lines.

The reader loop now:
- logs malformed stdout at WARN instead of silently ignoring it
- stores sanitized recent malformed stdout
- stores sanitized recent stderr while preserving existing stderr WARN logging

The adapter now:
- keeps JSON-RPC errors on the structured `format_coded_error()` path
- treats EOF, process death, and hard timeout without a JSON-RPC error as missing structured ACP errors
- logs a request-level ERROR summary with recent diagnostics
- sends only a generic "check logs" message to Discord/Slack to avoid leaking raw provider output or local details

`JsonRpcError::user_detail()` also extracts nested `error.message` from JSON-encoded `error.data.message` when available, while falling back safely for normal plain-text messages.

## Why this approach?

This keeps JSON-RPC code semantics intact. OpenAB does not reinterpret `-32603` as a Codex-specific or agent-specific error. It only surfaces details already provided by the agent, and when the agent does not provide a structured JSON-RPC error, it records diagnostics at WARN/ERROR log levels so operators do not need DEBUG `acp_recv` logs to start investigation.

Raw stderr/stdout is not sent to chat because it can contain stack traces, local paths, provider responses, or account/auth hints.

## Alternatives Considered

1. Classify `-32603` by agent or message text.
   Rejected because different coding agents use `-32603` for different internal failures.

2. Send recent stderr/stdout directly to Discord/Slack.
   Rejected because raw agent output can leak sensitive or noisy implementation details.

3. Only parse nested `error.data.message`.
   Insufficient because some failures may never produce a JSON-RPC error.

## Validation

Rust changes:
- [x] `cargo check` passed in Docker
- [x] `cargo clippy -- -D warnings` passed in Docker
- [x] `cargo test` passed in Docker: 430 passed
- [x] targeted regression tests passed:
  - `cargo test malformed_stdout`
  - `cargo test user_detail`
- [x] `rustfmt --edition 2021 --check src/acp/protocol.rs src/acp/connection.rs src/adapter.rs` passed
- [x] Docker runs used `--rm`; no `rust:1-bookworm` containers remained

Note: Docker cargo updates the root package version in `Cargo.lock` due existing main-branch metadata drift; that unrelated lockfile change was reverted.
