### PR TITLE
feat(chart): render [workspace.aliases] from values.yaml

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -164,17 +164,6 @@ data:
     max_sessions = {{ ($cfg.pool).maxSessions | default 10 }}
     session_ttl_hours = {{ ($cfg.pool).sessionTtlHours | default 24 }}
 
-    {{- if ($cfg.workspace).aliases }}
-
-    [workspace.aliases]
-    {{- range $alias, $path := ($cfg.workspace).aliases }}
-    {{- if not (kindIs "string" $path) }}
-    {{- fail (printf "agents.%s.workspace.aliases.%s value must be a string — got: %v" $name $alias $path) }}
-    {{- end }}
-    {{ $alias | toJson }} = {{ $path | toJson }}
-    {{- end }}
-    {{- end }}
-
     [reactions]
     enabled = {{ if hasKey ($cfg.reactions) "enabled" }}{{ ($cfg.reactions).enabled }}{{ else }}true{{ end }}
     remove_after_reply = {{ if hasKey ($cfg.reactions) "removeAfterReply" }}{{ ($cfg.reactions).removeAfterReply }}{{ else }}false{{ end }}
@@ -183,6 +172,19 @@ data:
     {{- fail (printf "agents.%s.reactions.toolDisplay must be one of: full, compact, none — got: %s" $name ($cfg.reactions).toolDisplay) }}
     {{- end }}
     tool_display = {{ ($cfg.reactions).toolDisplay | toJson }}
