### PR TITLE
feat(helm): add configUrl to fetch remote config

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -1,5 +1,6 @@
 {{- range $name, $cfg := .Values.agents }}
 {{- if ne (include "openab.agentEnabled" $cfg) "false" }}
+{{- if not $cfg.configUrl }}
 {{- $d := dict "ctx" $ "agent" $name "cfg" $cfg }}
 ---
 apiVersion: v1
@@ -250,5 +251,6 @@ data:
   AGENTS.md: |
     {{- $cfg.agentsMd | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
         - name: openab
           image: {{ include "openab.agentImage" $d | quote }}
           imagePullPolicy: {{ include "openab.agentImagePullPolicy" $d }}
+          {{- if $cfg.configUrl }}
+          args: ["run", "-c", {{ $cfg.configUrl | quote }}]
+          {{- end }}
           {{- with $.Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -108,14 +111,16 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if not $cfg.configUrl }}
             - name: config
               mountPath: /etc/openab
               readOnly: true
+            {{- end }}
             {{- if $pvcEnabled }}
             - name: data
               mountPath: {{ $cfg.workingDir | default "/home/agent" }}
             {{- end }}
-            {{- if $cfg.agentsMd }}
+            {{- if and $cfg.agentsMd (not $cfg.configUrl) }}
             - name: config
               mountPath: {{ $cfg.workingDir | default "/home/agent" }}/AGENTS.md
               subPath: AGENTS.md
@@ -147,9 +152,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if not $cfg.configUrl }}
         - name: config
           configMap:
             name: {{ include "openab.agentFullname" $d }}
+        {{- end }}
         {{- if $pvcEnabled }}
         - name: data
           persistentVolumeClaim:

--- a/charts/openab/templates/deployment.yaml
+++ b/charts/openab/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           image: {{ include "openab.agentImage" $d | quote }}
           imagePullPolicy: {{ include "openab.agentImagePullPolicy" $d }}
           {{- if $cfg.configUrl }}
-          args: ["run", "-c", {{ $cfg.configUrl | quote }}]
+          args: ["openab", "run", "-c", {{ $cfg.configUrl | quote }}]
           {{- end }}
           {{- with $.Values.containerSecurityContext }}
           securityContext:

--- a/charts/openab/tests/config-url_test.yaml
+++ b/charts/openab/tests/config-url_test.yaml
@@ -1,0 +1,55 @@
+suite: configUrl remote config support
+templates:
+  - templates/configmap.yaml
+  - templates/deployment.yaml
+tests:
+  - it: skips ConfigMap when configUrl is set
+    template: templates/configmap.yaml
+    set:
+      agents.kiro.configUrl: "https://example.com/config.toml"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders ConfigMap when configUrl is not set
+    template: templates/configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: adds run -c args when configUrl is set
+    template: templates/deployment.yaml
+    set:
+      agents.kiro.configUrl: "https://example.com/config.toml"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value: ["run", "-c", "https://example.com/config.toml"]
+
+  - it: does not set args when configUrl is empty
+    template: templates/deployment.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].args
+
+  - it: omits config volume when configUrl is set
+    template: templates/deployment.yaml
+    set:
+      agents.kiro.configUrl: "https://example.com/config.toml"
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+          any: true
+
+  - it: omits config volumeMount when configUrl is set
+    template: templates/deployment.yaml
+    set:
+      agents.kiro.configUrl: "https://example.com/config.toml"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+          any: true

--- a/charts/openab/tests/config-url_test.yaml
+++ b/charts/openab/tests/config-url_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].args
-          value: ["run", "-c", "https://example.com/config.toml"]
+          value: ["openab", "run", "-c", "https://example.com/config.toml"]
 
   - it: does not set args when configUrl is empty
     template: templates/deployment.yaml

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -232,6 +232,8 @@ agents:
     # configUrl: when set, openab uses `-c <URL>` to fetch config remotely
     # instead of mounting the chart-generated ConfigMap. The ConfigMap and its
     # volume mount are skipped entirely. Use for externally managed configs.
+    # ⚠️ When configUrl is set, agentsMd has no effect (no ConfigMap to mount from).
+    # Provision AGENTS.md via the PVC, extraVolumes, or include it in the remote config.
     # Example: "https://raw.githubusercontent.com/myorg/config/main/openab.toml"
     configUrl: ""
     command: kiro-cli

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -229,6 +229,11 @@ agents:
     #     size: 1Gi
     #   image: "ghcr.io/openabdev/openab-grok"
     image: ""
+    # configUrl: when set, openab uses `-c <URL>` to fetch config remotely
+    # instead of mounting the chart-generated ConfigMap. The ConfigMap and its
+    # volume mount are skipped entirely. Use for externally managed configs.
+    # Example: "https://raw.githubusercontent.com/myorg/config/main/openab.toml"
+    configUrl: ""
     command: kiro-cli
     args:
       - acp


### PR DESCRIPTION
## Summary

Adds a `configUrl` field to per-agent values. When set, the chart:

1. **Skips** rendering the ConfigMap for that agent
2. **Passes** `args: ["run", "-c", "<URL>"]` to the container
3. **Omits** the config volume mount and AGENTS.md subPath mounts

This enables users who manage their `config.toml` externally (e.g. in a private S3/GCS bucket or a Git raw URL) to have openab fetch it at startup via `openab run -c <URL>` without needing chart-generated ConfigMaps.

## Usage

```yaml
agents:
  kiro:
    configUrl: "https://raw.githubusercontent.com/myorg/config/main/openab.toml"
    command: kiro-cli
    # ...
```

## What was tested

- `helm template` with default values (no configUrl) — renders ConfigMap + volume as before
- `helm template` with `configUrl` set — no ConfigMap, correct args, no config volume