### PR TITLE
feat: make [agent] block optional with env var defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,9 @@ COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=openab-agent
+ENV OPENAB_AGENT_COMMAND=kiro-cli
 ENV OPENAB_AGENT_WORKING_DIR=/home/agent
-ENV OPENAB_AGENT_AUTH_COMMAND="openab-agent auth codex-oauth"
+ENV OPENAB_AGENT_AUTH_COMMAND="kiro-cli login --use-device-flow"
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,8 @@ COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=openab-agent
+ENV OPENAB_AGENT_WORKING_DIR=/home/agent
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=openab-agent
 ENV OPENAB_AGENT_WORKING_DIR=/home/agent
+ENV OPENAB_AGENT_AUTH_COMMAND="openab-agent auth codex-oauth"
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=kiro-cli
-ENV OPENAB_AGENT_WORKING_DIR=/home/agent
 ENV OPENAB_AGENT_AUTH_COMMAND="kiro-cli login --use-device-flow"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -52,7 +52,6 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=antigravity
-ENV OPENAB_AGENT_WORKING_DIR=/home/agent
 ENV OPENAB_AGENT_AUTH_COMMAND="agy auth"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -51,5 +51,8 @@ RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=antigravity
+ENV OPENAB_AGENT_WORKING_DIR=/home/agent
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -53,6 +53,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=antigravity
 ENV OPENAB_AGENT_WORKING_DIR=/home/agent
+ENV OPENAB_AGENT_AUTH_COMMAND="agy auth"
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -37,6 +37,7 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=claude
+ENV OPENAB_AGENT_AUTH_COMMAND="claude auth"
 ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -36,5 +36,8 @@ RUN mkdir -p /home/node/.claude && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=claude
+ENV OPENAB_AGENT_WORKING_DIR=/home/node
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -37,7 +37,7 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=claude
-ENV OPENAB_AGENT_AUTH_COMMAND="claude auth"
+ENV OPENAB_AGENT_AUTH_COMMAND="claude auth login"
 ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -38,7 +38,6 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=claude
 ENV OPENAB_AGENT_AUTH_COMMAND="claude auth login"
-ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -34,6 +34,7 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=codex
+ENV OPENAB_AGENT_AUTH_COMMAND="codex auth"
 ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -35,7 +35,6 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=codex
 ENV OPENAB_AGENT_AUTH_COMMAND="codex login --device-auth"
-ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -34,7 +34,7 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=codex
-ENV OPENAB_AGENT_AUTH_COMMAND="codex auth"
+ENV OPENAB_AGENT_AUTH_COMMAND="codex login --device-auth"
 ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -33,5 +33,8 @@ RUN mkdir -p /home/node/.codex && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=codex
+ENV OPENAB_AGENT_WORKING_DIR=/home/node
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -33,6 +33,7 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=copilot
+ENV OPENAB_AGENT_AUTH_COMMAND="copilot auth"
 ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -33,7 +33,7 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=copilot
-ENV OPENAB_AGENT_AUTH_COMMAND="copilot auth"
+ENV OPENAB_AGENT_AUTH_COMMAND="copilot login"
 ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -34,7 +34,6 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=copilot
 ENV OPENAB_AGENT_AUTH_COMMAND="copilot login"
-ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -32,5 +32,8 @@ RUN mkdir -p /home/node/.copilot && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=copilot
+ENV OPENAB_AGENT_WORKING_DIR=/home/node
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -45,6 +45,7 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=cursor
+ENV OPENAB_AGENT_AUTH_COMMAND="cursor auth"
 ENV OPENAB_AGENT_WORKING_DIR=/home/agent
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -44,5 +44,8 @@ RUN mkdir -p /home/agent/.cursor && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=cursor
+ENV OPENAB_AGENT_WORKING_DIR=/home/agent
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -45,7 +45,7 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=cursor
-ENV OPENAB_AGENT_AUTH_COMMAND="cursor auth"
+ENV OPENAB_AGENT_AUTH_COMMAND="cursor-agent login"
 ENV OPENAB_AGENT_WORKING_DIR=/home/agent
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -46,7 +46,6 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=cursor
 ENV OPENAB_AGENT_AUTH_COMMAND="cursor-agent login"
