### PR TITLE
fix(discord): ignore reply-induced mentions for bot admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openab"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -15,7 +15,9 @@ use serenity::builder::{
 };
 use serenity::http::Http;
 use serenity::model::application::ButtonStyle;
-use serenity::model::application::{Command, CommandOptionType, ComponentInteractionDataKind, Interaction};
+use serenity::model::application::{
+    Command, CommandOptionType, ComponentInteractionDataKind, Interaction,
+};
 use serenity::model::channel::{AutoArchiveDuration, Message, MessageType, ReactionType};
 use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, MessageId, RoleId, UserId};
@@ -920,21 +922,30 @@ impl EventHandler for Handler {
             CreateCommand::new("reset").description("Reset the conversation session"),
             CreateCommand::new("remind")
                 .description("Set a one-shot reminder to mention users/roles after a delay")
-                .add_option(CreateCommandOption::new(
-                    CommandOptionType::String,
-                    "targets",
-                    "Users/roles to mention (e.g. @user1 @role1)",
-                ).required(true))
-                .add_option(CreateCommandOption::new(
-                    CommandOptionType::String,
-                    "message",
-                    "Reminder message",
-                ).required(true))
-                .add_option(CreateCommandOption::new(
-                    CommandOptionType::String,
-                    "delay",
-                    "Delay before firing (e.g. 30m, 2h, 1d)",
-                ).required(true)),
+                .add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "targets",
+                        "Users/roles to mention (e.g. @user1 @role1)",
+                    )
+                    .required(true),
+                )
+                .add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "message",
+                        "Reminder message",
+                    )
+                    .required(true),
+                )
+                .add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "delay",
+                        "Delay before firing (e.g. 30m, 2h, 1d)",
+                    )
+                    .required(true),
+                ),
             CreateCommand::new("export-thread")
                 .description("Download this thread as a text file")
                 .add_option(CreateCommandOption::new(
@@ -1263,7 +1274,9 @@ impl Handler {
 
         let msg = match result {
             Ok(()) if dropped > 0 => {
-                format!("🔄 Session reset. Dropped {dropped} buffered message(s). Start a new conversation!")
+                format!(
+                    "🔄 Session reset. Dropped {dropped} buffered message(s). Start a new conversation!"
+                )
             }
             Ok(()) => "🔄 Session reset. Start a new conversation!".to_string(),
             Err(_) if dropped > 0 => {
@@ -1303,15 +1316,18 @@ impl Handler {
 
         // Extract options
         let opts = &cmd.data.options;
-        let targets_raw = opts.iter()
+        let targets_raw = opts
+            .iter()
             .find(|o| o.name == "targets")
             .and_then(|o| o.value.as_str())
             .unwrap_or("");
-        let message = opts.iter()
+        let message = opts
+            .iter()
             .find(|o| o.name == "message")
             .and_then(|o| o.value.as_str())
             .unwrap_or("");
-        let delay_raw = opts.iter()
+        let delay_raw = opts
+            .iter()
             .find(|o| o.name == "delay")
             .and_then(|o| o.value.as_str())
             .unwrap_or("");
@@ -1373,7 +1389,10 @@ impl Handler {
         if targets.len() > remind::MAX_TARGETS {
             let response = CreateInteractionResponse::Message(
                 CreateInteractionResponseMessage::new()
-                    .content(format!("⚠️ Too many targets (max {}). Use a @role instead.", remind::MAX_TARGETS))
+                    .content(format!(
+                        "⚠️ Too many targets (max {}). Use a @role instead.",
+                        remind::MAX_TARGETS
+                    ))
                     .ephemeral(true),
             );
             let _ = cmd.create_response(&ctx.http, response).await;
@@ -1462,9 +1481,7 @@ impl Handler {
                 );
                 (in_thread, gc.name.clone())
             }
-            Ok(serenity::model::channel::Channel::Private(_)) => {
-                (self.allow_dm, "dm".to_string())
-            }
+            Ok(serenity::model::channel::Channel::Private(_)) => (self.allow_dm, "dm".to_string()),
             Ok(_) => (false, "channel".to_string()),
             Err(e) => {
                 tracing::warn!(channel_id = %channel_id, error = %e, "failed to inspect channel for export");
@@ -1486,16 +1503,34 @@ impl Handler {
 
         // --- Parse and validate filter params (mutual exclusion) ---
         let opts = &cmd.data.options;
-        let limit_opt = opts.iter().find(|o| o.name == "limit").and_then(|o| o.value.as_i64());
-        let since_opt = opts.iter().find(|o| o.name == "since").and_then(|o| o.value.as_str());
-        let days_opt = opts.iter().find(|o| o.name == "days").and_then(|o| o.value.as_i64());
-        let all_opt = opts.iter().find(|o| o.name == "all").and_then(|o| o.value.as_bool()).unwrap_or(false);
+        let limit_opt = opts
+            .iter()
+            .find(|o| o.name == "limit")
+            .and_then(|o| o.value.as_i64());
+        let since_opt = opts
+            .iter()
+            .find(|o| o.name == "since")
+            .and_then(|o| o.value.as_str());
+        let days_opt = opts
+            .iter()
+            .find(|o| o.name == "days")
+            .and_then(|o| o.value.as_i64());
+        let all_opt = opts
+            .iter()
+            .find(|o| o.name == "all")
+            .and_then(|o| o.value.as_bool())
+            .unwrap_or(false);
 
-        let filter_count = limit_opt.is_some() as u8 + since_opt.is_some() as u8 + days_opt.is_some() as u8 + all_opt as u8;
+        let filter_count = limit_opt.is_some() as u8
+            + since_opt.is_some() as u8
+            + days_opt.is_some() as u8
+            + all_opt as u8;
         if filter_count > 1 {
             let response = CreateInteractionResponse::Message(
                 CreateInteractionResponseMessage::new()
-                    .content("⚠️ Please specify only one filter: `limit`, `since`, `days`, or `all`.")
+                    .content(
+                        "⚠️ Please specify only one filter: `limit`, `since`, `days`, or `all`.",
+                    )
                     .ephemeral(true),
             );
             let _ = cmd.create_response(&ctx.http, response).await;
@@ -1865,7 +1900,10 @@ async fn export_channel_messages(
 
     let filename = export_filename(channel_id, channel_name);
     if attachment_size_limit < 2048 {
-        tracing::warn!(attachment_size_limit, "attachment_size_limit is very small; export will likely be truncated");
+        tracing::warn!(
+            attachment_size_limit,
+            "attachment_size_limit is very small; export will likely be truncated"
+        );
     }
     let max_bytes = usize::try_from(attachment_size_limit)
         .unwrap_or(8 * 1024 * 1024)
@@ -1935,10 +1973,7 @@ fn format_export_message(msg: &Message) -> String {
     let bot_marker = if msg.author.bot { " [bot]" } else { "" };
     let mut out = format!(
         "[{}] {}{} ({})\n",
-        msg.timestamp,
-        msg.author.name,
-        bot_marker,
-        msg.author.id
+        msg.timestamp, msg.author.name, bot_marker, msg.author.id
     );
 
     if msg.content.is_empty() {
@@ -2316,7 +2351,7 @@ fn turn_limit_warning_present(messages: &[(bool, &str)]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bot_turns::{TurnResult, HARD_BOT_TURN_LIMIT, BOT_TURN_LIMIT_WARNING_PREFIX};
+    use crate::bot_turns::{TurnResult, BOT_TURN_LIMIT_WARNING_PREFIX, HARD_BOT_TURN_LIMIT};
 
     #[test]
     fn reply_allowed_mentions_keeps_content_mentions_but_disables_reply_ping() {
@@ -2328,7 +2363,10 @@ mod tests {
         assert!(parse.iter().any(|v| v == "users"));
         assert!(parse.iter().any(|v| v == "roles"));
         assert!(parse.iter().any(|v| v == "everyone"));
-        assert_eq!(value.get("replied_user").and_then(|v| v.as_bool()), Some(false));
+        assert_eq!(
+            value.get("replied_user").and_then(|v| v.as_bool()),
+            Some(false)
+        );
     }
 
     // --- resolve_mentions tests ---
@@ -3149,9 +3187,8 @@ mod tests {
         trusted_bot_ids: &HashSet<u64>,
         author_id: u64,
     ) -> bool {
-        let trusted_mention = is_mentioned
-            && !trusted_bot_ids.is_empty()
-            && trusted_bot_ids.contains(&author_id);
+        let trusted_mention =
+            is_mentioned && !trusted_bot_ids.is_empty() && trusted_bot_ids.contains(&author_id);
 
         if !trusted_mention {
             match allow_bot_messages {
@@ -3184,7 +3221,12 @@ mod tests {
     #[test]
     fn bot_admission_untrusted_mention_blocked_by_off() {
         let trusted = HashSet::from([42]);
-        assert!(!should_admit_bot_message(AllowBots::Off, true, &trusted, 99));
+        assert!(!should_admit_bot_message(
+            AllowBots::Off,
+            true,
+            &trusted,
+            99
+        ));
     }
 
     /// GIVEN: allow_bot_messages=Off, trusted bot without @mention
@@ -3192,7 +3234,12 @@ mod tests {
     #[test]
     fn bot_admission_trusted_no_mention_blocked_by_off() {
         let trusted = HashSet::from([42]);
-        assert!(!should_admit_bot_message(AllowBots::Off, false, &trusted, 42));
+        assert!(!should_admit_bot_message(
+            AllowBots::Off,
+            false,
+            &trusted,
+            42
+        ));
     }
 
     /// GIVEN: allow_bot_messages=Off, empty trusted_bot_ids, bot @mentions
@@ -3200,7 +3247,12 @@ mod tests {
     #[test]
     fn bot_admission_empty_trusted_ids_off_mode() {
         let trusted: HashSet<u64> = HashSet::new();
-        assert!(!should_admit_bot_message(AllowBots::Off, true, &trusted, 42));
+        assert!(!should_admit_bot_message(
+            AllowBots::Off,
+            true,
+            &trusted,
+            42
+        ));
     }
 
     /// GIVEN: allow_bot_messages=Mentions, trusted bot @mentions
@@ -3208,7 +3260,12 @@ mod tests {
     #[test]
     fn bot_admission_mentions_mode_trusted_mention() {
         let trusted = HashSet::from([42]);
-        assert!(should_admit_bot_message(AllowBots::Mentions, true, &trusted, 42));
+        assert!(should_admit_bot_message(
+            AllowBots::Mentions,
+            true,
+            &trusted,
+            42
+        ));
     }
 
     /// GIVEN: allow_bot_messages=Mentions and a trusted bot replies to this bot
@@ -3240,7 +3297,12 @@ mod tests {
     #[test]
     fn bot_admission_all_mode_untrusted_bot_rejected() {
         let trusted = HashSet::from([42]);
-        assert!(!should_admit_bot_message(AllowBots::All, false, &trusted, 99));
+        assert!(!should_admit_bot_message(
+            AllowBots::All,
+            false,
+            &trusted,
+            99
+        ));
     }
 
     // --- DM gating tests (#656) ---
@@ -3330,19 +3392,28 @@ mod tests {
 
     #[test]
     fn dedup_detects_existing_bot_warning() {
-        let msg = format!("{} (20/20). A human must reply.", BOT_TURN_LIMIT_WARNING_PREFIX);
+        let msg = format!(
+            "{} (20/20). A human must reply.",
+            BOT_TURN_LIMIT_WARNING_PREFIX
+        );
         assert!(turn_limit_warning_present(&[(true, &msg)]));
     }
 
     #[test]
     fn dedup_ignores_human_warning_text() {
-        let msg = format!("{} (20/20). A human must reply.", BOT_TURN_LIMIT_WARNING_PREFIX);
+        let msg = format!(
+            "{} (20/20). A human must reply.",
+            BOT_TURN_LIMIT_WARNING_PREFIX
+        );
         assert!(!turn_limit_warning_present(&[(false, &msg)]));
     }
 
     #[test]
     fn dedup_returns_false_when_no_warning() {
-        assert!(!turn_limit_warning_present(&[(true, "hello"), (false, "world")]));
+        assert!(!turn_limit_warning_present(&[
+            (true, "hello"),
+            (false, "world")
+        ]));
     }
 
     #[test]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -18,7 +18,7 @@ use serenity::model::application::ButtonStyle;
 use serenity::model::application::{Command, CommandOptionType, ComponentInteractionDataKind, Interaction};
 use serenity::model::channel::{AutoArchiveDuration, Message, MessageType, ReactionType};
 use serenity::model::gateway::Ready;
-use serenity::model::id::{ChannelId, MessageId, UserId};
+use serenity::model::id::{ChannelId, MessageId, RoleId, UserId};
 use serenity::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
@@ -93,7 +93,8 @@ impl ChatAdapter for DiscordAdapter {
         }
         let builder = serenity::builder::CreateMessage::new()
             .content(content)
-            .reference_message((ChannelId::new(ch_id), MessageId::new(msg_id)));
+            .reference_message((ChannelId::new(ch_id), MessageId::new(msg_id)))
+            .allowed_mentions(reply_allowed_mentions());
         match ChannelId::new(ch_id)
             .send_message(&self.http, builder)
             .await
@@ -185,6 +186,14 @@ impl ChatAdapter for DiscordAdapter {
             .await?;
         Ok(())
     }
+}
+
+fn reply_allowed_mentions() -> serenity::builder::CreateAllowedMentions {
+    serenity::builder::CreateAllowedMentions::new()
+        .all_users(true)
+        .all_roles(true)
+        .everyone(true)
+        .replied_user(false)
 }
 
 // --- Handler: serenity EventHandler that delegates to AdapterRouter ---
@@ -447,13 +456,14 @@ impl EventHandler for Handler {
         let in_allowed_channel =
             self.allow_all_channels || self.allowed_channels.contains(&channel_id);
 
-        let is_mentioned = msg.mentions_user_id(bot_id)
-            || msg.content.contains(&format!("<@{}>", bot_id))
-            || (!self.allowed_role_ids.is_empty()
-                && msg
-                    .mention_roles
-                    .iter()
-                    .any(|r| self.allowed_role_ids.contains(&r.get())));
+        let is_mentioned = admission_mentions_bot(
+            &msg.content,
+            msg.mentions_user_id(bot_id),
+            msg.author.bot,
+            bot_id,
+            &msg.mention_roles,
+            &self.allowed_role_ids,
+        );
 
         // Bot message gating (from upstream #321)
         if msg.author.bot {
@@ -2190,6 +2200,44 @@ fn is_denied_user(
     !is_bot && !allow_all_users && !allowed_users.contains(&user_id)
 }
 
+fn content_mentions_user(content: &str, bot_id: UserId) -> bool {
+    content.contains(&format!("<@{}>", bot_id)) || content.contains(&format!("<@!{}>", bot_id))
+}
+
+fn mentions_allowed_role(mention_roles: &[RoleId], allowed_role_ids: &HashSet<u64>) -> bool {
+    !allowed_role_ids.is_empty()
+        && mention_roles
+            .iter()
+            .any(|r| allowed_role_ids.contains(&r.get()))
+}
+
+/// Returns `true` if a Discord message should count as mentioning this bot for
+/// admission-gate purposes.
+///
+/// Discord includes the replied-to user in the payload `mentions` array for
+/// replies unless the sender disables `allowed_mentions.replied_user`. For bot
+/// authors, treat only content-level `<@bot>` / `<@!bot>` mentions and allowed
+/// role mentions as triggers so reply metadata cannot wake another bot and
+/// start a ping-pong loop. Human authors keep the existing broader behavior so
+/// replying to the bot still works naturally.
+fn admission_mentions_bot(
+    content: &str,
+    payload_mentions_bot: bool,
+    author_is_bot: bool,
+    bot_id: UserId,
+    mention_roles: &[RoleId],
+    allowed_role_ids: &HashSet<u64>,
+) -> bool {
+    let explicit_content_mention = content_mentions_user(content, bot_id);
+    let allowed_role_mention = mentions_allowed_role(mention_roles, allowed_role_ids);
+
+    if author_is_bot {
+        explicit_content_mention || allowed_role_mention
+    } else {
+        payload_mentions_bot || explicit_content_mention || allowed_role_mention
+    }
+}
+
 /// Returns `true` if a bot message should bypass the `allow_bot_messages` mode check.
 /// A trusted bot that @mentions this bot is treated the same as a human @mention —
 /// it can pull the bot into a thread regardless of the `allow_bot_messages` setting.
@@ -2270,6 +2318,19 @@ mod tests {
     use super::*;
     use crate::bot_turns::{TurnResult, HARD_BOT_TURN_LIMIT, BOT_TURN_LIMIT_WARNING_PREFIX};
 
+    #[test]
+    fn reply_allowed_mentions_keeps_content_mentions_but_disables_reply_ping() {
+        let value = serde_json::to_value(reply_allowed_mentions()).unwrap();
+        let parse = value
+            .get("parse")
+            .and_then(|v| v.as_array())
+            .expect("allowed mentions should serialize parse modes");
+        assert!(parse.iter().any(|v| v == "users"));
+        assert!(parse.iter().any(|v| v == "roles"));
+        assert!(parse.iter().any(|v| v == "everyone"));
+        assert_eq!(value.get("replied_user").and_then(|v| v.as_bool()), Some(false));
+    }
+
     // --- resolve_mentions tests ---
 
     /// Bot's own <@UID> mention is stripped from the prompt.
@@ -2328,6 +2389,74 @@ mod tests {
         let roles: HashSet<u64> = [999].into_iter().collect();
         let result = resolve_mentions("<@&999> check <@&888>", bot_id, &roles);
         assert_eq!(result, "check @(role)");
+    }
+
+    // --- admission_mentions_bot tests ---
+
+    #[test]
+    fn bot_payload_only_reply_mention_does_not_count_as_admission_mention() {
+        let bot_id = UserId::new(111);
+        assert!(!admission_mentions_bot(
+            "ack",
+            true, // Discord payload mentions this bot via reply metadata
+            true, // author is another bot
+            bot_id,
+            &[],
+            &HashSet::new(),
+        ));
+    }
+
+    #[test]
+    fn bot_content_mention_counts_as_admission_mention() {
+        let bot_id = UserId::new(111);
+        assert!(admission_mentions_bot(
+            "please review <@111>",
+            false,
+            true,
+            bot_id,
+            &[],
+            &HashSet::new(),
+        ));
+    }
+
+    #[test]
+    fn bot_legacy_content_mention_counts_as_admission_mention() {
+        let bot_id = UserId::new(111);
+        assert!(admission_mentions_bot(
+            "please review <@!111>",
+            false,
+            true,
+            bot_id,
+            &[],
+            &HashSet::new(),
+        ));
+    }
+
+    #[test]
+    fn human_payload_only_reply_mention_still_counts_as_admission_mention() {
+        let bot_id = UserId::new(111);
+        assert!(admission_mentions_bot(
+            "following up",
+            true, // humans can still naturally reply to the bot
+            false,
+            bot_id,
+            &[],
+            &HashSet::new(),
+        ));
+    }
+
+    #[test]
+    fn bot_allowed_role_mention_counts_as_admission_mention() {
+        let bot_id = UserId::new(111);
+        let allowed_roles = HashSet::from([999]);
+        assert!(admission_mentions_bot(
+            "team handoff",
+            false,
+            true,
+            bot_id,
+            &[RoleId::new(999)],
+            &allowed_roles,
+        ));
     }
 
     #[test]
@@ -3080,6 +3209,30 @@ mod tests {
     fn bot_admission_mentions_mode_trusted_mention() {
         let trusted = HashSet::from([42]);
         assert!(should_admit_bot_message(AllowBots::Mentions, true, &trusted, 42));
+    }
+
+    /// GIVEN: allow_bot_messages=Mentions and a trusted bot replies to this bot
+    /// without a content-level mention
+    /// THEN:  rejected; Discord reply metadata must not count as a bot trigger.
+    #[test]
+    fn bot_admission_mentions_mode_ignores_reply_induced_mention() {
+        let trusted = HashSet::from([42]);
+        let bot_id = UserId::new(111);
+        let is_mentioned = admission_mentions_bot(
+            "ack",
+            true, // payload mention came from Discord reply metadata
+            true, // author is another bot
+            bot_id,
+            &[],
+            &HashSet::new(),
+        );
+        assert!(!is_mentioned);
+        assert!(!should_admit_bot_message(
+            AllowBots::Mentions,
+            is_mentioned,
+            &trusted,
+            42
+        ));
     }
 
     /// GIVEN: allow_bot_messages=All, untrusted bot (not in trusted_bot_ids)


### PR DESCRIPTION
Discord Discussion URL: https://discord.com/channels/1504115981566345299/1512618418115842171/1512618418115842171

## Summary

Fix Discord bot-to-bot loops caused by reply-induced mentions being treated as explicit bot mentions.

Discord can include the replied-to user in the message payload `mentions` array for replies. OpenAB used `msg.mentions_user_id(bot_id)` as the admission trigger, so a bot reply could wake the replied-to bot even when the message content did not contain `<@bot_id>`. In `allow_bot_messages = "mentions"` mode with trusted bots, that turns ordinary acknowledgement replies into bot-to-bot ping-pong.

This PR fixes both sides:

- Outbound defense: Discord replies sent by OpenAB now set `allowed_mentions.replied_user(false)`, while still allowing normal content mentions (`users`, `roles`, `everyone`).
- Inbound admission: bot-authored messages only count content-level `<@bot_id>` / `<@!bot_id>` mentions and allowed role mentions as bot triggers. Human-authored messages keep the previous broader behavior, so a human can still naturally reply to the bot.

## Tests

- `cargo test --locked -p openab discord::tests`
- `cargo test --locked -p openab`

Both pass locally.

## Notes

`Cargo.lock` had a stale root package version (`openab` 0.8.4 while `Cargo.toml` is 0.8.5 on current `main`). Running locked tests requires the lockfile version sync included here.
