### PR TITLE
Add OpenShell Google Chat/Kiro reference architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openab"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/adr/openshell-websocket-auth.md
+++ b/docs/adr/openshell-websocket-auth.md
@@ -1,0 +1,306 @@
+# ADR: OpenShell-Compatible Gateway WebSocket Authentication
+
+- **Status:** Proposed
+- **Date:** 2026-06-06
+- **Author:** OpenAB POC contributors
+- **Related:** [ADR: Custom Gateway](./custom-gateway.md), [OpenShell](../openshell.md), [Google Chat](../google-chat.md)
+
+---
+
+## 1. Context
+
+OpenAB's Custom Gateway lets OAB connect outbound over WebSocket while the
+gateway owns inbound webhooks and platform credentials. This works well for
+Google Chat, LINE, Telegram, and other webhook platforms.
+
+When OAB runs inside an NVIDIA OpenShell sandbox, gateway authentication has an
+extra constraint: long-lived secrets should not be placed in the sandbox as raw
+environment variables or raw config values.
+
+OpenShell provider credentials appear in the sandbox as resolver placeholders,
+for example:
+
+```text
+provider-OPENSHELL-RESOLVE-ENV-GATEWAY_WS_TOKEN
+openshell:resolve:env:...
+```
+
+OpenShell resolves those placeholders at the network boundary only when the
+policy proxy can inspect the request. This allows the agent process to use a
+credential without ever seeing the raw value.
+
+## 2. Problem
+
+The original gateway auth path appended the token to the WebSocket URL:
+
+```text
+ws://gateway/ws?token=<token>
+```
+
+That is simple for ordinary Docker/Kubernetes deployments, but it is a poor fit
+for OpenShell provider credentials:
+
+- The sandbox config would otherwise need a raw gateway token.
+- WebSocket handshake query/header credential rewrite was unreliable in the
+  OpenShell bridge path used by this POC.
+- A Rust WebSocket client may not honor the injected HTTP proxy environment, so
+  local OpenShell/Docker setups sometimes need a small local bridge to reach the
+  host gateway.
+
+During the POC, these routes were tested and rejected as the primary OpenShell
+path:
+
+```text
+[gateway].token = "${GATEWAY_WS_TOKEN}"
+[gateway].token = "openshell:resolve:env:GATEWAY_WS_TOKEN"
+[gateway].token = "provider-OPENSHELL-RESOLVE-ENV-GATEWAY_WS_TOKEN"
+ws://.../ws?token=<placeholder>
+Authorization: Bearer <placeholder>
+```
+
+OpenShell can rewrite placeholders in normal HTTP requests. For example, a
+`curl` request with `Authorization: Bearer <placeholder>` to the gateway's HTTP
+endpoint proves header rewrite works when the request is inspected as REST.
+However, WebSocket auth in the upgrade handshake is not the right compatibility
+point for the OpenShell setup.
+
+OpenShell's documented WebSocket credential rewrite applies to client-to-server
+WebSocket text frames after the `101 Switching Protocols` upgrade.
+
+## 3. Decision
+
+Add a first-text-frame gateway authentication message.
+
+OAB connects to the gateway WebSocket without putting the gateway token in the
+URL query string. Immediately after the WebSocket upgrade succeeds, OAB sends:
+
+```json
+{
+  "schema": "openab.gateway.auth.v1",
+  "token": "provider-OPENSHELL-RESOLVE-ENV-GATEWAY_WS_TOKEN"
+}
+```
+
+When running under OpenShell with:
+
+```text
+websocket_credential_rewrite: true
+```
+
+the policy proxy rewrites the provider placeholder inside that client-to-server
+text frame before forwarding it to the gateway.
+
+The gateway behavior is:
+
+1. If `GATEWAY_WS_TOKEN` is not set, accept WebSocket clients with a warning.
+2. If a legacy query token or `Authorization: Bearer` token is present, validate
+   it before upgrade handling continues.
+3. Otherwise, accept the upgrade and require the first client text frame to be
+   `openab.gateway.auth.v1` with the expected token.
+4. If the first frame is missing, malformed, or invalid, close the socket and
+   do not forward events.
+
+This keeps the old query-token path compatible while enabling a hardened
+OpenShell path.
+
+## 4. Reference Architecture
+
+```text
+                         Google Workspace
+                    +-----------------------+
+                    |      Google Chat      |
+                    |  signed HTTPS webhook |
+                    +-----------+-----------+
+                                |
+                                v
++-----------------------------------------------------------------------+
+| Host / trusted runtime                                                |
+|                                                                       |
+|  +-----------------------------+        +---------------------------+ |
+|  | openab-gateway              |        | Host secret/token broker   | |
+|  |                             |        |                           | |
+|  | - owns webhook endpoint     |        | - stores SA JSON          | |
+|  | - verifies Google Chat JWT  |        | - mints short-lived       | |
+|  | - owns Google Chat SA JSON  |        |   Google access tokens    | |
+|  | - owns raw GATEWAY_WS_TOKEN |        | - updates OpenShell       | |
+|  +--------------+--------------+        |   provider credentials    | |
+|                 ^                       +-------------+-------------+ |
+|                 |                                     |               |
+|                 | validates raw token                  | stores raw    |
+|                 | after rewrite                        | provider data |
+|                 |                                     v               |
+|  +--------------+--------------------------------------+-------------+ |
+|  |                  OpenShell provider store                         | |
+|  |  GATEWAY_WS_TOKEN, GOOGLE_ACCESS_TOKEN                            | |
+|  +--------------+--------------------------------------+-------------+ |
++-----------------+--------------------------------------+---------------+
+                  |                                      |
+                  | WebSocket 101 + text-frame rewrite   |
+                  | REST header rewrite for Google APIs  |
+                  v                                      v
++-----------------------------------------------------------------------+
+| OpenShell sandbox                                                     |
+|                                                                       |
+|  +-----------------------------+       +----------------------------+ |
+|  | openab                      |       | curl / Google API tools     | |
+|  |                             |       |                            | |
+|  | - config has placeholders   |       | - Authorization header     | |
+|  | - opens ws://gateway/ws     |       |   contains placeholder     | |
+|  | - first text frame sends    |       | - OpenShell rewrites       | |
+|  |   openab.gateway.auth.v1    |       |   token at egress          | |
+|  +--------------+--------------+       +----------------------------+ |
+|                 |                                                     |
+|                 | stdio ACP                                           |
+|                 v                                                     |
+|  +-----------------------------+                                      |
+|  | kiro-cli                    |                                      |
+|  |                             |                                      |
+|  | - agent-owned auth state    |                                      |
+|  |   remains local credential  |                                      |
+|  |   material                  |                                      |
+|  +-----------------------------+                                      |
++-----------------------------------------------------------------------+
+```
+
+Credential flow:
+
+```text
+Host/OpenShell provider stores raw GATEWAY_WS_TOKEN
+  -> sandbox config stores provider placeholder only
+  -> OAB sends placeholder in first WebSocket text frame
+  -> OpenShell rewrites placeholder at network boundary
+  -> gateway validates raw token
+```
+
+Google API credential flow:
+
+```text
+service-account JSON stays on host/gateway side
+  -> host broker mints short-lived GOOGLE_ACCESS_TOKEN
+  -> OpenShell provider stores raw short-lived token
+  -> sandbox command sends provider placeholder in HTTP Authorization header
+  -> OpenShell rewrites placeholder at egress
+  -> Google API receives raw short-lived token
+```
+
+## 5. Change From Earlier `openshell.md` Guidance
+
+The earlier OpenShell quick-start pattern focused on running OAB inside an
+OpenShell sandbox with provider placeholders for simple outbound APIs such as
+Discord. It did not cover webhook platforms where a Custom Gateway receives
+inbound traffic, owns platform credentials, and authenticates OAB over
+WebSocket.
+
+The new recommendation keeps that provider-placeholder principle but changes
+where secrets live and how WebSocket auth is performed.
+
+| Area | Earlier `openshell.md` pattern | New Google Chat/Kiro gateway pattern |
+|---|---|---|
+| Platform surface | Direct bot API from sandbox, for example Discord gateway/API | Google Chat HTTPS webhook terminates at `openab-gateway` outside OpenShell |
+| Platform credentials | Provider placeholder in sandbox config for the bot token | Google Chat service-account JSON stays in the gateway/host layer |
+| Gateway auth | Not applicable, or token could be appended to `ws://.../ws?token=...` in non-OpenShell deployments | OAB sends `openab.gateway.auth.v1` as first WebSocket text frame so OpenShell can rewrite the provider placeholder after upgrade |
+| `.env` / local secret practice | Easy to accidentally fall back to raw env/config values during local setup | Sandbox config should contain placeholders only; raw values live in OpenShell provider, gateway env, or host token broker |
+| Google Drive/Sheets/Docs access | Not covered | Host keeps service-account JSON, mints short-lived Google token, passes only a provider placeholder through sandbox egress |
+| Agent-owned auth state | Not addressed | Explicitly documented as a remaining limitation: Kiro's own login cache is still local credential material |
+
+This is not a claim that OpenShell can make all agent secrets disappear. It is a
+more precise split:
+
+```text
+Injected operator/platform secrets
+  -> use provider placeholders, gateway ownership, or host token broker
+
+Agent CLI's own login cache
+  -> remains agent-owned credential material unless the CLI supports brokering
+```
+
+## 6. Consequences
+
+Positive:
+
+- The sandbox does not need the raw gateway token.
+- OpenShell can enforce which binary may send the credential and to which
+  endpoint.
+- Gateway authentication remains enabled for OpenShell deployments.
+- Existing query-token deployments continue to work.
+
+Tradeoffs:
+
+- The gateway briefly accepts the WebSocket upgrade before authentication
+  completes. It must not send events until the first-frame auth succeeds.
+- A malformed or unauthenticated client consumes a socket briefly until the
+  auth timeout expires or the gateway closes it.
+- Operators need a WebSocket policy with credential rewrite enabled.
+
+## 7. Operational Notes
+
+Minimal OpenShell endpoint shape:
+
+```bash
+openshell policy update oab \
+  --add-endpoint gateway-host:8080:read-write:websocket:enforce:websocket-credential-rewrite \
+  --binary /usr/local/bin/openab \
+  --wait
+
+openshell policy update oab \
+  --add-allow 'gateway-host:8080:GET:/ws' \
+  --wait
+```
+
+For local Docker Desktop setups where direct TCP to the host gateway is not
+available to the Rust WebSocket client, a small bridge may be used inside the
+sandbox. Even then, policy should classify the upstream gateway endpoint rather
+than treating the OpenShell HTTP proxy as the application endpoint.
+
+## 8. Security Boundary
+
+Do not pass long-lived platform secrets or service-account JSON files into the
+agent sandbox. Keep those in the host gateway or in a host-side token broker.
+
+For Google Drive/Sheets/Docs access, prefer:
+
+```text
+service-account JSON on host
+  -> host mints short-lived OAuth access token
+  -> OpenShell provider stores GOOGLE_ACCESS_TOKEN
+  -> sandbox uses provider placeholder in Authorization header
+  -> OpenShell rewrites at egress
+```
+
+This avoids exposing the long-lived service-account private key to the agent.
+
+## 9. Limitation: Agent-Owned Credential Stores
+
+OpenShell provider placeholders protect credentials that the operator injects
+through OpenShell, such as gateway tokens or short-lived Google API access
+tokens. They do not automatically protect credentials that an agent CLI creates
+and persists for itself.
+
+For example, Kiro CLI maintains its own local authentication state. In the POC,
+Kiro could still boot after `.aws/sso/cache/*.json` was removed, but failed when
+`.local/share/kiro-cli/data.sqlite3` was removed. This means the decisive Kiro
+auth state is not only the AWS SSO cache files; it also lives in Kiro's own
+SQLite state under `.local/share/kiro-cli/`.
+
+Observed credential-bearing paths include:
+
+```text
+/sandbox/.local/share/kiro-cli/data.sqlite3
+/sandbox/.aws/sso/cache/*.json
+```
+
+Those files are agent-owned credential stores, not OpenShell provider
+credentials. Replacing their JSON fields with provider placeholder strings is
+not a natural fix unless the agent CLI itself supports placeholder resolution or
+external credential brokering. Otherwise, the CLI expects its native local token
+format and needs readable auth state to start.
+
+Operational consequence:
+
+- Provider placeholders are appropriate for injected secrets controlled by
+  OpenAB, the gateway, or a host-side broker.
+- They are not sufficient to isolate a third-party agent's own login cache.
+- Treat agent auth state such as Kiro's `data.sqlite3` as high-risk credential
+  material.
+- Use a dedicated low-privilege agent identity per bot, avoid shared sandboxes,
+  and prefer an agent-supported auth proxy/token broker when available.

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -7,6 +7,11 @@ Google Chat ──POST──▶ Gateway (:8080) ◀──WebSocket── OAB Pod
                                           (OAB connects out)
 ```
 
+For a hardened OpenShell deployment with Kiro, gateway first-frame WebSocket
+auth, and Google Drive/Sheets/Docs access through provider-rewritten short-lived
+tokens, see
+[Google Chat + OpenShell + Kiro Reference Architecture](./refarch/google-chat-openshell-kiro.md).
+
 ## Prerequisites
 
 - **A Google Workspace (Business or Enterprise) account** — required by Google to configure the Chat API. Regular `@gmail.com` consumer accounts cannot create Google Chat apps. Workspace Individual or Business Starter is the cheapest qualifying tier. See [Configure the Google Chat API](https://developers.google.com/workspace/chat/configure-chat-api).

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -2,6 +2,10 @@
 
 Run OAB inside an [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandbox for isolated, policy-enforced execution.
 
+For webhook platforms such as Google Chat, where a Custom Gateway receives
+inbound HTTPS webhooks and OAB connects outbound over WebSocket, see
+[Google Chat + OpenShell + Kiro Reference Architecture](./refarch/google-chat-openshell-kiro.md).
+
 ## Architecture
 
 ```
