### PR TITLE
fix(slack): reconnect on silent (half-open) Socket Mode disconnect via read idle timeout

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -697,7 +697,22 @@ pub async fn run_slack_adapter(
 
                 loop {
                     tokio::select! {
-                        msg_result = read.next() => {
+                        msg_result = tokio::time::timeout(
+                            std::time::Duration::from_secs(60),
+                            read.next(),
+                        ) => {
+                            // Half-open detection: Slack sends a ping ~every 30s, so 60s with no
+                            // frame means the socket is silently dead (e.g. a NAT/firewall dropped
+                            // the idle TCP connection without a Close frame or RST). Break so the
+                            // outer reconnect loop runs; otherwise read.next() blocks forever here
+                            // and the bot silently stops receiving events.
+                            let msg_result = match msg_result {
+                                Ok(inner) => inner,
+                                Err(_elapsed) => {
+                                    warn!("no frame from Slack for 60s; assuming dead connection, reconnecting");
+                                    break;
+                                }
+                            };
                             let Some(msg_result) = msg_result else { break };
                             match msg_result {
                                 Ok(tungstenite::Message::Text(text)) => {

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -57,9 +57,10 @@ const PARTICIPATION_CACHE_MAX: usize = 1000;
 /// aborted turns that begin a stream but never reach stream_finish).
 const STREAM_CACHE_MAX: usize = 1024;
 
-/// Reconnect the Slack Socket Mode socket if no frame arrives within this
-/// window. Slack server-pings ~every 30s, so 60s of silence means the
-/// connection is half-open (dead) — detects silent NAT/firewall drops.
+/// Reconnect the Slack Socket Mode socket if no frame (ping, ack, or event)
+/// arrives within this window. A healthy Socket Mode connection is never silent
+/// this long, so 60s of silence means the connection is half-open (dead) —
+/// detects silent NAT/firewall drops.
 const SLACK_READ_IDLE_TIMEOUT_SECS: u64 = 60;
 
 #[derive(Default)]
@@ -702,21 +703,22 @@ pub async fn run_slack_adapter(
 
                 loop {
                     tokio::select! {
-                        msg_result = tokio::time::timeout(
+                        timeout_result = tokio::time::timeout(
                             std::time::Duration::from_secs(SLACK_READ_IDLE_TIMEOUT_SECS),
                             read.next(),
                         ) => {
-                            // Half-open detection: Slack sends a ping ~every 30s, so 60s with no
-                            // frame means the socket is silently dead (e.g. a NAT/firewall dropped
-                            // the idle TCP connection without a Close frame or RST). Break so the
-                            // outer reconnect loop runs; otherwise read.next() blocks forever here
-                            // and the bot silently stops receiving events.
-                            let msg_result = match msg_result {
-                                Ok(inner) => inner,
+                            // Half-open detection: any inbound frame (ping, ack, event, close)
+                            // resets this timer, so a healthy connection is never frame-silent
+                            // this long. 60s of silence is treated as a dead/half-open socket
+                            // (e.g. a NAT/firewall dropped the idle TCP connection without a Close
+                            // frame or RST), which can otherwise block read.next() indefinitely and
+                            // silently stop the bot from receiving events. Break so the outer
+                            // reconnect loop runs.
+                            let msg_result = match timeout_result {
+                                Ok(Some(msg)) => msg,
+                                Ok(None) => break,
                                 Err(_) => {
-                                    warn!(
-                                        timeout_secs = SLACK_READ_IDLE_TIMEOUT_SECS,
-                                        "no frame from Slack within idle timeout; assuming dead connection, reconnecting");
+                                    warn!("no frame from Slack within idle timeout; assuming dead connection, reconnecting");
                                     break;
                                 }
                             };
@@ -732,9 +734,13 @@ pub async fn run_slack_adapter(
                                     // Acknowledge the envelope immediately
                                     if let Some(envelope_id) = envelope["envelope_id"].as_str() {
                                         let ack = serde_json::json!({"envelope_id": envelope_id});
-                                        let _ = write
+                                        if let Err(e) = write
                                             .send(tungstenite::Message::Text(ack.to_string()))
-                                            .await;
+                                            .await
+                                        {
+                                            warn!(error = %e, "failed to ack Slack envelope; connection likely dead, reconnecting");
+                                            break;
+                                        }
                                     }
 
                                     // Slash commands and interactive block_actions aren't
@@ -1045,7 +1051,10 @@ pub async fn run_slack_adapter(
                                     }
                                 }
                                 Ok(tungstenite::Message::Ping(data)) => {
-                                    let _ = write.send(tungstenite::Message::Pong(data)).await;
+                                    if let Err(e) = write.send(tungstenite::Message::Pong(data)).await {
+                                        warn!(error = %e, "failed to send pong; connection likely dead, reconnecting");
+                                        break;
+                                    }
                                 }
                                 Ok(tungstenite::Message::Close(_)) => {
                                     warn!("Slack Socket Mode connection closed by server");

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -57,6 +57,11 @@ const PARTICIPATION_CACHE_MAX: usize = 1000;
 /// aborted turns that begin a stream but never reach stream_finish).
 const STREAM_CACHE_MAX: usize = 1024;
 
+/// Reconnect the Slack Socket Mode socket if no frame arrives within this
+/// window. Slack server-pings ~every 30s, so 60s of silence means the
+/// connection is half-open (dead) — detects silent NAT/firewall drops.
+const SLACK_READ_IDLE_TIMEOUT_SECS: u64 = 60;
+
 #[derive(Default)]
 struct StreamEntry {
     active: bool,
@@ -698,7 +703,7 @@ pub async fn run_slack_adapter(
                 loop {
                     tokio::select! {
                         msg_result = tokio::time::timeout(
-                            std::time::Duration::from_secs(60),
+                        std::time::Duration::from_secs(SLACK_READ_IDLE_TIMEOUT_SECS),
                             read.next(),
                         ) => {
                             // Half-open detection: Slack sends a ping ~every 30s, so 60s with no
@@ -708,7 +713,7 @@ pub async fn run_slack_adapter(
                             // and the bot silently stops receiving events.
                             let msg_result = match msg_result {
                                 Ok(inner) => inner,
-                                Err(_elapsed) => {
+                                Err(_) => {
                                     warn!("no frame from Slack for 60s; assuming dead connection, reconnecting");
                                     break;
                                 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -703,7 +703,7 @@ pub async fn run_slack_adapter(
                 loop {
                     tokio::select! {
                         msg_result = tokio::time::timeout(
-                        std::time::Duration::from_secs(SLACK_READ_IDLE_TIMEOUT_SECS),
+                            std::time::Duration::from_secs(SLACK_READ_IDLE_TIMEOUT_SECS),
                             read.next(),
                         ) => {
                             // Half-open detection: Slack sends a ping ~every 30s, so 60s with no
@@ -714,7 +714,9 @@ pub async fn run_slack_adapter(
                             let msg_result = match msg_result {
                                 Ok(inner) => inner,
                                 Err(_) => {
-                                    warn!("no frame from Slack for 60s; assuming dead connection, reconnecting");
+                                    warn!(
+                                        timeout_secs = SLACK_READ_IDLE_TIMEOUT_SECS,
+                                        "no frame from Slack within idle timeout; assuming dead connection, reconnecting");
                                     break;
                                 }
                             };

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -722,7 +722,6 @@ pub async fn run_slack_adapter(
                                     break;
                                 }
                             };
-                            let Some(msg_result) = msg_result else { break };
                             match msg_result {
                                 Ok(tungstenite::Message::Text(text)) => {
                                     let envelope: serde_json::Value =


### PR DESCRIPTION
Implement timeout for Slack WebSocket read to detect half-open connections.

## What problem does this solve?

The Slack Socket Mode read loop in `src/slack.rs` awaits `read.next()` inside `tokio::select!` with **no timeout**. On a half-open connection — a NAT/firewall silently drops the idle TCP socket without sending a Close frame or TCP RST — `read.next()` blocks forever. The existing reconnect loop is therefore never reached, and the bot silently stops receiving events while the pod stays `Running` (last log line: `Slack Socket Mode connected`). Only a manual restart recovers it.

Closes #1050

Discord Discussion URL:https://discord.com/channels/1491295327620169908/1491969620754567270/1514113993063792660

## At a Glance

```
 Slack server ──ping ~every 30s──▶ ┌──────────────────────────────┐
                                   │ slack.rs Socket Mode loop    │
 (before)                          │   tokio::select! {           │
 NAT/firewall silently drops the   │     read.next()  ⚠ NO TIMEOUT│
 idle TCP socket (no Close, no RST)│   }                          │
            │                      └──────────────────────────────┘
            ▼                                    │ read.next() never returns
     no frames ever arrive  ───────────▶  reconnect loop (already exists) UNREACHABLE
                                                 │
                                                 ▼   bot silently goes dark

 (after)  tokio::select! { timeout(60s, read.next()) }
          └─ 60s with no frame ⇒ Elapsed ⇒ break ⇒ existing reconnect loop runs
```

## Prior Art & Industry Research

**OpenClaw:** Uses the official Slack SDK with `autoReconnect` enabled **plus** an application-level health monitor that detects stale sockets and restarts with bounded backoff (~2s→30s, capped attempts). It exposes `clientPingTimeout` (default 15000ms) / `serverPingTimeout` and fails fast on non-recoverable auth errors. The exact class of bug — and their stale-socket health-monitor mitigation — is tracked in [openclaw/openclaw#61072](https://github.com/openclaw/openclaw/issues/61072). Docs: [OpenClaw Slack channel](https://docs.openclaw.ai/channels/slack).

**Hermes Agent:** Not applicable — Hermes is an ACP coding backend, not a chat transport. Slack connection handling lives entirely in OpenAB's shared `src/slack.rs`, independent of which agent is running.

**Other references:** The official Slack SDKs implement a proactive ping/pong heartbeat to detect dead connections: the client expects a pong within `clientPingTimeout` (default 5000ms) and a server ping within `serverPingTimeout` (default 30000ms); on timeout it reconnects when auto-reconnect is enabled (the Python SDK flags a stale connection when idle exceeds `ping_interval × 4`). See [Node SDK `SocketModeOptions`](https://tools.slack.dev/node-slack-sdk/reference/socket-mode/interfaces/SocketModeOptions/) and [python-slack-sdk Socket Mode](https://docs.slack.dev/tools/python-slack-sdk/socket-mode/). OpenAB's adapter is a custom `tokio-tungstenite` client with **no** such heartbeat, hence this gap.

## Proposed Solution

Wrap the inbound read in a 60-second idle timeout inside the existing `tokio::select!`:

```rust
msg_result = tokio::time::timeout(std::time::Duration::from_secs(60), read.next()) => {
    let msg_result = match msg_result {
        Ok(inner) => inner,
        Err(_elapsed) => {
            warn!("no frame from Slack for 60s; assuming dead connection, reconnecting");
            break;
        }
    };
    let Some(msg_result) = msg_result else { break };
    // ... existing match on msg_result unchanged ...
}
```

Slack's server sends a ping roughly every 30s, so 60s with no frame at all is a reliable dead-connection signal. On timeout we `break`, which lets the **already-existing** reconnect loop run.

## Why this approach?

OpenAB's Slack adapter is a hand-rolled `tokio-tungstenite` client with no SDK-level heartbeat, and it *already* has a reconnect loop — the only defect is that the loop is unreachable while `read.next()` blocks forever. A read/idle timeout is the **smallest, most localized** fix that closes the gap and reuses existing recovery, with no new tasks, channels, or config. Tradeoff: up to ~60s detection latency (acceptable; easily tunable). Known limitation: it relies on Slack's server pings (~30s) as the liveness signal rather than sending client-side pings; if a future need arises, a full client ping/pong (SDK-style) can be layered on top.

## Alternatives Considered

- **Client-side ping + pong-timeout (Slack-SDK style):** most robust, but more code and unnecessary here since the server already pings ~every 30s. Deferred.
- **Outer retry loop like the Discord adapter (#791, #919):** doesn't apply — Slack already has a reconnect loop; the bug is reachability, which the timeout solves directly.
- **TCP keepalive (SO_KEEPALIVE):** OS-level, not exposed in the current socket setup and less portable; doesn't cover application-layer staleness.
- **Dedicated stale-socket health-monitor task (OpenClaw-style):** heavier; overkill for this single-connection adapter.

## Validation

- [x] Manual testing — Reproduced in production (self-hosted k3s behind NAT): the bot went dark every few hours with `Slack Socket Mode connected` as the last log line and no further events; a manual `kubectl rollout restart` always recovered it. With the idle timeout in place, the `Elapsed` branch fires and the existing reconnect path runs.
- [ ] `cargo check` — not run locally (no Rust toolchain on the reporter's machine); change is minimal and self-contained. Please verify via CI.
- [ ] `cargo test`
- [ ] `cargo clippy`