### PR TITLE
feat: implement Control Directives Phase 1

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -177,3 +177,12 @@ error_hold_ms = 2500
 # schedule = "0 0 * * 0"
 # channel = "123456789"
 # message = "generate weekly status report"
+
+# Workspace aliases for control directives: [[ws:@alias]]
+# Users can specify a workspace when starting a session, e.g.:
+#   @Bot [[ws:@openab]] help me debug the tests
+#
+# [workspace.aliases]
+# openab = "~/projects/openab"
+# infra  = "~/projects/infra-cdk"
+# web    = "~/projects/frontend"

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -291,6 +291,30 @@ Speech-to-text transcription for voice messages. Uses an OpenAI-compatible `/aud
 
 ---
 
+## `[workspace]`
+
+Workspace aliases for [Control Directives](adr/control-directives.md). Users specify `[[ws:@alias]]` in their first message to set the session's working directory.
+
+```toml
+[workspace.aliases]
+openab = "~/projects/openab"
+infra  = "~/projects/infra-cdk"
+web    = "~/projects/frontend"
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `aliases` | map | `{}` | Key-value map of alias name → path. Users reference with `@` prefix: `[[ws:@openab]]`. Paths starting with `~` expand to `$HOME`. All paths must be within the bot's home directory (security boundary). |
+
+**Security:**
+- Relative paths are rejected
+- `~` expands to bot home (`$HOME`)
+- Paths are canonicalized and must be within bot home subtree
+- Symlink escapes are caught by canonicalization
+- Target must be an existing directory (not a file)
+
+---
+
 ## `[cron]`
 
 Everything cron-related lives under `[cron]`.

--- a/docs/control-directives.md
+++ b/docs/control-directives.md
@@ -61,7 +61,7 @@ Set the initial thread/channel title (max 100 characters, truncated silently).
 - Directives are **immutable** — once a session starts, parameters cannot be changed mid-conversation
 - To change workspace or title, start a new session
 - If no `[[ws:...]]` is specified, the session uses the bot's default working directory
-- If workspace resolution fails on a new session, the session is not created (no stale state left behind)
+- If workspace resolution fails on a new session, the session is not created. However, `[[title:...]]` is applied independently before workspace validation — the thread title may already be set even if the session aborts.
 
 ## Relationship to Output Directives
 

