### PR TITLE
feat(helm): render hooks.preBoot/preShutdown in ConfigMap

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -247,40 +247,62 @@ data:
     {{- end }}
     {{- end }}
     {{- if ($cfg.hooks).preBoot }}
+    {{- $pb := ($cfg.hooks).preBoot }}
+    {{- $pbSources := 0 }}{{- if $pb.script }}{{- $pbSources = add $pbSources 1 }}{{- end }}{{- if $pb.inline }}{{- $pbSources = add $pbSources 1 }}{{- end }}{{- if $pb.url }}{{- $pbSources = add $pbSources 1 }}{{- end }}
+    {{- if ne (int $pbSources) 1 }}
+    {{- fail (printf "agents.%s.hooks.preBoot must set exactly one of: script, inline, url — got %d sources" $name (int $pbSources)) }}
+    {{- end }}
+    {{- if and $pb.onFailure (not (has $pb.onFailure (list "abort" "warn"))) }}
+    {{- fail (printf "agents.%s.hooks.preBoot.onFailure must be one of: abort, warn — got: %s" $name $pb.onFailure) }}
+    {{- end }}
+    {{- if and (hasKey $pb "timeoutSeconds") (lt (int $pb.timeoutSeconds) 1) }}
+    {{- fail (printf "agents.%s.hooks.preBoot.timeoutSeconds must be a positive integer — got: %v" $name $pb.timeoutSeconds) }}
+    {{- end }}
 
     [hooks.pre_boot]
-    {{- if ($cfg.hooks).preBoot.script }}
-    script = {{ ($cfg.hooks).preBoot.script | toJson }}
+    {{- if $pb.script }}
+    script = {{ $pb.script | toJson }}
     {{- end }}
-    {{- if ($cfg.hooks).preBoot.inline }}
-    inline = {{ ($cfg.hooks).preBoot.inline | toJson }}
+    {{- if $pb.inline }}
+    inline = {{ $pb.inline | toJson }}
     {{- end }}
-    {{- if ($cfg.hooks).preBoot.url }}
-    url = {{ ($cfg.hooks).preBoot.url | toJson }}
+    {{- if $pb.url }}
+    url = {{ $pb.url | toJson }}
     {{- end }}
-    {{- if ($cfg.hooks).preBoot.sha256 }}
-    sha256 = {{ ($cfg.hooks).preBoot.sha256 | toJson }}
+    {{- if $pb.sha256 }}
+    sha256 = {{ $pb.sha256 | toJson }}
     {{- end }}
-    timeout_seconds = {{ ($cfg.hooks).preBoot.timeoutSeconds | default 60 }}
-    on_failure = {{ ($cfg.hooks).preBoot.onFailure | default "abort" | toJson }}
+    timeout_seconds = {{ $pb.timeoutSeconds | default 60 }}
+    on_failure = {{ $pb.onFailure | default "abort" | toJson }}
     {{- end }}
     {{- if ($cfg.hooks).preShutdown }}
+    {{- $ps := ($cfg.hooks).preShutdown }}
+    {{- $psSources := 0 }}{{- if $ps.script }}{{- $psSources = add $psSources 1 }}{{- end }}{{- if $ps.inline }}{{- $psSources = add $psSources 1 }}{{- end }}{{- if $ps.url }}{{- $psSources = add $psSources 1 }}{{- end }}
+    {{- if ne (int $psSources) 1 }}
+    {{- fail (printf "agents.%s.hooks.preShutdown must set exactly one of: script, inline, url — got %d sources" $name (int $psSources)) }}
+    {{- end }}
+    {{- if and $ps.onFailure (not (has $ps.onFailure (list "abort" "warn"))) }}
+    {{- fail (printf "agents.%s.hooks.preShutdown.onFailure must be one of: abort, warn — got: %s" $name $ps.onFailure) }}
+    {{- end }}
+    {{- if and (hasKey $ps "timeoutSeconds") (lt (int $ps.timeoutSeconds) 1) }}
+    {{- fail (printf "agents.%s.hooks.preShutdown.timeoutSeconds must be a positive integer — got: %v" $name $ps.timeoutSeconds) }}
+    {{- end }}
 
     [hooks.pre_shutdown]