-ENV OPENAB_AGENT_WORKING_DIR=/home/agent
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -34,6 +34,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=gemini
 ENV OPENAB_AGENT_WORKING_DIR=/home/node
+ENV OPENAB_AGENT_AUTH_COMMAND="gemini auth"
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -32,6 +32,9 @@ RUN mkdir -p /home/node/.gemini && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=gemini
+ENV OPENAB_AGENT_WORKING_DIR=/home/node
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -33,7 +33,6 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=gemini
-ENV OPENAB_AGENT_WORKING_DIR=/home/node
 ENV OPENAB_AGENT_AUTH_COMMAND="gemini auth"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -55,6 +55,7 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=grok
+ENV OPENAB_AGENT_AUTH_COMMAND="grok auth"
 ENV OPENAB_AGENT_WORKING_DIR=/home/agent
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -54,5 +54,8 @@ RUN mkdir -p /home/agent/.grok && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=grok
+ENV OPENAB_AGENT_WORKING_DIR=/home/agent
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -55,7 +55,7 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=grok
-ENV OPENAB_AGENT_AUTH_COMMAND="grok auth"
+ENV OPENAB_AGENT_AUTH_COMMAND="grok login --device-auth"
 ENV OPENAB_AGENT_WORKING_DIR=/home/agent
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -56,7 +56,6 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=grok
 ENV OPENAB_AGENT_AUTH_COMMAND="grok login --device-auth"
-ENV OPENAB_AGENT_WORKING_DIR=/home/agent
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -48,5 +48,8 @@ RUN chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=hermes
+ENV OPENAB_AGENT_WORKING_DIR=/home/agent
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -50,6 +50,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=hermes
 ENV OPENAB_AGENT_WORKING_DIR=/home/agent
+ENV OPENAB_AGENT_AUTH_COMMAND="hermes auth add"
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -49,7 +49,6 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=hermes
-ENV OPENAB_AGENT_WORKING_DIR=/home/agent
 ENV OPENAB_AGENT_AUTH_COMMAND="hermes auth add"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -34,6 +34,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=openab-agent
 ENV OPENAB_AGENT_WORKING_DIR=/home/agent
+ENV OPENAB_AGENT_AUTH_COMMAND="openab-agent auth codex-oauth"
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -33,7 +33,6 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=openab-agent
-ENV OPENAB_AGENT_WORKING_DIR=/home/agent
 ENV OPENAB_AGENT_AUTH_COMMAND="openab-agent auth codex-oauth"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -32,5 +32,8 @@ RUN mkdir -p /home/agent/.openab && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=openab-agent
+ENV OPENAB_AGENT_WORKING_DIR=/home/agent
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -48,6 +48,7 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=opencode
+ENV OPENAB_AGENT_AUTH_COMMAND="opencode auth"
 ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -47,5 +47,8 @@ RUN mkdir -p /home/node/.opencode && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=opencode
+ENV OPENAB_AGENT_WORKING_DIR=/home/node
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -48,7 +48,7 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=opencode
-ENV OPENAB_AGENT_AUTH_COMMAND="opencode auth"
+ENV OPENAB_AGENT_AUTH_COMMAND="opencode auth login"
 ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -49,7 +49,6 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=opencode
 ENV OPENAB_AGENT_AUTH_COMMAND="opencode auth login"
-ENV OPENAB_AGENT_WORKING_DIR=/home/node
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.pi
+++ b/Dockerfile.pi
@@ -34,5 +34,8 @@ RUN mkdir -p /home/node/.pi && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND=openab-agent
+ENV OPENAB_AGENT_WORKING_DIR=/home/node
+
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.pi
+++ b/Dockerfile.pi
@@ -35,7 +35,6 @@ USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=openab-agent
-ENV OPENAB_AGENT_WORKING_DIR=/home/node
 ENV OPENAB_AGENT_AUTH_COMMAND="pi /login"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.pi
