### PR TITLE
feat: OPENAB_AGENT_COMMAND supports inline args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openab"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=kiro-cli
+ENV OPENAB_AGENT_COMMAND="kiro-cli acp --trust-all-tools"
 ENV OPENAB_AGENT_AUTH_COMMAND="kiro-cli login --use-device-flow"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -51,7 +51,7 @@ RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=agy-acp
+ENV OPENAB_AGENT_COMMAND="agy-acp"
 ENV OPENAB_AGENT_AUTH_COMMAND="agy auth"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -36,7 +36,7 @@ RUN mkdir -p /home/node/.claude && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=claude
+ENV OPENAB_AGENT_COMMAND="claude"
 ENV OPENAB_AGENT_AUTH_COMMAND="claude auth login"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -33,7 +33,7 @@ RUN mkdir -p /home/node/.codex && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=codex
+ENV OPENAB_AGENT_COMMAND="codex"
 ENV OPENAB_AGENT_AUTH_COMMAND="codex login --device-auth"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -32,7 +32,7 @@ RUN mkdir -p /home/node/.copilot && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=copilot
+ENV OPENAB_AGENT_COMMAND="copilot --acp --stdio"
 ENV OPENAB_AGENT_AUTH_COMMAND="copilot login"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -44,7 +44,7 @@ RUN mkdir -p /home/agent/.cursor && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=cursor
+ENV OPENAB_AGENT_COMMAND="cursor acp"
 ENV OPENAB_AGENT_AUTH_COMMAND="cursor-agent login"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -44,7 +44,7 @@ RUN mkdir -p /home/agent/.cursor && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND="cursor acp"
+ENV OPENAB_AGENT_COMMAND="cursor-agent acp"
 ENV OPENAB_AGENT_AUTH_COMMAND="cursor-agent login"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -32,7 +32,7 @@ RUN mkdir -p /home/node/.gemini && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=gemini
+ENV OPENAB_AGENT_COMMAND="gemini --acp"
 ENV OPENAB_AGENT_AUTH_COMMAND="gemini auth"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -54,7 +54,7 @@ RUN mkdir -p /home/agent/.grok && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=grok
+ENV OPENAB_AGENT_COMMAND="grok agent stdio"
 ENV OPENAB_AGENT_AUTH_COMMAND="grok login --device-auth"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -48,7 +48,7 @@ RUN chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=hermes
+ENV OPENAB_AGENT_COMMAND="hermes-acp"
 ENV OPENAB_AGENT_AUTH_COMMAND="hermes auth add"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -32,7 +32,7 @@ RUN mkdir -p /home/agent/.openab && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=openab-agent
+ENV OPENAB_AGENT_COMMAND="openab-agent"
 ENV OPENAB_AGENT_AUTH_COMMAND="openab-agent auth codex-oauth"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -47,7 +47,7 @@ RUN mkdir -p /home/node/.opencode && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=opencode
+ENV OPENAB_AGENT_COMMAND="opencode acp"
 ENV OPENAB_AGENT_AUTH_COMMAND="opencode auth login"
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile.pi
+++ b/Dockerfile.pi
@@ -34,7 +34,7 @@ RUN mkdir -p /home/node/.pi && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND=openab-agent
+ENV OPENAB_AGENT_COMMAND="openab-agent"
 ENV OPENAB_AGENT_AUTH_COMMAND="pi /login"
 
 ENTRYPOINT ["tini", "--"]

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -18,9 +18,8 @@ openab ──ACP JSON-RPC──► agy-acp ──spawns──► agy --add-dir /
 
 ```toml
 [agent]
-# command = "agy-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
-args = []
-# working_dir = "/home/agent"  # optional — defaults to $HOME
+# command defaults from OPENAB_AGENT_COMMAND="agy-acp"
+# Only override if you need non-default behavior
 ```
 
 ### Environment Variables

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -28,9 +28,8 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-# command = "claude-agent-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
-args = []
-# working_dir = "/home/node"  # optional — defaults to $HOME
+# command defaults from OPENAB_AGENT_COMMAND="claude"
+# Only override if you need non-default behavior
 ```
 
 ## Authentication

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -32,9 +32,8 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-# command = "codex-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
-args = []
-# working_dir = "/home/node"  # optional — defaults to $HOME
+# command defaults from OPENAB_AGENT_COMMAND="codex"
+# Only override if you need non-default behavior
 ```
 
 ## Authentication
