### PR TITLE
fix(ci): add pending-decision reusable workflow, fix label conflict

### DIFF
--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           script: |
             const REBASE = 'needs-rebase';
+            const MAINTAINER = 'pending-maintainer';
             const CONTRIBUTOR = 'pending-contributor';
 
             const prs = await github.rest.pulls.list({
@@ -25,7 +26,6 @@ jobs:
             });
 
             for (const pr of prs.data) {
-              // Fetch full PR detail for mergeable status
               const { data: detail } = await github.rest.pulls.get({
                 ...context.repo,
                 pull_number: pr.number
@@ -40,7 +40,12 @@ jobs:
                   issue_number: pr.number,
                   labels: [REBASE, CONTRIBUTOR]
                 });
-                console.log(`#${pr.number} — added ${REBASE} + ${CONTRIBUTOR}`);
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: pr.number,
+                  name: MAINTAINER
+                }).catch(() => {});
+                console.log(`#${pr.number} — +${REBASE} +${CONTRIBUTOR} -${MAINTAINER}`);
               } else if (!conflicting && hasRebase) {
                 await github.rest.issues.removeLabel({
                   ...context.repo,

--- a/.github/workflows/pending-decision.yml
+++ b/.github/workflows/pending-decision.yml
@@ -1,0 +1,45 @@
+name: Pending Decision
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: number
+      decision:
+        required: true
+        type: string  # "maintainer" or "contributor"
+
+jobs:
+  flip:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const MAINTAINER = 'pending-maintainer';
+            const CONTRIBUTOR = 'pending-contributor';
+            const prNumber = ${{ inputs.pr_number }};
+            const decision = '${{ inputs.decision }}';
+
+            const addLabel = decision === 'maintainer' ? MAINTAINER : CONTRIBUTOR;
+            const removeLabel = decision === 'maintainer' ? CONTRIBUTOR : MAINTAINER;
+
+            // Add the target label
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: prNumber,
+              labels: [addLabel]
+            });
+
+            // Remove the opposite label
+            await github.rest.issues.removeLabel({
+              ...context.repo,
+              issue_number: prNumber,
+              name: removeLabel
+            }).catch(() => {}); // ignore if not present
+
+            console.log(`#${prNumber} — +${addLabel}, -${removeLabel}`);


### PR DESCRIPTION
## Problem

`needs-rebase.yml` adds `pending-contributor` without removing `pending-maintainer`, causing PRs (e.g. #959) to have both labels simultaneously.

## Solution

1. **New `.github/workflows/pending-decision.yml`** — reusable workflow that enforces mutual exclusion:
   - Input: `pr_number` + `decision` (`maintainer` or `contributor`)
   - Adds the target label, removes the opposite

2. **Fix `needs-rebase.yml`** — now removes `pending-maintainer` when adding `pending-contributor`

## Usage (for future workflows)

```yaml
uses: ./.github/workflows/pending-decision.yml
with:
  pr_number: ${{ github.event.pull_request.number }}
  decision: contributor
```

## Note

`pending-maintainer.yml` already handles both directions correctly — this fix targets the gap in `needs-rebase.yml` and provides the reusable workflow for any future callers.