+++ b/Dockerfile.pi
@@ -36,6 +36,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND=openab-agent
 ENV OPENAB_AGENT_WORKING_DIR=/home/node
+ENV OPENAB_AGENT_AUTH_COMMAND="pi /login"
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -137,9 +137,13 @@ data:
     {{- end }}
 
     [agent]
+    {{- if $cfg.command }}
     command = {{ $cfg.command | toJson }}
+    {{- end }}
     args = {{ if $cfg.args }}{{ $cfg.args | toJson }}{{ else }}[]{{ end }}
-    working_dir = {{ $cfg.workingDir | default "/home/agent" | toJson }}
+    {{- if $cfg.workingDir }}
+    working_dir = {{ $cfg.workingDir | toJson }}
+    {{- end }}
     {{- if $cfg.env }}
     env = { {{ $first := true }}{{ range $k, $v := $cfg.env }}{{ if not $first }}, {{ end }}{{ $k }} = {{ $v | toJson }}{{ $first = false }}{{ end }} }
     {{- end }}

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -18,9 +18,9 @@ openab ──ACP JSON-RPC──► agy-acp ──spawns──► agy --add-dir /
 
 ```toml
 [agent]
-command = "agy-acp"
+command = "agy-acp" # optional — defaults from OPENAB_AGENT_COMMAND
 args = []
-working_dir = "/home/agent"
+working_dir = "/home/agent" # optional — defaults to $HOME
 ```
 
 ### Environment Variables

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -51,7 +51,7 @@ docker build -f Dockerfile.antigravity -t openab-antigravity .
 Antigravity CLI uses Google Sign-In (OAuth). Authenticate inside the container:
 
 ```bash
-kubectl exec -it deployment/openab-antigravity -- /lib64/ld-linux-x86-64.so.2 /usr/local/bin/agy auth
+kubectl exec -it deployment/openab-antigravity -- sh -c "$OPENAB_AGENT_AUTH_COMMAND"
 ```
 
 Complete the device flow in your browser. Auth tokens persist in the PVC at `~/.gemini/`.

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -18,9 +18,9 @@ openab ──ACP JSON-RPC──► agy-acp ──spawns──► agy --add-dir /
 
 ```toml
 [agent]
-command = "agy-acp" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "agy-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = []
-working_dir = "/home/agent" # optional — defaults to $HOME
+# working_dir = "/home/agent"  # optional — defaults to $HOME
 ```
 
 ### Environment Variables

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -38,7 +38,7 @@ args = []
 Sign in interactively using the OAuth device flow. Credentials are stored on disk (persisted via PVC across pod restarts):
 
 ```bash
-kubectl exec -it deployment/openab-claude -- claude auth login
+kubectl exec -it deployment/openab-claude -- sh -c "$OPENAB_AGENT_AUTH_COMMAND"
 ```
 
 After authenticating, restart the pod so the bot process loads the new credentials:

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -28,9 +28,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "claude-agent-acp"
+command = "claude-agent-acp" # optional — defaults from OPENAB_AGENT_COMMAND
 args = []
-working_dir = "/home/node"
+working_dir = "/home/node" # optional — defaults to $HOME
 ```
 
 ## Authentication

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -28,9 +28,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "claude-agent-acp" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "claude-agent-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = []
-working_dir = "/home/node" # optional — defaults to $HOME
+# working_dir = "/home/node"  # optional — defaults to $HOME
 ```
 
 ## Authentication

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -40,7 +40,7 @@ args = []
 ## Authentication
 
 ```bash
-kubectl exec -it deployment/openab-codex -- codex login --device-auth
+kubectl exec -it deployment/openab-codex -- sh -c "$OPENAB_AGENT_AUTH_COMMAND"
 ```
 
 Follow the device code flow in your browser, then restart the pod:

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -32,9 +32,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "codex-acp"
+command = "codex-acp" # optional — defaults from OPENAB_AGENT_COMMAND
 args = []
