### PR TITLE
feat(openshell): add OAB open-tier network policy

### DIFF
--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -92,6 +92,14 @@ openshell sandbox create --name oab \
 
 ### 3. Set network policy (from host)
 
+Apply the OAB open-tier policy (Discord + LLM providers + GitHub + package registries):
+
+```bash
+openshell policy set --policy openshell/policies/oab-open.yaml oab
+```
+
+Or, for a minimal policy with only Discord + one LLM backend:
+
 ```bash
 openshell policy update oab \
   --add-endpoint "discord.com:443:read-write:rest:enforce" \
@@ -135,14 +143,17 @@ sandbox$ openab run --config config.toml
 
 ## Network Policy
 
-OpenShell sandboxes have **default-deny egress**. Required endpoints by backend:
+OpenShell sandboxes have **default-deny egress**. The full OAB open-tier policy is maintained in [`openshell/policies/oab-open.yaml`](../openshell/policies/oab-open.yaml). Required endpoints by backend:
 
 | Backend | Endpoints |
 |---------|-----------|
 | All | `discord.com:443`, `gateway.discord.gg:443`, `cdn.discordapp.com:443` |
-| Native Agent (codex) | `chatgpt.com:443`, `auth0.openai.com:443` |
+| Native Agent (codex) | `chatgpt.com:443`, `api.openai.com:443`, `auth0.openai.com:443` |
 | Native Agent (anthropic) | `api.anthropic.com:443` |
+| Native Agent (gemini) | `generativelanguage.googleapis.com:443` |
 | GitHub access | `api.github.com:443`, `github.com:443` |
+| npm | `registry.npmjs.org:443` |
+| PyPI | `pypi.org:443`, `files.pythonhosted.org:443` |
 
 ## Reconnecting
 

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -95,10 +95,19 @@ openshell sandbox create --name oab \
 Apply the OAB open-tier policy (Discord + LLM providers + GitHub + package registries):
 
 ```bash
+# If you haven't cloned the repo, download the policy file first:
+curl -LO https://raw.githubusercontent.com/openabdev/openab/main/openshell/policies/oab-open.yaml
+
+openshell policy set --policy oab-open.yaml oab
+```
+
+Or, from a cloned repo:
+
+```bash
 openshell policy set --policy openshell/policies/oab-open.yaml oab
 ```
 
-Or, for a minimal policy with only Discord + one LLM backend:
+For a minimal policy with only Discord + one LLM backend:
 
 ```bash
 openshell policy update oab \

--- a/openshell/policies/oab-open.yaml
+++ b/openshell/policies/oab-open.yaml
@@ -1,0 +1,118 @@
+# OAB Open Tier — Network policy for OpenAB running inside OpenShell.
+# Allows all endpoints OAB needs: Discord, LLM providers, GitHub, package
+# registries, and web search. Apply with:
+#   openshell policy set --policy openshell/policies/oab-open.yaml oab
+version: 1
+
+network_policies:
+  # ── Discord ────────────────────────────────────────────────────────────
+  discord:
+    name: discord
+    endpoints:
+      - host: discord.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+      - host: gateway.discord.gg
+        port: 443
+        protocol: websocket
+        enforcement: enforce
+      - host: cdn.discordapp.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+      - allow: { method: PUT, path: "/**" }
+      - allow: { method: PATCH, path: "/**" }
+      - allow: { method: DELETE, path: "/**" }
+
+  # ── OpenAI / ChatGPT ──────────────────────────────────────────────────
+  openai:
+    name: openai
+    endpoints:
+      - host: api.openai.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+      - host: chatgpt.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+      - host: auth0.openai.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+
+  # ── Anthropic ──────────────────────────────────────────────────────────
+  anthropic:
+    name: anthropic
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+
+  # ── Google AI (Gemini) ─────────────────────────────────────────────────
+  google:
+    name: google
+    endpoints:
+      - host: generativelanguage.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+
+  # ── GitHub ─────────────────────────────────────────────────────────────
+  github:
+    name: github
+    endpoints:
+      - host: github.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+      - host: api.github.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+      - allow: { method: PUT, path: "/**" }
+      - allow: { method: PATCH, path: "/**" }
+      - allow: { method: DELETE, path: "/**" }
+
+  # ── npm registry ───────────────────────────────────────────────────────
+  npm:
+    name: npm
+    endpoints:
+      - host: registry.npmjs.org
+        port: 443
+        protocol: rest
+        enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+
+  # ── PyPI ───────────────────────────────────────────────────────────────
+  pypi:
+    name: pypi
+    endpoints:
+      - host: pypi.org
+        port: 443
+        protocol: rest
+        enforcement: enforce
+      - host: files.pythonhosted.org
+        port: 443
+        protocol: rest
+        enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }

