### PR TITLE
fix(slack): dedupe native-stream finalize + render final as Block Kit markdown

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -140,6 +140,11 @@ tables = "code"  # "code" (default) | "bullets" | "off"
                  # code: wrap tables in fenced code blocks with aligned columns
                  # bullets: convert each row into bullet points (• Header: Value)
                  # off: pass through unchanged
+                 # NOTE: ignored on Slack — Slack messages are sent as Block Kit
+                 # `markdown` blocks (and `markdown_text` stream chunks), which
+                 # render Markdown tables (and headings, lists, code fences)
+                 # natively. This setting applies to platforms that cannot render
+                 # tables (Discord and gateway integrations).
 
 [reactions]
 enabled = true

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -208,7 +208,9 @@ pub trait ChatAdapter: Send + Sync + 'static {
     /// Platform name for logging and session key namespacing.
     fn platform(&self) -> &'static str;
 
-    /// Maximum message length for this platform (e.g. 2000 for Discord, 4000 for Slack).
+    /// Maximum message length (chars) for this platform; the router splits longer
+    /// replies into multiple messages at this bound. Platform-specific (e.g. 2000
+    /// for Discord; Slack uses its Block Kit `markdown` block cap).
     fn message_limit(&self) -> usize;
 
     /// Send a new message, returns a reference to the sent message.
@@ -302,6 +304,16 @@ pub trait ChatAdapter: Send + Sync + 'static {
     /// Empty string clears it. Default: no-op (platforms without a status API).
     async fn set_status(&self, _channel: &ChannelRef, _status: &str) -> Result<()> {
         Ok(())
+    }
+
+    /// Whether this platform renders Markdown tables natively. When `true`, the
+    /// router skips the `convert_tables` pre-pass (which rewrites tables into
+    /// code blocks / bullet lists for platforms that cannot render them) and
+    /// lets the platform render the raw Markdown table itself.
+    /// Default: `false` (keep converting). Overridden by Slack (Block Kit
+    /// `markdown` blocks / `markdown_text` stream chunks render tables natively).
+    fn renders_native_tables(&self) -> bool {
+        false
     }
 
     /// Whether this adapter should use streaming edit (true) or send-once (false).
