### PR TITLE
feat(openshell): add open tier network policy preset

### DIFF
--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -135,7 +135,23 @@ sandbox$ openab run --config config.toml
 
 ## Network Policy
 
-OpenShell sandboxes have **default-deny egress**. Required endpoints by backend:
+OpenShell sandboxes have **default-deny egress**. OAB ships its own policy preset at `openshell/policies/openab-full.yaml` that covers all supported backends in one file:
+
+```bash
+openshell policy set oab --policy openshell/policies/openab-full.yaml --wait
+```
+
+This "open tier" uses L4 passthrough (no HTTP inspection) for maximum compatibility. You can also apply it at sandbox creation:
+
+```bash
+openshell sandbox create --name oab \
+  --from ghcr.io/openabdev/openab-native-sandbox:latest \
+  --policy openshell/policies/openab-full.yaml \
+  --provider discord \
+  -- bash
+```
+
+### Required endpoints by backend
 
 | Backend | Endpoints |
 |---------|-----------|

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -135,13 +135,13 @@ sandbox$ openab run --config config.toml
 
 ## Network Policy
 
-OpenShell sandboxes have **default-deny egress**. OAB ships its own policy preset at `openshell/policies/openab-full.yaml` that covers all supported backends in one file:
+OpenShell sandboxes have **default-deny egress**. OAB ships a complete policy file at `openshell/policies/openab-full.yaml` that covers all supported backends. It includes the required static sections (`version`, `filesystem_policy`, `landlock`, `process`) so it works directly with `openshell policy set`:
 
 ```bash
 openshell policy set oab --policy openshell/policies/openab-full.yaml --wait
 ```
 
-This "open tier" uses L4 passthrough (no HTTP inspection) for maximum compatibility. You can also apply it at sandbox creation:
+You can also apply it at sandbox creation:
 
 ```bash
 openshell sandbox create --name oab \
@@ -150,6 +150,8 @@ openshell sandbox create --name oab \
   --provider discord \
   -- bash
 ```
+
+> **Note:** This file lives in the source repo. Clone the repo or download the file before referencing it with `--policy`.
 
 ### Required endpoints by backend
 

--- a/openshell/policies/openab-full.yaml
+++ b/openshell/policies/openab-full.yaml
@@ -5,6 +5,19 @@
 #
 # This uses L4 passthrough (no protocol inspection) for maximum compatibility.
 
+version: 1
+
+filesystem_policy:
+  read_only: [/usr, /lib, /etc]
+  read_write: [/home/sandbox, /tmp]
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
 network_policies:
   discord:
     name: discord
@@ -85,6 +98,8 @@ network_policies:
       - { host: registry.npmjs.org, port: 443 }
       - { host: ghcr.io, port: 443 }
     binaries:
+      - { path: /usr/bin/python3 }
+      - { path: /usr/local/bin/python3 }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/pip }
       - { path: /usr/local/bin/uv }

--- a/openshell/policies/openab-full.yaml
+++ b/openshell/policies/openab-full.yaml
@@ -25,13 +25,18 @@ network_policies:
       - { host: auth0.openai.com, port: 443 }
     binaries:
       - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
 
   anthropic:
     name: anthropic
     endpoints:
       - { host: api.anthropic.com, port: 443 }
+      - { host: claude.ai, port: 443 }
+      - { host: platform.claude.com, port: 443 }
+      - { host: downloads.claude.ai, port: 443 }
     binaries:
       - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
 
   github:
     name: github
@@ -42,6 +47,7 @@ network_policies:
       - { host: raw.githubusercontent.com, port: 443 }
     binaries:
       - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
       - { path: /usr/bin/gh }
       - { path: /usr/bin/git }
 
@@ -53,6 +59,7 @@ network_policies:
       - { host: accounts.google.com, port: 443 }
     binaries:
       - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
 
   groq:
     name: groq