-    {{- if ($cfg.hooks).preShutdown.script }}
-    script = {{ ($cfg.hooks).preShutdown.script | toJson }}
+    {{- if $ps.script }}
+    script = {{ $ps.script | toJson }}
     {{- end }}
-    {{- if ($cfg.hooks).preShutdown.inline }}
-    inline = {{ ($cfg.hooks).preShutdown.inline | toJson }}
+    {{- if $ps.inline }}
+    inline = {{ $ps.inline | toJson }}
     {{- end }}
-    {{- if ($cfg.hooks).preShutdown.url }}
-    url = {{ ($cfg.hooks).preShutdown.url | toJson }}
+    {{- if $ps.url }}
+    url = {{ $ps.url | toJson }}
     {{- end }}
-    {{- if ($cfg.hooks).preShutdown.sha256 }}
-    sha256 = {{ ($cfg.hooks).preShutdown.sha256 | toJson }}
+    {{- if $ps.sha256 }}
+    sha256 = {{ $ps.sha256 | toJson }}
     {{- end }}
-    timeout_seconds = {{ ($cfg.hooks).preShutdown.timeoutSeconds | default 60 }}
-    on_failure = {{ ($cfg.hooks).preShutdown.onFailure | default "abort" | toJson }}
+    timeout_seconds = {{ $ps.timeoutSeconds | default 60 }}
+    on_failure = {{ $ps.onFailure | default "abort" | toJson }}
     {{- end }}
   {{- if $cfg.agentsMd }}
   AGENTS.md: |

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -255,6 +255,9 @@ data:
     {{- if and $pb.onFailure (not (has $pb.onFailure (list "abort" "warn"))) }}
     {{- fail (printf "agents.%s.hooks.preBoot.onFailure must be one of: abort, warn — got: %s" $name $pb.onFailure) }}
     {{- end }}
+    {{- if and $pb.url (not $pb.sha256) }}
+    {{- fail (printf "agents.%s.hooks.preBoot.sha256 is required when url is set" $name) }}
+    {{- end }}
     {{- if and (hasKey $pb "timeoutSeconds") (lt (int $pb.timeoutSeconds) 1) }}
     {{- fail (printf "agents.%s.hooks.preBoot.timeoutSeconds must be a positive integer — got: %v" $name $pb.timeoutSeconds) }}
     {{- end }}
@@ -283,6 +286,9 @@ data:
     {{- end }}
     {{- if and $ps.onFailure (not (has $ps.onFailure (list "abort" "warn"))) }}
     {{- fail (printf "agents.%s.hooks.preShutdown.onFailure must be one of: abort, warn — got: %s" $name $ps.onFailure) }}