@@ -148,9 +147,8 @@ itself, explicitly expose an upload token to the agent:
 
 ```toml
 [agent]
-# command = "codex-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
-args = []
-# working_dir = "/home/node"  # optional — defaults to $HOME
+# command defaults from OPENAB_AGENT_COMMAND="codex"
+# Only override if you need non-default behavior
 env = { DISCORD_FILE_BOT_TOKEN = "${DISCORD_FILE_BOT_TOKEN}" }
 ```
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -93,12 +93,14 @@ Custom Gateway adapter for platforms like Telegram, LINE, Feishu/Lark, and Googl
 
 The AI agent subprocess that OpenAB spawns to handle messages via ACP.
 
-> **This entire section is optional.** If omitted, `command` defaults to `$OPENAB_AGENT_COMMAND` (or `"openab-agent"`) and `working_dir` defaults to `$HOME`. Each Docker image sets these env vars so you typically don't need an `[agent]` block unless you want to customize `env` or `args`.
+> **This entire section is optional.** If omitted, `command` and `args` default from `$OPENAB_AGENT_COMMAND` (e.g. `"opencode acp"` — first token is command, rest are args). Each Docker image sets this env var so you typically don't need an `[agent]` block unless you want to override `env` or `args`.
+
+**Resolution priority:** config `[agent].command`/`args` > `$OPENAB_AGENT_COMMAND` > `"openab-agent"`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `command` | string | `$OPENAB_AGENT_COMMAND` or `"openab-agent"` | Agent binary. Optional — defaults from image env var. |
-| `args` | string[] | `[]` | CLI arguments passed to the agent. |
+| `command` | string | from `$OPENAB_AGENT_COMMAND` or `"openab-agent"` | Agent binary. Optional — defaults from image env var. |
+| `args` | string[] | from `$OPENAB_AGENT_COMMAND` or `[]` | CLI arguments passed to the agent. |
 | `working_dir` | string | `$HOME` | Working directory for the agent process. Optional — defaults to container's `$HOME`. |
 | `env` | map | `{}` | Extra environment variables (e.g. `{ OPENAI_API_KEY = "${OPENAI_API_KEY}" }`). |
 | `inherit_env` | string[] | `[]` | Env var names to inherit from the OAB process (e.g. vars injected via K8s `envFrom`). Keys in `env` take precedence. |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -97,10 +97,12 @@ The AI agent subprocess that OpenAB spawns to handle messages via ACP.
 
 **Resolution priority:** config `[agent].command`/`args` > `$OPENAB_AGENT_COMMAND` > `"openab-agent"`
 
+> **Partial override rule:** Setting `command` without `args` resets args to `[]`. This prevents a custom command from inheriting the env var's args. To keep env-var args with a custom command, set both fields explicitly.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `command` | string | from `$OPENAB_AGENT_COMMAND` or `"openab-agent"` | Agent binary. Optional — defaults from image env var. |
-| `args` | string[] | from `$OPENAB_AGENT_COMMAND` or `[]` | CLI arguments passed to the agent. |
+| `args` | string[] | from `$OPENAB_AGENT_COMMAND` or `[]` | CLI arguments. Defaults to env var args only when `command` is also defaulted. |
 | `working_dir` | string | `$HOME` | Working directory for the agent process. Optional — defaults to container's `$HOME`. |
 | `env` | map | `{}` | Extra environment variables (e.g. `{ OPENAI_API_KEY = "${OPENAI_API_KEY}" }`). |
 | `inherit_env` | string[] | `[]` | Env var names to inherit from the OAB process (e.g. vars injected via K8s `envFrom`). Keys in `env` take precedence. |

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -22,9 +22,8 @@ OpenAB spawns `copilot --acp --stdio` as a child process and communicates via st
 
 ```toml
 [agent]
-# command = "copilot"  # optional — defaults from OPENAB_AGENT_COMMAND
-args = ["--acp", "--stdio"]
-# working_dir = "/home/node"  # optional — defaults to $HOME
+# command and args default from OPENAB_AGENT_COMMAND="copilot --acp --stdio"
+# Only override if you need non-default behavior
 ```
 
 ## Docker

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -22,9 +22,8 @@ OpenAB spawns `cursor-agent acp` as a child process and communicates via stdio J
 
 ```toml
 [agent]
-# command = "cursor-agent"  # optional — defaults from OPENAB_AGENT_COMMAND
-args = ["acp"]
-# working_dir = "/home/agent"  # optional — defaults to $HOME
+# command and args default from OPENAB_AGENT_COMMAND="cursor acp"
+# Only override if you need non-default behavior
 # Auth via: kubectl exec -it <pod> -- cursor-agent login
 ```
 