-working_dir = "/home/node"
+working_dir = "/home/node" # optional — defaults to $HOME
 ```
 
 ## Authentication
@@ -148,9 +148,9 @@ itself, explicitly expose an upload token to the agent:
 
 ```toml
 [agent]
-command = "codex-acp"
+command = "codex-acp" # optional — defaults from OPENAB_AGENT_COMMAND
 args = []
-working_dir = "/home/node"
+working_dir = "/home/node" # optional — defaults to $HOME
 env = { DISCORD_FILE_BOT_TOKEN = "${DISCORD_FILE_BOT_TOKEN}" }
 ```
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -32,9 +32,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "codex-acp" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "codex-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = []
-working_dir = "/home/node" # optional — defaults to $HOME
+# working_dir = "/home/node"  # optional — defaults to $HOME
 ```
 
 ## Authentication
@@ -148,9 +148,9 @@ itself, explicitly expose an upload token to the agent:
 
 ```toml
 [agent]
-command = "codex-acp" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "codex-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = []
-working_dir = "/home/node" # optional — defaults to $HOME
+# working_dir = "/home/node"  # optional — defaults to $HOME
 env = { DISCORD_FILE_BOT_TOKEN = "${DISCORD_FILE_BOT_TOKEN}" }
 ```
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -105,6 +105,16 @@ The AI agent subprocess that OpenAB spawns to handle messages via ACP.
 
 > **Default inherited vars:** After `env_clear()`, the agent always receives `HOME`, `PATH`, and `USER` (on Windows: `USERPROFILE`, `USERNAME`, `PATH`, `SystemRoot`, `SystemDrive`). Use `inherit_env` to pass additional vars beyond this baseline.
 
+### Authentication
+
+Each image sets `OPENAB_AGENT_AUTH_COMMAND` with the correct auth command. To authenticate any agent:
+
+```bash
+kubectl exec -it deployment/openab-<name> -- sh -c "$OPENAB_AGENT_AUTH_COMMAND"
+```
+
+This works for all agents regardless of backend — no need to remember the specific auth command.
+
 ### Agent examples
 
 ```toml

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -93,11 +93,13 @@ Custom Gateway adapter for platforms like Telegram, LINE, Feishu/Lark, and Googl
 
 The AI agent subprocess that OpenAB spawns to handle messages via ACP.
 
+> **This entire section is optional.** If omitted, `command` defaults to `$OPENAB_AGENT_COMMAND` (or `"openab-agent"`) and `working_dir` defaults to `$HOME`. Each Docker image sets these env vars so you typically don't need an `[agent]` block unless you want to customize `env` or `args`.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `command` | string | *required* | Agent binary (e.g. `kiro-cli`, `claude-agent-acp`, `codex`, `gemini`, `copilot`, `opencode`, `pi-acp`, `cursor-agent`). |
+| `command` | string | `$OPENAB_AGENT_COMMAND` or `"openab-agent"` | Agent binary. Optional — defaults from image env var. |
 | `args` | string[] | `[]` | CLI arguments passed to the agent. |
-| `working_dir` | string | `"/tmp"` | Working directory for the agent process. |
+| `working_dir` | string | `$HOME` | Working directory for the agent process. Optional — defaults to container's `$HOME`. |
 | `env` | map | `{}` | Extra environment variables (e.g. `{ OPENAI_API_KEY = "${OPENAI_API_KEY}" }`). |
 | `inherit_env` | string[] | `[]` | Env var names to inherit from the OAB process (e.g. vars injected via K8s `envFrom`). Keys in `env` take precedence. |
 

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -22,9 +22,9 @@ OpenAB spawns `copilot --acp --stdio` as a child process and communicates via st
 
 ```toml
 [agent]
