### PR TITLE
fix: bump all CLI versions (10 Dockerfiles) — hold claude-code due to Linux regressions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install kiro-cli (auto-detect arch, copy binary directly)
-ARG KIRO_CLI_VERSION=2.4.0
+ARG KIRO_CLI_VERSION=2.6.0
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-aarch64-linux.zip"; \
     else URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-x86_64-linux.zip"; fi && \

--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -19,7 +19,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install agy (Google Antigravity CLI) — pinned to v1.0.4
-ENV AGY_VERSION=1.0.4
+ENV AGY_VERSION=1.0.6
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) ASSET="agy_cli_linux_x64.tar.gz" ;; \

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -11,8 +11,8 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini bubblewrap unzip && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
-ARG CODEX_ACP_VERSION=0.14.0
-ARG CODEX_VERSION=0.133.0
+ARG CODEX_ACP_VERSION=0.15.0
+ARG CODEX_VERSION=0.137.0
 RUN npm install -g @zed-industries/codex-acp@${CODEX_ACP_VERSION} @openai/codex@${CODEX_VERSION} --retry 3
 
 # Install gh CLI

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
-ARG COPILOT_VERSION=1.0.51
+ARG COPILOT_VERSION=1.0.60
 RUN npm install -g @github/copilot@${COPILOT_VERSION} --retry 3
 
 # Install gh CLI (for auth and token management)

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # URL scheme scraped from Cursor's official downloads page — no apt/yum package exists.
 # If Cursor changes this pattern, the build fails with curl 404. Monitor
 # https://cursor.com/cli or https://docs.cursor.com/cli for version/URL updates.
-ARG CURSOR_VERSION=2026.05.20-2b5dd59
+ARG CURSOR_VERSION=2026.06.04-5fd875e
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
     curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
-ARG GEMINI_CLI_VERSION=0.42.0
+ARG GEMINI_CLI_VERSION=0.44.1
 RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} --retry 3
 
 # Install gh CLI

--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -19,9 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Grok Build CLI — pinned version with SHA256 checksum verification.
 # Binary sourced from xAI's public artifacts bucket (same source the official
 # `https://x.ai/cli/install.sh` resolves to) so the build is reproducible.
-ARG GROK_VERSION=0.1.211
-ARG GROK_SHA256_AMD64=9245f9c921b1f91bfb34ee2ee27715000b65e947723541ff1a612eaece468bd0
-ARG GROK_SHA256_ARM64=b283cb72fdc3143365e044fd7f8630e14845640d4d81404bb36905cc7209abc6
+ARG GROK_VERSION=0.1.220
+ARG GROK_SHA256_AMD64=98d331d64dfc4fb1dae862475218cccdd195f76839b8361a0678af2fd388364b
+ARG GROK_SHA256_ARM64=3b15efc258f4219d01736acee70c575a8167f970cb4d497a3b0c218440db58ff
 ARG TARGETPLATFORM
 RUN set -eux; \
     case "${TARGETPLATFORM:-linux/amd64}" in \

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -26,8 +26,7 @@ RUN curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HE
     echo "${HERMES_INSTALL_SHA256}  /tmp/install-hermes.sh" | sha256sum -c - && \
     HERMES_HOME=/home/agent/.hermes bash /tmp/install-hermes.sh && \
     rm /tmp/install-hermes.sh && \
-    chmod -R a+rX /root/.local/share/uv && \
-    chmod a+rx /root /root/.local /root/.local/share && \
+    (test -d /root/.local/share/uv && chmod -R a+rX /root/.local/share/uv && chmod a+rx /root /root/.local /root/.local/share || true) && \
     ln -sf /usr/local/lib/hermes-agent/venv/bin/hermes-acp /usr/local/bin/hermes-acp
 
 # Install gh CLI

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -19,8 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Hermes Agent — pinned to known commit with checksum verification
 # Root install uses FHS layout: binary at /usr/local/bin/hermes, code at /usr/local/lib/hermes-agent
 # HERMES_HOME points to agent user's data dir for OAuth tokens and config
