### PR TITLE
fix(gateway/telegram): replace reaction accumulation with single-emoji mode

### DIFF
--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -300,9 +300,9 @@ pub async fn handle_reply(
             let mut reactions = reaction_state.lock().await;
             let set = reactions.entry(msg_key.clone()).or_default();
             if is_add {
-                if !set.contains(&tg_emoji.to_string()) {
-                    set.push(tg_emoji.to_string());
-                }
+                // Telegram only supports one bot reaction per message — replace instead of accumulate
+                set.clear();
+                set.push(tg_emoji.to_string());
             } else {
                 set.retain(|e| e != tg_emoji);
             }


### PR DESCRIPTION
## Summary

Fix emoji status reactions never visually updating on Telegram. The bot always shows the first emoji (👀) and never transitions to subsequent states (🤔→🔥→👍).

## Root Cause

The `reaction_state` handler accumulates emoji into a Vec (designed for Discord's multi-reaction model). When `add_reaction` is called, new emoji are appended without removing previous ones, resulting in `setMessageReaction` sending arrays like `[👀, 🤔]`. Telegram bots can only have one reaction per message — the API silently keeps only the first element.

## Changes

- On `add_reaction`: call `set.clear()` before pushing the new emoji, ensuring exactly one reaction is sent per API call
- `remove_reaction` behavior unchanged

## Testing

- `cargo test` — 183 tests pass
- Manually verified: emoji now transitions 👀→🤔→🔥→👍 correctly on a live Telegram bot