### PR TITLE
feat(gateway/line): group @mention gating via keyword substring (#642)

### DIFF
--- a/charts/openab/templates/gateway.yaml
+++ b/charts/openab/templates/gateway.yaml
@@ -83,6 +83,10 @@ spec:
                   name: {{ include "openab.agentFullname" $d }}
                   key: line-channel-access-token
             {{- end }}
+            {{- if (($cfg.gateway).line).groupMentionKeyword }}
+            - name: LINE_GROUP_MENTION_KEYWORD
+              value: {{ (($cfg.gateway).line).groupMentionKeyword | quote }}
+            {{- end }}
             {{- end }}
             {{- if $hasTeams }}
             - name: TEAMS_APP_ID

--- a/charts/openab/tests/gateway_test.yaml
+++ b/charts/openab/tests/gateway_test.yaml
@@ -227,6 +227,32 @@ tests:
                 key: line-channel-access-token
         documentIndex: 0
 
+  - it: injects LINE_GROUP_MENTION_KEYWORD when set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.line.channelSecret: "line-secret"
+      agents.kiro.gateway.line.groupMentionKeyword: "@MyBot"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LINE_GROUP_MENTION_KEYWORD
+            value: "@MyBot"
+        documentIndex: 0
+
+  - it: omits LINE_GROUP_MENTION_KEYWORD when not set
+    set:
+      agents.kiro.gateway.enabled: true
+      agents.kiro.gateway.url: "ws://openab-gateway:8080/ws"
+      agents.kiro.gateway.line.channelSecret: "line-secret"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LINE_GROUP_MENTION_KEYWORD
+        documentIndex: 0
+
   # --- Google Chat deployment env var rendering ---
 
   - it: enables Google Chat adapter when only audience is set (receive-only mode)

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -375,6 +375,12 @@ agents:
       line:
         channelSecret: ""      # → LINE_CHANNEL_SECRET (webhook signature validation)
         channelAccessToken: "" # → LINE_CHANNEL_ACCESS_TOKEN (reply/push API)
+        # Optional: gate group/room messages on a substring keyword.
+        # When set (e.g. "@MyBot"), only forward LINE group/room messages containing
+        # this substring (case-sensitive). 1:1 messages are unaffected.
+        # Empty/unset = forward all group messages (default).
+        # → LINE_GROUP_MENTION_KEYWORD
+        groupMentionKeyword: ""
       # MS Teams adapter config (gateway-side env vars)
       # See docs/msteams-enterprise.md for full setup guide
       teams:

--- a/docs/line.md
+++ b/docs/line.md
@@ -98,7 +98,7 @@ In the LINE Developers Console → **Messaging API** tab → scan the QR code wi
 |---|---|---|
 | `LINE_CHANNEL_SECRET` | Yes | Channel secret for webhook signature validation |
 | `LINE_CHANNEL_ACCESS_TOKEN` | Yes | Channel access token for Push Message API |
-| `LINE_GROUP_MENTION_KEYWORD` | No | If set, only forward group/room messages containing this substring (e.g. `@Go醬`). 1:1 messages are unaffected. Empty/unset = forward all (default). |
+| `LINE_GROUP_MENTION_KEYWORD` | No | If set, only forward group/room messages containing this substring (case-sensitive, e.g. `@Go醬`). 1:1 messages are unaffected. Empty/unset = forward all (default). |
 
 ## Troubleshooting
 

--- a/docs/line.md
+++ b/docs/line.md
@@ -89,7 +89,7 @@ In the LINE Developers Console → **Messaging API** tab → scan the QR code wi
 
 - **Threads** — LINE has no thread/topic concept. All messages in a chat share one agent session.
 - **Reactions** — LINE Bot API does not support message reactions.
-- **@mention gating** — LINE does not expose mention entities. In groups, the bot responds to all messages. To limit this, use a dedicated group for the bot.
+- **Native @mention gating** — LINE does not expose mention entities. As a workaround, the gateway supports keyword-based gating: set `LINE_GROUP_MENTION_KEYWORD` (e.g. `@Go醬`) and the gateway will only forward group/room messages containing that substring. 1:1 messages are unaffected.
 - **Markdown rendering** — LINE uses its own text formatting. Agent replies are sent as plain text.
 
 ## Environment Variables
@@ -98,6 +98,7 @@ In the LINE Developers Console → **Messaging API** tab → scan the QR code wi
 |---|---|---|
 | `LINE_CHANNEL_SECRET` | Yes | Channel secret for webhook signature validation |
 | `LINE_CHANNEL_ACCESS_TOKEN` | Yes | Channel access token for Push Message API |
+| `LINE_GROUP_MENTION_KEYWORD` | No | If set, only forward group/room messages containing this substring (e.g. `@Go醬`). 1:1 messages are unaffected. Empty/unset = forward all (default). |
 
 ## Troubleshooting
 

--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -1112,7 +1112,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openab-gateway"
-version = "0.4.0"
+version = "0.5.2"
 dependencies = [
  "aes",
  "anyhow",

--- a/gateway/src/adapters/line.rs
+++ b/gateway/src/adapters/line.rs
@@ -157,7 +157,7 @@ pub async fn webhook(
             info!(
                 channel = %channel_id,
                 keyword = ?state.line_group_mention_keyword.as_deref(),
-                "line group message dropped (no mention keyword)"
+                "line group message dropped (mention keyword not found in text)"
             );
             continue;
         }

--- a/gateway/src/adapters/line.rs
+++ b/gateway/src/adapters/line.rs
@@ -44,6 +44,21 @@ struct LineMessage {
 /// Base URL for LINE Messaging API. Overridden in tests via the `api_base` parameter.
 pub const LINE_API_BASE: &str = "https://api.line.me";
 
+/// Decide whether to silently drop a LINE message based on group-mention gating.
+///
+/// LINE webhooks don't expose mention entities, so the gateway gates on a configurable
+/// substring keyword. 1:1 ("user") messages are never gated. When no keyword is configured,
+/// nothing is gated (legacy behavior).
+fn should_drop_group_message(channel_type: &str, text: &str, keyword: Option<&str>) -> bool {
+    if channel_type == "user" {
+        return false;
+    }
+    match keyword {
+        Some(kw) if !kw.is_empty() => !text.contains(kw),
+        _ => false,
+    }
+}
+
 // --- Webhook handler ---
 
 pub async fn webhook(
@@ -134,6 +149,19 @@ pub async fn webhook(
                 continue;
             }
         };
+        if should_drop_group_message(
+            &channel_type,
+            text,
+            state.line_group_mention_keyword.as_deref(),
+        ) {
+            info!(
+                channel = %channel_id,
+                keyword = ?state.line_group_mention_keyword.as_deref(),
+                "line group message dropped (no mention keyword)"
+            );
+            continue;
+        }
+
         let user_id = source
             .and_then(|s| s.user_id.as_deref())
             .unwrap_or("unknown");
@@ -273,4 +301,47 @@ pub async fn dispatch_line_reply(
     }
 
     used_reply
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_drop_group_message;
+
+    #[test]
+    fn user_1on1_never_dropped_even_without_keyword() {
+        assert!(!should_drop_group_message("user", "hello", Some("@Go")));
+        assert!(!should_drop_group_message("user", "hello", None));
+    }
+
+    #[test]
+    fn group_without_keyword_config_is_not_dropped() {
+        assert!(!should_drop_group_message("group", "anything", None));
+        assert!(!should_drop_group_message("room", "anything", None));
+    }
+
+    #[test]
+    fn group_with_keyword_drops_when_missing() {
+        assert!(should_drop_group_message("group", "weather is great", Some("@Go醬")));
+        assert!(should_drop_group_message("room",  "lunch?",            Some("@Go醬")));
+    }
+
+    #[test]
+    fn group_with_keyword_passes_when_present() {
+        assert!(!should_drop_group_message("group", "@Go醬 hi",         Some("@Go醬")));
+        assert!(!should_drop_group_message("group", "hey @Go醬, plan?", Some("@Go醬")));
+        assert!(!should_drop_group_message("room",  "@Go醬",            Some("@Go醬")));
+    }
+
+    #[test]
+    fn empty_keyword_treated_as_unset() {
+        assert!(!should_drop_group_message("group", "anything", Some("")));
+    }
+
+    #[test]
+    fn keyword_match_is_case_and_substring_sensitive() {
+        // Substring match — partial keyword inside a longer token still counts.
+        assert!(!should_drop_group_message("group", "x@Go醬y", Some("@Go醬")));
+        // Case-sensitive — different casing is treated as no match.
+        assert!(should_drop_group_message("group", "@go醬 hi", Some("@Go醬")));
+    }
 }

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -44,6 +44,10 @@ pub struct AppState {
     pub line_channel_secret: Option<String>,
     /// LINE channel access token for reply API
     pub line_access_token: Option<String>,
+    /// Optional keyword that gates group/room messages.
+    /// When set, LINE group/room messages must contain this substring to be forwarded.
+    /// 1:1 messages are unaffected. Empty/unset = forward all (legacy behavior).
+    pub line_group_mention_keyword: Option<String>,
     /// Teams adapter (None if Teams disabled)
     pub teams: Option<adapters::teams::TeamsAdapter>,
     /// service_url cache for Teams reply routing (conversation_id → (service_url, last_seen))
@@ -242,6 +246,12 @@ async fn main() -> Result<()> {
     // even without an access token (signature validation only needs LINE_CHANNEL_SECRET).
     let line_channel_secret = std::env::var("LINE_CHANNEL_SECRET").ok();
     let line_access_token = std::env::var("LINE_CHANNEL_ACCESS_TOKEN").ok();
+    let line_group_mention_keyword = std::env::var("LINE_GROUP_MENTION_KEYWORD")
+        .ok()
+        .filter(|s| !s.is_empty());
+    if let Some(ref kw) = line_group_mention_keyword {
+        info!(keyword = %kw, "line group mention gating enabled");
+    }
     info!("line adapter enabled");
     app = app.route("/webhook/line", post(adapters::line::webhook));
 
@@ -358,6 +368,7 @@ async fn main() -> Result<()> {
         telegram_secret_token,
         line_channel_secret,
         line_access_token,
+        line_group_mention_keyword,
         teams,
         teams_service_urls: Mutex::new(HashMap::new()),
         feishu,


### PR DESCRIPTION
## Summary

Implements keyword-based group @mention gating for LINE, as proposed in #642.

LINE's Messaging API does not expose mention entities in webhook events, so the gateway cannot natively detect when the bot is `@`-mentioned in a group. Today, the bot replies to every group message, which is disruptive in any chat where the bot is one of many participants (e.g. a travel-planning group where the bot is only meant to act when explicitly summoned).

This PR adds an opt-in workaround: when `LINE_GROUP_MENTION_KEYWORD` is set, the gateway will silently drop LINE group/room messages whose text does not contain that substring. 1:1 messages are never gated.

When the env var is unset or empty, behavior is identical to before — all messages are forwarded.

## Design notes

- **Substring match, not regex** — simple, predictable, no injection risk. Issue #642 left the choice open; opted for the smallest viable surface.
- **Case-sensitive** — matches user expectation (\`@Go醬\` ≠ \`@go醬\`); documented in the test suite.
- **Gating happens at the gateway** — same effect as the existing OAB-side mention gate (see \`src/gateway.rs:648-660\` for the Telegram/Discord-style \`mentions\` check), but doesn't require OAB-side config and works without populating a synthetic mention.
- **1:1 (\`user\`) channel is never gated** — matches the issue's described UX.

## Changes

- \`gateway/src/main.rs\`: load \`LINE_GROUP_MENTION_KEYWORD\` env var into \`AppState\`
- \`gateway/src/adapters/line.rs\`: pure helper \`should_drop_group_message()\` invoked in the webhook loop
- \`docs/line.md\`: update the \"@mention gating\" limitation note + env-var table
- 6 unit tests covering all branches (1:1 / group / room × keyword set / unset / empty / present / missing / case sensitivity)

## Test plan

- [x] \`cargo test adapters::line\` — 6 passed
- [x] Deployed to a live LINE bot (Go醬) and verified in a real group:
  - Group + \`@Go醬 hi\` → bot replies normally
  - Group + plain text (no keyword) → bot silently ignores; gateway logs \`line group message dropped (no mention keyword)\`
  - 1:1 chat → bot replies regardless of keyword (unchanged behavior)
- [x] Backward compat: with no env var set, all six test cases that previously passed still pass

Closes #642

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1512452935928254547