--- a/docs/control-directives.md
+++ b/docs/control-directives.md
@@ -1,0 +1,86 @@
+# Control Directives
+
+## Overview
+
+Users can configure session-level parameters by adding `[[key:value]]` directives to their first message. These are parsed and stripped before the prompt reaches the agent.
+
+## Format
+
+```
+@Bot [[ws:@openab]] [[title:Fix CI workflow]]
+help me debug the smoke test failures
+```
+
+Rules:
+- Directives are only processed on the **first message** of a session
+- Consecutive `[[key:value]]` tokens at the start = directive header
+- First non-directive token/line = prompt content begins
+- Later `[[key:value]]` text in the message body is preserved verbatim
+- Duplicate keys: last value wins
+- Unknown keys: silently ignored (forward compatible)
+- Directives may span multiple lines:
+  ```
+  [[ws:@openab]]
+  [[title:Review PR]]
+  please review this change
+  ```
+
+## Available Directives
+
+### `ws` — Workspace
+
+Set the session's working directory. The agent starts with this path as cwd, loading steering files and skills from it.
+
+```
+[[ws:~/projects/myapp]]
+[[ws:@openab]]
+```
+
+**Alias syntax:** Use `@name` to reference a configured alias (see [Workspaces](workspaces.md)).
+
+**Security:**
+- Path must be absolute (`~` or `/` prefix)
+- `~` expands to bot home directory (`$HOME`)
+- Path must exist and be a directory
+- Path must be within bot home subtree (symlink escapes caught by canonicalization)
+- Invalid paths abort the session with a user-visible error
+
+### `title` — Thread Title
+
+Set the initial thread/channel title (max 100 characters, truncated silently).
+
+```
+[[title:Bug triage #42]]
+```
+
+- Empty value (`[[title:]]`) = use auto-generated title
+- The agent may override this later per its own workflow
+
+## Behavior
+
+- Directives are **immutable** — once a session starts, parameters cannot be changed mid-conversation
+- To change workspace or title, start a new session
+- If no `[[ws:...]]` is specified, the session uses the bot's default working directory
+- If workspace resolution fails on a new session, the session is not created (no stale state left behind)
+
+## Relationship to Output Directives
+
+| Aspect | Output Directives | Control Directives |
+|--------|-------------------|-------------------|
+| Direction | Agent → Platform | User → Bot |
+| Timing | Every response | First message only |
+| Syntax | `[[key:value]]` | `[[key:value]]` |
+
+## Future Directives (Phase 2+)
+
+| Directive | Purpose |
+|-----------|---------|
+| `[[model:...]]` | Select model for the session |
+| `[[repo:owner/repo]]` | Bind GitHub repository context |
+| `[[timeout:300]]` | Session timeout in seconds |
+
+## See Also
+
+- [Workspaces](workspaces.md) — configuring workspace aliases
+- [Output Directives](output-directives.md) — agent → platform directives
+- [ADR: Control Directives](adr/control-directives.md) — design rationale

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,0 +1,71 @@
+# Workspaces
+
+## Overview
+
+A single OAB bot instance can serve multiple projects. Workspaces let users switch project context at session start using the `[[ws:...]]` [control directive](control-directives.md).
+
+When a workspace is set, the agent:
+- Uses the workspace path as its working directory
+- Loads steering rules from `AGENTS.md` and `.kiro/steering/`
+- Activates skills from `.kiro/skills/`
+- Has correct git context (branch, remote, history)
+
+## Configuration
+
+Define workspace aliases in `config.toml`:
+
+```toml
+[workspace.aliases]
+openab = "~/projects/openab"
+infra  = "~/projects/infra-cdk"
+web    = "~/projects/frontend"
+```
+
+Paths starting with `~` expand to the bot's home directory (`$HOME`).
+
+## Usage
+
+Reference aliases with `@` prefix in the first message:
+
+```
+@Bot [[ws:@openab]] help me debug the smoke tests
+```
+
+Or use raw paths:
+
+```
+@Bot [[ws:~/projects/myapp]] investigate the build failure
+```
+
+## Security Boundary
+
+All workspace paths are validated before use:
+
+1. **Must be absolute** — relative paths (e.g., `../secrets`) are rejected
+2. **`~` expands to bot home** — not the requesting user's home
+3. **Canonicalized** — symlinks, `..`, `.` are resolved
+4. **Must be within bot home subtree** — paths outside are rejected
+5. **Must be a directory** — file paths are rejected
+6. **Must exist** — non-existent paths are rejected with a clear error showing the expanded path
+
+## Session Behavior
+
+- Workspace is set **once** at session creation and is immutable
+- The workspace persists across session suspend/resume and eviction rebuilds
+- To change workspace, start a new session
+- If workspace resolution fails, no session is created (clean failure)
+
+## Error Messages
+
+| Scenario | Error |
+|----------|-------|
+| Unknown alias | `Unknown workspace alias @foo. Available: openab, infra, web` |
+| Relative path | `Workspace path must be absolute (start with ~ or /): relative/path` |
+| Outside home | `Workspace path is outside allowed directory: /etc/passwd` |
+| Not a directory | `Workspace path is not a directory: /home/bot/Cargo.toml` |
+| Does not exist | `Workspace path does not exist: ~/nope (expanded to /home/bot/nope)` |
+
+## See Also
+
+- [Control Directives](control-directives.md) — full directive syntax and rules
+- [Config Reference](config-reference.md#workspace) — `[workspace.aliases]` configuration

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -28,6 +28,9 @@ struct PoolState {
     /// Serializes create/resume work per thread so rapid same-thread requests
     /// cannot race each other into duplicate `session/load` attempts.
     creating: HashMap<String, Arc<Mutex<()>>>,
+    /// Per-session working directory overrides (from control directives).
+    /// thread_key → canonical workspace path.
+    session_workdirs: HashMap<String, String>,
 }
 
 pub struct SessionPool {
@@ -35,6 +38,7 @@ pub struct SessionPool {
     config: AgentConfig,
     max_sessions: usize,
     mapping_path: PathBuf,
+    meta_path: PathBuf,
 }
 
 type EvictionCandidate = (String, Arc<Mutex<AcpConnection>>, Instant, Option<String>);
@@ -68,7 +72,9 @@ impl SessionPool {
             .join(".openab");
         let _ = std::fs::create_dir_all(&openab_dir);
         let mapping_path = openab_dir.join("thread_map.json");
+        let meta_path = openab_dir.join("session_meta.json");
         let suspended = Self::load_mapping(&mapping_path);
+        let session_workdirs = Self::load_mapping(&meta_path);
         Self {
             state: RwLock::new(PoolState {
                 active: HashMap::new(),
@@ -76,10 +82,12 @@ impl SessionPool {
                 persisted: suspended.clone(),
                 suspended,
                 creating: HashMap::new(),
+                session_workdirs,
             }),
             config,
             max_sessions,
             mapping_path,
+            meta_path,
         }
     }
 
@@ -109,7 +117,23 @@ impl SessionPool {
         }
     }
 
-    pub async fn get_or_create(&self, thread_id: &str) -> Result<()> {
+    fn save_meta(&self, workdirs: &HashMap<String, String>) {
+        let data = match serde_json::to_string_pretty(workdirs) {
+            Ok(d) => d,
+            Err(e) => {
+                warn!(error = %e, "failed to serialize session metadata");
+                return;
+            }
+        };
+        let tmp = self.meta_path.with_extension("json.tmp");
+        if let Err(e) =
+            std::fs::write(&tmp, &data).and_then(|_| std::fs::rename(&tmp, &self.meta_path))
+        {
+            warn!(path = %self.meta_path.display(), error = %e, "failed to persist session metadata");
+        }
+    }
+
+    pub async fn get_or_create(&self, thread_id: &str, working_dir_override: Option<&str>) -> Result<()> {
         let create_gate = {
             let mut state = self.state.write().await;
             get_or_insert_gate(&mut state.creating, thread_id)
@@ -169,12 +193,33 @@ impl SessionPool {
             }
         }
 
+        // Resolve effective working directory: explicit override > stored per-session > global config.
+        let effective_workdir: String = if let Some(wd) = working_dir_override {
+            wd.to_string()
+        } else {
+            let state = self.state.read().await;
+            state
+                .session_workdirs
+                .get(thread_id)
+                .cloned()
+                .unwrap_or_else(|| self.config.working_dir.clone())
+        };
+
+        // Persist the workspace override for future reconnects/eviction rebuilds.
+        if working_dir_override.is_some() {
+            let mut state = self.state.write().await;
+            state
+                .session_workdirs
+                .insert(thread_id.to_string(), effective_workdir.clone());
+            self.save_meta(&state.session_workdirs);
+        }
+
         // Build the replacement connection outside the state lock so one stuck
         // initialization does not block all unrelated sessions.
         let mut new_conn = AcpConnection::spawn(
             &self.config.command,
             &self.config.args,
-            &self.config.working_dir,
+            &effective_workdir,
             &self.config.env,
             &self.config.inherit_env,
         )
@@ -185,7 +230,7 @@ impl SessionPool {
         let mut resumed = false;
         if let Some(ref sid) = saved_session_id {
             if new_conn.supports_load_session {
-                match new_conn.session_load(sid, &self.config.working_dir).await {
+                match new_conn.session_load(sid, &effective_workdir).await {
                     Ok(()) => {
                         info!(thread_id, session_id = %sid, "session resumed via session/load");
                         resumed = true;
@@ -198,7 +243,7 @@ impl SessionPool {
         }
 
         if !resumed {
-            new_conn.session_new(&self.config.working_dir).await?;
+            new_conn.session_new(&effective_workdir).await?;
             // Surface the reset banner both for restored sessions and for stale
             // live entries that died before we could recover a resumable
             // session id. In both cases the caller is continuing after an

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -193,20 +193,22 @@ impl SessionPool {
             }
         }
 
-        // Resolve effective working directory: explicit override > stored per-session > global config.
-        let effective_workdir: String = if let Some(wd) = working_dir_override {
-            wd.to_string()
-        } else {
+        // Resolve effective working directory: stored per-session > explicit override > global config.
+        // Stored value has highest priority to enforce immutability (ADR §4.5).
+        let stored_workdir = {
             let state = self.state.read().await;
-            state
-                .session_workdirs
-                .get(thread_id)
-                .cloned()
-                .unwrap_or_else(|| self.config.working_dir.clone())
+            state.session_workdirs.get(thread_id).cloned()
         };
 
-        // Persist the workspace override for future reconnects/eviction rebuilds.
-        // Only persist on first assignment (session directives are immutable per ADR).
+        let effective_workdir = if let Some(stored) = stored_workdir {
+            stored
+        } else if let Some(wd) = working_dir_override {
+            wd.to_string()
+        } else {
+            self.config.working_dir.clone()
+        };
+
+        // Persist the workspace for future reconnects/eviction rebuilds (first time only).
         if working_dir_override.is_some() {
             let mut state = self.state.write().await;
             state

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -134,7 +134,7 @@ impl SessionPool {
     }
 
     /// Check if session state exists for this thread (active, suspended, or persisted).
-    /// Used to determine whether control directives should be parsed (first-message-only).
+    #[allow(dead_code)]
     pub async fn has_active_session(&self, thread_id: &str) -> bool {
         let state = self.state.read().await;
         // Any of these means the thread already has session state.
@@ -150,7 +150,11 @@ impl SessionPool {
         false
     }
 
-    pub async fn get_or_create(&self, thread_id: &str, working_dir_override: Option<&str>) -> Result<()> {
+    pub async fn get_or_create(
+        &self,
+        thread_id: &str,
+        working_dir_override: Option<&str>,
+    ) -> Result<bool> {
         let create_gate = {
             let mut state = self.state.write().await;
             get_or_insert_gate(&mut state.creating, thread_id)
@@ -170,7 +174,7 @@ impl SessionPool {
         if let Some(conn) = existing.clone() {
             let conn = conn.lock().await;
             if conn.alive() {
-                return Ok(());
+                return Ok(false);
             }
             if saved_session_id.is_none() {
                 saved_session_id = conn.acp_session_id.clone();
@@ -225,16 +229,6 @@ impl SessionPool {
             self.config.working_dir.clone()
         };
 
-        // Persist the workspace for future reconnects/eviction rebuilds (first time only).
-        if working_dir_override.is_some() {
-            let mut state = self.state.write().await;
-            state
-                .session_workdirs
-                .entry(thread_id.to_string())
-                .or_insert_with(|| effective_workdir.clone());
-            self.save_meta(&state.session_workdirs);
-        }
-
         // Build the replacement connection outside the state lock so one stuck
         // initialization does not block all unrelated sessions.
         let mut new_conn = AcpConnection::spawn(
@@ -284,10 +278,10 @@ impl SessionPool {
         // initializing this one.
         if let Some(existing) = state.active.get(thread_id).cloned() {
             let Ok(existing) = existing.try_lock() else {
-                return Ok(());
+                return Ok(false);
             };
             if existing.alive() {
-                return Ok(());
+                return Ok(false);
             }
             warn!(thread_id, "stale connection, rebuilding");
             drop(existing);
@@ -337,7 +331,21 @@ impl SessionPool {
                 .insert(thread_id.to_string(), (cancel_handle, cancel_session_id));
         }
         self.save_mapping(&state.persisted);
-        Ok(())
+
+        // Persist workspace override only after session spawn succeeded (口渡 F2).
+        if working_dir_override.is_some() {
+            state
+                .session_workdirs
+                .entry(thread_id.to_string())
+                .or_insert_with(|| effective_workdir.clone());
+            self.save_meta(&state.session_workdirs);
+        }
+
+        // Return true only for genuinely new sessions — not resumed or reconnected ones.
+        // A session with prior state (saved_session_id or had_existing) is a resume,
+        // even if we had to spawn a new ACP process. ADR §2.2: directives are first-message-only.
+        let is_fresh = !had_existing && saved_session_id.is_none();
+        Ok(is_fresh)
     }
 
     /// Get mutable access to a connection. Caller must have called get_or_create first.
@@ -503,10 +511,12 @@ impl SessionPool {
                     state.suspended.insert(key, sid);
                 } else {
                     state.persisted.remove(&key);
+                    state.session_workdirs.remove(&key);
                 }
             }
         }
         self.save_mapping(&state.persisted);
+        self.save_meta(&state.session_workdirs);
     }
 
     pub async fn shutdown(&self) {
@@ -589,14 +599,21 @@ mod tests {
     fn persisted_mapping_can_include_active_and_suspended_sessions() {
         let persisted = HashMap::from([
             ("active-thread".to_string(), "session-active".to_string()),
-            ("suspended-thread".to_string(), "session-suspended".to_string()),
+            (
+                "suspended-thread".to_string(),
+                "session-suspended".to_string(),
+            ),
         ]);
 
-        let serialized = serde_json::to_string_pretty(&persisted).expect("serialize persisted mapping");
+        let serialized =
+            serde_json::to_string_pretty(&persisted).expect("serialize persisted mapping");
         let roundtrip: HashMap<String, String> =
             serde_json::from_str(&serialized).expect("deserialize persisted mapping");
 
-        assert_eq!(roundtrip.get("active-thread"), Some(&"session-active".to_string()));
+        assert_eq!(
+            roundtrip.get("active-thread"),
+            Some(&"session-active".to_string())
+        );
         assert_eq!(
             roundtrip.get("suspended-thread"),
             Some(&"session-suspended".to_string())

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -137,8 +137,9 @@ impl SessionPool {
     pub async fn has_active_session(&self, thread_id: &str) -> bool {
         let state = self.state.read().await;
         if let Some(conn) = state.active.get(thread_id) {
-            if let Ok(c) = conn.try_lock() {
-                return c.alive();
+            match conn.try_lock() {
+                Ok(c) => return c.alive(),
+                Err(_) => return true, // lock held = connection busy streaming = alive
             }
         }
         false

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -133,6 +133,17 @@ impl SessionPool {
         }
     }
 
+    /// Check if an active, alive session exists for this thread (non-blocking).
+    pub async fn has_active_session(&self, thread_id: &str) -> bool {
+        let state = self.state.read().await;
+        if let Some(conn) = state.active.get(thread_id) {
+            if let Ok(c) = conn.try_lock() {
+                return c.alive();
+            }
+        }
+        false
+    }
+
     pub async fn get_or_create(&self, thread_id: &str, working_dir_override: Option<&str>) -> Result<()> {
         let create_gate = {
             let mut state = self.state.write().await;

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -133,9 +133,14 @@ impl SessionPool {
         }
     }
 
-    /// Check if an active, alive session exists for this thread (non-blocking).
+    /// Check if session state exists for this thread (active, suspended, or persisted).
+    /// Used to determine whether control directives should be parsed (first-message-only).
     pub async fn has_active_session(&self, thread_id: &str) -> bool {
         let state = self.state.read().await;
+        // Any of these means the thread already has session state.
+        if state.suspended.contains_key(thread_id) || state.persisted.contains_key(thread_id) {
+            return true;
+        }
         if let Some(conn) = state.active.get(thread_id) {
             match conn.try_lock() {
                 Ok(c) => return c.alive(),

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -94,7 +94,7 @@ impl SessionPool {
     fn load_mapping(path: &Path) -> HashMap<String, String> {
         match std::fs::read_to_string(path) {
             Ok(data) => serde_json::from_str(&data).unwrap_or_else(|e| {
-                warn!(path = %path.display(), error = %e, "corrupt thread_map.json, starting fresh");
+                warn!(path = %path.display(), error = %e, "corrupt mapping file, starting fresh");
                 HashMap::new()
             }),
             Err(_) => HashMap::new(),
@@ -206,11 +206,13 @@ impl SessionPool {
         };
 
         // Persist the workspace override for future reconnects/eviction rebuilds.
+        // Only persist on first assignment (session directives are immutable per ADR).
         if working_dir_override.is_some() {
             let mut state = self.state.write().await;
             state
                 .session_workdirs
-                .insert(thread_id.to_string(), effective_workdir.clone());
+                .entry(thread_id.to_string())
+                .or_insert_with(|| effective_workdir.clone());
             self.save_meta(&state.session_workdirs);
         }
 
@@ -432,7 +434,9 @@ impl SessionPool {
         state.suspended.remove(thread_id);
         state.persisted.remove(thread_id);
         state.creating.remove(thread_id);
+        state.session_workdirs.remove(thread_id);
         self.save_mapping(&state.persisted);
+        self.save_meta(&state.session_workdirs);
         if had_active {
             info!(thread_id, "session reset");
             Ok(())

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -246,6 +246,11 @@ pub trait ChatAdapter: Send + Sync + 'static {
         self.send_message(channel, content).await
     }
 
+    /// Rename the thread/channel title. Default: no-op (not all platforms support it).
+    async fn rename_thread(&self, _channel: &ChannelRef, _title: &str) -> Result<()> {
+        Ok(())
+    }
+
     /// Delete a message. Used to remove streaming placeholders when reply_to is set.
     /// Default: edits to zero-width space (fallback for platforms without delete support).
     async fn delete_message(&self, msg: &MessageRef) -> Result<()> {
@@ -273,6 +278,10 @@ pub struct AdapterRouter {
     prompt_hard_timeout: std::time::Duration,
     /// Polling cadence for the recv-loop liveness check (#732).
     liveness_check_interval: std::time::Duration,
+    /// Workspace aliases from `[workspace.aliases]` config.
+    workspace_aliases: std::collections::HashMap<String, String>,
+    /// Bot home directory (security boundary for workspace directives).
+    bot_home: std::path::PathBuf,
 }
 
 impl AdapterRouter {
@@ -282,6 +291,8 @@ impl AdapterRouter {
         table_mode: TableMode,
         prompt_hard_timeout_secs: u64,
         liveness_check_secs: u64,
+        workspace_aliases: std::collections::HashMap<String, String>,
+        bot_home: std::path::PathBuf,
     ) -> Self {
         if liveness_check_secs >= prompt_hard_timeout_secs {
             warn!(
@@ -298,6 +309,8 @@ impl AdapterRouter {
             table_mode,
             prompt_hard_timeout: std::time::Duration::from_secs(prompt_hard_timeout_secs),
             liveness_check_interval: std::time::Duration::from_secs(liveness_check_secs),
+            workspace_aliases,
+            bot_home,
         }
     }
 
@@ -309,6 +322,16 @@ impl AdapterRouter {
     /// Access the reactions config (used by dispatch.rs).
     pub fn reactions_config(&self) -> &ReactionsConfig {
         &self.reactions_config
+    }
+
+    /// Workspace aliases for control directive resolution.
+    pub fn workspace_aliases_map(&self) -> std::collections::HashMap<String, String> {
+        self.workspace_aliases.clone()
+    }
+
+    /// Bot home path for workspace security boundary.
+    pub fn bot_home_path(&self) -> std::path::PathBuf {
+        self.bot_home.clone()
     }
 
     /// Pack one arrival event into ContentBlocks. Per-arrival layout:
@@ -368,7 +391,7 @@ impl AdapterRouter {
                 .unwrap_or(&ctx.thread_channel.channel_id)
         );
 
-        if let Err(e) = self.pool.get_or_create(&thread_key).await {
+        if let Err(e) = self.pool.get_or_create(&thread_key, None).await {
             let msg = format_user_error(&e.to_string());
             let _ = adapter
                 .send_message(&ctx.thread_channel, &format!("⚠️ {msg}"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,16 @@ pub struct Config {
     pub cron: CronConfig,
     #[serde(default)]
     pub hooks: HooksConfig,
+    #[serde(default)]
+    pub workspace: WorkspaceConfig,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct WorkspaceConfig {
+    /// Workspace aliases: `name = "~/path/to/project"`
+    /// Used with `[[ws:@alias]]` control directives.
+    #[serde(default)]
+    pub aliases: std::collections::HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/src/directives.rs
+++ b/src/directives.rs
@@ -1,0 +1,297 @@
+//! Control Directives parser (ADR: control-directives.md).
+//!
+//! Extracts leading `[[key:value]]` directives from the first message in a
+//! session, strips them from the prompt, and returns structured metadata.
+
+use regex::Regex;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use tracing::warn;
+
+static DIRECTIVE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*\[\[([a-z_]+):([^\]]*)\]\]").unwrap());
+
+/// Parsed control directives from a session's first message.
+#[derive(Debug, Clone, Default)]
+pub struct SessionMetadata {
+    /// Resolved canonical workspace path (None = use default working_dir).
+    pub workspace: Option<PathBuf>,
+    /// Thread title override (None = use generated title).
+    pub title: Option<String>,
+    /// Raw directives map for forward-compatible unknown keys.
+    pub raw: HashMap<String, String>,
+}
+
+/// Result of parsing directives from a prompt.
+pub struct ParseResult {
+    /// The prompt with leading directives stripped.
+    pub prompt: String,
+    /// Parsed session metadata.
+    pub metadata: SessionMetadata,
+}
+
+/// Parse leading `[[key:value]]` directives from a prompt string.
+///
+/// Directives must appear at the start of the message (after optional
+/// whitespace). The first line/token that is not a directive stops parsing;
+/// any `[[key:value]]` text after that point is preserved verbatim.
+pub fn parse_directives(input: &str) -> ParseResult {
+    let mut raw: HashMap<String, String> = HashMap::new();
+    let mut remaining = input;
+
+    loop {
+        remaining = remaining.trim_start_matches(|c: char| c == ' ' || c == '\t');
+        if remaining.starts_with('\n') || remaining.starts_with("\r\n") {
+            // A blank line after directives = end of header
+            let next = remaining.trim_start_matches(['\r', '\n']);
+            if !next.starts_with("[[") {
+                remaining = next;
+                break;
+            }
+            remaining = remaining.trim_start_matches(['\r', '\n']);
+        }
+        if let Some(caps) = DIRECTIVE_RE.captures(remaining) {
+            let full_match = caps.get(0).unwrap();
+            let key = caps[1].to_string();
+            let value = caps[2].to_string();
+            // Last value wins for duplicate keys
+            raw.insert(key, value);
+            remaining = &remaining[full_match.end()..];
+        } else {
+            break;
+        }
+    }
+
+    let prompt = remaining.trim().to_string();
+    let metadata = SessionMetadata {
+        workspace: None, // resolved later by resolve_workspace
+        title: raw.get("title").cloned(),
+        raw,
+    };
+
+    ParseResult { prompt, metadata }
+}
+
+/// Resolve the `[[ws:...]]` directive value into a canonical path.
+///
+/// Supports:
+/// - Raw paths: `~/projects/foo` or `/home/bot/projects/foo`
+/// - Aliases: `@alias_name` → looked up in `aliases` map
+///
+/// Returns `Err` with a user-visible message on failure.
+pub fn resolve_workspace(
+    raw_value: &str,
+    aliases: &HashMap<String, String>,
+    bot_home: &Path,
+) -> Result<PathBuf, String> {
+    let path_str = if let Some(alias) = raw_value.strip_prefix('@') {
+        match aliases.get(alias) {
+            Some(resolved) => resolved.as_str(),
+            None => {
+                let available: Vec<&str> = aliases.keys().map(|s| s.as_str()).collect();
+                return Err(format!(
+                    "Unknown workspace alias `@{alias}`. Available: {}",
+                    if available.is_empty() {
+                        "(none configured)".to_string()
+                    } else {
+                        available.join(", ")
+                    }
+                ));
+            }
+        }
+    } else {
+        raw_value
+    };
+
+    // Rule 1: reject relative paths
+    if !path_str.starts_with('~') && !path_str.starts_with('/') {
+        return Err(format!(
+            "Workspace path must be absolute (start with `~` or `/`): `{path_str}`"
+        ));
+    }
+
+    // Rule 2: expand ~
+    let expanded = if let Some(rest) = path_str.strip_prefix('~') {
+        let rest = rest.strip_prefix('/').unwrap_or(rest);
+        bot_home.join(rest)
+    } else {
+        PathBuf::from(path_str)
+    };
+
+    // Rule 3: canonicalize both paths
+    let canonical_home = bot_home.canonicalize().map_err(|e| {
+        warn!(path = %bot_home.display(), error = %e, "cannot canonicalize bot home");
+        format!("Internal error: cannot resolve bot home directory")
+    })?;
+
+    let canonical_target = expanded.canonicalize().map_err(|e| {
+        warn!(path = %expanded.display(), error = %e, "cannot canonicalize workspace path");
+        format!("Workspace path does not exist: `{path_str}`")
+    })?;
+
+    // Rule 4+5: verify within bot home subtree
+    if !canonical_target.starts_with(&canonical_home) {
+        return Err(format!(
+            "Workspace path is outside allowed directory: `{path_str}`"
+        ));
+    }
+
+    Ok(canonical_target)
+}
+
+/// Persistence format for session metadata (JSON).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
+pub struct PersistedSessionMeta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+impl PersistedSessionMeta {
+    pub fn from_metadata(meta: &SessionMetadata) -> Self {
+        Self {
+            workspace: meta.workspace.as_ref().map(|p| p.display().to_string()),
+            title: meta.title.clone(),
+        }
+    }
+
+    pub fn to_metadata(&self) -> SessionMetadata {
+        SessionMetadata {
+            workspace: self.workspace.as_ref().map(PathBuf::from),
+            title: self.title.clone(),
+            raw: HashMap::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn parse_basic_directives() {
+        let input = "[[ws:~/projects/foo]] [[title:Bug fix]]\ninvestigate the build failure";
+        let result = parse_directives(input);
+        assert_eq!(result.prompt, "investigate the build failure");
+        assert_eq!(result.metadata.raw.get("ws").unwrap(), "~/projects/foo");
+        assert_eq!(result.metadata.title.as_deref(), Some("Bug fix"));
+    }
+
+    #[test]
+    fn parse_directives_multiline_header() {
+        let input = "[[ws:@openab]]\n[[title:Review PR]]\nplease review this change";
+        let result = parse_directives(input);
+        assert_eq!(result.prompt, "please review this change");
+        assert_eq!(result.metadata.raw.get("ws").unwrap(), "@openab");
+        assert_eq!(result.metadata.title.as_deref(), Some("Review PR"));
+    }
+
+    #[test]
+    fn parse_preserves_body_directives() {
+        let input = "[[title:Test]]\nHere is some code with [[key:value]] in it";
+        let result = parse_directives(input);
+        assert_eq!(
+            result.prompt,
+            "Here is some code with [[key:value]] in it"
+        );
+        assert_eq!(result.metadata.title.as_deref(), Some("Test"));
+        assert!(!result.metadata.raw.contains_key("key"));
+    }
+
+    #[test]
+    fn parse_no_directives() {
+        let input = "just a regular message";
+        let result = parse_directives(input);
+        assert_eq!(result.prompt, "just a regular message");
+        assert!(result.metadata.raw.is_empty());
+    }
+
+    #[test]
+    fn parse_duplicate_keys_last_wins() {
+        let input = "[[title:First]] [[title:Second]]\ndo stuff";
+        let result = parse_directives(input);
+        assert_eq!(result.metadata.title.as_deref(), Some("Second"));
+    }
+
+    #[test]
+    fn parse_empty_value() {
+        let input = "[[title:]]\ndo stuff";
+        let result = parse_directives(input);
+        assert_eq!(result.metadata.title.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn parse_unknown_keys_ignored() {
+        let input = "[[foo:bar]] [[ws:~/x]]\ndo stuff";
+        let result = parse_directives(input);
+        assert_eq!(result.metadata.raw.get("foo").unwrap(), "bar");
+        assert_eq!(result.prompt, "do stuff");
+    }
+
+    #[test]
+    fn resolve_alias_success() {
+        let tmp = TempDir::new().unwrap();
+        let projects = tmp.path().join("projects").join("openab");
+        fs::create_dir_all(&projects).unwrap();
+
+        let mut aliases = HashMap::new();
+        aliases.insert(
+            "openab".to_string(),
+            format!("{}/projects/openab", tmp.path().display()),
+        );
+
+        let result = resolve_workspace("@openab", &aliases, tmp.path()).unwrap();
+        assert_eq!(result, projects.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_alias_not_found() {
+        let tmp = TempDir::new().unwrap();
+        let aliases = HashMap::new();
+        let result = resolve_workspace("@nope", &aliases, tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown workspace alias"));
+    }
+
+    #[test]
+    fn resolve_relative_path_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let aliases = HashMap::new();
+        let result = resolve_workspace("relative/path", &aliases, tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must be absolute"));
+    }
+
+    #[test]
+    fn resolve_outside_home_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let aliases = HashMap::new();
+        let result = resolve_workspace("/tmp", &aliases, tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("outside allowed directory"));
+    }
+
+    #[test]
+    fn resolve_tilde_expansion() {
+        let tmp = TempDir::new().unwrap();
+        let projects = tmp.path().join("myapp");
+        fs::create_dir_all(&projects).unwrap();
+
+        let aliases = HashMap::new();
+        let result = resolve_workspace("~/myapp", &aliases, tmp.path()).unwrap();
+        assert_eq!(result, projects.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_nonexistent_path() {
+        let tmp = TempDir::new().unwrap();
+        let aliases = HashMap::new();
+        let result = resolve_workspace("~/does_not_exist", &aliases, tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("does not exist"));
+    }
+}

--- a/src/directives.rs
+++ b/src/directives.rs
@@ -46,7 +46,8 @@ pub fn parse_directives(input: &str) -> ParseResult {
         if remaining.starts_with('\n') || remaining.starts_with("\r\n") {
             // A blank line after directives = end of header
             let next = remaining.trim_start_matches(['\r', '\n']);
-            if !next.starts_with("[[") {
+            let next_trimmed = next.trim_start_matches([' ', '\t']);
+            if !next_trimmed.starts_with("[[") {
                 remaining = next;
                 break;
             }
@@ -128,13 +129,24 @@ pub fn resolve_workspace(
 
     let canonical_target = expanded.canonicalize().map_err(|e| {
         warn!(path = %expanded.display(), error = %e, "cannot canonicalize workspace path");
-        format!("Workspace path does not exist: `{path_str}`")
+        format!(
+            "Workspace path does not exist: `{path_str}` (expanded to `{}`)",
+            expanded.display()
+        )
     })?;
 
     // Rule 4+5: verify within bot home subtree
     if !canonical_target.starts_with(&canonical_home) {
         return Err(format!(
             "Workspace path is outside allowed directory: `{path_str}`"
+        ));
+    }
+
+    // Rule 6: must be a directory (not a file)
+    if !canonical_target.is_dir() {
+        return Err(format!(
+            "Workspace path is not a directory: `{}`",
+            canonical_target.display()
         ));
     }
 
@@ -169,10 +181,7 @@ mod tests {
     fn parse_preserves_body_directives() {
         let input = "[[title:Test]]\nHere is some code with [[key:value]] in it";
         let result = parse_directives(input);
-        assert_eq!(
-            result.prompt,
-            "Here is some code with [[key:value]] in it"
-        );
+        assert_eq!(result.prompt, "Here is some code with [[key:value]] in it");
         assert_eq!(result.metadata.title.as_deref(), Some("Test"));
         assert!(!result.metadata.raw.contains_key("key"));
     }

--- a/src/directives.rs
+++ b/src/directives.rs
@@ -16,6 +16,7 @@ static DIRECTIVE_RE: LazyLock<Regex> =
 #[derive(Debug, Clone, Default)]
 pub struct SessionMetadata {
     /// Resolved canonical workspace path (None = use default working_dir).
+    #[allow(dead_code)]
     pub workspace: Option<PathBuf>,
     /// Thread title override (None = use generated title).
     pub title: Option<String>,
@@ -41,7 +42,7 @@ pub fn parse_directives(input: &str) -> ParseResult {
     let mut remaining = input;
 
     loop {
-        remaining = remaining.trim_start_matches(|c: char| c == ' ' || c == '\t');
+        remaining = remaining.trim_start_matches([' ', '\t']);
         if remaining.starts_with('\n') || remaining.starts_with("\r\n") {
             // A blank line after directives = end of header
             let next = remaining.trim_start_matches(['\r', '\n']);
@@ -122,7 +123,7 @@ pub fn resolve_workspace(
     // Rule 3: canonicalize both paths
     let canonical_home = bot_home.canonicalize().map_err(|e| {
         warn!(path = %bot_home.display(), error = %e, "cannot canonicalize bot home");
-        format!("Internal error: cannot resolve bot home directory")
+        "Internal error: cannot resolve bot home directory".to_string()
     })?;
 
     let canonical_target = expanded.canonicalize().map_err(|e| {
@@ -138,32 +139,6 @@ pub fn resolve_workspace(
     }
 
     Ok(canonical_target)
-}
-
-/// Persistence format for session metadata (JSON).
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
-pub struct PersistedSessionMeta {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workspace: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-}
-
-impl PersistedSessionMeta {
-    pub fn from_metadata(meta: &SessionMetadata) -> Self {
-        Self {
-            workspace: meta.workspace.as_ref().map(|p| p.display().to_string()),
-            title: meta.title.clone(),
-        }
-    }
-
-    pub fn to_metadata(&self) -> SessionMetadata {
-        SessionMetadata {
-            workspace: self.workspace.as_ref().map(PathBuf::from),
-            title: self.title.clone(),
-            raw: HashMap::new(),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/directives.rs
+++ b/src/directives.rs
@@ -278,4 +278,37 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("does not exist"));
     }
+
+    #[test]
+    fn parse_directives_leading_spaces_on_newline() {
+        let input = "[[ws:@openab]]\n  [[title:Fix CI]]\nhelp me debug";
+        let result = parse_directives(input);
+        assert_eq!(result.prompt, "help me debug");
+        assert_eq!(result.metadata.raw.get("ws").unwrap(), "@openab");
+        assert_eq!(result.metadata.title.as_deref(), Some("Fix CI"));
+    }
+
+    #[test]
+    fn resolve_file_path_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let file_path = tmp.path().join("Cargo.toml");
+        fs::write(&file_path, "").unwrap();
+
+        let aliases = HashMap::new();
+        let result = resolve_workspace(&format!("{}", file_path.display()), &aliases, tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not a directory"));
+    }
+
+    #[test]
+    fn resolve_error_shows_expanded_path() {
+        let tmp = TempDir::new().unwrap();
+        let aliases = HashMap::new();
+        let result = resolve_workspace("~/no_such_dir", &aliases, tmp.path());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        // Error should contain both the original and expanded path
+        assert!(err.contains("~/no_such_dir"));
+        assert!(err.contains(&tmp.path().display().to_string()));
+    }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -10,8 +10,8 @@ use async_trait::async_trait;
 use serenity::builder::{
     CreateActionRow, CreateAttachment, CreateButton, CreateCommand, CreateCommandOption,
     CreateInteractionResponse, CreateInteractionResponseFollowup, CreateInteractionResponseMessage,
-    CreateSelectMenu, CreateSelectMenuKind, CreateSelectMenuOption, CreateThread, EditMessage,
-    GetMessages,
+    CreateSelectMenu, CreateSelectMenuKind, CreateSelectMenuOption, CreateThread, EditChannel,
+    EditMessage, GetMessages,
 };
 use serenity::http::Http;
 use serenity::model::application::ButtonStyle;
@@ -182,6 +182,15 @@ impl ChatAdapter for DiscordAdapter {
                 MessageId::new(msg_id),
                 &ReactionType::Unicode(emoji.to_string()),
             )
+            .await?;
+        Ok(())
+    }
+
+    async fn rename_thread(&self, channel: &ChannelRef, title: &str) -> Result<()> {
+        let ch_id: u64 = Self::resolve_channel(channel).parse()?;
+        let truncated = if title.len() > 100 { &title[..100] } else { title };
+        ChannelId::new(ch_id)
+            .edit(&self.http, EditChannel::new().name(truncated))
             .await?;
         Ok(())
     }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -188,7 +188,13 @@ impl ChatAdapter for DiscordAdapter {
 
     async fn rename_thread(&self, channel: &ChannelRef, title: &str) -> Result<()> {
         let ch_id: u64 = Self::resolve_channel(channel).parse()?;
-        let truncated = if title.len() > 100 { &title[..100] } else { title };
+        // Truncate at char boundary to avoid panic on multi-byte chars (中文/Emoji).
+        let truncated: &str = if title.chars().count() > 100 {
+            let end = title.char_indices().nth(100).map(|(i, _)| i).unwrap_or(title.len());
+            &title[..end]
+        } else {
+            title
+        };
         ChannelId::new(ch_id)
             .edit(&self.http, EditChannel::new().name(truncated))
             .await?;

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -186,7 +186,7 @@ impl ChatAdapter for DiscordAdapter {
         Ok(())
     }
 
-    async fn rename_thread(&self, channel: &ChannelRef, title: &str) -> Result<()> {
+    async fn rename_thread(&self, channel: &ChannelRef, title: &str) -> anyhow::Result<()> {
         let ch_id: u64 = Self::resolve_channel(channel).parse()?;
         // Truncate at char boundary to avoid panic on multi-byte chars (中文/Emoji).
         let truncated: &str = if title.chars().count() > 100 {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -697,20 +697,19 @@ async fn dispatch_batch(
     if created_now {
         if let Some(pr) = parse_result {
             if !pr.metadata.raw.is_empty() {
-                // Apply [[title:...]] override before ws check — title is independent.
-                if let Some(title) = &pr.metadata.title {
-                    if !title.is_empty() {
-                        if let Err(e) = adapter.rename_thread(&dispatch_channel, title).await {
-                            warn!(session_key, error = %e, "failed to apply title directive");
-                        }
-                    }
-                }
+                // Apply [[title:...]] independently — works regardless of ws outcome.
+                let title_to_apply = pr.metadata.title.clone();
 
                 // If workspace resolution failed on a NEW session, rollback and abort.
-                // The session was created with default cwd — we must not leave it alive
-                // when the user explicitly requested a different workspace (ADR §3.1).
+                // Reset FIRST to minimize TOCTOU window (擺渡 F1), then rename.
                 if let Some(Err(e)) = ws_resolved {
                     target.reset_session(&session_key).await;
+                    // Apply title after reset so the thread is identifiable.
+                    if let Some(ref title) = title_to_apply {
+                        if !title.is_empty() {
+                            let _ = adapter.rename_thread(&dispatch_channel, title).await;
+                        }
+                    }
                     let _ = adapter
                         .send_message(&dispatch_channel, &format!("⚠️ {e}"))
                         .await;
@@ -721,6 +720,15 @@ async fn dispatch_batch(
                 // Strip directives from the prompt
                 if let Some(first_msg) = batch.first_mut() {
                     first_msg.prompt = pr.prompt;
+                }
+
+                // Apply title on success path.
+                if let Some(ref title) = title_to_apply {
+                    if !title.is_empty() {
+                        if let Err(e) = adapter.rename_thread(&dispatch_channel, title).await {
+                            warn!(session_key, error = %e, "failed to apply title directive");
+                        }
+                    }
                 }
             }
         }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -697,6 +697,15 @@ async fn dispatch_batch(
     if created_now {
         if let Some(pr) = parse_result {
             if !pr.metadata.raw.is_empty() {
+                // Apply [[title:...]] override before ws check — title is independent.
+                if let Some(title) = &pr.metadata.title {
+                    if !title.is_empty() {
+                        if let Err(e) = adapter.rename_thread(&dispatch_channel, title).await {
+                            warn!(session_key, error = %e, "failed to apply title directive");
+                        }
+                    }
+                }
+
                 // If workspace resolution failed on a NEW session, rollback and abort.
                 // The session was created with default cwd — we must not leave it alive
                 // when the user explicitly requested a different workspace (ADR §3.1).
@@ -712,15 +721,6 @@ async fn dispatch_batch(
                 // Strip directives from the prompt
                 if let Some(first_msg) = batch.first_mut() {
                     first_msg.prompt = pr.prompt;
-                }
-
-                // Apply [[title:...]] override
-                if let Some(title) = &pr.metadata.title {
-                    if !title.is_empty() {
-                        if let Err(e) = adapter.rename_thread(&dispatch_channel, title).await {
-                            warn!(session_key, error = %e, "failed to apply title directive");
-                        }
-                    }
                 }
             }
         }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -117,8 +117,14 @@ impl ThreadHandle {
 pub trait DispatchTarget: Send + Sync + 'static {
     fn reactions_config(&self) -> &ReactionsConfig;
 
+    /// Workspace aliases from config (for `[[ws:@alias]]` resolution).
+    fn workspace_aliases(&self) -> std::collections::HashMap<String, String>;
+
+    /// Bot home directory (security boundary for workspace resolution).
+    fn bot_home(&self) -> std::path::PathBuf;
+
     /// Ensure the ACP session for `session_key` exists (idempotent).
-    async fn ensure_session(&self, session_key: &str) -> Result<()>;
+    async fn ensure_session(&self, session_key: &str, working_dir: Option<&str>) -> Result<()>;
 
     /// Drive one ACP turn with the pre-packed `content_blocks`.
     #[allow(clippy::too_many_arguments)]
@@ -139,8 +145,16 @@ impl DispatchTarget for AdapterRouter {
         AdapterRouter::reactions_config(self)
     }
 
-    async fn ensure_session(&self, session_key: &str) -> Result<()> {
-        self.pool().get_or_create(session_key).await
+    fn workspace_aliases(&self) -> std::collections::HashMap<String, String> {
+        self.workspace_aliases_map()
+    }
+
+    fn bot_home(&self) -> std::path::PathBuf {
+        self.bot_home_path()
+    }
+
+    async fn ensure_session(&self, session_key: &str, working_dir: Option<&str>) -> Result<()> {
+        self.pool().get_or_create(session_key, working_dir).await
     }
 
     async fn stream_prompt_blocks(
@@ -624,6 +638,45 @@ async fn dispatch_batch(
     // Pack all arrival events into one Vec<ContentBlock> (§3.3).
     // Uses into_iter() to avoid deep-copying extra_blocks (may contain base64 image data).
     let mut content_blocks: Vec<ContentBlock> = Vec::new();
+
+    // Parse control directives from the first message in the batch (ADR: control-directives).
+    // Directives are only processed on the session's first message. For subsequent batches
+    // the session already exists and ensure_session returns early, so this is a no-op.
+    let mut workspace_override: Option<String> = None;
+    let mut title_override: Option<String> = None;
+    let mut batch = batch;
+    if let Some(first_msg) = batch.first_mut() {
+        let parse_result = crate::directives::parse_directives(&first_msg.prompt);
+        if !parse_result.metadata.raw.is_empty() {
+            first_msg.prompt = parse_result.prompt;
+
+            // Resolve [[ws:...]] if present
+            if let Some(ws_value) = parse_result.metadata.raw.get("ws") {
+                let aliases = target.workspace_aliases();
+                let bot_home = target.bot_home();
+                match crate::directives::resolve_workspace(ws_value, &aliases, &bot_home) {
+                    Ok(path) => {
+                        workspace_override = Some(path.display().to_string());
+                    }
+                    Err(e) => {
+                        let _ = adapter
+                            .send_message(&dispatch_channel, &format!("⚠️ {e}"))
+                            .await;
+                        error!(session_key, error = %e, "workspace directive rejected");
+                        return;
+                    }
+                }
+            }
+
+            // Resolve [[title:...]] if present (non-empty value)
+            if let Some(title) = &parse_result.metadata.title {
+                if !title.is_empty() {
+                    title_override = Some(title.clone());
+                }
+            }
+        }
+    }
+
     for msg in batch {
         let mut event_blocks =
             AdapterRouter::pack_arrival_event(&msg.sender_json, &msg.prompt, msg.extra_blocks);
@@ -632,13 +685,20 @@ async fn dispatch_batch(
     let packed_block_count = content_blocks.len();
 
     // Ensure session exists.
-    if let Err(e) = target.ensure_session(&session_key).await {
+    if let Err(e) = target.ensure_session(&session_key, workspace_override.as_deref()).await {
         let user_msg = format_user_error(&e.to_string());
         let _ = adapter
             .send_message(&dispatch_channel, &format!("⚠️ {user_msg}"))
             .await;
         error!("pool error in dispatch_batch: {e}");
         return;
+    }
+
+    // Apply [[title:...]] override — rename the thread if a title directive was provided.
+    if let Some(ref title) = title_override {
+        if let Err(e) = adapter.rename_thread(&dispatch_channel, title).await {
+            warn!(session_key, error = %e, "failed to apply title directive");
+        }
     }
 
     let reactions_config = target.reactions_config().clone();
@@ -1082,6 +1142,8 @@ mod tests {
             crate::markdown::TableMode::Off,
             crate::config::default_prompt_hard_timeout_secs(),
             crate::config::default_liveness_check_secs(),
+            std::collections::HashMap::new(),
+            std::path::PathBuf::from("/tmp"),
         ));
         Dispatcher::with_idle_timeout(router, 10, 24_000, grouping, DEFAULT_CONSUMER_IDLE_TIMEOUT)
     }
@@ -1272,7 +1334,15 @@ mod tests {
             &self.reactions
         }
 
-        async fn ensure_session(&self, _session_key: &str) -> Result<()> {
+        fn workspace_aliases(&self) -> std::collections::HashMap<String, String> {
+            std::collections::HashMap::new()
+        }
+
+        fn bot_home(&self) -> std::path::PathBuf {
+            std::path::PathBuf::from("/tmp")
+        }
+
+        async fn ensure_session(&self, _session_key: &str, _working_dir: Option<&str>) -> Result<()> {
             if let Some(msg) = self.ensure_err.lock().unwrap().take() {
                 return Err(anyhow::anyhow!(msg));
             }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -124,10 +124,11 @@ pub trait DispatchTarget: Send + Sync + 'static {
     fn bot_home(&self) -> std::path::PathBuf;
 
     /// Ensure the ACP session for `session_key` exists (idempotent).
-    async fn ensure_session(&self, session_key: &str, working_dir: Option<&str>) -> Result<()>;
+    /// Returns `true` if a new session was created, `false` if it already existed.
+    async fn ensure_session(&self, session_key: &str, working_dir: Option<&str>) -> Result<bool>;
 
-    /// Check if a live session already exists for this key.
-    async fn session_exists(&self, session_key: &str) -> bool;
+    /// Destroy the session for `session_key` (used to rollback on directive failure).
+    async fn reset_session(&self, session_key: &str);
 
     /// Drive one ACP turn with the pre-packed `content_blocks`.
     #[allow(clippy::too_many_arguments)]
@@ -156,12 +157,12 @@ impl DispatchTarget for AdapterRouter {
         self.bot_home_path()
     }
 
-    async fn ensure_session(&self, session_key: &str, working_dir: Option<&str>) -> Result<()> {
+    async fn ensure_session(&self, session_key: &str, working_dir: Option<&str>) -> Result<bool> {
         self.pool().get_or_create(session_key, working_dir).await
     }
 
-    async fn session_exists(&self, session_key: &str) -> bool {
-        self.pool().has_active_session(session_key).await
+    async fn reset_session(&self, session_key: &str) {
+        let _ = self.pool().reset_session(session_key).await;
     }
 
     async fn stream_prompt_blocks(
@@ -647,39 +648,78 @@ async fn dispatch_batch(
     let mut content_blocks: Vec<ContentBlock> = Vec::new();
 
     // Parse control directives from the first message in the batch (ADR: control-directives).
-    // Directives are only processed on the session's first message (§2.2). Skip parsing
-    // entirely if the session already exists to avoid stripping [[...]] from normal prompts.
-    let mut workspace_override: Option<String> = None;
-    let mut title_override: Option<String> = None;
+    // Directives are only processed on the session's first message (§2.2).
+    //
+    // Strategy:
+    //   1. Parse directives (cheap text extraction — no mutation, no I/O)
+    //   2. Attempt workspace resolution if [[ws:...]] present (may fail gracefully)
+    //   3. Call ensure_session with resolved workspace — returns created_now
+    //   4. Only strip prompt and apply title/workspace if created_now == true
+    //   5. If created_now == false, the [[...]] text is preserved verbatim
     let mut batch = batch;
-    if !target.session_exists(&session_key).await {
-        if let Some(first_msg) = batch.first_mut() {
-            let parse_result = crate::directives::parse_directives(&first_msg.prompt);
-            if !parse_result.metadata.raw.is_empty() {
-                first_msg.prompt = parse_result.prompt;
+    let parse_result = batch
+        .first()
+        .map(|first_msg| crate::directives::parse_directives(&first_msg.prompt));
 
-                // Resolve [[ws:...]] if present
-                if let Some(ws_value) = parse_result.metadata.raw.get("ws") {
-                    let aliases = target.workspace_aliases();
-                    let bot_home = target.bot_home();
-                    match crate::directives::resolve_workspace(ws_value, &aliases, &bot_home) {
-                        Ok(path) => {
-                            workspace_override = Some(path.display().to_string());
-                        }
-                        Err(e) => {
-                            let _ = adapter
-                                .send_message(&dispatch_channel, &format!("⚠️ {e}"))
-                                .await;
-                            error!(session_key, error = %e, "workspace directive rejected");
-                            return;
-                        }
-                    }
+    // Tentatively resolve [[ws:...]] — if resolution fails and the session turns out to
+    // be new, we abort. If the session already existed, resolution failure is irrelevant.
+    let ws_resolved: Option<Result<String, String>> = parse_result.as_ref().and_then(|pr| {
+        pr.metadata.raw.get("ws").map(|ws_value| {
+            let aliases = target.workspace_aliases();
+            let bot_home = target.bot_home();
+            crate::directives::resolve_workspace(ws_value, &aliases, &bot_home)
+                .map(|p| p.display().to_string())
+        })
+    });
+
+    // Extract workspace path for ensure_session (None if no directive or resolution failed).
+    let workspace_override: Option<String> =
+        ws_resolved.as_ref().and_then(|r| r.as_ref().ok().cloned());
+
+    // Ensure session exists. The create_gate mutex inside get_or_create serializes
+    // concurrent callers — only the winner gets created_now == true.
+    let created_now = match target
+        .ensure_session(&session_key, workspace_override.as_deref())
+        .await
+    {
+        Ok(created) => created,
+        Err(e) => {
+            let user_msg = format_user_error(&e.to_string());
+            let _ = adapter
+                .send_message(&dispatch_channel, &format!("⚠️ {user_msg}"))
+                .await;
+            error!("pool error in dispatch_batch: {e}");
+            return;
+        }
+    };
+
+    // Only apply directives if this is genuinely the first message (fresh session).
+    if created_now {
+        if let Some(pr) = parse_result {
+            if !pr.metadata.raw.is_empty() {
+                // If workspace resolution failed on a NEW session, rollback and abort.
+                // The session was created with default cwd — we must not leave it alive
+                // when the user explicitly requested a different workspace (ADR §3.1).
+                if let Some(Err(e)) = ws_resolved {
+                    target.reset_session(&session_key).await;
+                    let _ = adapter
+                        .send_message(&dispatch_channel, &format!("⚠️ {e}"))
+                        .await;
+                    error!(session_key, error = %e, "workspace directive rejected");
+                    return;
                 }
 
-                // Resolve [[title:...]] if present (non-empty value)
-                if let Some(title) = &parse_result.metadata.title {
+                // Strip directives from the prompt
+                if let Some(first_msg) = batch.first_mut() {
+                    first_msg.prompt = pr.prompt;
+                }
+
+                // Apply [[title:...]] override
+                if let Some(title) = &pr.metadata.title {
                     if !title.is_empty() {
-                        title_override = Some(title.clone());
+                        if let Err(e) = adapter.rename_thread(&dispatch_channel, title).await {
+                            warn!(session_key, error = %e, "failed to apply title directive");
+                        }
                     }
                 }
             }
@@ -692,23 +732,6 @@ async fn dispatch_batch(
         content_blocks.append(&mut event_blocks);
     }
     let packed_block_count = content_blocks.len();
-
-    // Ensure session exists.
-    if let Err(e) = target.ensure_session(&session_key, workspace_override.as_deref()).await {
-        let user_msg = format_user_error(&e.to_string());
-        let _ = adapter
-            .send_message(&dispatch_channel, &format!("⚠️ {user_msg}"))
-            .await;
-        error!("pool error in dispatch_batch: {e}");
-        return;
-    }
-
-    // Apply [[title:...]] override — rename the thread if a title directive was provided.
-    if let Some(ref title) = title_override {
-        if let Err(e) = adapter.rename_thread(&dispatch_channel, title).await {
-            warn!(session_key, error = %e, "failed to apply title directive");
-        }
-    }
 
     let reactions_config = target.reactions_config().clone();
     let reactions = Arc::new(StatusReactionController::new(
@@ -1351,16 +1374,18 @@ mod tests {
             std::path::PathBuf::from("/tmp")
         }
 
-        async fn ensure_session(&self, _session_key: &str, _working_dir: Option<&str>) -> Result<()> {
+        async fn ensure_session(
+            &self,
+            _session_key: &str,
+            _working_dir: Option<&str>,
+        ) -> Result<bool> {
             if let Some(msg) = self.ensure_err.lock().unwrap().take() {
                 return Err(anyhow::anyhow!(msg));
             }
-            Ok(())
+            Ok(true)
         }
 
-        async fn session_exists(&self, _session_key: &str) -> bool {
-            false
-        }
+        async fn reset_session(&self, _session_key: &str) {}
 
         async fn stream_prompt_blocks(
             &self,

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -126,6 +126,9 @@ pub trait DispatchTarget: Send + Sync + 'static {
     /// Ensure the ACP session for `session_key` exists (idempotent).
     async fn ensure_session(&self, session_key: &str, working_dir: Option<&str>) -> Result<()>;
 
+    /// Check if a live session already exists for this key.
+    async fn session_exists(&self, session_key: &str) -> bool;
+
     /// Drive one ACP turn with the pre-packed `content_blocks`.
     #[allow(clippy::too_many_arguments)]
     async fn stream_prompt_blocks(
@@ -155,6 +158,10 @@ impl DispatchTarget for AdapterRouter {
 
     async fn ensure_session(&self, session_key: &str, working_dir: Option<&str>) -> Result<()> {
         self.pool().get_or_create(session_key, working_dir).await
+    }
+
+    async fn session_exists(&self, session_key: &str) -> bool {
+        self.pool().has_active_session(session_key).await
     }
 
     async fn stream_prompt_blocks(
@@ -640,38 +647,40 @@ async fn dispatch_batch(
     let mut content_blocks: Vec<ContentBlock> = Vec::new();
 
     // Parse control directives from the first message in the batch (ADR: control-directives).
-    // Directives are only processed on the session's first message. For subsequent batches
-    // the session already exists and ensure_session returns early, so this is a no-op.
+    // Directives are only processed on the session's first message (§2.2). Skip parsing
+    // entirely if the session already exists to avoid stripping [[...]] from normal prompts.
     let mut workspace_override: Option<String> = None;
     let mut title_override: Option<String> = None;
     let mut batch = batch;
-    if let Some(first_msg) = batch.first_mut() {
-        let parse_result = crate::directives::parse_directives(&first_msg.prompt);
-        if !parse_result.metadata.raw.is_empty() {
-            first_msg.prompt = parse_result.prompt;
+    if !target.session_exists(&session_key).await {
+        if let Some(first_msg) = batch.first_mut() {
+            let parse_result = crate::directives::parse_directives(&first_msg.prompt);
+            if !parse_result.metadata.raw.is_empty() {
+                first_msg.prompt = parse_result.prompt;
 
-            // Resolve [[ws:...]] if present
-            if let Some(ws_value) = parse_result.metadata.raw.get("ws") {
-                let aliases = target.workspace_aliases();
-                let bot_home = target.bot_home();
-                match crate::directives::resolve_workspace(ws_value, &aliases, &bot_home) {
-                    Ok(path) => {
-                        workspace_override = Some(path.display().to_string());
-                    }
-                    Err(e) => {
-                        let _ = adapter
-                            .send_message(&dispatch_channel, &format!("⚠️ {e}"))
-                            .await;
-                        error!(session_key, error = %e, "workspace directive rejected");
-                        return;
+                // Resolve [[ws:...]] if present
+                if let Some(ws_value) = parse_result.metadata.raw.get("ws") {
+                    let aliases = target.workspace_aliases();
+                    let bot_home = target.bot_home();
+                    match crate::directives::resolve_workspace(ws_value, &aliases, &bot_home) {
+                        Ok(path) => {
+                            workspace_override = Some(path.display().to_string());
+                        }
+                        Err(e) => {
+                            let _ = adapter
+                                .send_message(&dispatch_channel, &format!("⚠️ {e}"))
+                                .await;
+                            error!(session_key, error = %e, "workspace directive rejected");
+                            return;
+                        }
                     }
                 }
-            }
 
-            // Resolve [[title:...]] if present (non-empty value)
-            if let Some(title) = &parse_result.metadata.title {
-                if !title.is_empty() {
-                    title_override = Some(title.clone());
+                // Resolve [[title:...]] if present (non-empty value)
+                if let Some(title) = &parse_result.metadata.title {
+                    if !title.is_empty() {
+                        title_override = Some(title.clone());
+                    }
                 }
             }
         }
@@ -1347,6 +1356,10 @@ mod tests {
                 return Err(anyhow::anyhow!(msg));
             }
             Ok(())
+        }
+
+        async fn session_exists(&self, _session_key: &str) -> bool {
+            false
         }
 
         async fn stream_prompt_blocks(

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod adapter;
 mod bot_turns;
 mod config;
 mod cron;
+mod directives;
 mod discord;
 mod dispatch;
 mod error_display;
@@ -161,6 +162,10 @@ async fn main() -> anyhow::Result<()> {
         cfg.markdown.tables,
         cfg.pool.prompt_hard_timeout_secs,
         cfg.pool.liveness_check_secs,
+        cfg.workspace.aliases,
+        std::path::PathBuf::from(
+            std::env::var("HOME").unwrap_or_else(|_| "/tmp".into()),
+        ),
     ));
 
     // Shutdown signal for Slack adapter

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,9 +163,13 @@ async fn main() -> anyhow::Result<()> {
         cfg.pool.prompt_hard_timeout_secs,
         cfg.pool.liveness_check_secs,
         cfg.workspace.aliases,
-        std::path::PathBuf::from(
-            std::env::var("HOME").unwrap_or_else(|_| "/tmp".into()),
-        ),
+        std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| {
+            tracing::warn!(
+                "HOME environment variable is not set — falling back to /tmp as bot_home. \
+                 This weakens the workspace security boundary."
+            );
+            "/tmp".into()
+        })),
     ));
 
     // Shutdown signal for Slack adapter


### PR DESCRIPTION
Discord Discussion URL: https://discord.com/channels/1491295327620169908/1513289078177665106

## Summary

Implements Phase 1 of the [Control Directives ADR](docs/adr/control-directives.md) (merged in PR #978).

Users can now specify workspace and thread title when starting a session:

```
@Bot [[ws:@openab]] [[title:Fix CI workflow]]
help me debug the smoke test failures
```

## At a Glance

```
User message
     │
     ▼
┌─────────────────────┐
│  Directive Parser    │  ← extracts leading [[key:value]] header, strips it
│  (directives.rs)     │
└─────────────────────┘
     │
     ├── workspace_override → pool.get_or_create(key, Some(path))
     ├── title_override → adapter.rename_thread(channel, title)
     │
     ▼
┌─────────────────────┐
│  Agent Runtime       │  ← receives clean prompt + per-session cwd
└─────────────────────┘
```

## Changes

- **`src/directives.rs`** (new) — Parser module: extracts leading `[[key:value]]` directives, resolves `[[ws:...]]` with alias + security validation, includes unit tests
- **`src/config.rs`** — Add `WorkspaceConfig` with `aliases: HashMap<String, String>` under `[workspace]` section
- **`src/acp/pool.rs`** — `get_or_create` accepts optional `working_dir` override; persists per-session workspace to `~/.openab/session_meta.json`; uses stored workspace for session resume/eviction rebuild
- **`src/dispatch.rs`** — Parse directives in `dispatch_batch` before `ensure_session`; pass workspace to pool; apply title rename after session creation
- **`src/adapter.rs`** — Add `workspace_aliases`/`bot_home` to `DispatchTarget` trait; add `rename_thread` to `ChatAdapter` (default no-op)
- **`src/discord.rs`** — Implement `rename_thread` via `EditChannel`
- **`src/main.rs`** — Register `directives` module; pass workspace config to `AdapterRouter`

## Config Example

```toml
[workspace.aliases]
openab = "~/projects/openab"
infra  = "~/projects/infra-cdk"
web    = "~/projects/frontend"
```

## Security

- Workspace paths validated per ADR §3.1: reject relative → expand `~` → canonicalize both paths → verify within bot home subtree
- Unknown aliases return user-visible error listing available aliases
- Symlink escape attempts are caught by canonicalization

## Validation

- `cargo fmt` (clean)
- `cargo check` — C linker unavailable in this environment; code structure verified manually (same constraint as PR #985)
- Unit tests included in `directives.rs` covering: basic parsing, multiline headers, body preservation, duplicate keys, empty values, alias resolution, path rejection, outside-home rejection

## Prior Art

Not applicable — implementing the project's own merged ADR.