@@ -20,7 +24,7 @@ Run OAB inside an [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandbo
 │  │  Docker Container (sandbox: "oab")                            │  │
 │  │                                                               │  │
 │  │  /home/sandbox/                                               │  │
-│  │  └── config.toml         ← bot token + agent config           │  │
+│  │  └── config.toml         ← provider placeholders + config     │  │
 │  │                                                               │  │
 │  │  openab run ──stdio JSON-RPC──► openab-agent                  │  │
 │  │       │                              │                        │  │
@@ -111,10 +115,14 @@ Open the printed URL in your browser, approve, then paste the `localhost:1455/au
 
 ### 5. Create config and run
 
+Provider credentials appear in the sandbox as OpenShell resolver placeholders.
+Do not copy raw long-lived secrets into `config.toml` when a provider placeholder
+can be used instead.
+
 ```bash
 sandbox$ cat > config.toml <<'EOF'
 [discord]
-bot_token = "your-bot-token"
+bot_token = "provider-OPENSHELL-RESOLVE-ENV-DISCORD_BOT_TOKEN"
 allow_all_channels = true
 
 [agent]
@@ -132,6 +140,31 @@ EOF
 
 sandbox$ openab run --config config.toml
 ```
+
+## Provider Credential Handling
+
+OpenShell provider credentials are safer than ordinary container `.env` values
+because the sandbox receives placeholder strings, not raw secret material. The
+OpenShell policy proxy can rewrite those placeholders at approved egress
+boundaries.
+
+For ordinary HTTP APIs, use the placeholder in headers, query parameters, or
+paths according to OpenShell policy. For example:
+
+```bash
+curl -H "Authorization: Bearer provider-OPENSHELL-RESOLVE-ENV-API_TOKEN" \
+  https://api.example.com/v1/resource
+```
+
+For Custom Gateway WebSocket authentication, prefer
+`openab.gateway.auth.v1` first-frame auth instead of putting the token in the
+WebSocket URL. See
+[ADR: OpenShell-Compatible Gateway WebSocket Authentication](./adr/openshell-websocket-auth.md).
+
+Avoid mounting long-lived service-account JSON files into the sandbox. For
+Google Drive, Sheets, and Docs access, use a host-side token refresher that
+stores a short-lived `GOOGLE_ACCESS_TOKEN` in the OpenShell provider, then call
+Google APIs from the sandbox with the provider placeholder.
 
 ## Network Policy
 

--- a/docs/refarch/google-chat-openshell-kiro.md
+++ b/docs/refarch/google-chat-openshell-kiro.md
@@ -1,0 +1,217 @@
+# Google Chat + OpenShell + Kiro Reference Architecture
+
+Run OpenAB with Kiro inside an OpenShell sandbox while exposing Google Chat
+through the Custom Gateway outside the sandbox.
+
+This pattern is useful when the agent is powerful enough that long-lived
+credentials should not be placed in the same filesystem or environment that the
+agent can inspect.
+
+## Architecture
+
+```text
+Google Chat
+  -> HTTPS webhook
+  -> openab-gateway outside OpenShell
+  -> WebSocket
+  -> OpenShell policy proxy
+  -> openab inside OpenShell sandbox
+  -> kiro-cli acp --trust-all-tools
+```
+
+Local Docker Desktop deployments may need a sandbox-local bridge if the Rust
+WebSocket client cannot directly reach the host gateway:
+
+```text
+openab
+  -> ws://127.0.0.1:18080/ws
+  -> sandbox bridge
+  -> OpenShell proxy
+  -> host openab-gateway:8080/ws
+```
+
+The bridge is an operational workaround for local host routing. The security
+boundary remains OpenShell policy plus provider credential rewrite.
+
+## Credential Model
+
+Do not put raw gateway tokens, Google service-account JSON, or Google OAuth
+tokens in sandbox config.
+
+Use OpenShell providers:
+
+```bash
+openshell provider create --name openab-googlechat --type generic \
+  --credential GATEWAY_WS_TOKEN \
+  --credential GOOGLE_ACCESS_TOKEN
+```
+
+In sandbox config, use provider placeholders:
+
+```toml
+[gateway]
+url = "ws://127.0.0.1:18080/ws"
+platform = "googlechat"
+token = "provider-OPENSHELL-RESOLVE-ENV-GATEWAY_WS_TOKEN"
+allow_all_channels = true
+allow_all_users = true
+
+[agent]
+command = "kiro-cli"
+args = ["acp", "--trust-all-tools"]
+working_dir = "/sandbox"
+```
+
+`GATEWAY_WS_TOKEN` is authenticated using the first WebSocket text frame. See
+[ADR: OpenShell-Compatible Gateway WebSocket Authentication](../adr/openshell-websocket-auth.md).
+
+## Gateway
+
+Run the Custom Gateway outside OpenShell. The gateway should own Google Chat
+webhook verification and Google Chat reply credentials.
+
+Example:
+
+```bash
+docker run -d --name openab-gateway \
+  --env-file /path/to/gateway.env \
+  -v /path/to/google-chat-service-account.json:/secrets/google-chat-service-account.json:ro \
+  -p 8080:8080 \
+  ghcr.io/openabdev/openab-gateway:latest
+```
+
+Gateway env:
+
+```text
+GOOGLE_CHAT_ENABLED=true
+GOOGLE_CHAT_AUDIENCE=https://your-domain.example/webhook/googlechat
+GOOGLE_CHAT_WEBHOOK_PATH=/webhook/googlechat
+GOOGLE_CHAT_SA_KEY_FILE=/secrets/google-chat-service-account.json
+GATEWAY_WS_TOKEN=<long random token>
+```
+
+## OpenShell Policy
+
+Apply policy updates serially and wait for each revision to load.
+
+Gateway WebSocket endpoint:
+
+```bash
+openshell policy update oab \
+  --add-endpoint gateway-host:8080:read-write:websocket:enforce:websocket-credential-rewrite \
+  --binary /usr/local/bin/openab \
+  --wait
+
+openshell policy update oab \
+  --add-allow 'gateway-host:8080:GET:/ws' \
+  --wait
+```
+
+Kiro endpoints vary by version, but a typical policy includes:
+
+```bash
+openshell policy update oab \
+  --add-endpoint oidc.us-east-1.amazonaws.com:443:read-write:rest:enforce \
+  --binary /usr/local/bin/kiro-cli \
+  --wait
+
+openshell policy update oab \
+  --add-endpoint cognito-identity.us-east-1.amazonaws.com:443:read-write:rest:enforce \
+  --binary /usr/local/bin/kiro-cli \
+  --wait
+
+openshell policy update oab \
+  --add-endpoint q.us-east-1.amazonaws.com:443:read-write:rest:enforce \
+  --binary /usr/local/bin/kiro-cli \
+  --wait
+
+openshell policy update oab \
+  --add-endpoint client-telemetry.us-east-1.amazonaws.com:443:read-write:rest:enforce \
+  --binary /usr/local/bin/kiro-cli \
+  --wait
+```
+
+## Google Drive, Sheets, And Docs Access
+
+Keep the service-account JSON on the host. Do not mount it into the sandbox.
+
+For a simple POC, mint a short-lived access token on the host and store it in an
+OpenShell provider:
+
+```bash
+CLOUDSDK_CONFIG=/tmp/openab-gcloud-sa \
+  gcloud auth activate-service-account \
+  --key-file=/path/to/google-chat-service-account.json
+
+GOOGLE_ACCESS_TOKEN="$(
+  CLOUDSDK_CONFIG=/tmp/openab-gcloud-sa \
+    gcloud auth print-access-token \
+    --scopes=https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/spreadsheets.readonly,https://www.googleapis.com/auth/documents.readonly
+)"
+export GOOGLE_ACCESS_TOKEN
+
+openshell provider update openab-googlechat --credential GOOGLE_ACCESS_TOKEN
+```
+
+Allow read-only Google API hosts for the tool binary that will fetch content:
+
+```bash
+openshell policy update oab \
+  --add-endpoint www.googleapis.com:443:read-write:rest:enforce \
+  --binary /usr/bin/curl \
+  --wait
+
+openshell policy update oab \
+  --add-endpoint sheets.googleapis.com:443:read-write:rest:enforce \
+  --binary /usr/bin/curl \
+  --wait
+
+openshell policy update oab \
+  --add-endpoint docs.googleapis.com:443:read-write:rest:enforce \
+  --binary /usr/bin/curl \
+  --wait
+```
+
+Sandbox smoke tests:
+
+```bash
+curl -H "Authorization: Bearer provider-OPENSHELL-RESOLVE-ENV-GOOGLE_ACCESS_TOKEN" \
+  "https://www.googleapis.com/drive/v3/about?fields=user(displayName,emailAddress)"
+
+curl -H "Authorization: Bearer provider-OPENSHELL-RESOLVE-ENV-GOOGLE_ACCESS_TOKEN" \
+  "https://sheets.googleapis.com/v4/spreadsheets/SPREADSHEET_ID?fields=spreadsheetId,properties.title"
+
+curl -L -H "Authorization: Bearer provider-OPENSHELL-RESOLVE-ENV-GOOGLE_ACCESS_TOKEN" \
+  "https://www.googleapis.com/drive/v3/files/DOC_ID/export?mimeType=text/plain"
+```
+
+The service account must have access to the target Drive files or folders. A
+Drive `404` or Sheets `403` usually means the file has not been shared with the
+service account or a group that includes it.
+
+## Known Failure Modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Google Chat says "not responding" | Gateway unreachable or webhook URL stale | Check tunnel, gateway logs, and Chat app URL |
+| `Connection Lost` | Gateway received event but OAB/Kiro did not complete the round trip | Check WebSocket connection and Kiro auth |
+| `Internal Error (code: -32603)` | Agent process failed, often due to blocked Kiro endpoint | Add required Kiro endpoint policy |
+| WebSocket `401` | Gateway token mismatch or placeholder not rewritten | Use first-frame auth and sync provider token |
+| WebSocket `403` | WebSocket endpoint or `GET /ws` not allowed | Add websocket endpoint and `GET /ws` allow rule |
+| Drive `404` / Sheets `403` | Service account lacks file access | Share the file/folder with the service account |
+
+## Production Notes
+
+- Use a stable HTTPS domain for Google Chat webhooks.
+- Run the gateway in an always-on environment; local tunnels are only for POC.
+- Keep platform credentials in the gateway or a host-side broker.
+- Keep agent sandbox credentials as OpenShell provider placeholders.
+- Prefer short-lived Google access tokens over mounting service-account JSON
+  into the sandbox.
+- Treat Kiro's own auth state as a separate credential class. In the POC,
+  `.local/share/kiro-cli/data.sqlite3` was required for Kiro to boot even when
+  `.aws/sso/cache` was absent. OpenShell provider placeholders do not naturally
+  protect this agent-owned SQLite login state unless Kiro itself supports an
+  external credential broker or placeholder resolution.
+- Use a dedicated low-privilege Kiro identity per bot and do not share that
+  sandbox/state across users.

--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -1112,7 +1112,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openab-gateway"
-version = "0.4.0"
+version = "0.5.2"
 dependencies = [
  "aes",
  "anyhow",

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -143,20 +143,25 @@ pub struct GoogleChatSpace {
 
 const GOOGLE_CHAT_ISSUER: &str = "https://accounts.google.com";
 const GOOGLE_CHAT_JWKS_URL: &str = "https://www.googleapis.com/oauth2/v3/certs";
-const GOOGLE_CHAT_SIGNER_EMAIL: &str = "chat@system.gserviceaccount.com";
+const GOOGLE_CHAT_LEGACY_SIGNER_EMAIL: &str = "chat@system.gserviceaccount.com";
+const GOOGLE_CHAT_SIGNER_EMAIL_SUFFIX: &str = "@gcp-sa-gsuiteaddons.iam.gserviceaccount.com";
 const JWKS_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(3600);
 
 /// Verify the JWT's `email` claim belongs to Google Chat.
-/// HTTP endpoint URL webhooks are signed by `chat@system.gserviceaccount.com`.
+/// Google Chat HTTP endpoint URL webhooks are signed by a Google-managed
+/// Workspace add-ons service account. Older deployments used
+/// `chat@system.gserviceaccount.com`.
 /// Without this check, any Google-issued ID token would be accepted.
 fn verify_email_claim(claims: &serde_json::Value) -> Result<(), String> {
     let email = claims
         .get("email")
         .and_then(|v| v.as_str())
         .ok_or("missing email claim")?;
-    if email != GOOGLE_CHAT_SIGNER_EMAIL {
+    if email != GOOGLE_CHAT_LEGACY_SIGNER_EMAIL
+        && !email.ends_with(GOOGLE_CHAT_SIGNER_EMAIL_SUFFIX)
+    {
         return Err(format!(
-            "email claim mismatch: expected {GOOGLE_CHAT_SIGNER_EMAIL}, got {email}"
+            "email claim mismatch: expected {GOOGLE_CHAT_LEGACY_SIGNER_EMAIL} or *{GOOGLE_CHAT_SIGNER_EMAIL_SUFFIX}, got {email}"
         ));
     }
     Ok(())

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -6,6 +6,7 @@ pub mod store;
 use anyhow::Result;
 use axum::{
     extract::State,
+    http::HeaderMap,
     response::IntoResponse,
     routing::{get, post},
     Router,
@@ -68,23 +69,65 @@ pub struct AppState {
 
 // --- WebSocket handler (OAB connects here) ---
 
+#[derive(serde::Deserialize)]
+struct GatewayAuth {
+    schema: String,
+    token: String,
+}
+
 async fn ws_handler(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     query: axum::extract::Query<HashMap<String, String>>,
     ws: axum::extract::WebSocketUpgrade,
 ) -> axum::response::Response {
+    let mut preauthenticated = false;
     if let Some(ref expected) = state.ws_token {
-        let provided = query.get("token").map(|s| s.as_str());
-        if provided != Some(expected.as_str()) {
-            warn!("WebSocket rejected: invalid or missing token");
-            return axum::http::StatusCode::UNAUTHORIZED.into_response();
+        let provided = query.get("token").map(|s| s.as_str()).or_else(|| {
+            headers
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.strip_prefix("Bearer "))
+        });
+        if let Some(provided) = provided {
+            if provided != expected.as_str() {
+                warn!("WebSocket rejected: invalid token");
+                return axum::http::StatusCode::UNAUTHORIZED.into_response();
+            }
+            preauthenticated = true;
         }
     }
-    ws.on_upgrade(move |socket| handle_oab_connection(state, socket))
+    ws.on_upgrade(move |socket| handle_oab_connection(state, socket, preauthenticated))
 }
 
-async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::WebSocket) {
+async fn handle_oab_connection(
+    state: Arc<AppState>,
+    mut socket: axum::extract::ws::WebSocket,
+    preauthenticated: bool,
+) {
     use axum::extract::ws::Message;
+
+    if !preauthenticated {
+        if let Some(ref expected) = state.ws_token {
+            let auth_result =
+                tokio::time::timeout(std::time::Duration::from_secs(5), socket.recv()).await;
+            let valid = match auth_result {
+                Ok(Some(Ok(Message::Text(text)))) => serde_json::from_str::<GatewayAuth>(&text)
+                    .map(|auth| {
+                        auth.schema == "openab.gateway.auth.v1" && auth.token == *expected
+                    })
+                    .unwrap_or(false),
+                _ => false,
+            };
+            if !valid {
+                warn!("WebSocket rejected: missing or invalid auth frame");
+                let _ = socket.close().await;
+                return;
+            }
+        } else {
+            warn!("GATEWAY_WS_TOKEN not set — accepted unauthenticated WebSocket");
+        }
+    }
 
     let (mut ws_tx, mut ws_rx) = socket.split();
     let mut event_rx = state.event_tx.subscribe();

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::{client::IntoClientRequest, Message};
 use tracing::{error, info, warn};
 
 /// Timeout for waiting on gateway reply acknowledgement.
@@ -30,6 +30,12 @@ struct GatewayEvent {
     #[allow(dead_code)]
     mentions: Vec<String>,
     message_id: String,
+}
+
+#[derive(Serialize)]
+struct GatewayAuth {
+    schema: String,
+    token: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -544,7 +550,6 @@ pub async fn run_gateway_adapter(
 ) -> Result<()> {
     let platform: &'static str = Box::leak(params.platform.into_boxed_str());
 
-    // Append auth token as query param if configured
     let gateway_url = params.url;
     let bot_username = params.bot_username;
     let allow_all_channels = params.allow_all_channels;
@@ -554,16 +559,7 @@ pub async fn run_gateway_adapter(
     let streaming = params.streaming;
     let stt_config = params.stt;
 
-    let connect_url = match &params.token {
-        Some(token) => {
-            let sep = if gateway_url.contains('?') { "&" } else { "?" };
-            format!("{gateway_url}{sep}token={token}")
-        }
-        None => {
-            warn!("gateway.token not set — WebSocket connection is NOT authenticated");
-            gateway_url.clone()
-        }
-    };
+    let connect_request = gateway_url.clone().into_client_request()?;
     let mut backoff_secs = 1u64;
     const MAX_BACKOFF: u64 = 30;
 
@@ -576,7 +572,7 @@ pub async fn run_gateway_adapter(
 
         info!(url = %gateway_url, "connecting to custom gateway");
 
-        let ws_stream = match tokio_tungstenite::connect_async(&connect_url).await {
+        let ws_stream = match tokio_tungstenite::connect_async(connect_request.clone()).await {
             Ok((stream, _)) => {
                 backoff_secs = 1; // reset on success
                 info!("connected to gateway");
@@ -595,6 +591,19 @@ pub async fn run_gateway_adapter(
 
         let (ws_tx, mut ws_rx) = ws_stream.split();
         let ws_tx: SharedWsTx = Arc::new(Mutex::new(ws_tx));
+        if let Some(token) = &params.token {
+            let auth = GatewayAuth {
+                schema: "openab.gateway.auth.v1".into(),
+                token: token.clone(),
+            };
+            ws_tx
+                .lock()
+                .await
+                .send(Message::Text(serde_json::to_string(&auth)?))
+                .await?;
+        } else {
+            warn!("gateway.token not set — WebSocket connection is NOT authenticated");
+        }
         let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
         let adapter: Arc<dyn ChatAdapter> = Arc::new(GatewayAdapter::new(
             ws_tx.clone(),


### PR DESCRIPTION
## Summary

This PR documents and implements the OpenShell-compatible route for running OpenAB with Google Chat and Kiro through the Custom Gateway.

It adds:

1. An ADR for first-frame WebSocket gateway authentication, because OpenShell can rewrite provider placeholders in client text frames after the WebSocket upgrade but cannot reliably rewrite the original upgrade query/header for this route.
2. A Google Chat + OpenShell + Kiro reference architecture, including provider placeholders, gateway placement, policy shape, and a host-side Google API token broker pattern.
3. Gateway/client code that keeps the existing query/header auth path while adding `openab.gateway.auth.v1` first-frame auth.
4. Google Chat JWT issuer support for the observed Google service-agent signer suffix.

## Before / After

```text
BEFORE:
OpenAB authenticated to the Custom Gateway by putting the token in the
WebSocket URL query string. In OpenShell, provider placeholders were not
reliably rewritten before the WebSocket upgrade reached the gateway, producing
403s or repeated missing/invalid auth failures.