-command = "copilot"
+command = "copilot" # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["--acp", "--stdio"]
-working_dir = "/home/node"
+working_dir = "/home/node" # optional — defaults to $HOME
 ```
 
 ## Docker

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -22,9 +22,9 @@ OpenAB spawns `copilot --acp --stdio` as a child process and communicates via st
 
 ```toml
 [agent]
-command = "copilot" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "copilot"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["--acp", "--stdio"]
-working_dir = "/home/node" # optional — defaults to $HOME
+# working_dir = "/home/node"  # optional — defaults to $HOME
 ```
 
 ## Docker

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -22,9 +22,9 @@ OpenAB spawns `cursor-agent acp` as a child process and communicates via stdio J
 
 ```toml
 [agent]
-command = "cursor-agent"
+command = "cursor-agent" # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["acp"]
-working_dir = "/home/agent"
+working_dir = "/home/agent" # optional — defaults to $HOME
 # Auth via: kubectl exec -it <pod> -- cursor-agent login
 ```
 
@@ -85,7 +85,7 @@ To specify a model, pass `--model` as an arg:
 
 ```toml
 [agent]
-command = "cursor-agent"
+command = "cursor-agent" # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["acp", "--model", "auto"]
 ```
 
@@ -99,7 +99,7 @@ Cursor Agent CLI supports MCP servers configured via `.cursor/mcp.json` in the a
 
 ```toml
 [agent]
-command = "cursor-agent"
+command = "cursor-agent" # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["acp", "--model", "auto", "--workspace", "/home/agent"]
 ```
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -22,9 +22,9 @@ OpenAB spawns `cursor-agent acp` as a child process and communicates via stdio J
 
 ```toml
 [agent]
-command = "cursor-agent" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "cursor-agent"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["acp"]
-working_dir = "/home/agent" # optional — defaults to $HOME
+# working_dir = "/home/agent"  # optional — defaults to $HOME
 # Auth via: kubectl exec -it <pod> -- cursor-agent login
 ```
 
@@ -85,7 +85,7 @@ To specify a model, pass `--model` as an arg:
 
 ```toml
 [agent]
-command = "cursor-agent" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "cursor-agent"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["acp", "--model", "auto"]
 ```
 
@@ -99,7 +99,7 @@ Cursor Agent CLI supports MCP servers configured via `.cursor/mcp.json` in the a
 
 ```toml
 [agent]
-command = "cursor-agent" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "cursor-agent"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["acp", "--model", "auto", "--workspace", "/home/agent"]
 ```
 

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -410,6 +410,6 @@ The bot token is wrong or expired. Reset it in the Developer Portal and redeploy
 The agent CLI isn't authenticated. For kiro-cli:
 
 ```bash
-kubectl exec -it deployment/openab-kiro -- kiro-cli login --use-device-flow
+kubectl exec -it deployment/openab-kiro -- sh -c "$OPENAB_AGENT_AUTH_COMMAND"
 kubectl rollout restart deployment/openab-kiro
 ```

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -32,9 +32,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "gemini"
+command = "gemini" # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["--acp"]
-working_dir = "/home/node"
+working_dir = "/home/node" # optional — defaults to $HOME
 env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 ```
 

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -32,9 +32,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "gemini" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "gemini"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["--acp"]
-working_dir = "/home/node" # optional — defaults to $HOME
+# working_dir = "/home/node"  # optional — defaults to $HOME
 env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 ```
 

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -57,7 +57,7 @@ Get a key from <https://console.x.ai/>. No interactive login needed.
 If you want to use a SuperGrok subscription instead of pay-per-token API billing:
 
 ```bash
-kubectl exec -it <pod> -- grok login --device-auth
+kubectl exec -it <pod> -- sh -c "$OPENAB_AGENT_AUTH_COMMAND"
 ```
 
 The CLI prints a short code and URL — open the URL on any device, enter the code, approve. The token is stored at `~/.grok/auth.json` inside the container.

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -31,9 +31,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "grok"
+command = "grok" # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["agent", "stdio"]
-working_dir = "/home/agent"
+working_dir = "/home/agent" # optional — defaults to $HOME
 ```
 
 ## Authentication