+    {{- end }}
+    {{- if and $ps.url (not $ps.sha256) }}
+    {{- fail (printf "agents.%s.hooks.preShutdown.sha256 is required when url is set" $name) }}
     {{- end }}
     {{- if and (hasKey $ps "timeoutSeconds") (lt (int $ps.timeoutSeconds) 1) }}
     {{- fail (printf "agents.%s.hooks.preShutdown.timeoutSeconds must be a positive integer — got: %v" $name $ps.timeoutSeconds) }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -246,6 +246,42 @@ data:
     {{- end }}
     {{- end }}
     {{- end }}
+    {{- if ($cfg.hooks).preBoot }}
+
+    [hooks.pre_boot]
+    {{- if ($cfg.hooks).preBoot.script }}
+    script = {{ ($cfg.hooks).preBoot.script | toJson }}
+    {{- end }}
+    {{- if ($cfg.hooks).preBoot.inline }}
+    inline = {{ ($cfg.hooks).preBoot.inline | toJson }}
+    {{- end }}
+    {{- if ($cfg.hooks).preBoot.url }}
+    url = {{ ($cfg.hooks).preBoot.url | toJson }}
+    {{- end }}
+    {{- if ($cfg.hooks).preBoot.sha256 }}
+    sha256 = {{ ($cfg.hooks).preBoot.sha256 | toJson }}
+    {{- end }}
+    timeout_seconds = {{ ($cfg.hooks).preBoot.timeoutSeconds | default 60 }}
+    on_failure = {{ ($cfg.hooks).preBoot.onFailure | default "abort" | toJson }}
+    {{- end }}
+    {{- if ($cfg.hooks).preShutdown }}
+
+    [hooks.pre_shutdown]
+    {{- if ($cfg.hooks).preShutdown.script }}
+    script = {{ ($cfg.hooks).preShutdown.script | toJson }}
+    {{- end }}
+    {{- if ($cfg.hooks).preShutdown.inline }}
+    inline = {{ ($cfg.hooks).preShutdown.inline | toJson }}
+    {{- end }}
+    {{- if ($cfg.hooks).preShutdown.url }}
+    url = {{ ($cfg.hooks).preShutdown.url | toJson }}
+    {{- end }}
+    {{- if ($cfg.hooks).preShutdown.sha256 }}
+    sha256 = {{ ($cfg.hooks).preShutdown.sha256 | toJson }}
+    {{- end }}
+    timeout_seconds = {{ ($cfg.hooks).preShutdown.timeoutSeconds | default 60 }}
+    on_failure = {{ ($cfg.hooks).preShutdown.onFailure | default "abort" | toJson }}
+    {{- end }}
   {{- if $cfg.agentsMd }}
   AGENTS.md: |
     {{- $cfg.agentsMd | nindent 4 }}

--- a/charts/openab/tests/hooks_test.yaml
+++ b/charts/openab/tests/hooks_test.yaml
@@ -92,3 +92,34 @@ tests:
       - matchRegex:
           path: data["config.toml"]
           pattern: '\[hooks\.pre_shutdown\]'
+
+  - it: rejects when no script source is set in preBoot
+    set:
+      agents.kiro.hooks.preBoot.timeoutSeconds: 60
+    asserts:
+      - failedTemplate:
+          errorPattern: "must set exactly one of: script, inline, url"
+
+  - it: rejects when multiple sources are set in preBoot
+    set:
+      agents.kiro.hooks.preBoot.script: "/boot.sh"
+      agents.kiro.hooks.preBoot.inline: "#!/bin/sh\necho hi"
+    asserts:
+      - failedTemplate:
+          errorPattern: "must set exactly one of: script, inline, url"
+
+  - it: rejects invalid onFailure value
+    set:
+      agents.kiro.hooks.preBoot.script: "/boot.sh"
+      agents.kiro.hooks.preBoot.onFailure: "ignore"
+    asserts:
+      - failedTemplate:
+          errorPattern: "onFailure must be one of: abort, warn"
+
+  - it: rejects non-positive timeoutSeconds
+    set:
+      agents.kiro.hooks.preBoot.script: "/boot.sh"
+      agents.kiro.hooks.preBoot.timeoutSeconds: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: "timeoutSeconds must be a positive integer"

--- a/charts/openab/tests/hooks_test.yaml
+++ b/charts/openab/tests/hooks_test.yaml
@@ -123,3 +123,10 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "timeoutSeconds must be a positive integer"
+
+  - it: rejects url without sha256
+    set:
+      agents.kiro.hooks.preBoot.url: "https://example.com/boot.sh"
+    asserts:
+      - failedTemplate:
+          errorPattern: "sha256 is required when url is set"

--- a/charts/openab/tests/hooks_test.yaml
+++ b/charts/openab/tests/hooks_test.yaml
@@ -1,0 +1,94 @@
+suite: lifecycle hooks
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: does not render hooks when not configured
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: '\[hooks'
+
+  - it: renders [hooks.pre_boot] with inline script
+    set:
+      agents.kiro.hooks.preBoot.inline: |
+        #!/bin/sh
+        set -e
+        echo "boot"
+      agents.kiro.hooks.preBoot.timeoutSeconds: 120
+      agents.kiro.hooks.preBoot.onFailure: abort
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[hooks\.pre_boot\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'timeout_seconds = 120'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'on_failure = "abort"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'inline = '
+
+  - it: renders [hooks.pre_boot] with url and sha256
+    set:
+      agents.kiro.hooks.preBoot.url: "https://example.com/boot.sh"
+      agents.kiro.hooks.preBoot.sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[hooks\.pre_boot\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'url = "https://example.com/boot.sh"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"'
+
+  - it: renders [hooks.pre_boot] with script path
+    set:
+      agents.kiro.hooks.preBoot.script: "/etc/openab/pre-boot.sh"
+      agents.kiro.hooks.preBoot.timeoutSeconds: 60
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'script = "/etc/openab/pre-boot.sh"'
+
+  - it: renders [hooks.pre_shutdown] with warn on_failure
+    set:
+      agents.kiro.hooks.preShutdown.script: "/etc/openab/shutdown.sh"
+      agents.kiro.hooks.preShutdown.timeoutSeconds: 30
+      agents.kiro.hooks.preShutdown.onFailure: warn
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[hooks\.pre_shutdown\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'on_failure = "warn"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'timeout_seconds = 30'
+
+  - it: defaults timeout to 60 and on_failure to abort
+    set:
+      agents.kiro.hooks.preBoot.script: "/boot.sh"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'timeout_seconds = 60'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'on_failure = "abort"'
+
+  - it: renders both hooks together
+    set:
+      agents.kiro.hooks.preBoot.script: "/boot.sh"
+      agents.kiro.hooks.preShutdown.script: "/shutdown.sh"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[hooks\.pre_boot\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[hooks\.pre_shutdown\]'

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -428,6 +428,22 @@ agents:
     #       senderName: "DailyOps"
     #       timezone: "Asia/Taipei"
     #       threadId: ""
+    # Lifecycle hooks — run custom scripts at container lifecycle events.
+    # See docs/hooks.md for full reference. Each hook supports exactly ONE of:
+    #   script (absolute path), inline (script content), or url + sha256.
+    # hooks:
+    #   preBoot:
+    #     timeoutSeconds: 120
+    #     onFailure: abort    # "abort" | "warn"
+    #     inline: |
+    #       #!/bin/sh
+    #       set -e
+    #       aws s3 sync "$BOOTSTRAP_URI" "$HOME/"
+    #   preShutdown:
+    #     timeoutSeconds: 30
+    #     onFailure: warn
+    #     script: /etc/openab/pre-shutdown.sh
+    hooks: {}
     cron:
       usercronEnabled: false
       usercronPath: ""


### PR DESCRIPTION
## Summary

Adds lifecycle hooks support to the Helm chart, rendering `[hooks.pre_boot]` and `[hooks.pre_shutdown]` sections in the ConfigMap `config.toml`.

Closes #1008

## Changes

- **values.yaml**: adds `hooks: {}` with documented examples for `preBoot` and `preShutdown`
- **configmap.yaml**: renders `[hooks.pre_boot]` / `[hooks.pre_shutdown]` TOML blocks when configured

## Supported hook fields

Each hook supports exactly one script source:
- `script` — absolute path to an executable
- `inline` — script content (written to temp file at runtime)
- `url` + `sha256` — remote script with integrity verification

Plus:
- `timeoutSeconds` (default: 60)
- `onFailure` — `"abort"` (default) or `"warn"`

## Usage

```yaml
agents:
  kiro:
    hooks:
      preBoot:
        timeoutSeconds: 120
        onFailure: abort
        inline: |
          #!/bin/sh
          set -e
          aws s3 sync "$BOOTSTRAP_URI" "$HOME/"
      preShutdown:
        timeoutSeconds: 30
        onFailure: warn
        script: /etc/openab/pre-shutdown.sh
```

## What was tested

- `helm template` with no hooks — no `[hooks.*]` blocks rendered
- `helm template` with `preBoot.inline` — correct TOML output
- `helm template` with `preBoot.url`+`sha256` and `preShutdown.script` — both blocks rendered correctly