AFTER:
OpenAB connects to the base WebSocket URL, then immediately sends:

  {"schema":"openab.gateway.auth.v1","token":"..."}

The gateway accepts legacy query/header auth for existing deployments, or waits
up to 5 seconds for the first auth text frame when no legacy token is present.
```

## Data Flow

```text
Google Chat
  -> HTTPS webhook
  -> openab-gateway outside OpenShell
  -> ws://gateway-host:8080/ws
  -> OpenShell policy proxy
  -> OpenAB inside sandbox
  -> first WebSocket text frame with provider placeholder token
  -> OpenShell rewrites provider placeholder at the network boundary
  -> gateway authenticates OAB client
  -> Kiro ACP session
```

## Prior Research

- Existing issues/PRs checked: searched `OpenShell Google Chat Kiro`; no matching issues or PRs found.
- Existing docs/code checked:
  - `docs/openshell.md`
  - `docs/google-chat.md`
  - `docs/adr/custom-gateway.md`
  - `src/gateway.rs`
  - `gateway/src/main.rs`
  - `gateway/src/adapters/googlechat.rs`
- POC findings:
  - Query/header auth is still useful for non-OpenShell deployments.
  - OpenShell credential placeholders should remain out of raw sandbox config when possible.
  - Long-lived Google service-account JSON should stay on the host or gateway side; sandboxed agents should receive short-lived access tokens through provider rewrite.

## Changes

| File | Change |
|------|--------|
| `docs/adr/openshell-websocket-auth.md` | Adds the ADR for first-frame WebSocket auth and provider credential handling. |
| `docs/refarch/google-chat-openshell-kiro.md` | Adds the operational reference architecture and Google API token broker pattern. |
| `docs/openshell.md` | Links the refarch and documents provider placeholder handling. |
| `docs/google-chat.md` | Links the hardened OpenShell/Kiro route from Google Chat docs. |
| `src/gateway.rs` | Sends `openab.gateway.auth.v1` as the first WebSocket text frame when `[gateway].token` is configured. |
| `gateway/src/main.rs` | Preserves legacy query/header auth and adds first-frame auth fallback. |
| `gateway/src/adapters/googlechat.rs` | Allows the observed Google Chat service-agent JWT signer suffix. |
| `Cargo.lock`, `gateway/Cargo.lock` | Updates package version metadata from the release branch state. |

## Testing

- `docker run --rm -v /Users/shaun/openab:/build -w /build rust:1-bookworm cargo check --bin openab`
- `docker run --rm -v /Users/shaun/openab/gateway:/build -w /build rust:1-bookworm cargo check --bin openab-gateway`
- Live POC: OpenShell provider placeholder first-frame auth connected the gateway WebSocket.
- Live POC: Google Chat webhook reached the gateway and dispatched through OpenAB/Kiro.
- Live POC: Google Drive, Sheets, and Docs reads succeeded with a host-minted short-lived Google access token passed through an OpenShell provider placeholder.

## Risks and Mitigations

- Risk: Adding first-frame auth changes the initial WebSocket message flow.
  - Mitigation: Legacy query and `Authorization: Bearer` auth remain supported.
- Risk: Operators may place long-lived Google service-account JSON in the sandbox.
  - Mitigation: The refarch documents the host-side token refresher pattern instead.
- Risk: Kiro endpoint allowlists vary by version.
  - Mitigation: The refarch calls this out as a policy discovery step.

## Compatibility / Migration

- Backward compatible: Yes.
- Config/env changes required: No for existing query/header auth deployments.
- Migration needed: No. OpenShell deployments can opt into first-frame auth by using provider placeholders for `[gateway].token`.
