### PR TITLE
docs(codex): correct CLI invocation + sandbox TOML shape

### DIFF
--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -33,7 +33,7 @@ RUN mkdir -p /home/node/.codex && chown -R node:node /home/node
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND="codex"
+ENV OPENAB_AGENT_COMMAND="codex-acp"
 ENV OPENAB_AGENT_AUTH_COMMAND="codex login --device-auth"
 
 ENTRYPOINT ["tini", "--"]

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -209,14 +209,32 @@ approval_policy = "auto-review"
 > `approval_policy` is a **top-level** key in `config.toml`, not under a
 > `[sandbox]` section. Codex silently ignores it if nested.
 
-Or pass it at install time via Helm:
+Or mount a `ConfigMap` containing the codex `config.toml` into the agent via the
+chart's `extraVolumes` / `extraVolumeMounts` (the chart does not expose a
+dedicated `extraConfig` value — anything written into the codex config file has
+to come in as a mounted file or be pre-seeded into the PVC):
 
 ```bash
-helm install openab openab/openab \
-  --set agents.codex.discord.enabled=true \
-  # ... other flags ...
-  --set-json 'agents.codex.extraConfig={"sandbox":{"approval_policy":"auto-review"}}'
+# Create the codex config as a ConfigMap.
+kubectl create configmap codex-config \
+  --from-literal=config.toml='approval_policy = "auto-review"'
+
+# values.yaml — mount it over /home/node/.codex/config.toml
+agents:
+  codex:
+    extraVolumes:
+      - name: codex-config
+        configMap:
+          name: codex-config
+    extraVolumeMounts:
+      - name: codex-config
+        mountPath: /home/node/.codex/config.toml
+        subPath: config.toml
 ```
+
+> Mounting `config.toml` from a ConfigMap makes the file read-only inside the
+> pod. If you also need codex to write back to it (e.g. `codex features enable`
+> persisting flags), pre-seed the config on the PVC instead.
 
 ### What Auto-review does
 
@@ -267,7 +285,7 @@ runtime already provides isolation):
 ```toml
 # /home/node/.codex/config.toml
 sandbox_mode = "danger-full-access"
-approval_policy = "on-request"
+approval_policy = "auto-review"
 ```
 
 > `sandbox_mode` and `approval_policy` are **top-level** keys in `config.toml`.
@@ -276,17 +294,39 @@ approval_policy = "on-request"
 > `bwrap: No permissions to create new namespace`; moving the same keys to the
 > top level makes `codex exec` report `sandbox: danger-full-access` and run.
 
+> **Do NOT pair `danger-full-access` with `approval_policy = "on-request"` on
+> an OpenAB deployment.** `on-request` pauses each tool call to wait for an
+> interactive human approval, and OpenAB agents have no terminal attached —
+> every tool call hangs in `in_progress` until openab's 1800 s hard timeout
+> fires. Use `"auto-review"` (recommended, see
+> [§Approval Policy](#approval-policy--auto-review)) or `"never"` for trusted
+> and already-isolated pods (`"never"` removes all per-call guardrails — the
+> outer pod isolation is the only remaining boundary).
+
 Or launch with:
 
 ```bash
 codex --sandbox danger-full-access
 ```
 
-Or via Helm:
+Or mount a ConfigMap via the chart's `extraVolumes` / `extraVolumeMounts`:
 
 ```bash
-helm install openab openab/openab \
-  --set-json 'agents.codex.extraConfig={"sandbox":{"sandbox_mode":"danger-full-access","approval_policy":"on-request"}}'
+kubectl create configmap codex-config --from-file=config.toml=/path/to/config.toml
+```
+
+```yaml
+# values.yaml
+agents:
+  codex:
+    extraVolumes:
+      - name: codex-config
+        configMap:
+          name: codex-config
+    extraVolumeMounts:
+      - name: codex-config
+        mountPath: /home/node/.codex/config.toml
+        subPath: config.toml
 ```
 
 > **Important:** `danger-full-access` disables only Codex's *inner* sandbox. It

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -203,9 +203,11 @@ manual approval is impractical and Full Access removes all guardrails.
 Enable Auto-review in `/home/node/.codex/config.toml`:
 
 ```toml
-[sandbox]
 approval_policy = "auto-review"
 ```
+
+> `approval_policy` is a **top-level** key in `config.toml`, not under a
+> `[sandbox]` section. Codex silently ignores it if nested.
 
 Or pass it at install time via Helm:
 
@@ -264,10 +266,15 @@ runtime already provides isolation):
 
 ```toml
 # /home/node/.codex/config.toml
-[sandbox]
 sandbox_mode = "danger-full-access"
 approval_policy = "on-request"
 ```
+
+> `sandbox_mode` and `approval_policy` are **top-level** keys in `config.toml`.
+> A `[sandbox]` section header is silently ignored by Codex 0.137+ — verified
+> empirically: with the nested form in place, `codex exec` still fails with
+> `bwrap: No permissions to create new namespace`; moving the same keys to the
+> top level makes `codex exec` report `sandbox: danger-full-access` and run.
 
 Or launch with:
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -138,8 +138,7 @@ working_dir = "/home/node"
 
 # Codex
 [agent]
-command = "codex"
-args = ["--acp"]
+command = "codex-acp"
 working_dir = "/home/node"
 env = { OPENAI_API_KEY = "${OPENAI_API_KEY}" }
 


### PR DESCRIPTION
## Summary

- Fix `docs/config-reference.md` — `command = "codex"` + `args = ["--acp"]` doesn't work; codex CLI has no `--acp` flag. Switch the reference example to the canonical `command = "codex-acp"`.
- Fix `docs/codex.md` §Auto-review and §Troubleshooting — `sandbox_mode` / `approval_policy` are top-level keys in `~/.codex/config.toml`, not under a `[sandbox]` section header. Codex 0.137+ silently ignores the nested form, which means anyone following the troubleshooting section verbatim does NOT actually disable codex's inner sandbox. Add inline call-out notes explaining why.

Production-impacting because on any host that blocks unprivileged user namespaces (OrbStack default, GKE Autopilot, many hardened nodes), every codex tool call hits `bwrap: No permissions to create a new namespace` and stalls until openab's 1800 s hard timeout fires. The published `codex-acp` 0.15.0 cancel fix only masks the failure mode.

Fixes #1047 (the linked issue).

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365157010542652/1513778937967280209

## Test plan

- [x] `codex --acp` reproduces `error: unexpected argument '--acp' found` on `openab-codex:0.8.5-beta.6`
- [x] `[sandbox]` form in `~/.codex/config.toml` → `codex exec --skip-git-repo-check "echo hi"` fails with `bwrap: No permissions to create new namespace`
- [x] Top-level form (this PR's change) → `codex exec` reports `sandbox: danger-full-access` in the session header and the command runs (`succeeded in 0ms: hi`)
- [ ] Maintainer to confirm preferred direction on the third bug (the `agents.codex.extraConfig` chart value that doesn't exist — see linked issue)

## Out of scope

- Whether to add `agents.codex.extraConfig` to the chart, or remove its mentions from `docs/codex.md`. Both helm examples in §Auto-review and §Troubleshooting currently reference a value the chart doesn't expose. Flagged in the issue for discussion.