--- a/openshell/policies/oab-open.yaml
+++ b/openshell/policies/oab-open.yaml
@@ -21,6 +21,10 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
+      - host: media.discordapp.net
+        port: 443
+        protocol: rest
+        enforcement: enforce
     rules:
       - allow: { method: GET, path: "/**" }
       - allow: { method: POST, path: "/**" }
@@ -72,6 +76,10 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
+      - host: downloads.claude.ai
+        port: 443
+        protocol: rest
+        enforcement: enforce
     rules:
       - allow: { method: GET, path: "/**" }
       - allow: { method: POST, path: "/**" }
@@ -85,6 +93,38 @@ network_policies:
     name: google
     endpoints:
       - host: generativelanguage.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
+
+  # ── xAI (Grok) ────────────────────────────────────────────────────────
+  xai:
+    name: xai
+    endpoints:
+      - host: api.x.ai
+        port: 443
+        protocol: rest
+        enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
+
+  # ── Groq ───────────────────────────────────────────────────────────────
+  groq:
+    name: groq
+    endpoints:
+      - host: api.groq.com
         port: 443
         protocol: rest
         enforcement: enforce

--- a/openshell/policies/oab-open.yaml
+++ b/openshell/policies/oab-open.yaml
@@ -27,6 +27,10 @@ network_policies:
       - allow: { method: PUT, path: "/**" }
       - allow: { method: PATCH, path: "/**" }
       - allow: { method: DELETE, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
 
   # ── OpenAI / ChatGPT ──────────────────────────────────────────────────
   openai:
@@ -47,6 +51,10 @@ network_policies:
     rules:
       - allow: { method: GET, path: "/**" }
       - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
 
   # ── Anthropic ──────────────────────────────────────────────────────────
   anthropic:
@@ -56,9 +64,21 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
+      - host: claude.ai
+        port: 443
+        protocol: rest
+        enforcement: enforce
+      - host: console.anthropic.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
     rules:
       - allow: { method: GET, path: "/**" }
       - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
 
   # ── Google AI (Gemini) ─────────────────────────────────────────────────
   google:
@@ -71,6 +91,10 @@ network_policies:
     rules:
       - allow: { method: GET, path: "/**" }
       - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
 
   # ── GitHub ─────────────────────────────────────────────────────────────
   github:
@@ -90,6 +114,12 @@ network_policies:
       - allow: { method: PUT, path: "/**" }
       - allow: { method: PATCH, path: "/**" }
       - allow: { method: DELETE, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
+      - { path: /usr/bin/git }
+      - { path: /usr/local/bin/gh }
 
   # ── npm registry ───────────────────────────────────────────────────────
   npm:
@@ -101,6 +131,11 @@ network_policies:
         enforcement: enforce
     rules:
       - allow: { method: GET, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openab-agent }
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
+      - { path: /usr/local/bin/npm }
 
   # ── PyPI ───────────────────────────────────────────────────────────────
   pypi:
@@ -116,3 +151,7 @@ network_policies:
         enforcement: enforce
     rules:
       - allow: { method: GET, path: "/**" }
+    binaries:
+      - { path: /usr/bin/python3 }
+      - { path: /usr/local/bin/pip }
+      - { path: /usr/local/bin/pip3 }

--- a/openshell/policies/oab-open.yaml
+++ b/openshell/policies/oab-open.yaml
@@ -1,8 +1,31 @@
-# OAB Open Tier — Network policy for OpenAB running inside OpenShell.
-# Allows all endpoints OAB needs: Discord, LLM providers, GitHub, package
-# registries, and web search. Apply with:
+# OAB Open Tier — Full OpenShell policy for OpenAB sandbox.
+# Apply with:
 #   openshell policy set --policy openshell/policies/oab-open.yaml oab
+#
+# Note: openshell policy set replaces the entire policy, so this file
+# includes all required static sections (filesystem, process, landlock).
 version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /dev/urandom
+    - /etc
+  read_write:
+    - /tmp
+    - /dev/null
+    - /dev/pts
+    - /home/sandbox
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
 
 network_policies:
   # ── Discord ────────────────────────────────────────────────────────────
@@ -32,6 +55,7 @@ network_policies:
       - allow: { method: PATCH, path: "/**" }
       - allow: { method: DELETE, path: "/**" }
     binaries:
+      - { path: /usr/local/bin/openab }
       - { path: /usr/local/bin/openab-agent }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }
@@ -56,6 +80,7 @@ network_policies:
       - allow: { method: GET, path: "/**" }
       - allow: { method: POST, path: "/**" }
     binaries:
+      - { path: /usr/local/bin/openab }
       - { path: /usr/local/bin/openab-agent }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }
