### PR TITLE
feat: download-to-disk for unhandled inbound file attachments (PDF, docx, video, etc.)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openab"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,11 @@ tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
 cron = "0.16.0"
 chrono = { version = "0.4.44", features = ["serde"] }
 chrono-tz = "0.10.4"
+sha2 = "0.10"
+tempfile = "3.27.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]
-tempfile = "3.27.0"
+mockito = "1"

--- a/charts/openab/README.md
+++ b/charts/openab/README.md
@@ -34,6 +34,7 @@ Each agent lives under `agents.<name>`.
 | `workingDir` | Working directory and HOME inside the container. | `"/home/agent"` |
 | `env` | Inline environment variables passed to the agent process. | `{}` |
 | `envFrom` | Additional environment sources from existing Secrets or ConfigMaps. | `[]` |
+| `mcpServers` | MCP servers forwarded to ACP `session/new` and `session/load`. | `{}` |
 | `pool.maxSessions` | Maximum concurrent ACP sessions for the agent. | `10` |
 | `pool.sessionTtlHours` | Idle session TTL in hours. | `24` |
 | `reactions.enabled` | Enable status reactions. | `true` |
@@ -81,6 +82,25 @@ agents:
 ```
 
 This is useful for credentials such as `GH_TOKEN` without storing them directly in Helm values.
+
+### Forward MCP servers
+
+```yaml
+agents:
+  codex:
+    command: codex-acp
+    workingDir: /home/agent
+    mcpServers:
+      local-tools:
+        command: example-mcp-server
+        args:
+          - --data-dir
+          - /home/agent/.cache/example-mcp
+        env:
+          MCP_STORAGE: /home/agent/.cache/example-mcp
+```
+
+OpenAB renders this as `[agent.mcp_servers."local-tools"]` and forwards it to ACP agents that support client MCP servers.
 
 ### Provide `AGENTS.md` with `--set-file`
 

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -154,6 +154,28 @@ data:
     {{- if $mergedInheritEnv }}
     inherit_env = {{ $mergedInheritEnv | toJson }}
     {{- end }}
+    {{- range $serverName, $server := $cfg.mcpServers }}
+
+    [agent.mcp_servers.{{ $serverName | toJson }}]
+    {{- if $server.type }}
+    type = {{ $server.type | toJson }}
+    {{- end }}
+    {{- if $server.command }}
+    command = {{ $server.command | toJson }}
+    {{- end }}
+    {{- if $server.args }}
+    args = {{ $server.args | toJson }}
+    {{- end }}
+    {{- if $server.url }}
+    url = {{ $server.url | toJson }}
+    {{- end }}
+    {{- if $server.env }}
+    env = { {{ $first := true }}{{ range $k, $v := $server.env }}{{ if not $first }}, {{ end }}{{ $k }} = {{ $v | toJson }}{{ $first = false }}{{ end }} }
+    {{- end }}
+    {{- if $server.headers }}
+    headers = { {{ $first := true }}{{ range $k, $v := $server.headers }}{{ if not $first }}, {{ end }}{{ $k }} = {{ $v | toJson }}{{ $first = false }}{{ end }} }
+    {{- end }}
+    {{- end }}
 
     [pool]
     max_sessions = {{ ($cfg.pool).maxSessions | default 10 }}

--- a/charts/openab/tests/configmap_test.yaml
+++ b/charts/openab/tests/configmap_test.yaml
@@ -158,3 +158,55 @@ tests:
       - notMatchRegex:
           path: data["config.toml"]
           pattern: 'inherit_env'
+
+  - it: renders MCP stdio servers
+    set:
+      agents.kiro.mcpServers:
+        local-tools:
+          command: example-mcp-server
+          args:
+            - "--data-dir"
+            - "/home/agent/.cache/example-mcp"
+          env:
+            MCP_STORAGE: /home/agent/.cache/example-mcp
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[agent\.mcp_servers\."local-tools"\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'command = "example-mcp-server"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'args = \["--data-dir","/home/agent/.cache/example-mcp"\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'env = \{ MCP_STORAGE = "/home/agent/.cache/example-mcp" \}'
+
+  - it: renders MCP HTTP servers
+    set:
+      agents.kiro.mcpServers:
+        remote-tools:
+          type: http
+          url: https://mcp.example.com/mcp
+          headers:
+            Authorization: "${REMOTE_MCP_AUTH_HEADER}"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[agent\.mcp_servers\."remote-tools"\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'type = "http"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'url = "https://mcp.example.com/mcp"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'headers = \{ Authorization = "\$\{REMOTE_MCP_AUTH_HEADER\}" \}'
+
+  - it: does not render MCP servers when unset
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'mcp_servers'

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -59,6 +59,14 @@ agents:
     #   #     secretName: my-secrets
     #   #     secretKey: GEMINI_API_KEY
     #   secretEnv: []
+    #   # MCP servers forwarded to ACP session/new and session/load.
+    #   # Example:
+    #   # mcpServers:
+    #   #   local-tools:
+    #   #     command: example-mcp-server
+    #   #     args: ["--data-dir", "/home/agent/.cache/example-mcp"]
+    #   #     env: {}
+    #   mcpServers: {}
     #   pool:
     #     maxSessions: 10
     #     sessionTtlHours: 24
@@ -272,6 +280,14 @@ agents:
     # Load env vars from existing Secrets or ConfigMaps, e.g. GH_TOKEN.
     envFrom: []
     secretEnv: []  # list of {name, secretName, secretKey} — rendered as valueFrom.secretKeyRef; keys auto-added to inherit_env
+    # MCP servers forwarded to ACP session/new and session/load.
+    # Example:
+    # mcpServers:
+    #   local-tools:
+    #     command: example-mcp-server
+    #     args: ["--data-dir", "/home/agent/.cache/example-mcp"]
+    #     env: {}
+    mcpServers: {}
     pool:
       maxSessions: 10
       sessionTtlHours: 24

--- a/config.toml.example
+++ b/config.toml.example
@@ -71,6 +71,17 @@ working_dir = "/home/agent"
 # To pass additional env vars from the OAB process (e.g. vars injected via K8s envFrom),
 # list them in inherit_env. Keys in [agent].env take precedence over inherited ones.
 # inherit_env = ["API_BASE_URL", "MODEL_NAME"]
+#
+# To forward MCP servers to agents that support ACP client MCP servers:
+# [agent.mcp_servers.local_tools]
+# command = "example-mcp-server"
+# args = ["--data-dir", "/home/agent/.cache/example-mcp"]
+# env = { MCP_STORAGE = "/home/agent/.cache/example-mcp" }
+#
+# [agent.mcp_servers.remote_tools]
+# type = "http"
+# url = "https://mcp.example.com/mcp"
+# headers = { Authorization = "${REMOTE_MCP_AUTH_HEADER}" }
 
 # [agent]
 # command = "codex"

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -100,8 +100,44 @@ The AI agent subprocess that OpenAB spawns to handle messages via ACP.
 | `working_dir` | string | `"/tmp"` | Working directory for the agent process. |
 | `env` | map | `{}` | Extra environment variables (e.g. `{ OPENAI_API_KEY = "${OPENAI_API_KEY}" }`). |
 | `inherit_env` | string[] | `[]` | Env var names to inherit from the OAB process (e.g. vars injected via K8s `envFrom`). Keys in `env` take precedence. |
+| `mcp_servers` | table | `{}` | MCP servers forwarded to the ACP agent in `session/new` and `session/load`. |
 
 > **Default inherited vars:** After `env_clear()`, the agent always receives `HOME`, `PATH`, and `USER` (on Windows: `USERPROFILE`, `USERNAME`, `PATH`, `SystemRoot`, `SystemDrive`). Use `inherit_env` to pass additional vars beyond this baseline.
+
+### Agent MCP servers
+
+Configure MCP servers under `[agent.mcp_servers.<name>]`. OpenAB forwards these entries to ACP-compatible agents that support client MCP servers, including `codex-acp` and `claude-agent-acp`.
+
+Stdio server example:
+
+```toml
+[agent.mcp_servers.local_tools]
+command = "example-mcp-server"
+args = ["--data-dir", "/home/agent/.cache/example-mcp"]
+env = { MCP_STORAGE = "/home/agent/.cache/example-mcp" }
+```
+
+HTTP server example:
+
+```toml
+[agent.mcp_servers.remote_tools]
+type = "http"
+url = "https://mcp.example.com/mcp"
+headers = { Authorization = "${REMOTE_MCP_AUTH_HEADER}" }
+```
+
+Supported fields:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `type` | string | `"stdio"` | MCP transport: `"stdio"`, `"http"`, or `"sse"`. |
+| `command` | string | *required for stdio* | Local command to launch a stdio MCP server. |
+| `args` | string[] | `[]` | Arguments passed to the stdio MCP server command. |
+| `env` | map | `{}` | Environment variables passed to the stdio MCP server. |
+| `url` | string | *required for http/sse* | Remote MCP server URL. |
+| `headers` | map | `{}` | Headers sent to a remote HTTP or SSE MCP server. |
+
+> **Security note:** MCP servers run inside the agent trust boundary. OpenAB still clears the child process environment before spawning the agent, so platform credentials such as Discord and Slack tokens are not passed unless you explicitly put them in `[agent].env`, `inherit_env`, or an MCP server `env`/`headers` value.
 
 ### Agent examples
 

--- a/docs/design-inbound-file-attachments.md
+++ b/docs/design-inbound-file-attachments.md
@@ -1,0 +1,275 @@
+# Design: Inbound File Attachment Support
+
+## Problem
+
+目前 openAB 對非圖片/非音訊/非文字的檔案（PDF、docx、xlsx、video、zip 等）**靜默丟棄**，agent 完全不知道用戶傳了檔案。
+
+## Solution Overview
+
+所有未處理的 inbound 檔案 → download to local disk → 在 prompt 中注入 metadata + 路徑 → agent 用 file-read tool 自行處理 → TTL 過期自動清除。
+
+---
+
+## Architecture Diagrams
+
+### Current State（現狀）
+
+```mermaid
+flowchart TD
+    User[用戶傳檔案] --> Adapter{Platform Adapter}
+    Adapter -->|image/*| IMG[下載 → resize → base64 → prompt]
+    Adapter -->|audio/*| STT[下載 → STT 轉錄 → prompt]
+    Adapter -->|text file| TXT[下載 → inline 內容 → prompt]
+    Adapter -->|PDF/docx/zip...| DROP[❌ 靜默丟棄]
+    
+    IMG --> LLM[LLM]
+    STT --> LLM
+    TXT --> LLM
+    DROP -.->|agent 看不到| LLM
+```
+
+### Proposed State（新設計）
+
+```mermaid
+flowchart TD
+    User[用戶傳檔案] --> Adapter{Platform Adapter}
+    Adapter -->|image/*| IMG[下載 → resize → base64 → prompt]
+    Adapter -->|audio/*| STT[下載 → STT 轉錄 → prompt]
+    Adapter -->|text file| TXT[下載 → inline 內容 → prompt]
+    Adapter -->|其他檔案| DISK[download_to_disk]
+    
+    DISK --> Store[存到 /tmp/openab-attachments/msg_id/filename]
+    Store --> Inject[注入 metadata block 到 prompt]
+    Inject --> LLM[LLM + Agent]
+    LLM -->|agent 需要時| Read[Agent 用 file-read tool 讀取]
+    Read --> Store
+    
+    Store --> TTL[TTL eviction loop 定期清理]
+    
+    IMG --> LLM
+    STT --> LLM
+    TXT --> LLM
+```
+
+---
+
+## Detailed Flow: Discord / Slack（直連平台）
+
+```mermaid
+sequenceDiagram
+    participant U as 用戶
+    participant D as Discord/Slack
+    participant OAB as openAB 主程式
+    participant FS as Local Filesystem
+    participant Agent as LLM Agent
+
+    U->>D: 傳送 report.pdf
+    D->>OAB: Webhook/Event (attachment URL + metadata)
+    
+    Note over OAB: 判斷 MIME type
+    Note over OAB: 不是 image/audio/text → download_to_disk
+    
+    OAB->>D: GET attachment URL (+ Bearer token for Slack)
+    D-->>OAB: File bytes
+    OAB->>FS: 寫入 /tmp/openab-attachments/{msg_id}/report.pdf
+    
+    Note over OAB: 構建 metadata content block
+    OAB->>Agent: prompt + metadata block:<br/>[File attachment received]<br/>filename: report.pdf<br/>mimetype: application/pdf<br/>size: 2.3 MB<br/>path: /tmp/openab-attachments/{msg_id}/report.pdf
+    
+    Agent->>FS: read_file(/tmp/.../report.pdf)
+    FS-->>Agent: file contents
+    Agent->>U: 回覆（基於檔案內容）
+    
+    Note over FS: 10 分鐘後 eviction loop 刪除
+```
+
+## Detailed Flow: Gateway 平台（Telegram/飛書/WeChat）
+
+```mermaid
+sequenceDiagram
+    participant U as 用戶
+    participant TG as Telegram API
+    participant GW as Gateway Process
+    participant FS as Local Filesystem
+    participant OAB as openAB 主程式
+    participant Agent as LLM Agent
+
+    U->>TG: 傳送 report.pdf
+    TG->>GW: Webhook (file_id)
+    
+    GW->>TG: getFile(file_id) + bot_token
+    TG-->>GW: file_path
+    GW->>TG: GET /file/bot{token}/{file_path}
+    TG-->>GW: File bytes
+    
+    GW->>FS: store_media(bytes) → /home/.openab/media/inbound/{uuid}
+    GW->>OAB: WebSocket event:<br/>attachment_type: "document"<br/>filename: "report.pdf"<br/>mime_type: "application/pdf"<br/>path: "/home/.openab/media/inbound/{uuid}"
+    
+    OAB->>FS: read file from path
+    Note over OAB: 構建 metadata content block
+    OAB->>Agent: prompt + metadata block:<br/>[File attachment received]<br/>path: /tmp/openab-attachments/{msg_id}/report.pdf
+    
+    Agent->>FS: read_file(path)
+    FS-->>Agent: file contents
+    Agent->>U: 回覆
+    
+    Note over FS: Gateway: 2 min TTL 刪原始檔<br/>openAB: 10 min TTL 刪 copy
+```
+
+---
+
+## Component Changes
+
+### 1. `src/media.rs` — 新增 `download_to_disk()`
+
+```mermaid
+flowchart LR
+    A[download_to_disk] --> B{URL empty?}
+    B -->|Yes| C[return None]
+    B -->|No| D[HTTP GET + auth_token]
+    D --> E{size > MAX?}
+    E -->|Yes| F[log warn, return None]
+    E -->|No| G[sanitize filename]
+    G --> H[write to disk]
+    H --> I[return ContentBlock::Text with metadata]
+```
+
+**函數簽名：**
+```rust
+pub async fn download_to_disk(
+    url: &str,
+    filename: &str,
+    mime_type: &str,
+    size: u64,
+    bucket_id: &str,
+    auth_token: Option<&str>,
+) -> Option<ContentBlock>
+```
+
+**輸出的 ContentBlock 內容：**
+```
+<<<EXTERNAL_UNTRUSTED_CONTENT>>>
+[File attachment received — not auto-parsed by OpenAB]
+- filename: report.pdf
+- mimetype: application/pdf
+- size: 2.3 MB
+- local_path: /tmp/openab-attachments/1234567890/report.pdf
+
+Use your file-reading tools to access this file if needed.
+<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>
+```
+
+### 2. Adapter 改動
+
+```mermaid
+flowchart TD
+    subgraph "Discord adapter (src/discord.rs)"
+        D1[for attachment in msg.attachments] --> D2{is_audio?}
+        D2 -->|Yes| D3[STT]
+        D2 -->|No| D4{is_text_file?}
+        D4 -->|Yes| D5[inline text]
+        D4 -->|No| D6[download_and_encode_image]
+        D6 -->|Ok| D7[image block]
+        D6 -->|NotAnImage| D8{is_video?}
+        D8 -->|Yes| D9[video URL block]
+        D8 -->|No| D10[✨ download_to_disk ✨]
+    end
+    
+    subgraph "Slack adapter (src/slack.rs)"
+        S1[for file in files] --> S2{is_audio?}
+        S2 -->|Yes| S3[STT]
+        S2 -->|No| S4{is_text_file?}
+        S4 -->|Yes| S5[inline text]
+        S4 -->|No| S6[download_and_encode_image]
+        S6 -->|Ok| S7[image block]
+        S6 -->|NotAnImage| S10[✨ download_to_disk ✨]
+    end
+```
+
+### 3. Gateway 改動
+
+```mermaid
+flowchart TD
+    subgraph "Gateway main (src/gateway.rs)"
+        G1[for att in event.content.attachments] --> G2{attachment_type?}
+        G2 -->|image| G3[base64 → ContentBlock::Image]
+        G2 -->|text_file| G4[UTF-8 → code block]
+        G2 -->|audio| G5[STT]
+        G2 -->|document ✨| G6[read file → metadata block]
+        G2 -->|unknown| G7[✨ same as document ✨]
+    end
+    
+    subgraph "Telegram adapter (gateway)"
+        T1[TelegramMessage] --> T2{photo?}
+        T2 -->|Yes| T3[download_telegram_media Image]
+        T2 -->|No| T4{document?}
+        T4 -->|Yes| T5{is_text?}
+        T5 -->|Yes| T6[download_telegram_document text]
+        T5 -->|No| T7[✨ download_telegram_document binary ✨]
+        T4 -->|No| T8{voice/audio?}
+    end
+```
+
+### 4. Cleanup 機制
+
+```mermaid
+flowchart TD
+    subgraph "Eviction (existing gateway pattern)"
+        Loop[每 60 秒掃描一次] --> Scan[讀取 /tmp/openab-attachments/]
+        Scan --> Check{file age > TTL?}
+        Check -->|Yes| Del[刪除檔案]
+        Check -->|No| Skip[保留]
+        Del --> Loop
+        Skip --> Loop
+    end
+    
+    subgraph "Config"
+        TTL[OPENAB_ATTACHMENTS_TTL_SECS = 600]
+        MAX[OPENAB_ATTACHMENTS_MAX_BYTES = 500MB]
+        DIR[OPENAB_ATTACHMENTS_DIR = /tmp/openab-attachments]
+    end
+```
+
+---
+
+## Security Checklist
+
+| Item | Status |
+|------|--------|
+| Filename sanitization（path separators, null bytes, `..`） | 必做 |
+| Path containment check（resolve 後確認在 target dir 內） | 必做 |
+| `<<<EXTERNAL_UNTRUSTED_CONTENT>>>` markers | 必做 |
+| Per-file size cap（configurable, default 200MB） | 必做 |
+| Total dir size cap（500MB default） | 必做 |
+| TTL eviction（10 min default） | 必做 |
+| SSRF guard on download URL（block private IP ranges） | 可選（Discord/Slack URL 已知安全）|
+
+---
+
+## Config (config.toml)
+
+```toml
+[attachments]
+enabled = true
+dir = "/tmp/openab-attachments"
+max_file_size_mb = 200
+max_total_size_mb = 500
+ttl_secs = 600
+```
+
+---
+
+## Scope
+
+### Phase 1（本次 PR）
+- Discord + Slack: download_to_disk for unhandled files
+- Gateway: 新增 `document` attachment_type 處理
+- Telegram adapter: binary document 支援
+- Eviction loop
+- Security: filename sanitize + path containment + markers
+
+### Phase 2（後續）
+- 飛書/WeChat/Google Chat adapter 同步支援
+- PDF text extraction（optional，像 OpenClaw 那樣）
+- Config-driven allowlist/blocklist
+- Metrics/logging for attachment types

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -1374,7 +1374,7 @@ pub enum MediaRef {
 const IMAGE_MAX_DIMENSION_PX: u32 = 1200;
 const IMAGE_JPEG_QUALITY: u8 = 75;
 const IMAGE_MAX_DOWNLOAD: u64 = 10 * 1024 * 1024; // 10 MB
-const FILE_MAX_DOWNLOAD: u64 = 512 * 1024; // 512 KB
+const FILE_MAX_DOWNLOAD: u64 = 20 * 1024 * 1024; // 20 MB
 
 /// Resize image so longest side <= 1200px, then encode as JPEG.
 /// GIFs are passed through unchanged to preserve animation.
@@ -1470,17 +1470,6 @@ pub async fn download_feishu_file(
     file_key: &str,
     file_name: &str,
 ) -> Option<crate::schema::Attachment> {
-    // Only download text-like files
-    let ext = file_name.rsplit('.').next().unwrap_or("").to_lowercase();
-    const TEXT_EXTS: &[&str] = &[
-        "txt", "csv", "log", "md", "json", "jsonl", "yaml", "yml", "toml", "xml",
-        "rs", "py", "js", "ts", "jsx", "tsx", "go", "java", "c", "cpp", "h", "hpp",
-        "rb", "sh", "bash", "sql", "html", "css", "ini", "cfg", "conf", "env",
-    ];
-    if !TEXT_EXTS.contains(&ext.as_str()) {
-        tracing::debug!(file_name, "skipping non-text file attachment");
-        return None;
-    }
     let url = format!(
         "{}/open-apis/im/v1/messages/{}/resources/{}?type=file",
         api_base, message_id, file_key
@@ -1508,14 +1497,24 @@ pub async fn download_feishu_file(
     let bytes = resp.bytes().await.ok()?;
     // Fallback check (Content-Length may be absent or misreported)
     if bytes.len() as u64 > FILE_MAX_DOWNLOAD {
-        tracing::warn!(file_name, size = bytes.len(), "feishu file exceeds 512KB limit");
+        tracing::warn!(file_name, size = bytes.len(), "feishu file exceeds limit");
         return None;
     }
     let path = crate::store::store_media(&bytes).await?;
+
+    // Determine attachment type: text_file if recognized text extension and valid UTF-8
+    let att_type = if crate::media::is_text_extension(file_name) && String::from_utf8(bytes.to_vec()).is_ok() {
+        "text_file"
+    } else {
+        "document"
+    };
+    let mime = if att_type == "text_file" { "text/plain" } else { "application/octet-stream" };
+
+    tracing::info!(file_name, size = bytes.len(), att_type, "feishu file stored");
     Some(crate::schema::Attachment {
-        attachment_type: "text_file".into(),
+        attachment_type: att_type.into(),
         filename: file_name.to_string(),
-        mime_type: "text/plain".into(),
+        mime_type: mime.into(),
         data: String::new(),
         size: bytes.len() as u64,
         path: Some(path),

--- a/gateway/src/adapters/googlechat.rs
+++ b/gateway/src/adapters/googlechat.rs
@@ -1279,11 +1279,8 @@ pub async fn download_googlechat_file(
     remaining_budget: u64,
 ) -> Option<crate::schema::Attachment> {
     let ext = content_name.rsplit('.').next().unwrap_or("").to_lowercase();
-    if !TEXT_EXTS.contains(&ext.as_str()) {
-        tracing::debug!(content_name, "skipping non-text googlechat file attachment");
-        return None;
-    }
-    let max_size = FILE_MAX_DOWNLOAD.min(remaining_budget);
+    let is_text = TEXT_EXTS.contains(&ext.as_str());
+    let max_size = if is_text { FILE_MAX_DOWNLOAD.min(remaining_budget) } else { remaining_budget.min(20 * 1024 * 1024) };
     let url = media_url(api_base, resource_name);
     let resp = match client.get(&url).bearer_auth(token).timeout(MEDIA_REQUEST_TIMEOUT).send().await {
         Ok(r) => r,
@@ -1310,10 +1307,18 @@ pub async fn download_googlechat_file(
         return None;
     }
     let path = crate::store::store_media(&bytes).await?;
+
+    let att_type = if is_text && String::from_utf8(bytes.to_vec()).is_ok() {
+        "text_file"
+    } else {
+        "document"
+    };
+    let mime = if att_type == "text_file" { "text/plain" } else { "application/octet-stream" };
+
     Some(crate::schema::Attachment {
-        attachment_type: "text_file".into(),
+        attachment_type: att_type.into(),
         filename: content_name.to_string(),
-        mime_type: "text/plain".into(),
+        mime_type: mime.into(),
         data: String::new(),
         size: bytes.len() as u64,
         path: Some(path),

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -426,7 +426,9 @@ async fn download_telegram_media(
     })
 }
 
-/// Download text document from Telegram → store to filesystem.
+/// Download document from Telegram → store to filesystem.
+/// Supports both text and binary files. Text files get attachment_type "text_file",
+/// binary files get "document".
 async fn download_telegram_document(
     client: &reqwest::Client,
     bot_token: &str,
@@ -434,11 +436,6 @@ async fn download_telegram_document(
     file_name: &str,
     mime_type: &str,
 ) -> Option<Attachment> {
-    if !crate::media::is_text_extension(file_name) {
-        tracing::debug!(file_name, "skipping non-text file attachment");
-        return None;
-    }
-
     let get_file_url = format!("{TELEGRAM_API_BASE}/bot{}/getFile", bot_token);
     let resp = client.get(&get_file_url).query(&[("file_id", file_id)]).send().await.ok()?;
     let body: serde_json::Value = resp.json().await.ok()?;
@@ -465,17 +462,19 @@ async fn download_telegram_document(
         return None;
     }
 
-    // Validate UTF-8 — reject binary files
-    if String::from_utf8(bytes.to_vec()).is_err() {
-        warn!(file_id, file_name, "Telegram document is not valid UTF-8, skipping");
-        return None;
-    }
-
     let path = store::store_media(&bytes).await?;
-    info!(file_id, file_name, size = bytes.len(), "Telegram document stored");
+
+    // Determine attachment type: text_file if it's a recognized text format and valid UTF-8
+    let att_type = if crate::media::is_text_extension(file_name) && String::from_utf8(bytes.to_vec()).is_ok() {
+        "text_file"
+    } else {
+        "document"
+    };
+
+    info!(file_id, file_name, size = bytes.len(), att_type, "Telegram document stored");
 
     Some(Attachment {
-        attachment_type: "text_file".into(),
+        attachment_type: att_type.into(),
         filename: file_name.to_string(),
         mime_type: mime_type.to_string(),
         data: String::new(),

--- a/gateway/src/adapters/wecom.rs
+++ b/gateway/src/adapters/wecom.rs
@@ -1261,8 +1261,17 @@ async fn download_wecom_file(
     }
 
     if !is_text_file(filename) {
-        info!(filename, "wecom: skipping non-text file");
-        return None;
+        // Binary file — store as document
+        let path = crate::store::store_media(&bytes).await?;
+        info!(filename, size = bytes.len(), "wecom: binary file stored as document");
+        return Some(crate::schema::Attachment {
+            attachment_type: "document".into(),
+            filename: filename.to_string(),
+            mime_type: "application/octet-stream".into(),
+            data: String::new(),
+            size: bytes.len() as u64,
+            path: Some(path),
+        });
     }
 
     let text_content = match String::from_utf8(bytes.to_vec()) {

--- a/src/acp/connection.rs
+++ b/src/acp/connection.rs
@@ -10,6 +10,7 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader
 use tokio::process::{Child, ChildStdin};
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::task::JoinHandle;
+use tokio::time::Instant;
 use tracing::{debug, error, info, trace};
 
 /// Pick the most permissive selectable permission option from ACP options.
@@ -74,6 +75,48 @@ fn build_permission_response(params: Option<&Value>) -> Value {
     }
 }
 
+fn session_new_params(cwd: &str, mcp_servers: &[Value]) -> Value {
+    json!({"cwd": cwd, "mcpServers": mcp_servers})
+}
+
+fn session_load_params(session_id: &str, cwd: &str, mcp_servers: &[Value]) -> Value {
+    json!({"sessionId": session_id, "cwd": cwd, "mcpServers": mcp_servers})
+}
+
+fn redact_acp_log_data(data: &str) -> String {
+    let trimmed = data.trim();
+    let Ok(mut value) = serde_json::from_str::<Value>(trimmed) else {
+        return trimmed.to_owned();
+    };
+
+    if let Some(servers) = value
+        .get_mut("params")
+        .and_then(|params| params.get_mut("mcpServers"))
+        .and_then(Value::as_array_mut)
+    {
+        for server in servers {
+            redact_name_value_array(server, "env");
+            redact_name_value_array(server, "headers");
+        }
+    }
+
+    serde_json::to_string(&value).unwrap_or_else(|_| trimmed.to_owned())
+}
+
+fn redact_name_value_array(value: &mut Value, field: &str) {
+    let Some(entries) = value.get_mut(field).and_then(Value::as_array_mut) else {
+        return;
+    };
+
+    for entry in entries {
+        if let Some(object) = entry.as_object_mut() {
+            if object.contains_key("value") {
+                object.insert("value".to_owned(), Value::String("[redacted]".to_owned()));
+            }
+        }
+    }
+}
+
 fn expand_env(val: &str) -> String {
     if val.starts_with("${") && val.ends_with('}') {
         let key = &val[2..val.len() - 1];
@@ -82,7 +125,6 @@ fn expand_env(val: &str) -> String {
         val.to_string()
     }
 }
-use tokio::time::Instant;
 
 /// A content block for the ACP prompt — either text or image.
 #[derive(Debug, Clone)]
@@ -371,7 +413,8 @@ impl AcpConnection {
                         Ok(_) => {
                             let trimmed = line.trim();
                             if !trimmed.is_empty() {
-                                let sanitized: String = trimmed.chars()
+                                let sanitized: String = trimmed
+                                    .chars()
                                     .filter(|c| !c.is_control() || *c == '\t')
                                     .collect();
                                 if !sanitized.is_empty() {
@@ -421,7 +464,9 @@ impl AcpConnection {
     }
 
     pub(crate) async fn send_raw(&self, data: &str) -> Result<()> {
-        debug!(data = data.trim(), "acp_send");
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            debug!(data = redact_acp_log_data(data), "acp_send");
+        }
         let mut w = self.stdin.lock().await;
         w.write_all(data.as_bytes()).await?;
         w.write_all(b"\n").await?;
@@ -482,9 +527,9 @@ impl AcpConnection {
         Ok(())
     }
 
-    pub async fn session_new(&mut self, cwd: &str) -> Result<String> {
+    pub async fn session_new(&mut self, cwd: &str, mcp_servers: &[Value]) -> Result<String> {
         let resp = self
-            .send_request("session/new", Some(json!({"cwd": cwd, "mcpServers": []})))
+            .send_request("session/new", Some(session_new_params(cwd, mcp_servers)))
             .await?;
 
         let session_id = resp
@@ -640,11 +685,16 @@ impl AcpConnection {
 
     /// Resume a previous session by ID. Returns Ok(()) if the agent accepted
     /// the load, or an error if it failed (caller should fall back to session/new).
-    pub async fn session_load(&mut self, session_id: &str, cwd: &str) -> Result<()> {
+    pub async fn session_load(
+        &mut self,
+        session_id: &str,
+        cwd: &str,
+        mcp_servers: &[Value],
+    ) -> Result<()> {
         let resp = self
             .send_request(
                 "session/load",
-                Some(json!({"sessionId": session_id, "cwd": cwd, "mcpServers": []})),
+                Some(session_load_params(session_id, cwd, mcp_servers)),
             )
             .await?;
         // Accept any non-error response as success
@@ -699,8 +749,11 @@ impl Drop for AcpConnection {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_agent_env, build_permission_response, pick_best_option};
-    use serde_json::json;
+    use super::{
+        build_agent_env, build_permission_response, pick_best_option, redact_acp_log_data,
+        session_load_params, session_new_params,
+    };
+    use serde_json::{json, Value};
 
     #[test]
     fn picks_allow_always_over_other_options() {
@@ -794,6 +847,91 @@ mod tests {
     }
 
     #[test]
+    fn session_new_params_include_mcp_servers() {
+        let servers = vec![json!({
+            "name": "local-tools",
+            "command": "example-mcp-server",
+            "args": ["--data-dir", "/tmp/example-mcp"],
+            "env": []
+        })];
+
+        assert_eq!(
+            session_new_params("/workspace", &servers),
+            json!({
+                "cwd": "/workspace",
+                "mcpServers": servers
+            })
+        );
+    }
+
+    #[test]
+    fn session_load_params_include_mcp_servers() {
+        let servers = vec![json!({
+            "name": "local-tools",
+            "command": "example-mcp-server",
+            "args": [],
+            "env": []
+        })];
+
+        assert_eq!(
+            session_load_params("session-1", "/workspace", &servers),
+            json!({
+                "sessionId": "session-1",
+                "cwd": "/workspace",
+                "mcpServers": servers
+            })
+        );
+    }
+
+    #[test]
+    fn redacts_mcp_server_env_and_headers_from_log_data() {
+        let data = serde_json::to_string(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {
+                "cwd": "/workspace",
+                "mcpServers": [
+                    {
+                        "name": "remote-memory",
+                        "type": "http",
+                        "url": "https://mcp.example.test/mcp",
+                        "headers": [
+                            {"name": "Authorization", "value": "Bearer secret-token"}
+                        ]
+                    },
+                    {
+                        "name": "local-tools",
+                        "command": "mcp-server",
+                        "args": [],
+                        "env": [
+                            {"name": "MCP_API_KEY", "value": "env-secret"}
+                        ]
+                    }
+                ]
+            }
+        }))
+        .unwrap();
+
+        let redacted = redact_acp_log_data(&data);
+
+        assert!(!redacted.contains("Bearer secret-token"));
+        assert!(!redacted.contains("env-secret"));
+        assert!(redacted.contains("remote-memory"));
+        assert!(redacted.contains("local-tools"));
+
+        let value: Value = serde_json::from_str(&redacted).unwrap();
+        assert_eq!(
+            value["params"]["mcpServers"][0]["headers"][0]["value"],
+            "[redacted]"
+        );
+        assert_eq!(
+            value["params"]["mcpServers"][1]["env"][0]["value"],
+            "[redacted]"
+        );
+    }
+
+    #[test]
     fn explicit_env_takes_precedence_over_inherit_env() {
         let key = "OAB_TEST_PRECEDENCE";
         std::env::set_var(key, "from_process");
@@ -872,13 +1010,10 @@ mod reader_loop_tests {
         agent_stdout_writer.write_all(stale).await.unwrap();
         agent_stdout_writer.flush().await.unwrap();
 
-        let forwarded = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            sub_rx.recv(),
-        )
-        .await
-        .expect("subscriber should receive stale message before timeout")
-        .expect("subscriber channel should not be closed");
+        let forwarded = tokio::time::timeout(std::time::Duration::from_secs(2), sub_rx.recv())
+            .await
+            .expect("subscriber should receive stale message before timeout")
+            .expect("subscriber channel should not be closed");
         assert_eq!(forwarded.id, Some(42));
         assert!(pending.lock().await.is_empty());
 

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -163,6 +163,8 @@ impl SessionPool {
             }
         }
 
+        let mcp_servers = self.config.acp_mcp_servers()?;
+
         // Build the replacement connection outside the state lock so one stuck
         // initialization does not block all unrelated sessions.
         let mut new_conn = AcpConnection::spawn(
@@ -179,7 +181,10 @@ impl SessionPool {
         let mut resumed = false;
         if let Some(ref sid) = saved_session_id {
             if new_conn.supports_load_session {
-                match new_conn.session_load(sid, &self.config.working_dir).await {
+                match new_conn
+                    .session_load(sid, &self.config.working_dir, &mcp_servers)
+                    .await
+                {
                     Ok(()) => {
                         info!(thread_id, session_id = %sid, "session resumed via session/load");
                         resumed = true;
@@ -192,7 +197,9 @@ impl SessionPool {
         }
 
         if !resumed {
-            new_conn.session_new(&self.config.working_dir).await?;
+            new_conn
+                .session_new(&self.config.working_dir, &mcp_servers)
+                .await?;
             // Surface the reset banner both for restored sessions and for stale
             // live entries that died before we could recover a resumable
             // session id. In both cases the caller is continuing after an

--- a/src/config.rs
+++ b/src/config.rs
@@ -310,6 +310,99 @@ pub struct AgentConfig {
     pub env: HashMap<String, String>,
     #[serde(default)]
     pub inherit_env: Vec<String>,
+    #[serde(default)]
+    pub mcp_servers: HashMap<String, AgentMcpServerConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AgentMcpServerConfig {
+    /// MCP transport type. Omit for stdio.
+    #[serde(default, rename = "type")]
+    pub server_type: Option<String>,
+    /// Stdio server command.
+    pub command: Option<String>,
+    /// Stdio server arguments.
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// HTTP or SSE server URL.
+    pub url: Option<String>,
+    /// Stdio server environment.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// HTTP or SSE request headers.
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+}
+
+impl AgentConfig {
+    pub fn acp_mcp_servers(&self) -> anyhow::Result<Vec<serde_json::Value>> {
+        let mut servers: Vec<_> = self.mcp_servers.iter().collect();
+        servers.sort_by_key(|(name, _)| *name);
+        servers
+            .into_iter()
+            .map(|(name, config)| config.to_acp_value(name))
+            .collect()
+    }
+}
+
+impl AgentMcpServerConfig {
+    fn to_acp_value(&self, name: &str) -> anyhow::Result<serde_json::Value> {
+        anyhow::ensure!(
+            !name.trim().is_empty(),
+            "agent.mcp_servers name cannot be empty"
+        );
+
+        match self
+            .server_type
+            .as_deref()
+            .unwrap_or("stdio")
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "stdio" => {
+                let command = self.command.as_deref().unwrap_or("").trim();
+                anyhow::ensure!(
+                    !command.is_empty(),
+                    "agent.mcp_servers.{name}.command is required for stdio MCP servers"
+                );
+                Ok(serde_json::json!({
+                    "name": name,
+                    "command": command,
+                    "args": &self.args,
+                    "env": name_value_entries(&self.env),
+                }))
+            }
+            "http" | "sse" => {
+                let server_type = self.server_type.as_deref().unwrap_or("http");
+                let url = self.url.as_deref().unwrap_or("").trim();
+                anyhow::ensure!(
+                    !url.is_empty(),
+                    "agent.mcp_servers.{name}.url is required for {server_type} MCP servers"
+                );
+                let mut value = serde_json::json!({
+                    "name": name,
+                    "type": server_type.to_ascii_lowercase(),
+                    "url": url,
+                });
+                if !self.headers.is_empty() {
+                    value["headers"] = serde_json::Value::Array(name_value_entries(&self.headers));
+                }
+                Ok(value)
+            }
+            other => anyhow::bail!(
+                "agent.mcp_servers.{name}.type must be one of: stdio, http, sse (got {other})"
+            ),
+        }
+    }
+}
+
+fn name_value_entries(map: &HashMap<String, String>) -> Vec<serde_json::Value> {
+    let mut entries: Vec<_> = map.iter().collect();
+    entries.sort_by_key(|(name, _)| *name);
+    entries
+        .into_iter()
+        .map(|(name, value)| serde_json::json!({ "name": name, "value": value }))
+        .collect()
 }
 
 #[derive(Debug, Deserialize)]
@@ -664,6 +757,7 @@ fn parse_config(raw: &str, source: &str) -> anyhow::Result<Config> {
         config.pool.liveness_check_secs > 0,
         "pool.liveness_check_secs must be > 0 (zero would spin the recv loop)"
     );
+    let _ = config.agent.acp_mcp_servers()?;
 
     Ok(config)
 }
@@ -686,8 +780,140 @@ command = "echo"
         let cfg = parse_config(MINIMAL_TOML, "test").unwrap();
         assert_eq!(cfg.discord.unwrap().bot_token, "test-token");
         assert_eq!(cfg.agent.command, "echo");
+        assert!(cfg.agent.mcp_servers.is_empty());
+        assert_eq!(
+            cfg.agent.acp_mcp_servers().unwrap(),
+            Vec::<serde_json::Value>::new()
+        );
         assert_eq!(cfg.pool.max_sessions, 10);
         assert!(cfg.reactions.enabled);
+    }
+
+    #[test]
+    fn parse_agent_mcp_stdio_config() {
+        let toml = r#"
+[discord]
+bot_token = "test-token"
+
+[agent]
+command = "codex-acp"
+
+[agent.mcp_servers.local_tools]
+command = "example-mcp-server"
+args = ["--data-dir", "/tmp/example-mcp"]
+env = { MCP_STORAGE = "/tmp/example-mcp" }
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        let servers = cfg.agent.acp_mcp_servers().unwrap();
+        assert_eq!(
+            servers,
+            vec![serde_json::json!({
+                "name": "local_tools",
+                "command": "example-mcp-server",
+                "args": ["--data-dir", "/tmp/example-mcp"],
+                "env": [
+                    {"name": "MCP_STORAGE", "value": "/tmp/example-mcp"}
+                ]
+            })]
+        );
+    }
+
+    #[test]
+    fn parse_agent_mcp_http_config() {
+        let toml = r#"
+[discord]
+bot_token = "test-token"
+
+[agent]
+command = "codex-acp"
+
+[agent.mcp_servers.memory]
+type = "http"
+url = "https://example.test/mcp"
+headers = { Authorization = "Bearer test" }
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        let servers = cfg.agent.acp_mcp_servers().unwrap();
+        assert_eq!(
+            servers,
+            vec![serde_json::json!({
+                "name": "memory",
+                "type": "http",
+                "url": "https://example.test/mcp",
+                "headers": [
+                    {"name": "Authorization", "value": "Bearer test"}
+                ]
+            })]
+        );
+    }
+
+    #[test]
+    fn parse_agent_mcp_sse_config() {
+        let toml = r#"
+[discord]
+bot_token = "test-token"
+
+[agent]
+command = "codex-acp"
+
+[agent.mcp_servers.events]
+type = "sse"
+url = "https://example.test/events"
+headers = { Authorization = "Bearer test" }
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        let servers = cfg.agent.acp_mcp_servers().unwrap();
+        assert_eq!(
+            servers,
+            vec![serde_json::json!({
+                "name": "events",
+                "type": "sse",
+                "url": "https://example.test/events",
+                "headers": [
+                    {"name": "Authorization", "value": "Bearer test"}
+                ]
+            })]
+        );
+    }
+
+    #[test]
+    fn agent_mcp_servers_are_sorted_by_name() {
+        let toml = r#"
+[discord]
+bot_token = "test-token"
+
+[agent]
+command = "codex-acp"
+
+[agent.mcp_servers.zeta]
+command = "zeta-mcp"
+
+[agent.mcp_servers.alpha]
+command = "alpha-mcp"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        let servers = cfg.agent.acp_mcp_servers().unwrap();
+        let names: Vec<_> = servers
+            .iter()
+            .map(|server| server["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["alpha", "zeta"]);
+    }
+
+    #[test]
+    fn parse_agent_mcp_stdio_requires_command() {
+        let toml = r#"
+[discord]
+bot_token = "test-token"
+
+[agent]
+command = "codex-acp"
+
+[agent.mcp_servers.bad]
+args = ["--flag"]
+"#;
+        let err = parse_config(toml, "test").unwrap_err().to_string();
+        assert!(err.contains("agent.mcp_servers.bad.command is required"));
     }
 
     #[test]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -746,6 +746,16 @@ impl EventHandler for Handler {
                                 u64::from(attachment.size),
                                 &attachment.url,
                             ));
+                        } else if let Some(block) = media::download_to_disk(
+                            &attachment.url,
+                            &attachment.filename,
+                            attachment.content_type.as_deref().unwrap_or("application/octet-stream"),
+                            u64::from(attachment.size),
+                            &msg.id.to_string(),
+                            None,
+                        ).await {
+                            debug!(filename = %attachment.filename, "file saved to disk");
+                            extra_blocks.push(block);
                         }
                     }
                     Err(e) => {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1066,6 +1066,7 @@ mod tests {
             working_dir: "/tmp".into(),
             env: std::collections::HashMap::new(),
             inherit_env: vec![],
+            mcp_servers: std::collections::HashMap::new(),
         };
         let pool = Arc::new(SessionPool::new(agent_cfg, 1));
         let router = Arc::new(AdapterRouter::new(

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -785,7 +785,29 @@ pub async fn run_gateway_adapter(
                                             "audio" => {
                                                 tracing::debug!(filename = %att.filename, "audio attachment skipped — STT not enabled");
                                             }
-                                            _ => {}
+                                            // document / unknown types: store to disk
+                                            _ => {
+                                                let bytes_result = if let Some(ref path) = att.path {
+                                                    tokio::fs::read(path).await.map_err(|e| e.to_string())
+                                                } else if !att.data.is_empty() {
+                                                    use base64::Engine;
+                                                    base64::engine::general_purpose::STANDARD
+                                                        .decode(&att.data)
+                                                        .map_err(|e| e.to_string())
+                                                } else {
+                                                    Err("no path or data".into())
+                                                };
+                                                if let Ok(bytes) = bytes_result {
+                                                    if let Some(block) = crate::media::store_to_disk(
+                                                        &bytes,
+                                                        &att.filename,
+                                                        &att.mime_type,
+                                                        &event.message_id,
+                                                    ).await {
+                                                        extra_blocks.push(block);
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,9 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
+    // Spawn attachments eviction loop (download-to-disk cleanup)
+    tokio::spawn(media::attachments_eviction_loop());
+
     // Pre-build shared adapters for cron scheduler (avoids duplicate Http clients / rate-limit buckets)
     let shared_discord_adapter: Option<Arc<dyn adapter::ChatAdapter>> =
         cfg.discord.as_ref().map(|dc| {

--- a/src/media.rs
+++ b/src/media.rs
@@ -534,6 +534,226 @@ pub async fn download_and_read_text_file(
     ))
 }
 
+/// Default attachment storage directory.
+const DEFAULT_ATTACHMENTS_DIR: &str = "/tmp/openab-attachments";
+
+/// Default max file size for download-to-disk (200 MB).
+const DISK_MAX_SIZE: u64 = 200 * 1024 * 1024;
+
+/// Default TTL for stored attachments (1 hour).
+pub const DEFAULT_ATTACHMENTS_TTL_SECS: u64 = 3600;
+
+/// Sanitize a filename: strip path separators, null bytes, control chars, `..`.
+fn sanitize_filename(name: &str) -> String {
+    let name = name
+        .replace(['/', '\\', '\0'], "_")
+        .replace("..", "_");
+    let name = name.trim().trim_matches('.');
+    if name.is_empty() {
+        "unnamed_file".to_string()
+    } else {
+        name.chars().take(200).collect()
+    }
+}
+
+/// Format bytes as human-readable size string.
+fn format_size_human(bytes: u64) -> String {
+    if bytes < 1024 {
+        format!("{bytes} B")
+    } else if bytes < 1024 * 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+/// Get the attachments directory (creates if needed).
+pub fn attachments_dir() -> std::path::PathBuf {
+    let dir = std::env::var("OPENAB_ATTACHMENTS_DIR")
+        .unwrap_or_else(|_| DEFAULT_ATTACHMENTS_DIR.to_string());
+    std::path::PathBuf::from(dir)
+}
+
+/// Download a file to local disk and return a metadata ContentBlock with the path.
+///
+/// Used for inbound attachments that aren't image/audio/text — PDFs, office docs,
+/// archives, video, etc. The agent can then use file-reading tools to access the file.
+///
+/// `bucket_id` is used as a subdirectory (typically message ID) to namespace files.
+pub async fn download_to_disk(
+    url: &str,
+    filename: &str,
+    mime_type: &str,
+    size: u64,
+    bucket_id: &str,
+    auth_token: Option<&str>,
+) -> Option<ContentBlock> {
+    if url.is_empty() {
+        return None;
+    }
+
+    if size > DISK_MAX_SIZE {
+        warn!(filename, size, "file exceeds 200MB limit, skipping download_to_disk");
+        return None;
+    }
+
+    let mut req = HTTP_CLIENT.get(url);
+    if let Some(token) = auth_token {
+        req = req.header("Authorization", format!("Bearer {token}"));
+    }
+
+    let resp = match req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(url, error = %e, "download_to_disk: request failed");
+            return None;
+        }
+    };
+    if !resp.status().is_success() {
+        warn!(url, status = %resp.status(), "download_to_disk: HTTP error");
+        return None;
+    }
+
+    let bytes = match resp.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(url, error = %e, "download_to_disk: body read failed");
+            return None;
+        }
+    };
+
+    if bytes.len() as u64 > DISK_MAX_SIZE {
+        warn!(filename, size = bytes.len(), "download_to_disk: downloaded file exceeds limit");
+        return None;
+    }
+
+    let safe_name = sanitize_filename(filename);
+    let dir = attachments_dir().join(bucket_id);
+    if let Err(e) = tokio::fs::create_dir_all(&dir).await {
+        error!(error = %e, "download_to_disk: failed to create directory");
+        return None;
+    }
+
+    let path = dir.join(&safe_name);
+    // Path containment check: ensure the resolved path stays within the bucket dir.
+    // We canonicalize the dir (which exists) and check the filename doesn't escape.
+    let base_resolved = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+    let resolved_path = base_resolved.join(&safe_name);
+    if !resolved_path.starts_with(&base_resolved) {
+        error!(filename, "download_to_disk: path containment violation");
+        return None;
+    }
+
+    if let Err(e) = tokio::fs::write(&path, &bytes).await {
+        error!(error = %e, "download_to_disk: failed to write file");
+        return None;
+    }
+
+    let actual_size = bytes.len() as u64;
+    let path_str = path.to_string_lossy();
+    debug!(filename = safe_name, size = actual_size, path = %path_str, "file saved to disk");
+
+    Some(ContentBlock::Text {
+        text: format!(
+            "<<<EXTERNAL_UNTRUSTED_CONTENT>>>\n\
+             [File attachment received]\n\
+             - filename: {safe_name}\n\
+             - mimetype: {mime_type}\n\
+             - size: {}\n\
+             - local_path: {path_str}\n\n\
+             Use your file-reading tools to access this file if needed.\n\
+             <<<END_EXTERNAL_UNTRUSTED_CONTENT>>>",
+            format_size_human(actual_size),
+        ),
+    })
+}
+
+/// Store file bytes directly to disk (for gateway path — bytes already downloaded).
+/// Returns a metadata ContentBlock with the path.
+pub async fn store_to_disk(
+    bytes: &[u8],
+    filename: &str,
+    mime_type: &str,
+    bucket_id: &str,
+) -> Option<ContentBlock> {
+    if bytes.len() as u64 > DISK_MAX_SIZE {
+        warn!(filename, size = bytes.len(), "store_to_disk: exceeds limit");
+        return None;
+    }
+
+    let safe_name = sanitize_filename(filename);
+    let dir = attachments_dir().join(bucket_id);
+    if let Err(e) = tokio::fs::create_dir_all(&dir).await {
+        error!(error = %e, "store_to_disk: failed to create directory");
+        return None;
+    }
+
+    let path = dir.join(&safe_name);
+    if let Err(e) = tokio::fs::write(&path, bytes).await {
+        error!(error = %e, "store_to_disk: failed to write file");
+        return None;
+    }
+
+    let actual_size = bytes.len() as u64;
+    let path_str = path.to_string_lossy();
+    debug!(filename = safe_name, size = actual_size, path = %path_str, "file stored to disk");
+
+    Some(ContentBlock::Text {
+        text: format!(
+            "<<<EXTERNAL_UNTRUSTED_CONTENT>>>\n\
+             [File attachment received]\n\
+             - filename: {safe_name}\n\
+             - mimetype: {mime_type}\n\
+             - size: {}\n\
+             - local_path: {path_str}\n\n\
+             Use your file-reading tools to access this file if needed.\n\
+             <<<END_EXTERNAL_UNTRUSTED_CONTENT>>>",
+            format_size_human(actual_size),
+        ),
+    })
+}
+
+/// Background eviction loop: removes files older than TTL from the attachments directory.
+pub async fn attachments_eviction_loop() {
+    let ttl_secs: u64 = std::env::var("OPENAB_ATTACHMENTS_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_ATTACHMENTS_TTL_SECS);
+
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+    loop {
+        interval.tick().await;
+        if let Err(e) = evict_attachments(ttl_secs).await {
+            error!(error = %e, "attachments eviction error");
+        }
+    }
+}
+
+async fn evict_attachments(ttl_secs: u64) -> std::io::Result<()> {
+    let dir = attachments_dir();
+    if !dir.exists() {
+        return Ok(());
+    }
+    let mut entries = tokio::fs::read_dir(&dir).await?;
+    let now = std::time::SystemTime::now();
+    while let Some(entry) = entries.next_entry().await? {
+        let meta = entry.metadata().await?;
+        if meta.is_dir() {
+            // Check bucket directory age
+            if let Ok(modified) = meta.modified() {
+                if let Ok(age) = now.duration_since(modified) {
+                    if age.as_secs() > ttl_secs {
+                        let path = entry.path();
+                        let _ = tokio::fs::remove_dir_all(&path).await;
+                        tracing::debug!(path = %path.display(), "evicted expired attachment bucket");
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -842,5 +1062,178 @@ mod tests {
     fn hex_prefix_handles_short_buffer() {
         let bytes = [0xffu8, 0xd8];
         assert_eq!(hex_prefix(&bytes), "ffd8");
+    }
+
+    #[test]
+    fn sanitize_filename_strips_path_separators() {
+        assert_eq!(sanitize_filename("../../../etc/passwd"), "______etc_passwd");
+        assert_eq!(sanitize_filename("foo/bar\\baz"), "foo_bar_baz");
+        assert_eq!(sanitize_filename("normal.pdf"), "normal.pdf");
+    }
+
+    #[test]
+    fn sanitize_filename_handles_empty_and_dots() {
+        assert_eq!(sanitize_filename(""), "unnamed_file");
+        assert_eq!(sanitize_filename("..."), "_");
+        assert_eq!(sanitize_filename(".."), "_");
+    }
+
+    #[test]
+    fn sanitize_filename_truncates_long_names() {
+        let long = "a".repeat(300);
+        assert_eq!(sanitize_filename(&long).len(), 200);
+    }
+
+    #[test]
+    fn sanitize_filename_strips_null_bytes() {
+        assert_eq!(sanitize_filename("file\0name.pdf"), "file_name.pdf");
+    }
+
+    #[test]
+    fn format_size_human_works() {
+        assert_eq!(format_size_human(500), "500 B");
+        assert_eq!(format_size_human(1024), "1.0 KB");
+        assert_eq!(format_size_human(2 * 1024 * 1024), "2.0 MB");
+    }
+
+    #[tokio::test]
+    async fn store_to_disk_creates_file_and_returns_metadata() {
+        let dir = std::env::temp_dir().join("openab-test-store");
+        std::env::set_var("OPENAB_ATTACHMENTS_DIR", dir.to_str().unwrap());
+
+        let result = store_to_disk(b"hello pdf", "test.pdf", "application/pdf", "bucket123").await;
+        assert!(result.is_some());
+
+        let block = result.unwrap();
+        if let ContentBlock::Text { text } = block {
+            assert!(text.contains("test.pdf"));
+            assert!(text.contains("application/pdf"));
+            assert!(text.contains("bucket123"));
+            assert!(text.contains("<<<EXTERNAL_UNTRUSTED_CONTENT>>>"));
+        } else {
+            panic!("expected Text block");
+        }
+
+        // Verify file exists
+        let path = dir.join("bucket123").join("test.pdf");
+        assert!(path.exists());
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello pdf");
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&dir);
+        std::env::remove_var("OPENAB_ATTACHMENTS_DIR");
+    }
+
+    #[tokio::test]
+    async fn store_to_disk_rejects_oversized() {
+        let big = vec![0u8; 201 * 1024 * 1024];
+        let result = store_to_disk(&big, "huge.bin", "application/octet-stream", "bucket").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn download_to_disk_success() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("GET", "/report.pdf")
+            .with_body(b"fake pdf bytes")
+            .create_async().await;
+
+        let dir = std::env::temp_dir().join(format!("openab-test-dl-{}", std::process::id()));
+        std::env::set_var("OPENAB_ATTACHMENTS_DIR", dir.to_str().unwrap());
+
+        let result = download_to_disk(
+            &format!("{}/report.pdf", server.url()),
+            "report.pdf",
+            "application/pdf",
+            14,
+            "msg001",
+            None,
+        ).await;
+
+        mock.assert_async().await;
+        assert!(result.is_some());
+        let block = result.unwrap();
+        if let ContentBlock::Text { text } = block {
+            assert!(text.contains("report.pdf"));
+            assert!(text.contains("application/pdf"));
+        } else {
+            panic!("expected Text block");
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+        std::env::remove_var("OPENAB_ATTACHMENTS_DIR");
+    }
+
+    #[tokio::test]
+    async fn download_to_disk_returns_none_on_404() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("GET", "/missing.pdf")
+            .with_status(404)
+            .create_async().await;
+
+        let result = download_to_disk(
+            &format!("{}/missing.pdf", server.url()),
+            "missing.pdf",
+            "application/pdf",
+            0,
+            "msg002",
+            None,
+        ).await;
+
+        mock.assert_async().await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn download_to_disk_returns_none_on_empty_url() {
+        let result = download_to_disk(
+            "",
+            "file.pdf",
+            "application/pdf",
+            0,
+            "msg003",
+            None,
+        ).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn download_to_disk_returns_none_when_size_exceeds_limit() {
+        let result = download_to_disk(
+            "http://example.com/huge.bin",
+            "huge.bin",
+            "application/octet-stream",
+            201 * 1024 * 1024,
+            "msg004",
+            None,
+        ).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn download_to_disk_sends_auth_header() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("GET", "/private.pdf")
+            .match_header("Authorization", "Bearer slack-token-123")
+            .with_body(b"private content")
+            .create_async().await;
+
+        let dir = std::env::temp_dir().join(format!("openab-test-auth-{}", std::process::id()));
+        std::env::set_var("OPENAB_ATTACHMENTS_DIR", dir.to_str().unwrap());
+
+        let result = download_to_disk(
+            &format!("{}/private.pdf", server.url()),
+            "private.pdf",
+            "application/pdf",
+            15,
+            "msg005",
+            Some("slack-token-123"),
+        ).await;
+
+        mock.assert_async().await;
+        assert!(result.is_some());
+
+        let _ = std::fs::remove_dir_all(&dir);
+        std::env::remove_var("OPENAB_ATTACHMENTS_DIR");
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1073,7 +1073,19 @@ async fn handle_message(
                         debug!(filename, "adding image attachment");
                         extra_blocks.push(block);
                     }
-                    Err(media::MediaFetchError::NotAnImage) => {}
+                    Err(media::MediaFetchError::NotAnImage) => {
+                        if let Some(block) = media::download_to_disk(
+                            url,
+                            filename,
+                            mimetype,
+                            size,
+                            &ts,
+                            Some(bot_token),
+                        ).await {
+                            debug!(filename, "file saved to disk");
+                            extra_blocks.push(block);
+                        }
+                    }
                     Err(media::MediaFetchError::SizeExceeded { actual, limit }) => {
                         warn!(filename, actual, limit, "image exceeds size limit");
                         failed_image_files.push(filename.to_string());


### PR DESCRIPTION
## What problem does this solve?

Inbound non-image, non-audio, non-text-extension files (PDFs, .docx, .xlsx, video, archives, etc.) are silently dropped by all adapters. The agent receives the user's text prompt with no indication that an attachment was even sent.

Users upload `report.pdf` and ask the bot to read it → bot responds as if no file was attached.

Closes #738

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1510166872132423801

## At a Glance

```
BEFORE:
  User sends PDF → adapter routing:
    image/*  → base64 → prompt ✓
    audio/*  → STT    → prompt ✓
    text/*   → inline → prompt ✓
    other    → ❌ silently dropped

AFTER:
  User sends PDF → adapter routing:
    image/*  → base64 → prompt ✓
    audio/*  → STT    → prompt ✓
    text/*   → inline → prompt ✓
    other    → download_to_disk → metadata block in prompt ✓
                 │
                 ├─ /tmp/openab-attachments/{msg_id}/{filename}
                 ├─ Agent sees: path + mimetype + size
                 ├─ Agent uses file-read/shell tools to process
                 └─ 1 hour TTL → auto-eviction
```

## Prior Art & Industry Research

**OpenClaw:**
- Has a dedicated `pdf` tool registered in the agent's tool registry ([docs/tools/pdf.md](https://github.com/openclaw/openclaw/blob/main/docs/tools/pdf.md))
- Native provider mode for Anthropic/Google (base64 PDF → API directly)
- Extraction fallback for other providers (text + page images via `document-extractor` plugin)
- Files downloaded to local disk, agent accesses via file path

**Hermes Agent:**
- Binary files are **rejected** — `context_references.py` returns `"binary files are not supported"` ([source](https://github.com/NousResearch/hermes-agent/blob/main/agent/context_references.py))
- Agent cannot access the file at all — no path, no URL, no workaround
- Open feature request #5850 "feat: workspace PDF and DOCX parser plugins" (P3, no activity)
- Multiple open bugs around Discord mixed attachments causing 400 errors (#25935, #29711)

**Conclusion:** OpenClaw is the only project with full PDF support. Hermes Agent has the same gap as openAB. Our approach (download-to-disk + let agent handle) is a strict improvement over silent drop, similar to OpenClaw's foundation but without requiring PDF-specific dependencies in the binary.

## Proposed Solution

1. **`download_to_disk()`** in `src/media.rs` — downloads unhandled files from platform CDN/API to `/tmp/openab-attachments/{bucket_id}/{filename}`, returns a `ContentBlock::Text` with metadata (filename, mimetype, size, local_path).

2. **`store_to_disk()`** — same but for gateway platforms where bytes are already downloaded.

3. **Adapter changes** — Discord, Slack: call `download_to_disk` in the `NotAnImage` else branch. Gateway: handle `"document"` and catch-all `_` attachment types with `store_to_disk`.

4. **Gateway adapter changes** — Telegram, Feishu, WeChat, Google Chat: removed `is_text_extension` gates, all document types now stored and forwarded.

5. **TTL eviction loop** — background task runs every 60s, deletes bucket directories older than 1 hour (configurable via `OPENAB_ATTACHMENTS_TTL_SECS`).

6. **Security** — filename sanitization (path separators, null bytes, `..`, truncation), path containment check, `<<<EXTERNAL_UNTRUSTED_CONTENT>>>` markers in the metadata block.

### PDF reading guidance (docs follow-up)

The project intentionally does **not** pre-install Python or PDF tools in the container image to keep it lean. A follow-up docs PR will guide users to instruct their agent to download a standalone Python binary and install `pymupdf` on-demand when PDF reading is needed. Since PVC persists `/home/agent`, tools only need to be installed once and survive pod restarts.

## Why this approach?

- **Agent-agnostic** — openAB does not need to know what the agent can do with the file. It just makes the file accessible.
- **No new binary dependencies** — no `pdftotext`, no Python, no extra crates for PDF parsing in the openAB binary.
- **Consistent with existing patterns** — gateway already uses `store_media()` + TTL eviction for images. We reuse the same model.
- **Progressive enhancement** — agents with shell/MCP tools can read PDFs immediately. Future work can add native PDF content blocks for Claude/Gemini.

## Alternatives Considered

1. **Pass-through URL only (PR #875's approach)** — inject file URL + metadata without downloading. Rejected because Slack/Telegram/Feishu URLs require auth tokens that the agent does not have access to.

2. **PDF text extraction in openAB (Rust crate `pdf-extract`)** — inline extracted text directly into prompt. Rejected for Phase 1 to keep scope manageable and avoid adding PDF parsing dependencies. May revisit in Phase 2.

3. **Pre-install Python + pymupdf in Dockerfile** — works but bloats the image for all users. Rejected in favor of on-demand installation by the agent, persisted in PVC.

## Validation

- [x] `cargo check` passes (openab + gateway)
- [x] `cargo test` passes — 39 media tests (openab) + 170 gateway tests, 0 failures
- [x] Manual testing — deployed to OrbStack k8s, Discord bot connected, PDF attachment received metadata block successfully

### Unit Tests Added (12 tests)

Filename security:
- sanitize_filename: path traversal (../../etc/passwd), null bytes, empty/dots, truncation at 200 chars

Core functionality:
- store_to_disk: writes file correctly, returns metadata ContentBlock with filename/mimetype/path
- store_to_disk: rejects files > 200MB

HTTP download (mock server):
- download_to_disk: successful download → file on disk + correct metadata
- download_to_disk: HTTP 404 → returns None
- download_to_disk: empty URL → returns None
- download_to_disk: declared size > 200MB → returns None (no HTTP request made)
- download_to_disk: Bearer auth token sent correctly (Slack scenario)

Utility:
- format_size_human: B / KB / MB formatting