+    {{- end }}
+    {{- if ($cfg.workspace).aliases }}
+    {{- if not (kindIs "map" ($cfg.workspace).aliases) }}
+    {{- fail (printf "agents.%s.workspace.aliases must be a map — got: %T" $name ($cfg.workspace).aliases) }}
+    {{- end }}
+
+    [workspace.aliases]
+    {{- range $alias, $path := ($cfg.workspace).aliases }}
+    {{- if not (kindIs "string" $path) }}
+    {{- fail (printf "agents.%s.workspace.aliases.%s value must be a string — got: %v" $name $alias $path) }}
+    {{- end }}
+    {{ $alias | toJson }} = {{ $path | toJson }}
+    {{- end }}
     {{- end }}
     {{- if ($cfg.stt).enabled }}
     {{- if not ($cfg.stt).apiKey }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -319,6 +319,9 @@ data:
     {{- fail (printf "agents.%s.workspace must be a map — got: %v" $name $cfg.workspace) }}
     {{- end }}
     {{- if ($cfg.workspace).aliases }}
+    {{- if not (kindIs "map" ($cfg.workspace).aliases) }}
+    {{- fail (printf "agents.%s.workspace.aliases must be a map — got: %v" $name ($cfg.workspace).aliases) }}
+    {{- end }}
 
     [workspace.aliases]
     {{- range $alias, $path := ($cfg.workspace).aliases }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -173,19 +173,6 @@ data:
     {{- end }}
     tool_display = {{ ($cfg.reactions).toolDisplay | toJson }}
     {{- end }}
-    {{- if ($cfg.workspace).aliases }}
-    {{- if not (kindIs "map" ($cfg.workspace).aliases) }}
-    {{- fail (printf "agents.%s.workspace.aliases must be a map — got: %T" $name ($cfg.workspace).aliases) }}
-    {{- end }}
-
-    [workspace.aliases]
-    {{- range $alias, $path := ($cfg.workspace).aliases }}
-    {{- if not (kindIs "string" $path) }}
-    {{- fail (printf "agents.%s.workspace.aliases.%s value must be a string — got: %v" $name $alias $path) }}
-    {{- end }}
-    {{ $alias | toJson }} = {{ $path | toJson }}
-    {{- end }}
-    {{- end }}
     {{- if ($cfg.stt).enabled }}
     {{- if not ($cfg.stt).apiKey }}
     {{ fail (printf "agents.%s.stt.apiKey is required when stt.enabled=true" $name) }}
@@ -327,6 +314,19 @@ data:
     {{- end }}
     timeout_seconds = {{ $ps.timeoutSeconds | default 60 }}
     on_failure = {{ $ps.onFailure | default "abort" | toJson }}
+    {{- end }}
+    {{- if and ($cfg.workspace) (not (kindIs "map" $cfg.workspace)) }}
+    {{- fail (printf "agents.%s.workspace must be a map — got: %v" $name $cfg.workspace) }}
+    {{- end }}
+    {{- if ($cfg.workspace).aliases }}
+
+    [workspace.aliases]
+    {{- range $alias, $path := ($cfg.workspace).aliases }}
+    {{- if not (kindIs "string" $path) }}
+    {{- fail (printf "agents.%s.workspace.aliases.%s value must be a string — got: %v" $name $alias $path) }}
+    {{- end }}
+    {{ $alias | toJson }} = {{ $path | toJson }}
+    {{- end }}
     {{- end }}
   {{- if $cfg.agentsMd }}
   AGENTS.md: |

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -164,6 +164,14 @@ data:
     max_sessions = {{ ($cfg.pool).maxSessions | default 10 }}
     session_ttl_hours = {{ ($cfg.pool).sessionTtlHours | default 24 }}
 
+    {{- if ($cfg.workspace).aliases }}
+
+    [workspace.aliases]
+    {{- range $alias, $path := ($cfg.workspace).aliases }}
+    {{ $alias }} = {{ $path | toJson }}
+    {{- end }}
+    {{- end }}
+
     [reactions]
     enabled = {{ if hasKey ($cfg.reactions) "enabled" }}{{ ($cfg.reactions).enabled }}{{ else }}true{{ end }}
     remove_after_reply = {{ if hasKey ($cfg.reactions) "removeAfterReply" }}{{ ($cfg.reactions).removeAfterReply }}{{ else }}false{{ end }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -168,7 +168,10 @@ data:
 
     [workspace.aliases]
     {{- range $alias, $path := ($cfg.workspace).aliases }}
-    {{ $alias }} = {{ $path | toJson }}
+    {{- if not (kindIs "string" $path) }}
+    {{- fail (printf "agents.%s.workspace.aliases.%s value must be a string — got: %v" $name $alias $path) }}
+    {{- end }}
+    {{ $alias | toJson }} = {{ $path | toJson }}
     {{- end }}
     {{- end }}
 

--- a/charts/openab/tests/workspace-aliases_test.yaml
+++ b/charts/openab/tests/workspace-aliases_test.yaml
@@ -47,3 +47,10 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "workspace must be a map"
+
+  - it: rejects workspace.aliases as non-map type
+    set:
+      agents.kiro.workspace.aliases: "not-a-map"
+    asserts:
+      - failedTemplate:
+          errorPattern: "workspace.aliases must be a map"

--- a/charts/openab/tests/workspace-aliases_test.yaml
+++ b/charts/openab/tests/workspace-aliases_test.yaml
@@ -40,3 +40,10 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "value must be a string"
+
+  - it: rejects workspace as non-map type
+    set:
+      agents.kiro.workspace: "not-a-map"
+    asserts:
+      - failedTemplate:
+          errorPattern: "workspace must be a map"

--- a/charts/openab/tests/workspace-aliases_test.yaml
+++ b/charts/openab/tests/workspace-aliases_test.yaml
@@ -1,0 +1,42 @@
+suite: workspace.aliases
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: renders [workspace.aliases] with quoted keys and values
+    set:
+      agents.kiro.workspace.aliases:
+        myproject: "~/projects/myproject"
+        openab: "~/openab"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[workspace\.aliases\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '"myproject" = "~/projects/myproject"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '"openab" = "~/openab"'
+
+  - it: renders key with dot correctly as quoted string
+    set:
+      agents.kiro.workspace.aliases:
+        my.project: "~/projects/myproject"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '"my\.project" = "~/projects/myproject"'
+
+  - it: does not render [workspace.aliases] when unset
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: '\[workspace\.aliases\]'
+
+  - it: rejects non-string alias value
+    set:
+      agents.kiro.workspace.aliases:
+        bad: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "value must be a string"

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -143,6 +143,11 @@ agents:
     #   reactions:
     #     enabled: true
     #     removeAfterReply: false
+    #   # workspace.aliases: map alias names to paths for [[ws:@alias]] directives
+    #   workspace:
+    #     aliases:
+    #       myproject: "~/projects/myproject"
+    #       openab: "~/openab"
     #   persistence:
     #     enabled: true
     #     storageClass: ""

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -502,6 +502,7 @@ Key mapping (`values.yaml` → `config.toml`):
 | `agents.<name>.pool.sessionTtlHours` | `[pool] session_ttl_hours` |
 | `agents.<name>.reactions.enabled` | `[reactions] enabled` |
 | `agents.<name>.reactions.toolDisplay` | `[reactions] tool_display` |
+| `agents.<name>.workspace.aliases.<alias>` | `[workspace.aliases] <alias>` |
 | `agents.<name>.stt.apiKey` | `[stt] api_key` |
 | `agents.<name>.cronjobs[].enabled` | `[[cron.jobs]] enabled` |
 | `agents.<name>.cronjobs[].schedule` | `[[cron.jobs]] schedule` |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -503,7 +503,6 @@ Key mapping (`values.yaml` → `config.toml`):
 | `agents.<name>.workspace.aliases.<alias>` | `[workspace.aliases] <alias>` |
 | `agents.<name>.reactions.enabled` | `[reactions] enabled` |
 | `agents.<name>.reactions.toolDisplay` | `[reactions] tool_display` |
-| `agents.<name>.workspace.aliases.<alias>` | `[workspace.aliases] <alias>` |
 | `agents.<name>.stt.apiKey` | `[stt] api_key` |
 | `agents.<name>.cronjobs[].enabled` | `[[cron.jobs]] enabled` |
 | `agents.<name>.cronjobs[].schedule` | `[[cron.jobs]] schedule` |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -500,6 +500,7 @@ Key mapping (`values.yaml` → `config.toml`):
 | `agents.<name>.slack.*` | `[slack] *` (same pattern) |
 | `agents.<name>.pool.maxSessions` | `[pool] max_sessions` |
 | `agents.<name>.pool.sessionTtlHours` | `[pool] session_ttl_hours` |
+| `agents.<name>.workspace.aliases.<alias>` | `[workspace.aliases] <alias>` |
 | `agents.<name>.reactions.enabled` | `[reactions] enabled` |
 | `agents.<name>.reactions.toolDisplay` | `[reactions] tool_display` |
 | `agents.<name>.workspace.aliases.<alias>` | `[workspace.aliases] <alias>` |


### PR DESCRIPTION
## Context

Currently, `[workspace.aliases]` cannot be configured through `values.yaml`. The ConfigMap template does not render this section, so any manually-added workspace aliases are overwritten on every `helm upgrade`.

## Summary

Add rendering logic for `[workspace.aliases]` in the ConfigMap template, allowing users to configure workspace aliases directly in `values.yaml` without needing to use `configUrl` or manual patching after upgrades.

## Changes

- `charts/openab/templates/configmap.yaml`: Add conditional rendering of `[workspace.aliases]` section from `.Values.agents.<name>.workspace.aliases`
- `charts/openab/values.yaml`: Add commented example showing the workspace aliases configuration

## Usage

```yaml
agents:
  mybot:
    workspace:
      aliases:
        myproject: "~/projects/myproject"
        openab: "~/openab"
```

This renders as:

```toml
[workspace.aliases]
myproject = "~/projects/myproject"
openab = "~/openab"
```

Discord Discussion URL: https://discord.com/channels/1488041051187974246/1503381626456113202/1513812941630083214