### PR TITLE
fix: OPENAB_AGENT_COMMAND=agy-acp in Dockerfile.antigravity

### DIFF
--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -51,7 +51,7 @@ RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=antigravity
+ENV OPENAB_AGENT_COMMAND=agy-acp
 ENV OPENAB_AGENT_AUTH_COMMAND="agy auth"
 
 ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
The binary is `agy-acp` (the ACP adapter), not `antigravity` (which was renamed to `agy`).

Without this fix, bots using `openab-antigravity:beta` fail with:
```
failed to spawn antigravity: No such file or directory (os error 2)
```