### PR TITLE
pin kiro-cli to 2.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install kiro-cli (auto-detect arch, copy binary directly)
-ARG KIRO_CLI_VERSION=2.4.0
+ARG KIRO_CLI_VERSION=2.5.0
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-aarch64-linux.zip"; \
     else URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-x86_64-linux.zip"; fi && \


### PR DESCRIPTION
kiro-cli 2.6.0 introduced a regression: `kiro-cli-chat` now dynamically links `libasound.so.2` which is not available in our headless container image. This breaks ACP mode.

Pin to 2.5.0 which does not have this dependency.

Ref: https://github.com/kirodotdev/Kiro/issues/9286