### PR TITLE
fix(acp): unified stderr diagnostics with redaction for opaque -32603 errors

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -77,8 +77,7 @@ kubectl get pods -l app.kubernetes.io/name=openab -o jsonpath='{.items[0].spec.c
 ## Other categories
 
 - **Connection Lost** — agent process crashed mid-prompt. `kubectl logs` for the
-  broker will show `Agent process died` from the liveness check in
-  `AdapterRouter::stream_prompt_blocks`.
+  broker will show `Agent process died` from the broker's liveness check.
 - **Request Timeout** — agent didn't respond within 30s (or 120s for
   `session/new`). Either upstream is slow, agent is hung on a tool call, or
   the env config is wrong and initialization is looping.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,88 @@
+# Troubleshooting
+
+Diagnostic guide for OpenAB runtime issues. Most user-facing errors fall into one
+of the categories below.
+
+## `-32603 Internal Error` with no actionable detail
+
+### Symptom
+
+In Discord / Slack you see:
+
+```
+⚠️ **Internal Error** (code: -32603)
+Internal error
+```
+
+…but no further context, and `kubectl logs` show the same opaque message.
+
+### Why it happens
+
+JSON-RPC 2.0 §5.1 reserves `-32603` as the "Internal error" catch-all. ACP
+agents use it for wildly different failure modes (auth, model not supported,
+context overflow, crash). When the agent doesn't populate `error.data`, the
+client can only display the generic message.
+
+| Agent | `error.data` shape | Diagnostic source |
+|-------|-------------------|-------------------|
+| codex-acp | `{"message": "<nested JSON>"}` | `data.message` extracted + nested JSON unwrapped |
+| opencode | `{}` (empty) | **stderr tail** |
+| hermes-agent | absent | **stderr tail** |
+| claude-agent-acp | (varies) | `data.message` or stderr |
+
+Since OpenAB 0.8.4 (PR #885) the broker extracts `error.data.message` when
+present. Since 0.8.6, when `data` is empty/absent, the recent agent stderr is
+shown as a "Recent agent output:" blockquote (with secrets redacted).
+
+### Diagnostic path
+
+1. **Read the user-facing error first.** The stderr blockquote (if any) usually
+   points at the root cause directly.
+2. **If still unclear**, fetch the broker logs:
+   ```bash
+   kubectl logs -l app.kubernetes.io/name=openab --since=10m | grep -A 5 "agent="
+   ```
+   The `tracing::warn!` path in `connection.rs` always emits every sanitized
+   stderr line with `agent=<command name>`.
+3. **Match the cause to the table below and apply the fix.**
+
+### Common causes
+
+| stderr / data.message pattern | Cause | Fix |
+|------------------------------|-------|-----|
+| `Missing API key`, `API key not set`, `unauthorized`, `401` | Missing / invalid credentials | Verify the `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `*_TOKEN` env var is set in `[agent].env` or `[agent].inherit_env`. See `config.toml.example`. |
+| `model 'X' not supported`, `does not exist`, `deprecated` | Wrong / deprecated model | Switch `model` via `session/set_config_option`, or pin a supported model in agent CLI args. |
+| `rate limit`, `429`, `quota` | Upstream rate limit | Wait, or reduce concurrency via `pool.max_sessions`. |
+| `context length`, `too many tokens`, `maximum context` | Prompt too long | Start a new thread (auto-resets history), or `/cancel` then retry with a shorter prompt. |
+| `connection refused`, `DNS`, `tls handshake` | Network / DNS | Check egress from broker pod; verify `cluster.egressProxy` if set. |
+| Empty stderr + opaque `-32603` | Bug in agent | File an issue against the agent upstream with the `acp_recv` debug log line. |
+
+### Verifying the fix landed
+
+After deploying a build with the stderr-tail fallback:
+
+```bash
+# Confirm the new version is running
+kubectl get pods -l app.kubernetes.io/name=openab -o jsonpath='{.items[0].spec.containers[0].image}'
+
+# To force an auth failure for testing, update your config.toml to set an
+# invalid API key for a test agent, then restart the pod and send a prompt.
+# You should now see:
+# ⚠️ **Internal Error** (code: -32603)
+# Internal error
+# > _Recent agent output:_
+# > Error: ANTHROPIC_API_KEY not set
+```
+
+## Other categories
+
+- **Connection Lost** — agent process crashed mid-prompt. `kubectl logs` for the
+  broker will show `Agent process died` from the liveness check in
+  `AdapterRouter::stream_prompt_blocks`.
+- **Request Timeout** — agent didn't respond within 30s (or 120s for
+  `session/new`). Either upstream is slow, agent is hung on a tool call, or
+  the env config is wrong and initialization is looping.
+- **Agent Not Found** — the configured `command` doesn't exist or isn't
+  executable. Check `[agent].command` in `config.toml`.
+- **Service Busy** — `pool.max_sessions` reached. Increase the limit or
+  wait for existing sessions to TTL out (`pool.session_ttl_hours`).

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -2,15 +2,111 @@ use crate::acp::protocol::{
     parse_config_options, ConfigOption, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse,
 };
 use anyhow::{anyhow, Result};
+use regex::Regex;
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin};
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
+
+/// Maximum number of recent diagnostic lines kept per category.
+const DIAGNOSTIC_LINE_LIMIT: usize = 50;
+/// Maximum characters per diagnostic line before truncation.
+const DIAGNOSTIC_LINE_MAX_CHARS: usize = 500;
+
+/// Regex patterns for common secret formats that must be redacted before
+/// diagnostic lines are stored or displayed to users.
+static SECRET_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(concat!(
+        r"(?i)",
+        r"(?:",
+        // API keys with known prefixes
+        r"sk-ant-[a-zA-Z0-9_-]{10,}",
+        r"|sk-[a-zA-Z0-9_-]{20,}",
+        r"|ghp_[a-zA-Z0-9]{36,}",
+        r"|github_pat_[a-zA-Z0-9_]{22,}",
+        r"|xox[bpras]-[a-zA-Z0-9-]{10,}",
+        r"|gho_[a-zA-Z0-9]{36,}",
+        // Bearer tokens
+        r"|(?:bearer\s+)[a-zA-Z0-9_.~+/=-]{20,}",
+        // Generic KEY=value or TOKEN=value patterns
+        r"|(?:_(?:API_KEY|TOKEN|SECRET|PASSWORD)\s*=\s*)\S+",
+        // PEM private keys
+        r"|-----BEGIN\s[A-Z\s]*PRIVATE\sKEY-----[\s\S]*?-----END\s[A-Z\s]*PRIVATE\sKEY-----",
+        r")",
+    ))
+    .expect("secret redaction regex must compile")
+});
+
+/// Rolling diagnostic buffer for a single ACP session.
+/// Captures recent stderr and malformed stdout lines for error reporting.
+/// Scoped per session — torn down with the connection, no leak risk.
+#[derive(Default)]
+pub(crate) struct AgentDiagnostics {
+    stderr: VecDeque<String>,
+    malformed_stdout: VecDeque<String>,
+}
+
+/// Snapshot of diagnostic state at a point in time.
+#[derive(Default)]
+pub(crate) struct DiagnosticSnapshot {
+    pub stderr: Vec<String>,
+    pub malformed_stdout: Vec<String>,
+}
+
+impl DiagnosticSnapshot {
+    pub fn is_empty(&self) -> bool {
+        self.stderr.is_empty() && self.malformed_stdout.is_empty()
+    }
+}
+
+impl AgentDiagnostics {
+    fn push_stderr(&mut self, line: String) {
+        push_limited(&mut self.stderr, line);
+    }
+
+    fn push_malformed_stdout(&mut self, line: String) {
+        push_limited(&mut self.malformed_stdout, line);
+    }
+
+    pub fn snapshot(&self) -> DiagnosticSnapshot {
+        DiagnosticSnapshot {
+            stderr: self.stderr.iter().cloned().collect(),
+            malformed_stdout: self.malformed_stdout.iter().cloned().collect(),
+        }
+    }
+}
+
+fn push_limited(lines: &mut VecDeque<String>, line: String) {
+    if lines.len() >= DIAGNOSTIC_LINE_LIMIT {
+        lines.pop_front();
+    }
+    lines.push_back(line);
+}
+
+/// Sanitize a diagnostic line: strip control chars, cap length, redact secrets.
+pub(crate) fn sanitize_diagnostic_line(line: &str) -> String {
+    let mut out = String::new();
+    for ch in line.trim().chars() {
+        if out.len() >= DIAGNOSTIC_LINE_MAX_CHARS {
+            out.push_str(" [truncated]");
+            break;
+        }
+        if !ch.is_control() || ch == '\t' {
+            out.push(ch);
+        }
+    }
+    redact_secrets(&out)
+}
+
+/// Replace known secret patterns with [REDACTED].
+fn redact_secrets(line: &str) -> String {
+    SECRET_PATTERN.replace_all(line, "[REDACTED]").into_owned()
+}
 
 /// Pick the most permissive selectable permission option from ACP options.
 fn pick_best_option(options: &[Value]) -> Option<String> {
@@ -115,6 +211,7 @@ pub struct AcpConnection {
     next_id: AtomicU64,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<JsonRpcMessage>>>>,
     notify_tx: Arc<Mutex<Option<mpsc::UnboundedSender<JsonRpcMessage>>>>,
+    diagnostics: Arc<Mutex<AgentDiagnostics>>,
     pub acp_session_id: Option<String>,
     pub supports_load_session: bool,
     pub config_options: Vec<ConfigOption>,
@@ -160,6 +257,7 @@ pub(crate) async fn run_reader_loop<R, W>(
     writer: Arc<Mutex<W>>,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<JsonRpcMessage>>>>,
     notify_tx: Arc<Mutex<Option<mpsc::UnboundedSender<JsonRpcMessage>>>>,
+    diagnostics: Arc<Mutex<AgentDiagnostics>>,
 ) where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
@@ -178,7 +276,18 @@ pub(crate) async fn run_reader_loop<R, W>(
         }
         let msg: JsonRpcMessage = match serde_json::from_str(line.trim()) {
             Ok(m) => m,
-            Err(_) => continue,
+            Err(e) => {
+                let sanitized = sanitize_diagnostic_line(&line);
+                if !sanitized.is_empty() {
+                    warn!(
+                        parse_error = %e,
+                        line = %sanitized,
+                        "agent stdout was not valid JSON-RPC"
+                    );
+                    diagnostics.lock().await.push_malformed_stdout(sanitized);
+                }
+                continue;
+            }
         };
         debug!(line = line.trim(), "acp_recv");
 
@@ -356,11 +465,16 @@ impl AcpConnection {
         let stdout = proc.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
         let stdin = proc.stdin.take().ok_or_else(|| anyhow!("no stdin"))?;
         let stdin = Arc::new(Mutex::new(stdin));
+        let diagnostics: Arc<Mutex<AgentDiagnostics>> =
+            Arc::new(Mutex::new(AgentDiagnostics::default()));
 
         // Capture agent stderr and log it (ACP spec: agents MAY write to stderr
         // for logging; clients MAY capture or ignore it).
+        // Each sanitized+redacted line is pushed to the per-session diagnostics
+        // buffer so opaque JSON-RPC errors can surface the real cause to users.
         let stderr_handle = if let Some(stderr) = proc.stderr.take() {
             let cmd_name = command.to_string();
+            let diag = Arc::clone(&diagnostics);
             Some(tokio::spawn(async move {
                 let mut reader = BufReader::new(stderr);
                 let mut line = String::new();
@@ -369,14 +483,10 @@ impl AcpConnection {
                     match reader.read_line(&mut line).await {
                         Ok(0) => break,
                         Ok(_) => {
-                            let trimmed = line.trim();
-                            if !trimmed.is_empty() {
-                                let sanitized: String = trimmed.chars()
-                                    .filter(|c| !c.is_control() || *c == '\t')
-                                    .collect();
-                                if !sanitized.is_empty() {
-                                    tracing::warn!(agent = %cmd_name, "{sanitized}");
-                                }
+                            let sanitized = sanitize_diagnostic_line(&line);
+                            if !sanitized.is_empty() {
+                                tracing::warn!(agent = %cmd_name, "{sanitized}");
+                                diag.lock().await.push_stderr(sanitized);
                             }
                         }
                         Err(_) => break,
@@ -397,6 +507,7 @@ impl AcpConnection {
             stdin.clone(),
             pending.clone(),
             notify_tx.clone(),
+            diagnostics.clone(),
         ));
 
         Ok(Self {
@@ -406,6 +517,7 @@ impl AcpConnection {
             next_id: AtomicU64::new(1),
             pending,
             notify_tx,
+            diagnostics,
             acp_session_id: None,
             supports_load_session: false,
             config_options: Vec::new(),
@@ -418,6 +530,33 @@ impl AcpConnection {
 
     fn next_id(&self) -> u64 {
         self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Snapshot recent stderr lines for user-facing error display.
+    /// Returns lines in chronological order (oldest first, newest last).
+    pub async fn stderr_tail_snapshot(&self) -> Vec<String> {
+        self.diagnostics.lock().await.stderr.iter().cloned().collect()
+    }
+
+    /// Log a structured ERROR with recent diagnostics when the agent fails
+    /// without returning a JSON-RPC error (EOF, process death, timeout).
+    pub async fn log_diagnostics(&self, reason: &str, request_id: Option<u64>) {
+        let snapshot = self.diagnostics.lock().await.snapshot();
+        if snapshot.is_empty() {
+            error!(
+                reason,
+                ?request_id,
+                "agent request failed without JSON-RPC error"
+            );
+            return;
+        }
+        error!(
+            reason,
+            ?request_id,
+            recent_stderr = ?snapshot.stderr,
+            recent_malformed_stdout = ?snapshot.malformed_stdout,
+            "agent request failed without JSON-RPC error"
+        );
     }
 
     pub(crate) async fn send_raw(&self, data: &str) -> Result<()> {
@@ -861,11 +1000,13 @@ mod reader_loop_tests {
         *notify_tx.lock().await = Some(sub_tx);
 
         let writer = Arc::new(Mutex::new(agent_stdin_writer));
+        let diag: Arc<Mutex<AgentDiagnostics>> = Arc::new(Mutex::new(AgentDiagnostics::default()));
         let handle = tokio::spawn(run_reader_loop(
             agent_stdout_reader,
             writer,
             pending.clone(),
             notify_tx.clone(),
+            diag.clone(),
         ));
 
         let stale = b"{\"jsonrpc\":\"2.0\",\"id\":42,\"result\":{\"stopReason\":\"ok\"}}\n";
@@ -907,11 +1048,13 @@ mod reader_loop_tests {
         *notify_tx.lock().await = Some(sub_tx);
 
         let writer = Arc::new(Mutex::new(agent_stdin_writer));
+        let diag: Arc<Mutex<AgentDiagnostics>> = Arc::new(Mutex::new(AgentDiagnostics::default()));
         let handle = tokio::spawn(run_reader_loop(
             agent_stdout_reader,
             writer,
             pending.clone(),
             notify_tx.clone(),
+            diag.clone(),
         ));
 
         let payload = b"{\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{\"stopReason\":\"end_turn\"}}\n";
@@ -933,5 +1076,107 @@ mod reader_loop_tests {
 
         drop(agent_stdout_writer);
         handle.await.unwrap();
+    }
+
+    // ─── sanitize_diagnostic_line tests ─────────────────────────────────────
+
+    #[test]
+    fn sanitize_strips_control_chars() {
+        let input = "hello\x00world\x1b[31mred";
+        let result = sanitize_diagnostic_line(input);
+        assert_eq!(result, "helloworldred");
+    }
+
+    #[test]
+    fn sanitize_preserves_tabs() {
+        let input = "col1\tcol2\tcol3";
+        let result = sanitize_diagnostic_line(input);
+        assert_eq!(result, "col1\tcol2\tcol3");
+    }
+
+    #[test]
+    fn sanitize_truncates_long_lines() {
+        let input = "x".repeat(1000);
+        let result = sanitize_diagnostic_line(&input);
+        assert!(result.len() <= DIAGNOSTIC_LINE_MAX_CHARS + 15); // chars + " [truncated]"
+        assert!(result.ends_with("[truncated]"));
+    }
+
+    #[test]
+    fn sanitize_trims_whitespace() {
+        let result = sanitize_diagnostic_line("  hello world  \n");
+        assert_eq!(result, "hello world");
+    }
+
+    // ─── redaction tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn redact_anthropic_key() {
+        let input = "Error: key is sk-ant-api03-abcdefg1234567890";
+        let result = redact_secrets(input);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("sk-ant-"));
+    }
+
+    #[test]
+    fn redact_openai_key() {
+        let input = "OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwx";
+        let result = redact_secrets(input);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("sk-proj-"));
+    }
+
+    #[test]
+    fn redact_github_pat() {
+        let input = "token: github_pat_11ABCDEFG0123456789_abcdefghijklmnopqrstuvwxyz";
+        let result = redact_secrets(input);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("github_pat_"));
+    }
+
+    #[test]
+    fn redact_ghp_token() {
+        let input = "Authorization failed with ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789";
+        let result = redact_secrets(input);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("ghp_"));
+    }
+
+    #[test]
+    fn redact_slack_token() {
+        let input = "SLACK_TOKEN=xoxb-123456789-abcdefg";
+        let result = redact_secrets(input);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("xoxb-"));
+    }
+
+    #[test]
+    fn redact_bearer_token() {
+        let input = "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig";
+        let result = redact_secrets(input);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("eyJhbGci"));
+    }
+
+    #[test]
+    fn redact_generic_api_key_env() {
+        let input = "ANTHROPIC_API_KEY=sk-ant-something-secret-here";
+        let result = redact_secrets(input);
+        assert!(result.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn no_redact_safe_content() {
+        let input = "Error: model 'gpt-5' not found in available models";
+        let result = redact_secrets(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn sanitize_diagnostic_line_redacts_secrets() {
+        let input = "Failed auth: sk-ant-api03-mysecretkey1234567890";
+        let result = sanitize_diagnostic_line(input);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("mysecretkey"));
     }
 }

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -33,10 +33,11 @@ static SECRET_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
         r"|gho_[a-zA-Z0-9]{36,}",
         // Bearer tokens
         r"|(?:bearer\s+)[a-zA-Z0-9_.~+/=-]{20,}",
-        // Generic KEY=value or TOKEN=value patterns
-        r"|(?:_(?:API_KEY|TOKEN|SECRET|PASSWORD)\s*=\s*)\S+",
-        // PEM private keys
-        r"|-----BEGIN\s[A-Z\s]*PRIVATE\sKEY-----[\s\S]*?-----END\s[A-Z\s]*PRIVATE\sKEY-----",
+        // Generic KEY=value or TOKEN=value patterns (with or without prefix)
+        r"|(?:(?:^|[\s=])(?:\w*_)?(?:API_KEY|TOKEN|SECRET|PASSWORD)\s*=\s*)\S+",
+        // PEM private key markers (single-line detection; multi-line keys
+        // are handled line-by-line — the BEGIN line itself is sufficient signal)
+        r"|-----BEGIN\s[A-Z\s]*PRIVATE\sKEY-----",
         r")",
     ))
     .expect("secret redaction regex must compile")
@@ -104,7 +105,7 @@ pub(crate) fn sanitize_diagnostic_line(line: &str) -> String {
 }
 
 /// Replace known secret patterns with [REDACTED].
-fn redact_secrets(line: &str) -> String {
+pub(crate) fn redact_secrets(line: &str) -> String {
     SECRET_PATTERN.replace_all(line, "[REDACTED]").into_owned()
 }
 

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -33,8 +33,10 @@ static SECRET_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
         r"|gho_[a-zA-Z0-9]{36,}",
         // Bearer tokens
         r"|(?:bearer\s+)[a-zA-Z0-9_.~+/=-]{20,}",
-        // Generic KEY=value or TOKEN=value patterns (with or without prefix)
-        r"|(?:(?:^|[\s=])(?:\w*_)?(?:API_KEY|TOKEN|SECRET|PASSWORD)\s*=\s*)\S+",
+        // Generic KEY=value patterns — require prefix suggesting credential context
+        // (e.g. ANTHROPIC_API_KEY=, AUTH_TOKEN=, DB_PASSWORD=) but not arbitrary
+        // vars like MAX_RETRY_TOKEN=3 or LOG_SECRET=false.
+        r"|(?:(?:^|[\s=])(?:[A-Z_]*(?:API|AUTH|AWS|AZURE|GCP|OPENAI|ANTHROPIC|DATABASE|DB|REDIS|MONGO|SMTP|SSH|PRIVATE|SIGNING)[A-Z_]*(?:KEY|TOKEN|SECRET|PASSWORD))\s*=\s*)\S+",
         // PEM private key markers (single-line detection; multi-line keys
         // are handled line-by-line — the BEGIN line itself is sufficient signal)
         r"|-----BEGIN\s[A-Z\s]*PRIVATE\sKEY-----",
@@ -94,22 +96,27 @@ static ANSI_ESCAPE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\x1b\[[0-9;?]*[ -/]*[@-~]").expect("ANSI regex must compile")
 });
 
-/// Sanitize a diagnostic line: strip ANSI escapes, strip control chars, cap length, redact secrets.
+/// Sanitize a diagnostic line: strip ANSI escapes, strip control chars, redact secrets, then cap length.
 pub(crate) fn sanitize_diagnostic_line(line: &str) -> String {
     // First strip ANSI escape sequences (e.g. \x1b[31m) so they don't leave
     // residual bracket/number fragments after control char removal.
     let stripped = ANSI_ESCAPE.replace_all(line.trim(), "");
-    let mut out = String::new();
+    let mut clean = String::new();
     for ch in stripped.chars() {
-        if out.len() >= DIAGNOSTIC_LINE_MAX_CHARS {
-            out.push_str(" [truncated]");
-            break;
-        }
         if !ch.is_control() || ch == '\t' {
-            out.push(ch);
+            clean.push(ch);
         }
     }
-    redact_secrets(&out)
+    // Redact BEFORE truncating so secrets that would span the cutoff boundary
+    // are fully replaced rather than partially exposed.
+    let redacted = redact_secrets(&clean);
+    if redacted.chars().count() > DIAGNOSTIC_LINE_MAX_CHARS {
+        let mut out: String = redacted.chars().take(DIAGNOSTIC_LINE_MAX_CHARS).collect();
+        out.push_str(" [truncated]");
+        out
+    } else {
+        redacted
+    }
 }
 
 /// Replace known secret patterns with [REDACTED].
@@ -487,11 +494,30 @@ impl AcpConnection {
             Some(tokio::spawn(async move {
                 let mut reader = BufReader::new(stderr);
                 let mut line = String::new();
+                let mut in_pem_block = false;
                 loop {
                     line.clear();
                     match reader.read_line(&mut line).await {
                         Ok(0) => break,
                         Ok(_) => {
+                            let trimmed = line.trim();
+                            // Suppress lines inside PEM private key blocks
+                            if trimmed.contains("-----BEGIN") && trimmed.contains("PRIVATE KEY") {
+                                in_pem_block = true;
+                                let sanitized = sanitize_diagnostic_line(&line);
+                                if !sanitized.is_empty() {
+                                    tracing::warn!(agent = %cmd_name, "{sanitized}");
+                                    diag.lock().await.push_stderr(sanitized);
+                                }
+                                continue;
+                            }
+                            if in_pem_block {
+                                if trimmed.contains("-----END") && trimmed.contains("PRIVATE KEY") {
+                                    in_pem_block = false;
+                                }
+                                // Skip all lines inside PEM block (base64 body + END marker)
+                                continue;
+                            }
                             let sanitized = sanitize_diagnostic_line(&line);
                             if !sanitized.is_empty() {
                                 tracing::warn!(agent = %cmd_name, "{sanitized}");

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -89,10 +89,18 @@ fn push_limited(lines: &mut VecDeque<String>, line: String) {
     lines.push_back(line);
 }
 
-/// Sanitize a diagnostic line: strip control chars, cap length, redact secrets.
+/// Regex for ANSI escape sequences (CSI sequences like \x1b[31m, \x1b[0m, etc.)
+static ANSI_ESCAPE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\x1b\[[0-9;?]*[ -/]*[@-~]").expect("ANSI regex must compile")
+});
+
+/// Sanitize a diagnostic line: strip ANSI escapes, strip control chars, cap length, redact secrets.
 pub(crate) fn sanitize_diagnostic_line(line: &str) -> String {
+    // First strip ANSI escape sequences (e.g. \x1b[31m) so they don't leave
+    // residual bracket/number fragments after control char removal.
+    let stripped = ANSI_ESCAPE.replace_all(line.trim(), "");
     let mut out = String::new();
-    for ch in line.trim().chars() {
+    for ch in stripped.chars() {
         if out.len() >= DIAGNOSTIC_LINE_MAX_CHARS {
             out.push_str(" [truncated]");
             break;

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -2,6 +2,7 @@ pub mod connection;
 pub mod pool;
 pub mod protocol;
 
-pub use connection::{redact_secrets, ContentBlock};
+pub use connection::ContentBlock;
+pub(crate) use connection::redact_secrets;
 pub use pool::SessionPool;
 pub use protocol::{classify_notification, AcpEvent};

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -2,6 +2,6 @@ pub mod connection;
 pub mod pool;
 pub mod protocol;
 
-pub use connection::ContentBlock;
+pub use connection::{redact_secrets, ContentBlock};
 pub use pool::SessionPool;
 pub use protocol::{classify_notification, AcpEvent};

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -72,6 +72,38 @@ impl JsonRpcError {
             .and_then(|d| d.get("message"))
             .and_then(|m| m.as_str())
     }
+
+    /// Extract user-facing detail with nested JSON unwrapping.
+    ///
+    /// Some agents (e.g. codex-acp) encode the real upstream error as a JSON
+    /// string inside `error.data.message`. This method first tries plain string
+    /// extraction, then attempts to parse the string as JSON and extract
+    /// `.error.message` from within it (the nested case from issue #998).
+    pub fn user_detail(&self) -> Option<String> {
+        let raw = self.data_message()?;
+        if raw.is_empty() {
+            return None;
+        }
+        // Try parsing as nested JSON: {"error": {"message": "..."}}
+        if raw.starts_with('{') {
+            if let Ok(inner) = serde_json::from_str::<serde_json::Value>(raw) {
+                if let Some(msg) = inner
+                    .get("error")
+                    .and_then(|e| e.get("message"))
+                    .and_then(|m| m.as_str())
+                {
+                    return Some(msg.to_string());
+                }
+                // Fallback: just use the nested "message" if present
+                if let Some(msg) = inner.get("message").and_then(|m| m.as_str()) {
+                    if !msg.is_empty() {
+                        return Some(msg.to_string());
+                    }
+                }
+            }
+        }
+        Some(raw.to_string())
+    }
 }
 
 impl std::fmt::Display for JsonRpcError {
@@ -402,5 +434,68 @@ mod tests {
         let opts = parse_config_options(&result);
         assert_eq!(opts.len(), 1);
         assert_eq!(opts[0].id, "model");
+    }
+
+    // ─── user_detail tests (nested JSON parsing, #998/#1002) ────────────────
+
+    #[test]
+    fn user_detail_plain_string() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({"message": "model not supported"})),
+        };
+        assert_eq!(err.user_detail(), Some("model not supported".to_string()));
+    }
+
+    #[test]
+    fn user_detail_nested_json() {
+        // codex-acp wraps upstream errors as JSON inside data.message
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({"message": "{\"error\":{\"message\":\"invalid_api_key\"}}"})),
+        };
+        assert_eq!(err.user_detail(), Some("invalid_api_key".to_string()));
+    }
+
+    #[test]
+    fn user_detail_nested_json_with_message_key() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({"message": "{\"message\":\"rate limit exceeded\"}"})),
+        };
+        assert_eq!(err.user_detail(), Some("rate limit exceeded".to_string()));
+    }
+
+    #[test]
+    fn user_detail_empty_data() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({})),
+        };
+        assert_eq!(err.user_detail(), None);
+    }
+
+    #[test]
+    fn user_detail_empty_string() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: Some(json!({"message": ""})),
+        };
+        assert_eq!(err.user_detail(), None);
+    }
+
+    #[test]
+    fn user_detail_no_data() {
+        let err = JsonRpcError {
+            code: -32603,
+            message: "Internal error".into(),
+            data: None,
+        };
+        assert_eq!(err.user_detail(), None);
     }
 }

--- a/src/acp/protocol.rs
+++ b/src/acp/protocol.rs
@@ -66,7 +66,7 @@ impl JsonRpcError {
     /// The `"message"` key is a convention used by codex-acp and aligns with
     /// common JSON-RPC practice, but is NOT mandated by the ACP spec.
     /// Other agents may use `"detail"`, `"reason"`, etc. — extend here if needed.
-    pub fn data_message(&self) -> Option<&str> {
+    pub(crate) fn data_message(&self) -> Option<&str> {
         self.data
             .as_ref()
             .and_then(|d| d.get("message"))

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -564,7 +564,13 @@ impl AdapterRouter {
                                 continue;
                             }
                             if let Some(ref err) = notification.error {
-                                response_error = Some(format_coded_error(err.code, &err.message, err.data_message()));
+                                let stderr_tail = conn.stderr_tail_snapshot().await;
+                                response_error = Some(format_coded_error(
+                                    err.code,
+                                    &err.message,
+                                    err.user_detail().as_deref(),
+                                    &stderr_tail,
+                                ));
                             }
                             break;
                         }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use std::sync::Arc;
 use tracing::{error, warn};
 
-use crate::acp::{classify_notification, AcpEvent, ContentBlock, SessionPool};
+use crate::acp::{classify_notification, redact_secrets, AcpEvent, ContentBlock, SessionPool};
 use crate::config::{ReactionsConfig, ToolDisplay};
 use crate::error_display::{format_coded_error, format_user_error};
 use crate::format;
@@ -539,11 +539,13 @@ impl AdapterRouter {
                             },
                             _ = tokio::time::sleep(liveness_check_interval) => {
                                 if !conn.alive() {
+                                    conn.log_diagnostics("agent process died", Some(request_id)).await;
                                     response_error = Some("Agent process died".into());
                                     conn.abandon_request(request_id).await;
                                     break;
                                 }
                                 if prompt_start.elapsed() > prompt_hard_timeout {
+                                    conn.log_diagnostics("prompt hard timeout", Some(request_id)).await;
                                     response_error = Some(format!(
                                         "Agent exceeded hard timeout ({}s)",
                                         prompt_hard_timeout.as_secs(),
@@ -565,10 +567,11 @@ impl AdapterRouter {
                             }
                             if let Some(ref err) = notification.error {
                                 let stderr_tail = conn.stderr_tail_snapshot().await;
+                                let detail = err.user_detail().map(|d| redact_secrets(&d));
                                 response_error = Some(format_coded_error(
                                     err.code,
                                     &err.message,
-                                    err.user_detail().as_deref(),
+                                    detail.as_deref(),
                                     &stderr_tail,
                                 ));
                             }

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -50,9 +50,29 @@ pub fn format_user_error(message: &str) -> String {
 
 /// Format coded error from ACP agent for display in Discord.
 /// Used for response errors that have a JSON-RPC or HTTP status code.
-/// `data_message` is the optional detail extracted from `error.data.message`.
+///
+/// `data_message` is the optional detail extracted from `error.data.message`
+/// (see PR #885) or via nested JSON unwrapping (from #1002/#998).
+///
+/// `stderr_tail` is the agent's recent stderr output, used as a fallback
+/// detail when `data_message` is absent or empty. Some agents (e.g. opencode
+/// in #25568, hermes-agent) return `-32603` with `data: {}` or no `data` at
+/// all, leaving only stderr to carry the real cause. See #1000, #998.
+///
+/// Rendering rules:
+/// 1. If `data_message` is present and non-empty, render it (existing path).
+/// 2. Else if `stderr_tail` is non-empty, render last 5 lines as a "Recent
+///    agent output:" blockquote (Discord message budget).
+/// 3. Else, plain `prefix (code: N)`.
+/// 4. `data_message` and `stderr_tail` are never shown together.
+///
 /// Public for reuse by other adapters (e.g. Slack).
-pub fn format_coded_error(code: i64, message: &str, data_message: Option<&str>) -> String {
+pub fn format_coded_error(
+    code: i64,
+    message: &str,
+    data_message: Option<&str>,
+    stderr_tail: &[String],
+) -> String {
     let prefix = match code {
         400 => "**Bad Request**",
         401 => "**Unauthorized**",
@@ -76,10 +96,23 @@ pub fn format_coded_error(code: i64, message: &str, data_message: Option<&str>) 
     } else {
         format!("{} (code: {})\n{}", prefix, code, message)
     };
-    if let Some(detail) = data_message {
-        if !detail.is_empty() && !message.contains(detail) {
+    // Normalize empty string to None so stderr fallback fires.
+    let detail = data_message.filter(|s| !s.is_empty());
+    if let Some(detail) = detail {
+        if !message.contains(detail) {
             out.push_str("\n> ");
             out.push_str(detail);
+        }
+    } else if !stderr_tail.is_empty() {
+        // Fallback: opaque error envelope, no structured `data` to extract.
+        // Show the last 5 lines so users get actionable signal without
+        // flooding the channel. Full history is in operator logs.
+        out.push_str("\n> _Recent agent output:_\n");
+        let start = stderr_tail.len().saturating_sub(5);
+        for line in &stderr_tail[start..] {
+            out.push_str("> ");
+            out.push_str(line);
+            out.push('\n');
         }
     }
     out
@@ -172,9 +205,13 @@ mod tests {
 
     // ─── format_coded_error tests ───────────────────────────────────────────
 
+    fn empty_tail() -> Vec<String> {
+        Vec::new()
+    }
+
     #[test]
     fn format_coded_error_401() {
-        let result = format_coded_error(401, "invalid token", None);
+        let result = format_coded_error(401, "invalid token", None, &empty_tail());
         assert!(result.contains("Unauthorized"));
         assert!(result.contains("401"));
         assert!(result.contains("invalid token"));
@@ -182,7 +219,7 @@ mod tests {
 
     #[test]
     fn format_coded_error_429() {
-        let result = format_coded_error(429, "", None);
+        let result = format_coded_error(429, "", None, &empty_tail());
         assert!(result.contains("Rate Limited"));
         assert!(result.contains("429"));
         assert!(!result.contains("\n")); // no message, no newline
@@ -190,7 +227,7 @@ mod tests {
 
     #[test]
     fn format_coded_error_503() {
-        let result = format_coded_error(503, "service unavailable", None);
+        let result = format_coded_error(503, "service unavailable", None, &empty_tail());
         assert!(result.contains("Service Unavailable"));
         assert!(result.contains("503"));
         assert!(result.contains("service unavailable"));
@@ -198,28 +235,28 @@ mod tests {
 
     #[test]
     fn format_coded_error_json_rpc() {
-        let result = format_coded_error(-32602, "missing required parameter", None);
+        let result = format_coded_error(-32602, "missing required parameter", None, &empty_tail());
         assert!(result.contains("Invalid Params"));
         assert!(result.contains("-32602"));
     }
 
     #[test]
     fn format_coded_error_server_error_range() {
-        let result = format_coded_error(-32050, "internal failure", None);
+        let result = format_coded_error(-32050, "internal failure", None, &empty_tail());
         assert!(result.contains("Server Error"));
         assert!(result.contains("-32050"));
     }
 
     #[test]
     fn format_coded_error_connection_error() {
-        let result = format_coded_error(-32000, "connection refused", None);
-        assert!(result.contains("Server Error")); // -32000 falls in -32099..=-32000 range
+        let result = format_coded_error(-32000, "connection refused", None, &empty_tail());
+        assert!(result.contains("Server Error"));
         assert!(result.contains("-32000"));
     }
 
     #[test]
     fn format_coded_error_unknown_code() {
-        let result = format_coded_error(999, "something happened", None);
+        let result = format_coded_error(999, "something happened", None, &empty_tail());
         assert!(result.contains("Error"));
         assert!(result.contains("999"));
         assert!(result.contains("something happened"));
@@ -227,15 +264,70 @@ mod tests {
 
     #[test]
     fn format_coded_error_with_data_message() {
-        let result = format_coded_error(-32603, "Internal error", Some("model not supported"));
+        let result =
+            format_coded_error(-32603, "Internal error", Some("model not supported"), &empty_tail());
         assert!(result.contains("Internal Error"));
         assert!(result.contains("model not supported"));
     }
 
     #[test]
     fn format_coded_error_data_message_not_duplicated() {
-        // If data_message is already in message, don't repeat it
-        let result = format_coded_error(-32603, "model not supported", Some("model not supported"));
+        let result = format_coded_error(
+            -32603,
+            "model not supported",
+            Some("model not supported"),
+            &empty_tail(),
+        );
         assert_eq!(result.matches("model not supported").count(), 1);
+    }
+
+    // ─── stderr_tail fallback tests (#1000 / #998) ──────────────────────────
+
+    #[test]
+    fn format_coded_error_stderr_tail_when_data_empty() {
+        let stderr = vec!["Error: ANTHROPIC_API_KEY not set".to_string()];
+        let result = format_coded_error(-32603, "Internal error", None, &stderr);
+        assert!(result.contains("Internal Error"));
+        assert!(result.contains("-32603"));
+        assert!(result.contains("Recent agent output"));
+        assert!(result.contains("ANTHROPIC_API_KEY"));
+    }
+
+    #[test]
+    fn format_coded_error_data_message_suppresses_stderr() {
+        let stderr = vec!["DEBUG: connection pool idle".to_string()];
+        let result = format_coded_error(
+            -32603,
+            "Internal error",
+            Some("model not supported"),
+            &stderr,
+        );
+        assert!(result.contains("model not supported"));
+        assert!(!result.contains("Recent agent output"));
+        assert!(!result.contains("connection pool idle"));
+    }
+
+    #[test]
+    fn format_coded_error_stderr_tail_caps_at_five_lines() {
+        let stderr: Vec<String> = (1..=20).map(|i| format!("line {i}")).collect();
+        let result = format_coded_error(-32603, "Internal error", None, &stderr);
+        assert!(result.contains("line 16"));
+        assert!(result.contains("line 20"));
+        assert!(!result.contains("line 15"));
+    }
+
+    #[test]
+    fn format_coded_error_no_data_no_stderr() {
+        let result = format_coded_error(-32603, "Internal error", None, &empty_tail());
+        assert!(result.contains("Internal Error"));
+        assert!(!result.contains("Recent agent output"));
+    }
+
+    #[test]
+    fn format_coded_error_empty_data_string_falls_through_to_stderr() {
+        let stderr = vec!["real error in stderr".to_string()];
+        let result = format_coded_error(-32603, "Internal error", Some(""), &stderr);
+        assert!(result.contains("Recent agent output"));
+        assert!(result.contains("real error in stderr"));
     }
 }

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -111,11 +111,45 @@ pub fn format_coded_error(
         let start = stderr_tail.len().saturating_sub(5);
         for line in &stderr_tail[start..] {
             out.push_str("> ");
-            out.push_str(line);
+            out.push_str(&sanitize_mentions(line));
             out.push('\n');
         }
     }
     out
+}
+
+/// Strip Discord/Slack mention patterns from untrusted agent output so
+/// surfaced diagnostics cannot ping users or channels.
+/// Handles: <@ID>, <@!ID>, <@&ID>, <#ID>, @everyone, @here, <!here>, <!channel>, <!everyone>
+fn sanitize_mentions(line: &str) -> String {
+    let mut s = line.to_string();
+    // Discord mention patterns: <@123>, <@!123>, <@&123>, <#123>
+    while let Some(start) = s.find("<@") {
+        if let Some(end) = s[start..].find('>') {
+            s.replace_range(start..start + end + 1, "@\u{200B}mention");
+        } else {
+            break;
+        }
+    }
+    while let Some(start) = s.find("<#") {
+        if let Some(end) = s[start..].find('>') {
+            s.replace_range(start..start + end + 1, "#\u{200B}channel");
+        } else {
+            break;
+        }
+    }
+    // Slack special mentions: <!here>, <!channel>, <!everyone>
+    while let Some(start) = s.find("<!") {
+        if let Some(end) = s[start..].find('>') {
+            s.replace_range(start..start + end + 1, "@\u{200B}group");
+        } else {
+            break;
+        }
+    }
+    // Plain text @everyone / @here
+    s = s.replace("@everyone", "@\u{200B}everyone");
+    s = s.replace("@here", "@\u{200B}here");
+    s
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Context

Closes #998
Closes #1000
Supersedes #1002
Supersedes #1003

When ACP agents return JSON-RPC `-32603 Internal Error` with empty or absent `error.data`, users see only "Internal error" with zero actionable context. The real cause lives in the agent's stderr stream (auth failures, model errors, etc.) but was previously only visible in operator logs.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1512111385679626290

## Summary

This PR unifies the approaches from #1002 and #1003 into a single implementation that surfaces agent diagnostics to users **safely** (with secret redaction).

## Changes

| File | Change |
|------|--------|
| `src/acp/connection.rs` | `AgentDiagnostics` struct with ring buffer (50 lines × 500 chars cap), `sanitize_diagnostic_line()` with secret redaction via `LazyLock<Regex>`, malformed stdout capture in reader loop, `stderr_tail_snapshot()`, `log_diagnostics()` |
| `src/acp/protocol.rs` | `user_detail()` method on `JsonRpcError` — unwraps nested JSON inside `data.message` (codex-acp case from #998) |
| `src/adapter.rs` | Error path passes `stderr_tail_snapshot()` + `user_detail()` to `format_coded_error` |
| `src/error_display.rs` | `format_coded_error` extended with `stderr_tail` param; renders last 5 lines as blockquote fallback when `data_message` is absent/empty; `Some("")` correctly falls through via `.filter(\|s\| !s.is_empty())` |
| `docs/troubleshooting.md` | Diagnostic guide with common causes table and corrected verification procedure |

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Secret redaction at push time | Secrets never enter the buffer — safe even if buffer is read by multiple codepaths |
| Redaction patterns: `sk-ant-*`, `sk-*`, `ghp_*`, `github_pat_*`, `xoxb-*`, Bearer tokens, `*_API_KEY=value`, PEM keys | Covers common provider keys; not exhaustive but eliminates the highest-risk patterns |
| Line length cap (500 chars) | Prevents memory bloat from stack traces / JSON dumps; truncated with `[truncated]` suffix |
| `data_message` precedence over stderr | Structured data is always preferred; stderr only fires as fallback |
| Per-session buffer (not per-turn) | Simpler; known limitation documented. Per-turn isolation deferred as follow-up. |
| Nested JSON unwrapping in `user_detail()` | Handles codex-acp's `data.message = "{\"error\":{\"message\":\"...\"}}"` pattern |

## Known Limitations

- **Session-wide buffer**: stderr from a previous turn may appear in the next error's blockquote. Acceptable for now; per-turn cursor/clear deferred as follow-up.
- **Redaction is pattern-based**: novel secret formats not matching the regex will pass through. The regex can be extended as new patterns are identified.

## Validation

- [x] Brace-balanced across all modified files
- [x] All existing tests updated for new `format_coded_error` signature
- [x] 10+ new unit tests: redaction (8 patterns), sanitize (4 cases), `user_detail` (6 cases), stderr fallback (5 cases)
- [ ] `cargo check` / `cargo test` / `cargo clippy` — **CI will validate** (no local Rust toolchain)

## Credits

This PR unifies work from multiple contributors:

- **@slps970093** — PR #1001 (nested JSON parsing concept), PR #1002 (`AgentDiagnostics` struct, `sanitize_diagnostic_line`, malformed stdout capture, `log_diagnostics`, line length cap)
- **@agent-doro** — PR #1003 (user-facing stderr blockquote, ring buffer design, troubleshooting docs, `Some("")` test coverage)
- Secret redaction added per maintainer review feedback from the #1003 review cycle

Thank you both for the thorough prior work — this PR stands on your shoulders.