@@ -96,9 +96,9 @@ The default model is whichever Grok Build CLI selects (currently `grok-code-fast
 
 ```toml
 [agent]
-command = "grok"
+command = "grok" # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["agent", "stdio", "--model", "grok-4.3"]
-working_dir = "/home/agent"
+working_dir = "/home/agent" # optional — defaults to $HOME
 ```
 
 List available models inside the pod:

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -31,9 +31,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "grok" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "grok"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["agent", "stdio"]
-working_dir = "/home/agent" # optional — defaults to $HOME
+# working_dir = "/home/agent"  # optional — defaults to $HOME
 ```
 
 ## Authentication
@@ -96,9 +96,9 @@ The default model is whichever Grok Build CLI selects (currently `grok-code-fast
 
 ```toml
 [agent]
-command = "grok" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "grok"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["agent", "stdio", "--model", "grok-4.3"]
-working_dir = "/home/agent" # optional — defaults to $HOME
+# working_dir = "/home/agent"  # optional — defaults to $HOME
 ```
 
 List available models inside the pod:

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -31,8 +31,8 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "hermes-acp"
-working_dir = "/home/agent"
+command = "hermes-acp" # optional — defaults from OPENAB_AGENT_COMMAND
+working_dir = "/home/agent" # optional — defaults to $HOME
 ```
 
 ## Authentication
@@ -138,8 +138,8 @@ Any provider can also be configured with an API key via environment variables:
 
 ```toml
 [agent]
-command = "hermes-acp"
-working_dir = "/home/agent"
+command = "hermes-acp" # optional — defaults from OPENAB_AGENT_COMMAND
+working_dir = "/home/agent" # optional — defaults to $HOME
 env = { XAI_API_KEY = "${XAI_API_KEY}" }
 ```
 

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -31,8 +31,8 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "hermes-acp" # optional — defaults from OPENAB_AGENT_COMMAND
-working_dir = "/home/agent" # optional — defaults to $HOME
+# command = "hermes-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
+# working_dir = "/home/agent"  # optional — defaults to $HOME
 ```
 
 ## Authentication
@@ -138,8 +138,8 @@ Any provider can also be configured with an API key via environment variables:
 
 ```toml
 [agent]
-command = "hermes-acp" # optional — defaults from OPENAB_AGENT_COMMAND
-working_dir = "/home/agent" # optional — defaults to $HOME
+# command = "hermes-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
+# working_dir = "/home/agent"  # optional — defaults to $HOME
 env = { XAI_API_KEY = "${XAI_API_KEY}" }
 ```
 

--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -35,7 +35,7 @@ args = ["acp", "--trust-all-tools"]
 Kiro CLI requires a one-time OAuth login. The PVC persists tokens across pod restarts.
 
 ```bash
-kubectl exec -it deployment/openab-kiro -- kiro-cli login --use-device-flow
+kubectl exec -it deployment/openab-kiro -- sh -c "$OPENAB_AGENT_AUTH_COMMAND"
 ```
 
 Follow the device code flow in your browser, then restart the pod:

--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -25,9 +25,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "kiro-cli"
+command = "kiro-cli" # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["acp", "--trust-all-tools"]
-working_dir = "/home/agent"
+working_dir = "/home/agent" # optional — defaults to $HOME
 ```
 
 ## Authentication

--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -25,9 +25,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "kiro-cli" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "kiro-cli"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["acp", "--trust-all-tools"]
-working_dir = "/home/agent" # optional — defaults to $HOME
+# working_dir = "/home/agent"  # optional — defaults to $HOME
 ```
 
 ## Authentication

--- a/docs/native-agent.md
+++ b/docs/native-agent.md
@@ -22,8 +22,8 @@ openab-agent
 
 ```toml
 [agent]
-command = "openab-agent"
-working_dir = "/home/agent"
+command = "openab-agent" # optional — defaults from OPENAB_AGENT_COMMAND
+working_dir = "/home/agent" # optional — defaults to $HOME
 env = { OPENAB_AGENT_OPENAI_MODEL = "gpt-5.4-mini" }
 ```
 

--- a/docs/native-agent.md
+++ b/docs/native-agent.md
@@ -22,8 +22,8 @@ openab-agent
 
 ```toml
 [agent]
-command = "openab-agent" # optional — defaults from OPENAB_AGENT_COMMAND
-working_dir = "/home/agent" # optional — defaults to $HOME
+# command = "openab-agent"  # optional — defaults from OPENAB_AGENT_COMMAND
+# working_dir = "/home/agent"  # optional — defaults to $HOME
 env = { OPENAB_AGENT_OPENAI_MODEL = "gpt-5.4-mini" }
 ```
 

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -51,9 +51,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "opencode"
+command = "opencode" # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["acp"]
-working_dir = "/home/node"
+working_dir = "/home/node" # optional — defaults to $HOME
 ```
 
 ## Authentication

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -59,7 +59,7 @@ args = ["acp"]
 ## Authentication
 
 ```bash
-kubectl exec -it deployment/openab-opencode -- opencode auth login
+kubectl exec -it deployment/openab-opencode -- sh -c "$OPENAB_AGENT_AUTH_COMMAND"
 ```
 
 Follow the browser OAuth flow, then restart the pod:

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -51,9 +51,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-command = "opencode" # optional — defaults from OPENAB_AGENT_COMMAND
+# command = "opencode"  # optional — defaults from OPENAB_AGENT_COMMAND
 args = ["acp"]
-working_dir = "/home/node" # optional — defaults to $HOME
+# working_dir = "/home/node"  # optional — defaults to $HOME
 ```
 
 ## Authentication

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -47,8 +47,8 @@ Pi saves session history as trees, enabling clean branching of code exploration.
 
 ```toml
 [agent]
-command = "pi-acp"
-working_dir = "/home/node"
+command = "pi-acp" # optional — defaults from OPENAB_AGENT_COMMAND
+working_dir = "/home/node" # optional — defaults to $HOME
 ```
 
 ## Docker

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -47,8 +47,8 @@ Pi saves session history as trees, enabling clean branching of code exploration.
 
 ```toml
 [agent]
-command = "pi-acp" # optional — defaults from OPENAB_AGENT_COMMAND
-working_dir = "/home/node" # optional — defaults to $HOME
+# command = "pi-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
+# working_dir = "/home/node"  # optional — defaults to $HOME
 ```
 
 ## Docker

--- a/src/config.rs
+++ b/src/config.rs
@@ -530,9 +530,7 @@ pub struct ReactionTiming {
 // --- defaults ---
 
 fn default_working_dir() -> String {
-    std::env::var("OPENAB_AGENT_WORKING_DIR")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| "/tmp".into())
+    std::env::var("HOME").unwrap_or_else(|_| "/tmp".into())
 }
 fn default_agent_command() -> String {
     std::env::var("OPENAB_AGENT_COMMAND").unwrap_or_else(|_| "openab-agent".into())

--- a/src/config.rs
+++ b/src/config.rs
@@ -530,12 +530,12 @@ pub struct ReactionTiming {
 // --- defaults ---
 
 fn default_working_dir() -> String {
-    std::env::var("AGENT_WORKING_DIR")
+    std::env::var("OPENAB_AGENT_WORKING_DIR")
         .or_else(|_| std::env::var("HOME"))
         .unwrap_or_else(|_| "/tmp".into())
 }
 fn default_agent_command() -> String {
-    std::env::var("AGENT_COMMAND").unwrap_or_else(|_| "openab-agent".into())
+    std::env::var("OPENAB_AGENT_COMMAND").unwrap_or_else(|_| "openab-agent".into())
 }
 fn default_max_sessions() -> usize {
     10

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,7 @@ pub struct Config {
     pub discord: Option<DiscordConfig>,
     pub slack: Option<SlackConfig>,
     pub gateway: Option<GatewayConfig>,
+    #[serde(default)]
     pub agent: AgentConfig,
     #[serde(default)]
     pub pool: PoolConfig,
@@ -354,7 +355,9 @@ fn default_gateway_platform() -> String {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(default)]
 pub struct AgentConfig {
+    #[serde(default = "default_agent_command")]
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
@@ -364,6 +367,18 @@ pub struct AgentConfig {
     pub env: HashMap<String, String>,
     #[serde(default)]
     pub inherit_env: Vec<String>,
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            command: default_agent_command(),
+            args: Vec::new(),
+            working_dir: default_working_dir(),
+            env: HashMap::new(),
+            inherit_env: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -515,7 +530,12 @@ pub struct ReactionTiming {
 // --- defaults ---
 
 fn default_working_dir() -> String {
-    "/tmp".into()
+    std::env::var("AGENT_WORKING_DIR")
+        .or_else(|_| std::env::var("HOME"))
+        .unwrap_or_else(|_| "/tmp".into())
+}
+fn default_agent_command() -> String {
+    std::env::var("AGENT_COMMAND").unwrap_or_else(|_| "openab-agent".into())
 }
 fn default_max_sessions() -> usize {
     10


### PR DESCRIPTION
## Summary

Makes the `[agent]` section in config TOML fully optional by adding env var fallbacks, sets those env vars in all Dockerfiles, and updates the helm chart.

### Changes

1. **src/config.rs** — `[agent]` block is now optional with env var defaults:
   - `command` → `$OPENAB_AGENT_COMMAND` → `"openab-agent"`
   - `working_dir` → `$OPENAB_AGENT_WORKING_DIR` → `$HOME` → `"/tmp"`

2. **12 Dockerfiles** — each image declares its agent binary, working dir, and auth command:

   | Dockerfile | OPENAB_AGENT_COMMAND | OPENAB_AGENT_WORKING_DIR | OPENAB_AGENT_AUTH_COMMAND |
   |------------|---------------------|--------------------------|--------------------------|
   | Dockerfile (kiro) | kiro-cli | /home/agent | kiro-cli login --use-device-flow |
   | .antigravity | antigravity | /home/agent | agy auth |
   | .claude | claude | /home/node | claude auth login |
   | .codex | codex | /home/node | codex login --device-auth |
   | .copilot | copilot | /home/node | copilot login |
   | .cursor | cursor | /home/agent | cursor-agent login |
   | .gemini | gemini | /home/node | gemini auth |
   | .grok | grok | /home/agent | grok login --device-auth |
   | .hermes | hermes | /home/agent | hermes auth add |
   | .native | openab-agent | /home/agent | openab-agent auth codex-oauth |
   | .opencode | opencode | /home/node | opencode auth login |
   | .pi | openab-agent | /home/node | pi /login |

3. **Helm chart configmap** — `command` and `working_dir` only rendered when explicitly set in values.yaml; otherwise image env vars are used.

## Motivation

Each Docker image already knows its agent binary, home directory, and auth command. Requiring every config (gist or helm values) to hardcode these is redundant and error-prone — e.g., switching xdu from openab-agent to grok required editing the gist config manually.

## Usage

Config becomes minimal:
```toml
# No [agent] block needed, or just override env:
[agent]
env = { OPENAB_AGENT_OPENAI_MODEL = "grok-3-mini" }
```

Dockerfiles self-document their defaults:
```dockerfile
ENV OPENAB_AGENT_COMMAND=grok
ENV OPENAB_AGENT_WORKING_DIR=/home/agent
ENV OPENAB_AGENT_AUTH_COMMAND="grok login --device-auth"
```

## Backward Compatible

Existing configs with explicit `command` and `working_dir` continue to work unchanged.