@@ -84,6 +109,7 @@ network_policies:
       - allow: { method: GET, path: "/**" }
       - allow: { method: POST, path: "/**" }
     binaries:
+      - { path: /usr/local/bin/openab }
       - { path: /usr/local/bin/openab-agent }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }
@@ -100,6 +126,7 @@ network_policies:
       - allow: { method: GET, path: "/**" }
       - allow: { method: POST, path: "/**" }
     binaries:
+      - { path: /usr/local/bin/openab }
       - { path: /usr/local/bin/openab-agent }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }
@@ -116,6 +143,7 @@ network_policies:
       - allow: { method: GET, path: "/**" }
       - allow: { method: POST, path: "/**" }
     binaries:
+      - { path: /usr/local/bin/openab }
       - { path: /usr/local/bin/openab-agent }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }
@@ -132,6 +160,7 @@ network_policies:
       - allow: { method: GET, path: "/**" }
       - allow: { method: POST, path: "/**" }
     binaries:
+      - { path: /usr/local/bin/openab }
       - { path: /usr/local/bin/openab-agent }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }
@@ -155,10 +184,12 @@ network_policies:
       - allow: { method: PATCH, path: "/**" }
       - allow: { method: DELETE, path: "/**" }
     binaries:
+      - { path: /usr/local/bin/openab }
       - { path: /usr/local/bin/openab-agent }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }
       - { path: /usr/bin/git }
+      - { path: /usr/bin/gh }
       - { path: /usr/local/bin/gh }
 
   # ── npm registry ───────────────────────────────────────────────────────
@@ -172,10 +203,10 @@ network_policies:
     rules:
       - allow: { method: GET, path: "/**" }
     binaries:
-      - { path: /usr/local/bin/openab-agent }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }
       - { path: /usr/local/bin/npm }
+      - { path: /usr/bin/npm }
 
   # ── PyPI ───────────────────────────────────────────────────────────────
   pypi:
@@ -193,5 +224,8 @@ network_policies:
       - allow: { method: GET, path: "/**" }
     binaries:
       - { path: /usr/bin/python3 }
+      - { path: /usr/local/bin/python3 }
       - { path: /usr/local/bin/pip }
       - { path: /usr/local/bin/pip3 }
+      - { path: /usr/bin/pip }
+      - { path: /usr/bin/pip3 }


### PR DESCRIPTION
## Summary

Add a maintained OAB-specific open-tier network policy for OpenShell sandboxes.

### Changes

- **New file:** `openshell/policies/oab-open.yaml` — declares all endpoints OAB needs (Discord, OpenAI, Anthropic, Google Gemini, GitHub, npm, PyPI)
- **Updated:** `docs/openshell.md` — step 3 now uses `openshell policy set` with the policy file; expanded the Network Policy table with all backends

### Usage

```bash
openshell policy set --policy openshell/policies/oab-open.yaml oab
```

### Why

Instead of relying on NemoClaw's built-in open tier or manually adding endpoints one-by-one, OAB maintains its own policy file that covers exactly what we need. Easy to extend when new backends or integrations are added.
<!-- trigger -->