@@ -60,6 +67,7 @@ network_policies:
       - { host: api.groq.com, port: 443 }
     binaries:
       - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
 
   packages:
     name: packages
@@ -69,6 +77,7 @@ network_policies:
       - { host: registry.npmjs.org, port: 443 }
       - { host: ghcr.io, port: 443 }
     binaries:
+      - { path: /usr/local/bin/node }
       - { path: /usr/bin/pip }
       - { path: /usr/local/bin/uv }
       - { path: /usr/bin/npm }

--- a/openshell/policies/openab-full.yaml
+++ b/openshell/policies/openab-full.yaml
@@ -1,0 +1,75 @@
+# OpenAB "open tier" network policy preset for OpenShell sandboxes.
+# Allows all endpoints required by OAB across all supported backends.
+# Usage:
+#   openshell policy set oab --policy openshell/policies/openab-full.yaml --wait
+#
+# This uses L4 passthrough (no protocol inspection) for maximum compatibility.
+
+network_policies:
+  discord:
+    name: discord
+    endpoints:
+      - { host: discord.com, port: 443 }
+      - { host: gateway.discord.gg, port: 443 }
+      - { host: cdn.discordapp.com, port: 443 }
+      - { host: media.discordapp.net, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/openab }
+      - { path: /usr/local/bin/openab-agent }
+
+  openai:
+    name: openai
+    endpoints:
+      - { host: chatgpt.com, port: 443 }
+      - { host: api.openai.com, port: 443 }
+      - { host: auth0.openai.com, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+
+  anthropic:
+    name: anthropic
+    endpoints:
+      - { host: api.anthropic.com, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+
+  github:
+    name: github
+    endpoints:
+      - { host: github.com, port: 443 }
+      - { host: api.github.com, port: 443 }
+      - { host: objects.githubusercontent.com, port: 443 }
+      - { host: raw.githubusercontent.com, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/bin/gh }
+      - { path: /usr/bin/git }
+
+  google:
+    name: google
+    endpoints:
+      - { host: generativelanguage.googleapis.com, port: 443 }
+      - { host: oauth2.googleapis.com, port: 443 }
+      - { host: accounts.google.com, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+
+  groq:
+    name: groq
+    endpoints:
+      - { host: api.groq.com, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+
+  packages:
+    name: packages
+    endpoints:
+      - { host: pypi.org, port: 443 }
+      - { host: files.pythonhosted.org, port: 443 }
+      - { host: registry.npmjs.org, port: 443 }
+      - { host: ghcr.io, port: 443 }
+    binaries:
+      - { path: /usr/bin/pip }
+      - { path: /usr/local/bin/uv }
+      - { path: /usr/bin/npm }
+      - { path: /usr/bin/curl }

--- a/openshell/policies/openab-full.yaml
+++ b/openshell/policies/openab-full.yaml
@@ -69,6 +69,14 @@ network_policies:
       - { path: /usr/local/bin/openab-agent }
       - { path: /usr/local/bin/node }
 
+  xai:
+    name: xai
+    endpoints:
+      - { host: api.x.ai, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
+
   packages:
     name: packages
     endpoints:


### PR DESCRIPTION
## Summary

Add an OAB-maintained "open tier" network policy preset for OpenShell sandboxes.

## Changes

- **New**: `openshell/policies/openab-full.yaml` — covers all supported backends (Discord, OpenAI, Anthropic, GitHub, Google, Groq, package registries) using L4 passthrough (no HTTP inspection)
- **Updated**: `docs/openshell.md` — documents the preset and shows usage

## Usage

```bash
openshell policy set oab --policy openshell/policies/openab-full.yaml --wait
```

Or at sandbox creation:

```bash
openshell sandbox create --name oab \
  --from ghcr.io/openabdev/openab-native-sandbox:latest \
  --policy openshell/policies/openab-full.yaml \
  --provider discord \
  -- bash
```

## Testing

- Verified YAML structure is valid
- Endpoints match all backends documented in docs/openshell.md