@@ -546,7 +558,14 @@ impl AdapterRouter {
         let streaming = adapter.use_streaming(other_bot_present);
         let native = adapter.uses_native_streaming(other_bot_present);
         let assistant_status = adapter.uses_assistant_status();
-        let table_mode = self.table_mode;
+        // Platforms that render Markdown tables natively (e.g. Slack Block Kit
+        // `markdown` blocks / `markdown_text` stream chunks) skip the
+        // table→code/bullets pre-pass so the raw table renders natively.
+        let table_mode = if adapter.renders_native_tables() {
+            TableMode::Off
+        } else {
+            self.table_mode
+        };
         let tool_display = self.reactions_config.tool_display;
         let prompt_hard_timeout = self.prompt_hard_timeout;
         let liveness_check_interval = self.liveness_check_interval;
@@ -1107,6 +1126,9 @@ mod tests {
         let adapter = TestAdapter;
         // Verify the method is callable and returns the declared value
         assert!(!adapter.use_streaming(false));
+        // renders_native_tables defaults to false: platforms that don't override
+        // it keep the table→code/bullets conversion (e.g. Discord, Gateway).
+        assert!(!adapter.renders_native_tables());
     }
 
     #[test]

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -416,19 +416,30 @@ impl ChatAdapter for SlackAdapter {
     }
 
     fn message_limit(&self) -> usize {
-        4000
+        // Match the Block Kit `markdown` block cap (12k) minus headroom. Messages
+        // are sent as markdown blocks, so the old 4000 mrkdwn-era limit would
+        // split long replies (and Markdown tables) across messages needlessly —
+        // a mid-table split renders as raw pipes. 11_900 keeps typical tables in
+        // one block and cuts message-spam on long replies.
+        MARKDOWN_BLOCK_LIMIT
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
-        let mrkdwn = markdown_to_mrkdwn(content);
-        let mut body = serde_json::json!({
-            "channel": channel.channel_id,
-            "text": mrkdwn,
-        });
-        if let Some(thread_ts) = &channel.thread_id {
-            body["thread_ts"] = serde_json::Value::String(thread_ts.clone());
-        }
-        let resp = self.api_post("chat.postMessage", body).await?;
+        let thread_ts = channel.thread_id.as_deref();
+        let body = build_post_message_body(&channel.channel_id, thread_ts, content);
+        let resp = match self.api_post("chat.postMessage", body).await {
+            Ok(r) => r,
+            // Graceful degradation: if the `blocks` payload is rejected (workspace
+            // lacks the markdown block, or content exceeds the cumulative block
+            // cap), retry text-only so the message still lands (mrkdwn fallback)
+            // instead of failing outright.
+            Err(e) if is_block_payload_rejected(&e) => {
+                warn!(error = %e, "markdown block rejected; retrying chat.postMessage text-only");
+                let fallback = build_post_message_text_only(&channel.channel_id, thread_ts, content);
+                self.api_post("chat.postMessage", fallback).await?
+            }
+            Err(e) => return Err(e),
+        };
         let ts = resp["ts"]
             .as_str()
             .ok_or_else(|| anyhow!("no ts in chat.postMessage response"))?;
@@ -499,21 +510,27 @@ impl ChatAdapter for SlackAdapter {
     }
 
     async fn edit_message(&self, msg: &MessageRef, content: &str) -> Result<()> {
-        let mrkdwn = markdown_to_mrkdwn(content);
-        self.api_post(
-            "chat.update",
-            serde_json::json!({
-                "channel": msg.channel.channel_id,
-                "ts": msg.message_id,
-                "text": mrkdwn,
-            }),
-        )
-        .await?;
-        Ok(())
+        let body = build_update_body(&msg.channel.channel_id, &msg.message_id, content);
+        match self.api_post("chat.update", body).await {
+            Ok(_) => Ok(()),
+            // See send_message: degrade to text-only if the blocks payload is rejected.
+            Err(e) if is_block_payload_rejected(&e) => {
+                warn!(error = %e, "markdown block rejected; retrying chat.update text-only");
+                let fallback =
+                    build_update_text_only(&msg.channel.channel_id, &msg.message_id, content);
+                self.api_post("chat.update", fallback).await?;
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
     }
 
     fn use_streaming(&self, other_bot_present: bool) -> bool {
         !other_bot_present
+    }
+
+    fn renders_native_tables(&self) -> bool {
+        true
     }
 
     fn uses_assistant_status(&self) -> bool {
@@ -608,25 +625,30 @@ impl ChatAdapter for SlackAdapter {
             map.get(ts).map(|e| e.active).unwrap_or(false)
         };
         if active {
-            // Finalize content atomically via stopStream's markdown_text parameter
-            // instead of a separate chat.update — avoids a race window and extra API call.
-            let body = serde_json::json!({
-                "channel": msg.channel.channel_id,
-                "ts": ts,
-                "markdown_text": final_content,
-            });
-            if let Err(e) = self.api_post("chat.stopStream", body).await {
-                error!(error = %e, "chat.stopStream failed; falling back to chat.update");
-                if let Err(e2) = self.edit_message(msg, final_content).await {
-                    warn!(error = %e2, "fallback chat.update also failed; trying postMessage");
-                    if let Err(e3) = self.send_message(&msg.channel, final_content).await {
-                        error!(error = %e3, "final postMessage also failed; reply may be incomplete");
-                    }
-                }
+            // Close the native stream WITHOUT re-sending content. The reply was
+            // already streamed live via chat.appendStream; stopStream's
+            // `markdown_text` *appends* (it does not replace), so passing the full
+            // content here duplicates the whole reply (#1055). Close only, then
+            // replace with the finalized content via chat.update below.
+            let close = serde_json::json!({ "channel": msg.channel.channel_id, "ts": ts });
+            if let Err(e) = self.api_post("chat.stopStream", close).await {
+                warn!(error = %e, "chat.stopStream(close) failed; continuing to final replace");
             }
-        } else {
-            // Degraded path — already using post+edit, just do the final update.
-            if let Err(e) = self.edit_message(msg, final_content).await {
+        }
+        // Replace with the finalized content (Block Kit markdown). For the active
+        // path this overwrites the streamed preview with a single clean copy
+        // (rich rendering + native tables); for the degraded path it is the final
+        // post+edit update. chat.update replaces, so there is no duplication.
+        if let Err(e) = self.edit_message(msg, final_content).await {
+            if active {
+                // The native stream already delivered the reply (chat.appendStream),
+                // and stopStream left it in place. Do NOT postMessage a fallback
+                // here — that would post a duplicate copy. Keep the streamed
+                // content as the final message.
+                warn!(error = %e, "final chat.update failed; keeping streamed content (no duplicate post)");
+            } else {
+                // Degraded path: no streamed content exists (post+edit placeholder),
+                // so post the final as a new message to avoid losing the reply.
                 warn!(error = %e, "final chat.update failed; trying postMessage");
                 if let Err(e2) = self.send_message(&msg.channel, final_content).await {
                     error!(error = %e2, "final postMessage also failed; reply may be incomplete");
@@ -1551,7 +1573,113 @@ fn is_plain_user_message(subtype: &str, text: &str) -> bool {
     )
 }
 
+/// Slack caps a single Block Kit `markdown` block at 12,000 characters; we use
+/// 11,900 to keep ~100 chars of headroom. Doubles as the Slack `message_limit`
+/// so the router splits long replies into separate messages at the same bound
+/// (one markdown block per message stays under the API cap).
+const MARKDOWN_BLOCK_LIMIT: usize = 11_900;
+
+/// True if a Slack API error indicates the `blocks` payload was rejected, so the
+/// caller should retry text-only:
+/// - `invalid_blocks` — workspace can't render the Block Kit `markdown` block
+///   (malformed/unsupported payload).
+/// - `msg_blocks_too_long` — content exceeds Slack's cumulative ~12k cap across
+///   all `markdown` blocks in one message. Reachable by direct `send_message`
+///   callers that bypass the router's `message_limit` pre-split (e.g. STT echo).
+///
+/// `invalid_arguments` is deliberately excluded — it's a Slack catch-all (bad
+/// channel, missing/invalid `ts`, malformed `thread_ts`, …) and would trigger a
+/// pointless text-only retry that fails identically.
+///
+/// Matches the Slack error *code* exactly (the trailing token of `api_post`'s
+/// `"Slack API <method>: <code>"` message), not a substring of the message —
+/// so a future code like `invalid_blocks_field` does not falsely match.
+fn is_block_payload_rejected(e: &anyhow::Error) -> bool {
+    let s = e.to_string();
+    let code = s.rsplit(": ").next().unwrap_or(s.as_str()).trim();
+    code == "invalid_blocks" || code == "msg_blocks_too_long"
+}
+
+/// Build Block Kit `markdown` blocks from raw Markdown. Slack renders these
+/// natively — real headings, lists, tables, blockquotes, and language-tagged
+/// code fences — unlike the legacy `text` mrkdwn field, which flattens headings
+/// to bold and cannot render tables. Long content is split at the block limit,
+/// reusing `format::split_message` so code-fence balance is preserved.
+///
+/// Follow-up (non-blocking): `split_message` is not table-aware — a single
+/// Markdown table exceeding `MARKDOWN_BLOCK_LIMIT` (11,900 chars) splits at line
+/// boundaries, so continuation blocks lack the header/separator rows and render
+/// as raw pipes. The 4000→11,900 bump makes this rare; a future improvement is
+/// to re-emit the table header at the top of each continuation chunk.
+fn build_markdown_blocks(content: &str) -> Vec<serde_json::Value> {
+    let chunks = if content.len() <= MARKDOWN_BLOCK_LIMIT {
+        vec![content.to_string()]
+    } else {
+        crate::format::split_message(content, MARKDOWN_BLOCK_LIMIT)
+    };
+    chunks
+        .into_iter()
+        .map(|chunk| serde_json::json!({ "type": "markdown", "text": chunk }))
+        .collect()
+}
+
+/// Body for `chat.postMessage`: Block Kit `markdown` blocks (rich rendering)
+/// plus a `text` fallback used for notifications and accessibility.
+fn build_post_message_body(
+    channel_id: &str,
+    thread_ts: Option<&str>,
+    content: &str,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "channel": channel_id,
+        "blocks": build_markdown_blocks(content),
+        "text": markdown_to_mrkdwn(content),
+    });
+    if let Some(ts) = thread_ts {
+        body["thread_ts"] = serde_json::Value::String(ts.to_string());
+    }
+    body
+}
+
+/// Body for `chat.update`: same Block Kit `markdown` blocks + `text` fallback.
+fn build_update_body(channel_id: &str, ts: &str, content: &str) -> serde_json::Value {
+    serde_json::json!({
+        "channel": channel_id,
+        "ts": ts,
+        "blocks": build_markdown_blocks(content),
+        "text": markdown_to_mrkdwn(content),
+    })
+}
+
+/// Text-only `chat.postMessage` body (no `blocks`) — degradation path when a
+/// workspace rejects the Block Kit `markdown` block.
+fn build_post_message_text_only(
+    channel_id: &str,
+    thread_ts: Option<&str>,
+    content: &str,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "channel": channel_id,
+        "text": markdown_to_mrkdwn(content),
+    });
+    if let Some(ts) = thread_ts {
+        body["thread_ts"] = serde_json::Value::String(ts.to_string());
+    }
+    body
+}
+
+/// Text-only `chat.update` body (no `blocks`) — see `build_post_message_text_only`.
+fn build_update_text_only(channel_id: &str, ts: &str, content: &str) -> serde_json::Value {
+    serde_json::json!({
+        "channel": channel_id,
+        "ts": ts,
+        "text": markdown_to_mrkdwn(content),
+    })
+}
+
 /// Convert Markdown (as output by Claude Code) to Slack mrkdwn format.
+/// Used for the `text` fallback field that accompanies Block Kit blocks
+/// (shown in notification previews and to assistive tech).
 fn markdown_to_mrkdwn(text: &str) -> String {
     static BOLD_RE: LazyLock<regex::Regex> =
         LazyLock::new(|| regex::Regex::new(r"\*\*(.+?)\*\*").unwrap());
@@ -1969,5 +2097,122 @@ mod tests {
         assert!(!adapter2.uses_assistant_status());
         assert!(adapter2.use_streaming(false), "post+edit streaming independent of assistant_mode");
         assert!(!adapter2.uses_native_streaming(false), "native streaming requires assistant_mode");
+    }
+
+    /// chat.postMessage body carries Block Kit `markdown` blocks with the raw
+    /// Markdown preserved (NOT downgraded), plus a `text` fallback and thread_ts.
+    #[test]
+    fn post_message_body_uses_raw_markdown_blocks() {
+        let b = build_post_message_body("C1", Some("1700.1"), "## Heading\n- item");
+        assert_eq!(b["channel"], "C1");
+        assert_eq!(b["thread_ts"], "1700.1");
+        assert_eq!(b["blocks"][0]["type"], "markdown");
+        // Raw markdown preserved — heading is NOT flattened to `*Heading*`.
+        assert_eq!(b["blocks"][0]["text"], "## Heading\n- item");
+        assert!(b["text"].is_string(), "text fallback present for a11y/notifs");
+    }
+
+    /// thread_ts is omitted (top-level post) when the channel has no thread.
+    #[test]
+    fn post_message_body_omits_thread_ts_when_none() {
+        let b = build_post_message_body("C1", None, "hi");
+        assert!(b.get("thread_ts").is_none());
+    }
+
+    /// chat.update body also uses Block Kit `markdown` blocks with raw markdown.
+    #[test]
+    fn update_body_uses_raw_markdown_blocks() {
+        let b = build_update_body("C1", "1700.9", "**bold**");
+        assert_eq!(b["channel"], "C1");
+        assert_eq!(b["ts"], "1700.9");
+        assert_eq!(b["blocks"][0]["type"], "markdown");
+        assert_eq!(b["blocks"][0]["text"], "**bold**");
+    }
+
+    /// Content over the per-block cap (11,900) splits into multiple markdown
+    /// blocks, each within the limit. Assert on char count — `split_message`
+    /// enforces `chars().count() <= limit`, not byte length.
+    #[test]
+    fn long_content_splits_into_multiple_markdown_blocks() {
+        let big = "lorem ipsum dolor\n".repeat(1000); // > MARKDOWN_BLOCK_LIMIT
+        assert!(big.chars().count() > MARKDOWN_BLOCK_LIMIT);
+        let blocks = build_markdown_blocks(&big);
+        assert!(blocks.len() >= 2, "should split into multiple blocks");
+        for blk in &blocks {
+            assert_eq!(blk["type"], "markdown");
+            assert!(blk["text"].as_str().unwrap().chars().count() <= MARKDOWN_BLOCK_LIMIT);
+        }
+    }
+
+    /// Regression for the long-table split: a Markdown table that overflows the
+    /// old 4000 limit but fits the new 11,900 message_limit must stay in a single
+    /// chunk, so it isn't split mid-table into raw pipe text.
+    #[test]
+    fn typical_long_table_stays_in_one_chunk() {
+        let ttl = std::time::Duration::from_secs(300);
+        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, true);
+        let limit = adapter.message_limit();
+        assert_eq!(limit, MARKDOWN_BLOCK_LIMIT);
+        let mut table = String::from("| col a | col b | col c |\n|---|---|---|\n");
+        for i in 0..150 {
+            table.push_str(&format!("| row {i} aaaa | bbbb {i} | cccc {i} |\n"));
+        }
+        assert!(table.chars().count() > 4000, "table must exceed old limit");
+        assert!(table.chars().count() < limit, "but fit the new one");
+        assert_eq!(
+            crate::format::split_message(&table, limit).len(),
+            1,
+            "table within message_limit must not be split mid-table"
+        );
+    }
+
+    /// Text-only fallback bodies carry `text` and no `blocks` — used when a
+    /// workspace rejects the Block Kit markdown block.
+    #[test]
+    fn text_only_fallback_bodies_have_no_blocks() {
+        let post = build_post_message_text_only("C1", Some("1700.1"), "## H\n- x");
+        assert!(post.get("blocks").is_none());
+        assert!(post["text"].is_string());
+        assert_eq!(post["thread_ts"], "1700.1");
+        let upd = build_update_text_only("C1", "1700.9", "**b**");
+        assert!(upd.get("blocks").is_none());
+        assert!(upd["text"].is_string());
+    }
+
+    /// Error classifier matches `invalid_blocks` (malformed/unsupported blocks)
+    /// and `msg_blocks_too_long` (over the cumulative block cap) → degrade to
+    /// text. `invalid_arguments` is a Slack catch-all and must NOT trigger a
+    /// pointless text-only retry; unrelated errors are ignored too.
+    #[test]
+    fn detects_block_payload_rejected_errors() {
+        assert!(is_block_payload_rejected(&anyhow!(
+            "Slack API chat.postMessage: invalid_blocks"
+        )));
+        assert!(
+            is_block_payload_rejected(&anyhow!("Slack API chat.postMessage: msg_blocks_too_long")),
+            "oversize block payload should degrade to text-only"
+        );
+        assert!(
+            !is_block_payload_rejected(&anyhow!("Slack API chat.update: invalid_arguments")),
+            "invalid_arguments is a catch-all, not a block-rejection signal"
+        );
+        assert!(!is_block_payload_rejected(&anyhow!(
+            "Slack API chat.postMessage: channel_not_found"
+        )));
+        // Exact error-code match, not substring: a future code that merely
+        // contains `invalid_blocks` must NOT trigger a text-only retry.
+        assert!(
+            !is_block_payload_rejected(&anyhow!("Slack API chat.postMessage: invalid_blocks_field")),
+            "must match the error code exactly, not as a substring"
+        );
+    }
+
+    /// Slack opts into native table rendering (Block Kit markdown / markdown_text
+    /// stream chunks), so the router skips the table→code-block conversion.
+    #[test]
+    fn slack_renders_native_tables() {
+        let ttl = std::time::Duration::from_secs(300);
+        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, true);
+        assert!(adapter.renders_native_tables());
     }
 }


### PR DESCRIPTION
## What problem does this solve?

In `assistant_mode` (default), a Slack bot **alone in a thread** posts its **entire reply twice** (concatenated) — e.g. `say hello world` → `Hello world!Hello world!`. The reply is streamed live via `chat.appendStream` (which **appends**), then `stream_finish` re-sends the **full** content via `chat.stopStream`'s `markdown_text` — which **also appends**, not replaces — so the whole reply lands a second time. It only manifests in single-bot threads; with another bot present the adapter falls back to the post+edit path, whose finalize uses `chat.update` (replace).

Separately, finalized replies were sent as legacy `text` mrkdwn, which flattens `#` headings to bold, strips code-fence language tags, and cannot render tables.

Closes #1055

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491969620754567270/1514088560364355667

## At a Glance

```
              Before (buggy)                        After (this PR)
  ┌──────────────────────────────┐       ┌──────────────────────────────┐
  │ stream:  appendStream (append)│       │ stream:  appendStream (append)│
  │ finish:  stopStream(markdown_ │       │ finish:  stopStream(close,    │
  │   text = FULL) → appends again│       │   no markdown_text)           │
  │   → reply posted TWICE        │       │   + chat.update(Block Kit)    │
  │                               │       │   → REPLACE: single copy      │
  │ render:  flat text mrkdwn     │       │ render:  native headings,     │
  │   (headings→bold, no tables)  │       │   lists, code fences, TABLES  │
  └──────────────────────────────┘       └──────────────────────────────┘
   (single-bot threads only; multi-bot already used post+edit)
```

## Proposed Solution

**Fix the duplication** — `stream_finish` no longer re-sends content at `stopStream`:

1. `chat.stopStream { channel, ts }` to **close** the stream only (no `markdown_text`). The reply was already delivered live via `appendStream`.
2. `chat.update` to **replace** the message with the finalized content (a single clean copy). The active and degraded paths are unified on this final replace; the `chat.update`→`postMessage` fallbacks are preserved.

**Render the final richly** — `send_message` / `edit_message` send Block Kit `markdown` blocks (raw Markdown) instead of legacy `text` mrkdwn, so Slack renders real headings, lists, blockquotes, language-tagged code fences, and **tables natively**. A `text` fallback is kept for notifications/accessibility, with a graceful **text-only retry** on `invalid_blocks` / `msg_blocks_too_long`.

- `message_limit` 4000 → **11,900** (`MARKDOWN_BLOCK_LIMIT`): fits the per-block 12k cap, keeps Markdown tables in one block (no mid-table split), and cuts message-spam on long replies. Long content still splits via `format::split_message` (code-fence safe).
- New `ChatAdapter::renders_native_tables()` (**default `false`**, Slack `true`): the router sets `table_mode = Off` for native-table adapters so the raw table reaches the Block Kit block. **Discord and gateway adapters are unchanged** (own send paths + default `false`).

## Validation

The finalize sequence was verified directly against the live Slack Web API:

- `chat.stopStream { channel, ts }` (no `markdown_text`) → `ok: true`, closes cleanly.
- `chat.update` with `blocks: [{ "type": "markdown", "text": … }]` on the just-stopped message → **replaces** the streamed content (single copy, no duplication).
- The Block Kit `markdown` block **renders Markdown tables natively** (plus headings/lists/code).

## Testing

- `cargo test --bin openab` — passing, incl. new unit tests: Block Kit body builders preserve raw Markdown; `thread_ts` handling; 11,900 char-count splitting; long table stays in one chunk; text-only fallback bodies; `is_block_payload_rejected` classifier (incl. `msg_blocks_too_long`, excl. `invalid_arguments`); `renders_native_tables` true on Slack / default false elsewhere.
- `cargo clippy --all-targets -- -D warnings` — clean for the changed files.

## Scope

Slack-only. `src/discord.rs` and `src/gateway.rs` keep their own send paths and the existing table conversion.