### PR TITLE
fix(workflow): flip to pending-contributor when CI fails

### DIFF
--- a/.github/workflows/pending-maintainer.yml
+++ b/.github/workflows/pending-maintainer.yml
@@ -78,7 +78,21 @@ jobs:
               const ciRed = status.state === 'failure'
                 || checks.check_runs.some(c => c.conclusion === 'failure');
               if (ciRed) {
-                console.log(`#${prNumber} — CI failing, skipping`);
+                if (labels.includes(MAINTAINER)) {
+                  await github.rest.issues.removeLabel({
+                    ...context.repo,
+                    issue_number: prNumber,
+                    name: MAINTAINER
+                  }).catch(() => {});
+                }
+                if (!labels.includes(CONTRIBUTOR)) {
+                  await github.rest.issues.addLabels({
+                    ...context.repo,
+                    issue_number: prNumber,
+                    labels: [CONTRIBUTOR]
+                  });
+                }
+                console.log(`#${prNumber} — CI failing, flipped to ${CONTRIBUTOR}`);
                 continue;
               }
 


### PR DESCRIPTION
## Summary

`pending-maintainer.yml` was only skipping PRs with CI failures without flipping their label. Per CONTRIBUTING.md, CI failure should flip the label from `pending-maintainer` → `pending-contributor` so the contributor knows the ball is on them.

## Changes

- **`.github/workflows/pending-maintainer.yml`** — When `ciRed` is detected, remove `pending-maintainer` and add `pending-contributor` instead of just skipping.

## Validation

- Workflow syntax valid (YAML structure unchanged, only script logic added)
- Logic matches the PR Lifecycle diagram in CONTRIBUTING.md

## Prior Art

Not applicable — CI/workflow-only change.