### PR TITLE
fix(gateway): preserve legacy websocket auth fallback

### DIFF
--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -148,9 +148,10 @@ const GOOGLE_CHAT_SIGNER_EMAIL_SUFFIX: &str = "@gcp-sa-gsuiteaddons.iam.gservice
 const JWKS_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(3600);
 
 /// Verify the JWT's `email` claim belongs to Google Chat.
-/// Google Chat HTTP endpoint URL webhooks are signed by a Google-managed
-/// Workspace add-ons service account. Older deployments used
-/// `chat@system.gserviceaccount.com`.
+/// Google Chat HTTP endpoint URL webhooks are signed by Google-managed service
+/// accounts. Google documents `chat@system.gserviceaccount.com`; Workspace
+/// add-ons deployments have also been observed using
+/// `service-<PROJECT_NUMBER>@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`.
 /// Without this check, any Google-issued ID token would be accepted.
 fn verify_email_claim(claims: &serde_json::Value) -> Result<(), String> {
     let email = claims
@@ -1666,6 +1667,14 @@ mod tests {
     #[test]
     fn email_claim_accepts_chat_system_account() {
         let claims = serde_json::json!({"email": "chat@system.gserviceaccount.com"});
+        assert!(verify_email_claim(&claims).is_ok());
+    }
+
+    #[test]
+    fn email_claim_accepts_workspace_addons_service_agent() {
+        let claims = serde_json::json!({
+            "email": "service-123456@gcp-sa-gsuiteaddons.iam.gserviceaccount.com"
+        });
         assert!(verify_email_claim(&claims).is_ok());
     }
 

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -75,6 +75,24 @@ struct GatewayAuth {
     token: String,
 }
 
+fn legacy_ws_auth_token<'a>(
+    query: &'a HashMap<String, String>,
+    headers: &'a HeaderMap,
+) -> Option<&'a str> {
+    query.get("token").map(|s| s.as_str()).or_else(|| {
+        headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+    })
+}
+
+fn valid_gateway_auth_frame(text: &str, expected: &str) -> bool {
+    serde_json::from_str::<GatewayAuth>(text)
+        .map(|auth| auth.schema == "openab.gateway.auth.v1" && auth.token == expected)
+        .unwrap_or(false)
+}
+
 async fn ws_handler(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -83,12 +101,7 @@ async fn ws_handler(
 ) -> axum::response::Response {
     let mut preauthenticated = false;
     if let Some(ref expected) = state.ws_token {
-        let provided = query.get("token").map(|s| s.as_str()).or_else(|| {
-            headers
-                .get(axum::http::header::AUTHORIZATION)
-                .and_then(|v| v.to_str().ok())
-                .and_then(|v| v.strip_prefix("Bearer "))
-        });
+        let provided = legacy_ws_auth_token(&query, &headers);
         if let Some(provided) = provided {
             if provided != expected.as_str() {
                 warn!("WebSocket rejected: invalid token");
@@ -112,11 +125,7 @@ async fn handle_oab_connection(
             let auth_result =
                 tokio::time::timeout(std::time::Duration::from_secs(5), socket.recv()).await;
             let valid = match auth_result {
-                Ok(Some(Ok(Message::Text(text)))) => serde_json::from_str::<GatewayAuth>(&text)
-                    .map(|auth| {
-                        auth.schema == "openab.gateway.auth.v1" && auth.token == *expected
-                    })
-                    .unwrap_or(false),
+                Ok(Some(Ok(Message::Text(text)))) => valid_gateway_auth_frame(&text, expected),
                 _ => false,
             };
             if !valid {
@@ -531,6 +540,81 @@ mod tests {
 
     fn make_cache() -> ReplyTokenCache {
         Arc::new(std::sync::Mutex::new(HashMap::new()))
+    }
+
+    #[test]
+    fn legacy_ws_auth_token_prefers_query_token() {
+        let mut query = HashMap::new();
+        query.insert("token".to_string(), "query-secret".to_string());
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            axum::http::HeaderValue::from_static("Bearer header-secret"),
+        );
+
+        assert_eq!(legacy_ws_auth_token(&query, &headers), Some("query-secret"));
+    }
+
+    #[test]
+    fn legacy_ws_auth_token_accepts_bearer_header() {
+        let query = HashMap::new();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            axum::http::HeaderValue::from_static("Bearer header-secret"),
+        );
+
+        assert_eq!(legacy_ws_auth_token(&query, &headers), Some("header-secret"));
+    }
+
+    #[test]
+    fn legacy_ws_auth_token_rejects_non_bearer_header() {
+        let query = HashMap::new();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            axum::http::HeaderValue::from_static("Basic abc"),
+        );
+
+        assert_eq!(legacy_ws_auth_token(&query, &headers), None);
+    }
+
+    #[test]
+    fn gateway_auth_frame_accepts_expected_schema_and_token() {
+        let text = serde_json::json!({
+            "schema": "openab.gateway.auth.v1",
+            "token": "expected",
+        })
+        .to_string();
+
+        assert!(valid_gateway_auth_frame(&text, "expected"));
+    }
+
+    #[test]
+    fn gateway_auth_frame_rejects_wrong_token() {
+        let text = serde_json::json!({
+            "schema": "openab.gateway.auth.v1",
+            "token": "wrong",
+        })
+        .to_string();
+
+        assert!(!valid_gateway_auth_frame(&text, "expected"));
+    }
+
+    #[test]
+    fn gateway_auth_frame_rejects_wrong_schema() {
+        let text = serde_json::json!({
+            "schema": "openab.gateway.reply.v1",
+            "token": "expected",
+        })
+        .to_string();
+
+        assert!(!valid_gateway_auth_frame(&text, "expected"));
+    }
+
+    #[test]
+    fn gateway_auth_frame_rejects_malformed_json() {
+        assert!(!valid_gateway_auth_frame("not json", "expected"));
     }
 
     /// Cache hit: uses Reply API with correct replyToken, bearer token, and message body.

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -201,7 +201,12 @@ impl GatewayAdapter {
             return Err(e.into());
         }
         let msg_id = if let (Some(rx), Some(ref id)) = (pending_rx, &req_id) {
-            match tokio::time::timeout(std::time::Duration::from_secs(GATEWAY_REPLY_TIMEOUT_SECS), rx).await {
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(GATEWAY_REPLY_TIMEOUT_SECS),
+                rx,
+            )
+            .await
+            {
                 Ok(Ok(resp)) if resp.success => resp.message_id.unwrap_or_else(|| "gw_sent".into()),
                 Ok(Ok(_resp)) => {
                     tracing::warn!(request_id = %id, "gateway replied with failure");
@@ -401,7 +406,8 @@ impl ChatAdapter for GatewayAdapter {
         content: &str,
         reply_to_message_id: &str,
     ) -> Result<MessageRef> {
-        self.send_gateway_reply(channel, content, Some(reply_to_message_id)).await
+        self.send_gateway_reply(channel, content, Some(reply_to_message_id))
+            .await
     }
 
     async fn create_thread(
@@ -542,6 +548,13 @@ pub struct GatewayParams {
     pub stt: crate::config::SttConfig,
 }
 
+fn legacy_gateway_auth_url(gateway_url: &str, token: Option<&str>) -> Option<String> {
+    token.map(|token| {
+        let sep = if gateway_url.contains('?') { "&" } else { "?" };
+        format!("{gateway_url}{sep}token={token}")
+    })
+}
+
 pub async fn run_gateway_adapter(
     params: GatewayParams,
     mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
@@ -560,6 +573,7 @@ pub async fn run_gateway_adapter(
     let stt_config = params.stt;
 
     let connect_request = gateway_url.clone().into_client_request()?;
+    let legacy_connect_url = legacy_gateway_auth_url(&gateway_url, params.token.as_deref());
     let mut backoff_secs = 1u64;
     const MAX_BACKOFF: u64 = 30;
 
@@ -572,37 +586,70 @@ pub async fn run_gateway_adapter(
 
         info!(url = %gateway_url, "connecting to custom gateway");
 
-        let ws_stream = match tokio_tungstenite::connect_async(connect_request.clone()).await {
+        let (ws_stream, send_first_frame_auth) = match tokio_tungstenite::connect_async(
+            connect_request.clone(),
+        )
+        .await
+        {
             Ok((stream, _)) => {
                 backoff_secs = 1; // reset on success
                 info!("connected to gateway");
-                stream
+                (stream, true)
             }
             Err(e) => {
-                error!(err = %e, backoff = backoff_secs, "gateway connection failed, retrying");
-                tokio::select! {
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
-                    _ = shutdown_rx.changed() => { return Ok(()); }
+                if let Some(ref legacy_url) = legacy_connect_url {
+                    warn!(
+                        err = %e,
+                        "gateway first-frame auth connection failed; retrying legacy query-token auth"
+                    );
+                    match tokio_tungstenite::connect_async(legacy_url.as_str()).await {
+                        Ok((stream, _)) => {
+                            backoff_secs = 1; // reset on success
+                            info!("connected to gateway with legacy query-token auth");
+                            (stream, false)
+                        }
+                        Err(legacy_err) => {
+                            error!(
+                                err = %legacy_err,
+                                backoff = backoff_secs,
+                                "gateway connection failed, retrying"
+                            );
+                            tokio::select! {
+                                _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
+                                _ = shutdown_rx.changed() => { return Ok(()); }
+                            }
+                            backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF);
+                            continue;
+                        }
+                    }
+                } else {
+                    error!(err = %e, backoff = backoff_secs, "gateway connection failed, retrying");
+                    tokio::select! {
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
+                        _ = shutdown_rx.changed() => { return Ok(()); }
+                    }
+                    backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF);
+                    continue;
                 }
-                backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF);
-                continue;
             }
         };
 
         let (ws_tx, mut ws_rx) = ws_stream.split();
         let ws_tx: SharedWsTx = Arc::new(Mutex::new(ws_tx));
-        if let Some(token) = &params.token {
-            let auth = GatewayAuth {
-                schema: "openab.gateway.auth.v1".into(),
-                token: token.clone(),
-            };
-            ws_tx
-                .lock()
-                .await
-                .send(Message::Text(serde_json::to_string(&auth)?))
-                .await?;
-        } else {
-            warn!("gateway.token not set — WebSocket connection is NOT authenticated");
+        if send_first_frame_auth {
+            if let Some(token) = &params.token {
+                let auth = GatewayAuth {
+                    schema: "openab.gateway.auth.v1".into(),
+                    token: token.clone(),
+                };
+                ws_tx
+                    .lock()
+                    .await
+                    .send(Message::Text(serde_json::to_string(&auth)?))
+                    .await?;
+            } else {
+                warn!("gateway.token not set — WebSocket connection is NOT authenticated");
+            }
         }
         let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
         let adapter: Arc<dyn ChatAdapter> = Arc::new(GatewayAdapter::new(
@@ -914,4 +961,30 @@ pub async fn run_gateway_adapter(
         }
         backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF);
     } // outer reconnect loop
+}
+
+#[cfg(test)]
+mod tests {
+    use super::legacy_gateway_auth_url;
+
+    #[test]
+    fn legacy_gateway_auth_url_absent_without_token() {
+        assert_eq!(legacy_gateway_auth_url("ws://gateway/ws", None), None);
+    }
+
+    #[test]
+    fn legacy_gateway_auth_url_adds_query_token() {
+        assert_eq!(
+            legacy_gateway_auth_url("ws://gateway/ws", Some("secret")),
+            Some("ws://gateway/ws?token=secret".to_string())
+        );
+    }
+
+    #[test]
+    fn legacy_gateway_auth_url_preserves_existing_query() {
+        assert_eq!(
+            legacy_gateway_auth_url("ws://gateway/ws?platform=googlechat", Some("secret")),
+            Some("ws://gateway/ws?platform=googlechat&token=secret".to_string())
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1016.

PR #1016 added first-frame WebSocket auth for OpenShell, but it was merged before the compatibility fix could land. This PR preserves the new OpenShell path while restoring compatibility with older authenticated gateways.

## Changes

- OpenAB first tries the new bare WebSocket connection and sends `openab.gateway.auth.v1` as the first text frame.
- If the bare WebSocket handshake fails and `[gateway].token` is configured, OpenAB retries once with the legacy `?token=...` URL.
- Legacy fallback skips the first-frame auth message so older gateways do not receive an unexpected reply frame.
- Gateway auth parsing/first-frame validation now has focused helper coverage.
- Google Chat signer suffix support now has a positive regression test and clearer comment.

## Validation

- `cargo test legacy_gateway_auth_url --bin openab` — 3 passed
- `cargo test -p openab-gateway auth -- --nocapture` — 7 passed
- `cargo test -p openab-gateway email_claim_accepts_workspace_addons_service_agent -- --nocapture` — 1 passed
- Earlier on the same fix before the merged-base cherry-pick:
  - `cargo check --bin openab` — passed
  - `cargo check --bin openab-gateway` — passed
  - `cargo test -p openab-gateway googlechat -- --nocapture` — 67 passed

## Notes

`rustfmt --check` over gateway files reports pre-existing formatter churn in unrelated gateway adapters because rustfmt follows module files. This PR intentionally avoids carrying that unrelated formatting diff.

Discord Discussion URL: N/A — maintainer-requested follow-up to PR #1016.