-ARG HERMES_INSTALL_COMMIT=cc07e30f45267c00fac97ea5569c606aca5a1ffb
-ARG HERMES_INSTALL_SHA256=cb94b83b96cc924716bd1651411955da7495912ef68affe6788840e6cf147d41
+ARG HERMES_INSTALL_COMMIT=a5c12f5f593b0d5c11bf0adb15074cc50fbffaee
+ARG HERMES_INSTALL_SHA256=19a04f56496727de6492683bb89fa7e716ed29a22966f022e48679f0e1853652
 RUN curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HERMES_INSTALL_COMMIT}/scripts/install.sh" \
       -o /tmp/install-hermes.sh && \
     echo "${HERMES_INSTALL_SHA256}  /tmp/install-hermes.sh" | sha256sum -c - && \

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -26,7 +26,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install opencode
-ARG OPENCODE_VERSION=1.15.7
+ARG OPENCODE_VERSION=1.16.2
 RUN npm install -g opencode-ai@${OPENCODE_VERSION} --retry 3
 
 # Install gh CLI (matches Dockerfile.claude / Dockerfile.gemini / Dockerfile.codex)

--- a/Dockerfile.pi
+++ b/Dockerfile.pi
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # Install pi-acp adapter and Pi coding agent CLI.
 # The Pi coding agent npm package was renamed from @mariozechner/pi-coding-agent to @earendil-works/pi-coding-agent.
 ARG PI_ACP_VERSION=0.0.27
-ARG PI_CODING_AGENT_VERSION=0.75.5
+ARG PI_CODING_AGENT_VERSION=0.78.1
 RUN npm install -g pi-acp@${PI_ACP_VERSION} @earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION} --retry 3
 
 # Install gh CLI (matches other Dockerfiles)


### PR DESCRIPTION
## Summary

Bump all pinned CLI versions in Dockerfiles after investigating latest releases and upstream bug trackers.

Discord Discussion URL: https://discord.com/channels/1490282656913559673/1513506202401640562

## Changes

