### PR TITLE
fix(error): user-friendly message when agent returns -32603 with no details

### DIFF
--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -76,7 +76,7 @@ pub fn format_coded_error(code: i64, message: &str, data_message: Option<&str>) 
     } else {
         format!("{} (code: {})\n{}", prefix, code, message)
     };
-    let detail = data_message.filter(|s| !s.is_empty());
+    let detail = data_message.filter(|s| !s.trim().is_empty());
     if let Some(detail) = detail {
         if !message.contains(detail) {
             out.push_str("\n> ");
@@ -84,7 +84,7 @@ pub fn format_coded_error(code: i64, message: &str, data_message: Option<&str>) 
         }
     } else if code == -32603 {
         out.push_str(
-            "\n\n_The agent did not return any error details via ACP. \
+            "\n\n_The agent did not return any error details. \
              Please check the agent's own logs for more information._",
         );
     }
@@ -285,10 +285,8 @@ mod tests {
     fn format_coded_error_32603_whitespace_detail_shows_fallback() {
         // Whitespace-only detail should be treated as empty
         let result = format_coded_error(-32603, "Internal error", Some("   "));
-        // Current impl: "   " is non-empty so it won't trigger fallback,
-        // but it also won't be appended since message doesn't contain it.
-        // This documents the current behavior.
         assert!(result.contains("Internal Error"));
+        assert!(result.contains("did not return any error details"));
     }
 
     #[test]

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -272,4 +272,54 @@ mod tests {
         let result = format_coded_error(-32602, "bad params", None);
         assert!(!result.contains("did not return any error details"));
     }
+
+    #[test]
+    fn format_coded_error_32603_empty_message_still_shows_fallback() {
+        // Even when message is empty, fallback should appear
+        let result = format_coded_error(-32603, "", None);
+        assert!(result.contains("Internal Error"));
+        assert!(result.contains("did not return any error details"));
+    }
+
+    #[test]
+    fn format_coded_error_32603_whitespace_detail_shows_fallback() {
+        // Whitespace-only detail should be treated as empty
+        let result = format_coded_error(-32603, "Internal error", Some("   "));
+        // Current impl: "   " is non-empty so it won't trigger fallback,
+        // but it also won't be appended since message doesn't contain it.
+        // This documents the current behavior.
+        assert!(result.contains("Internal Error"));
+    }
+
+    #[test]
+    fn format_coded_error_500_no_detail_no_fallback() {
+        // HTTP 500 without detail should NOT get the ACP-specific hint
+        let result = format_coded_error(500, "server error", None);
+        assert!(result.contains("Internal Server Error"));
+        assert!(!result.contains("did not return any error details"));
+    }
+
+    #[test]
+    fn format_coded_error_32603_fallback_does_not_duplicate_with_detail() {
+        // When detail is present, no fallback appears — mutually exclusive
+        let result = format_coded_error(-32603, "Internal error", Some("rate limit exceeded"));
+        assert!(result.contains("rate limit exceeded"));
+        assert!(!result.contains("did not return any error details"));
+        assert!(!result.contains("agent's own logs"));
+    }
+
+    #[test]
+    fn format_coded_error_server_error_range_no_fallback() {
+        // Other JSON-RPC server error codes should NOT get the hint
+        let result = format_coded_error(-32099, "custom error", None);
+        assert!(!result.contains("did not return any error details"));
+    }
+
+    #[test]
+    fn format_coded_error_32603_fallback_message_is_italic() {
+        // Verify Discord markdown italic formatting
+        let result = format_coded_error(-32603, "Internal error", None);
+        assert!(result.contains("_The agent did not return"));
+        assert!(result.ends_with("_"));
+    }
 }

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -81,6 +81,11 @@ pub fn format_coded_error(code: i64, message: &str, data_message: Option<&str>) 
             out.push_str("\n> ");
             out.push_str(detail);
         }
+    } else if code == -32603 {
+        out.push_str(
+            "\n\n_The agent did not return any error details via ACP. \
+             Please check the agent's own logs for more information._",
+        );
     }
     out
 }
@@ -237,5 +242,33 @@ mod tests {
         // If data_message is already in message, don't repeat it
         let result = format_coded_error(-32603, "model not supported", Some("model not supported"));
         assert_eq!(result.matches("model not supported").count(), 1);
+    }
+
+    #[test]
+    fn format_coded_error_32603_no_detail_shows_fallback() {
+        let result = format_coded_error(-32603, "Internal error", None);
+        assert!(result.contains("Internal Error"));
+        assert!(result.contains("did not return any error details"));
+        assert!(result.contains("agent's own logs"));
+    }
+
+    #[test]
+    fn format_coded_error_32603_with_detail_no_fallback() {
+        let result = format_coded_error(-32603, "Internal error", Some("model not found"));
+        assert!(result.contains("model not found"));
+        assert!(!result.contains("did not return any error details"));
+    }
+
+    #[test]
+    fn format_coded_error_32603_empty_detail_shows_fallback() {
+        let result = format_coded_error(-32603, "Internal error", Some(""));
+        assert!(result.contains("did not return any error details"));
+    }
+
+    #[test]
+    fn format_coded_error_other_code_no_detail_no_fallback() {
+        // Fallback only applies to -32603
+        let result = format_coded_error(-32602, "bad params", None);
+        assert!(!result.contains("did not return any error details"));
     }
 }

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -76,8 +76,9 @@ pub fn format_coded_error(code: i64, message: &str, data_message: Option<&str>) 
     } else {
         format!("{} (code: {})\n{}", prefix, code, message)
     };
-    if let Some(detail) = data_message {
-        if !detail.is_empty() && !message.contains(detail) {
+    let detail = data_message.filter(|s| !s.is_empty());
+    if let Some(detail) = detail {
+        if !message.contains(detail) {
             out.push_str("\n> ");
             out.push_str(detail);
         }


### PR DESCRIPTION
## Context

Closes #1000
Related: #1005 (closed — different approach)

When ACP agents return JSON-RPC `-32603 Internal Error` without populating `error.data`, users see only:

```
⚠️ **Internal Error** (code: -32603)
Internal error
```

…with zero actionable context.

## Approach

Instead of scraping agent stderr (as #1005 proposed), we take the honest approach:

- When `-32603` arrives with no `data_message`, append a clear hint:
  > _The agent did not return any error details via ACP. Please check the agent's own logs for more information._

This respects the correct responsibility boundary — it's the agent CLI's job to return meaningful errors via ACP. When they don't, we tell the user honestly rather than trying to parse their internal logs.

## Changes

| File | Change |
|------|--------|
| `src/error_display.rs` | `format_coded_error`: fallback hint when code == -32603 and data_message is None/empty |
| `src/error_display.rs` | 4 new unit tests covering the fallback behavior |

## After

```
⚠️ **Internal Error** (code: -32603)
Internal error

_The agent did not return any error details via ACP. Please check the agent's own logs for more information._
```

## Validation

- [x] 4 new tests: fallback shown, not shown with detail, empty string triggers fallback, other codes unaffected
- [ ] `cargo test` — CI will validate (no local Rust toolchain)


https://discord.com/channels/1491295327620169908/1491365150664560881/1513607308855214371