@@ -85,7 +84,7 @@ To specify a model, pass `--model` as an arg:
 
 ```toml
 [agent]
-# command = "cursor-agent"  # optional — defaults from OPENAB_AGENT_COMMAND
+# Override args (command defaults from OPENAB_AGENT_COMMAND="cursor acp")
 args = ["acp", "--model", "auto"]
 ```
 
@@ -99,7 +98,7 @@ Cursor Agent CLI supports MCP servers configured via `.cursor/mcp.json` in the a
 
 ```toml
 [agent]
-# command = "cursor-agent"  # optional — defaults from OPENAB_AGENT_COMMAND
+# Override args (command defaults from OPENAB_AGENT_COMMAND="cursor acp")
 args = ["acp", "--model", "auto", "--workspace", "/home/agent"]
 ```
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -22,7 +22,7 @@ OpenAB spawns `cursor-agent acp` as a child process and communicates via stdio J
 
 ```toml
 [agent]
-# command and args default from OPENAB_AGENT_COMMAND="cursor acp"
+# command and args default from OPENAB_AGENT_COMMAND="cursor-agent acp"
 # Only override if you need non-default behavior
 # Auth via: kubectl exec -it <pod> -- cursor-agent login
 ```
@@ -84,7 +84,7 @@ To specify a model, pass `--model` as an arg:
 
 ```toml
 [agent]
-# Override args (command defaults from OPENAB_AGENT_COMMAND="cursor acp")
+# Override args (command defaults from OPENAB_AGENT_COMMAND="cursor-agent acp")
 args = ["acp", "--model", "auto"]
 ```
 
@@ -98,7 +98,7 @@ Cursor Agent CLI supports MCP servers configured via `.cursor/mcp.json` in the a
 
 ```toml
 [agent]
-# Override args (command defaults from OPENAB_AGENT_COMMAND="cursor acp")
+# Override args (command defaults from OPENAB_AGENT_COMMAND="cursor-agent acp")
 args = ["acp", "--model", "auto", "--workspace", "/home/agent"]
 ```
 

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -32,9 +32,8 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-# command = "gemini"  # optional — defaults from OPENAB_AGENT_COMMAND
-args = ["--acp"]
-# working_dir = "/home/node"  # optional — defaults to $HOME
+# command and args default from OPENAB_AGENT_COMMAND="gemini --acp"
+# Only override if you need non-default behavior
 env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 ```
 

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -31,9 +31,9 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-# command = "grok"  # optional — defaults from OPENAB_AGENT_COMMAND
-args = ["agent", "stdio"]
-# working_dir = "/home/agent"  # optional — defaults to $HOME
+# command and args default from OPENAB_AGENT_COMMAND="grok agent stdio"
+# Only override if you need non-default behavior:
+# args = ["agent", "stdio", "--model", "grok-4.3"]
 ```
 
 ## Authentication