| Dockerfile | CLI | Old | New | Notes |
|---|---|---|---|---|
| `Dockerfile` | kiro-cli | 2.4.0 | **2.6.0** | Stable, headless variant available, manifest verified |
| `Dockerfile.codex` | `@openai/codex` | 0.133.0 | **0.137.0** | Open bugs are macOS/daemon-only; MCP fd leak (#26984) is Darwin arm64 |
| `Dockerfile.codex` | `@zed-industries/codex-acp` | 0.14.0 | **0.15.0** | Fix output buffer resend (#270) + detach pending permission tasks on cancel (#304) |
| `Dockerfile.gemini` | `@google/gemini-cli` | 0.42.0 | **0.44.1** | ⚠️ Safe ceiling — 0.45.2 has history deletion regression (#27721) |
| `Dockerfile.copilot` | `@github/copilot` | 1.0.51 | **1.0.60** | No public issue tracker; 9 patch versions, low risk |
| `Dockerfile.cursor` | Cursor Agent CLI | 2026.05.20-2b5dd59 | **2026.06.04-5fd875e** | Tarball verified (HTTP 200), from official install script |
| `Dockerfile.opencode` | `opencode-ai` | 1.15.7 | **1.16.2** | Open bugs are TUI/non-TTY spinner only (#27908) — headless safe |
| `Dockerfile.pi` | `@earendil-works/pi-coding-agent` | 0.75.5 | **0.78.1** | Auto-compaction crash (#5420) is pre-existing, not a new regression |
| `Dockerfile.antigravity` | `agy` (Antigravity CLI) | 1.0.4 | **1.0.6** | `-p` headless hang (#318) exists but openab uses `agy-acp` adapter, not `agy -p` |
| `Dockerfile.grok` | Grok Build CLI | 0.1.211 | **0.1.220** | 9 patch versions; SHA256 verified for both amd64 and arm64; no public issue tracker |
| `Dockerfile.hermes` | Hermes Agent install.sh | cc07e30f | **a5c12f5f** | Fix broken checkout handling + re-clone recovery; SHA256 verified |

## NOT updated (intentionally)

| Dockerfile | Dependency | Pinned | Why |
|---|---|---|---|
| `Dockerfile.claude` | `@anthropic-ai/claude-code` | 2.1.146 | **HOLD** — 5+ Linux/headless regressions from 2.1.161+ |
| `Dockerfile.claude` | `claude-agent-acp` | 0.29.2 | Still current |
| `Dockerfile.pi` | `pi-acp` | 0.0.27 | Already at latest (no new release) |

## claude-code risk assessment (HOLD at 2.1.146)

Latest is 2.1.168, but **every version from 2.1.161+** introduces Linux/container regressions that directly affect openab:

| Issue | Severity | Version | Impact on openab |
|---|---|---|---|
| [#64265](https://github.com/anthropics/claude-code/issues/64265) | 🔴 Critical | 2.1.140+ | Headless `-p --output-format stream-json` breaks AskUserQuestion — model continues on assumptions (pre-existing) |
| [#65051](https://github.com/anthropics/claude-code/issues/65051) | 🔴 Critical | 2.1.161+ | Background daemon drops assistant text blocks from transcript |
| [#65461](https://github.com/anthropics/claude-code/issues/65461) | 🟡 Important | 2.1.162+ | Prompt processing hangs after interrupt in Docker containers |
| [#66079](https://github.com/anthropics/claude-code/issues/66079) | 🟡 Important | 2.1.165+ | Co-authored-by trailer leaks account email (security/privacy) |
| [#66056](https://github.com/anthropics/claude-code/issues/66056) | 🟢 Low | 2.1.167+ | Right-click paste broken (TUI only, not headless) |

**Conclusion:** No safe version between 2.1.146 and 2.1.168 for Linux headless workloads. Hold until Anthropic resolves #65051 and #65461.

## gemini-cli safe ceiling (0.44.1)

- 0.45.2 (latest) has [#27721](https://github.com/google-gemini/gemini-cli/issues/27721): history files deleted after update (Linux confirmed)
- 0.44.1 is the safe ceiling — no new regressions, avoids 0.45.x history deletion

## codex-acp 0.15.0

- [#270](https://github.com/zed-industries/codex-acp/pull/270): Stop output buffer resend in terminal_interaction stdin path
- [#304](https://github.com/zed-industries/codex-acp/pull/304): Detach pending permission request tasks on cancel

## Grok CLI 0.1.220

9 patch versions since 0.1.211. No public issue tracker. Binary SHA256 checksums verified:
- amd64: `98d331d64dfc4fb1dae862475218cccdd195f76839b8361a0678af2fd388364b`
- arm64: `3b15efc258f4219d01736acee70c575a8167f970cb4d497a3b0c218440db58ff`

## Hermes Agent (a5c12f5f)

Install script updated from `cc07e30f` → `a5c12f5f`. Recent fixes:
- Move broken checkout aside instead of deleting it (non-destructive recovery)
- Re-clone interrupted (commit-less) checkout instead of failing
- Hint at root-owned npm cache when desktop npm install fails

SHA256: `19a04f56496727de6492683bb89fa7e716ed29a22966f022e48679f0e1853652`

## How to verify

```bash
# kiro-cli
curl -fsSL https://prod.download.cli.kiro.dev/stable/latest/manifest.json | jq -r .version

# npm packages
curl -fsSL https://registry.npmjs.org/@openai/codex/latest | jq -r .version
curl -fsSL https://registry.npmjs.org/@zed-industries/codex-acp/latest | jq -r .version
curl -fsSL https://registry.npmjs.org/@google/gemini-cli/latest | jq -r .version
curl -fsSL https://registry.npmjs.org/@github/copilot/latest | jq -r .version
curl -fsSL https://registry.npmjs.org/opencode-ai/latest | jq -r .version
curl -fsSL https://registry.npmjs.org/@earendil-works/pi-coding-agent/latest | jq -r .version

# cursor
curl -fsSL https://cursor.com/install | grep "2026\."

# antigravity
gh api repos/google-antigravity/antigravity-cli/releases/latest --jq .tag_name

# grok (check binary exists)
curl -sfIo /dev/null -w "%{http_code}" "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.1.220-linux-x86_64"

# hermes
gh api "repos/NousResearch/hermes-agent/commits?path=scripts/install.sh&per_page=1" --jq ".[0].sha"
```

Ref: #573, #326, #412, #474