@@ -96,9 +96,8 @@ The default model is whichever Grok Build CLI selects (currently `grok-code-fast
 
 ```toml
 [agent]
-# command = "grok"  # optional — defaults from OPENAB_AGENT_COMMAND
+# Override args to select a specific model (command defaults from OPENAB_AGENT_COMMAND)
 args = ["agent", "stdio", "--model", "grok-4.3"]
-# working_dir = "/home/agent"  # optional — defaults to $HOME
 ```
 
 List available models inside the pod:

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -31,7 +31,7 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-# command = "hermes-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
+# command defaults from OPENAB_AGENT_COMMAND="hermes-acp"
 # working_dir = "/home/agent"  # optional — defaults to $HOME
 ```
 
@@ -138,7 +138,7 @@ Any provider can also be configured with an API key via environment variables:
 
 ```toml
 [agent]
-# command = "hermes-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
+# command defaults from OPENAB_AGENT_COMMAND="hermes-acp"
 # working_dir = "/home/agent"  # optional — defaults to $HOME
 env = { XAI_API_KEY = "${XAI_API_KEY}" }
 ```

--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -25,9 +25,8 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-# command = "kiro-cli"  # optional — defaults from OPENAB_AGENT_COMMAND
-args = ["acp", "--trust-all-tools"]
-# working_dir = "/home/agent"  # optional — defaults to $HOME
+# command and args default from OPENAB_AGENT_COMMAND="kiro-cli acp --trust-all-tools"
+# Only override if you need non-default behavior
 ```
 
 ## Authentication

--- a/docs/native-agent.md
+++ b/docs/native-agent.md
@@ -22,7 +22,7 @@ openab-agent
 
 ```toml
 [agent]
-# command = "openab-agent"  # optional — defaults from OPENAB_AGENT_COMMAND
+# command defaults from OPENAB_AGENT_COMMAND="openab-agent"
 # working_dir = "/home/agent"  # optional — defaults to $HOME
 env = { OPENAB_AGENT_OPENAI_MODEL = "gpt-5.4-mini" }
 ```

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -51,9 +51,8 @@ helm install openab openab/openab \
 
 ```toml
 [agent]
-# command = "opencode"  # optional — defaults from OPENAB_AGENT_COMMAND
-args = ["acp"]
-# working_dir = "/home/node"  # optional — defaults to $HOME
+# command and args default from OPENAB_AGENT_COMMAND="opencode acp"
+# Only override if you need non-default behavior
 ```
 
 ## Authentication

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -47,7 +47,7 @@ Pi saves session history as trees, enabling clean branching of code exploration.
 
 ```toml
 [agent]
-# command = "pi-acp"  # optional — defaults from OPENAB_AGENT_COMMAND
+# command defaults from OPENAB_AGENT_COMMAND="openab-agent"
 # working_dir = "/home/node"  # optional — defaults to $HOME
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -354,18 +354,35 @@ fn default_gateway_platform() -> String {
     "telegram".into()
 }
 
+/// Raw intermediate struct for serde — uses `Option` to detect explicit fields.
 #[derive(Debug, Deserialize)]
 #[serde(default)]
+struct AgentConfigRaw {
+    command: Option<String>,
+    args: Option<Vec<String>>,
+    working_dir: String,
+    env: HashMap<String, String>,
+    inherit_env: Vec<String>,
+}
+
+impl Default for AgentConfigRaw {
+    fn default() -> Self {
+        Self {
+            command: None,
+            args: None,
+            working_dir: default_working_dir(),
+            env: HashMap::new(),
+            inherit_env: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct AgentConfig {
-    #[serde(default = "default_agent_command")]
     pub command: String,
-    #[serde(default = "default_agent_args")]
     pub args: Vec<String>,
-    #[serde(default = "default_working_dir")]
     pub working_dir: String,
-    #[serde(default)]
     pub env: HashMap<String, String>,
-    #[serde(default)]
     pub inherit_env: Vec<String>,
 }
 
@@ -378,6 +395,31 @@ impl Default for AgentConfig {
             env: HashMap::new(),
             inherit_env: Vec::new(),
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AgentConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = AgentConfigRaw::deserialize(deserializer)?;
+        let cmd_explicit = raw.command.is_some();
+        let command = raw.command.unwrap_or_else(default_agent_command);
+        // If command was explicitly set but args was not, default args to []
+        // to avoid leaking env-var args into a custom command.
+        let args = match (cmd_explicit, raw.args) {
+            (_, Some(args)) => args,           // args explicitly set → use them
+            (true, None) => Vec::new(),        // command set, args omitted → empty
+            (false, None) => default_agent_args(), // neither set → env var
+        };
+        Ok(AgentConfig {
+            command,
+            args,
+            working_dir: raw.working_dir,
+            env: raw.env,
+            inherit_env: raw.inherit_env,
+        })
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -533,16 +533,16 @@ fn default_working_dir() -> String {
     std::env::var("HOME").unwrap_or_else(|_| "/tmp".into())
 }
 fn default_agent_command() -> String {
-    if let Ok(exec) = std::env::var("OPENAB_AGENT_EXEC") {
-        if let Some(cmd) = exec.split_whitespace().next() {
+    if let Ok(val) = std::env::var("OPENAB_AGENT_COMMAND") {
+        if let Some(cmd) = val.split_whitespace().next() {
             return cmd.to_string();
         }
     }
-    std::env::var("OPENAB_AGENT_COMMAND").unwrap_or_else(|_| "openab-agent".into())
+    "openab-agent".into()
 }
 fn default_agent_args() -> Vec<String> {
-    if let Ok(exec) = std::env::var("OPENAB_AGENT_EXEC") {
-        let parts: Vec<&str> = exec.split_whitespace().collect();
+    if let Ok(val) = std::env::var("OPENAB_AGENT_COMMAND") {
+        let parts: Vec<&str> = val.split_whitespace().collect();
         if parts.len() > 1 {
             return parts[1..].iter().map(|s| s.to_string()).collect();
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -359,7 +359,7 @@ fn default_gateway_platform() -> String {
 pub struct AgentConfig {
     #[serde(default = "default_agent_command")]
     pub command: String,
-    #[serde(default)]
+    #[serde(default = "default_agent_args")]
     pub args: Vec<String>,
     #[serde(default = "default_working_dir")]
     pub working_dir: String,
@@ -373,7 +373,7 @@ impl Default for AgentConfig {
     fn default() -> Self {
         Self {
             command: default_agent_command(),
-            args: Vec::new(),
+            args: default_agent_args(),
             working_dir: default_working_dir(),
             env: HashMap::new(),
             inherit_env: Vec::new(),
@@ -533,7 +533,21 @@ fn default_working_dir() -> String {
     std::env::var("HOME").unwrap_or_else(|_| "/tmp".into())
 }
 fn default_agent_command() -> String {
+    if let Ok(exec) = std::env::var("OPENAB_AGENT_EXEC") {
+        if let Some(cmd) = exec.split_whitespace().next() {
+            return cmd.to_string();
+        }
+    }
     std::env::var("OPENAB_AGENT_COMMAND").unwrap_or_else(|_| "openab-agent".into())
+}
+fn default_agent_args() -> Vec<String> {
+    if let Ok(exec) = std::env::var("OPENAB_AGENT_EXEC") {
+        let parts: Vec<&str> = exec.split_whitespace().collect();
+        if parts.len() > 1 {
+            return parts[1..].iter().map(|s| s.to_string()).collect();
+        }
+    }
+    Vec::new()
 }
 fn default_max_sessions() -> usize {
     10


### PR DESCRIPTION
## Summary

`OPENAB_AGENT_COMMAND` now accepts a full command+args string split by whitespace. The image carries a sensible default; the gist `[agent]` section can still override when needed.

## Background

The xdu bot (grok backend) failed because `OPENAB_AGENT_COMMAND=grok` spawned the bare TUI, which crashed with `ENXIO` (no terminal). The correct invocation is `grok agent stdio`, but there was no way to express default args in the env var — every gist had to specify them, causing config drift and boot failures.

## How It Works

`OPENAB_AGENT_COMMAND` splits on whitespace: first token = command, rest = default args.

```dockerfile
ENV OPENAB_AGENT_COMMAND="grok agent stdio"
ENV OPENAB_AGENT_COMMAND="opencode acp"
ENV OPENAB_AGENT_COMMAND="kiro-cli acp --trust-all-tools"
```

Fully backward compatible — single-token values (`openab-agent`, `claude`) work as before.

## Override via Config

The gist `[agent]` section **always wins** over the env var when present:

```toml
[agent]
# Override both command and args
command = "grok"
args = ["agent", "stdio", "--model", "grok-4.3"]
```

Or override just args (command still defaults from env var):

```toml
[agent]
args = ["agent", "stdio", "--model", "grok-4.3"]
```

If no `[agent]` section in the gist → uses `OPENAB_AGENT_COMMAND` from the image.

## Resolution Priority

| Priority | Source | Example |
|----------|--------|---------|
| 1 (highest) | `[agent].command` / `[agent].args` in gist config | Custom model, extra flags |
| 2 | `OPENAB_AGENT_COMMAND` env var (split by whitespace) | Image default |
| 3 (lowest) | Hardcoded `"openab-agent"` | Env var not set |

## Dockerfile Changes

| Image | Before | After |
|-------|--------|-------|
| Dockerfile (kiro) | `kiro-cli` | `kiro-cli acp --trust-all-tools` |
| Dockerfile.grok | `grok` | `grok agent stdio` |
| Dockerfile.copilot | `copilot` | `copilot --acp --stdio` |
| Dockerfile.cursor | `cursor` | `cursor acp` |
| Dockerfile.opencode | `opencode` | `opencode acp` |
| Dockerfile.gemini | `gemini` | `gemini --acp` |
| Dockerfile.hermes | `hermes` | `hermes-acp` |
| Others | unchanged | unchanged (no args needed) |

## Testing

- `cargo build` passes
- Single-token values still work (backward compatible)
- Multi-token values correctly split into command + args
- Config `[agent]` section overrides env var when present