### PR TITLE
fix(ci): skip closing-soon PRs in pending-maintainer workflow

### DIFF
--- a/.github/workflows/pending-maintainer.yml
+++ b/.github/workflows/pending-maintainer.yml
@@ -65,6 +65,12 @@ jobs:
                 continue;
               }
 
+              // Skip if closing-soon — don't override stale-close workflow
+              if (labels.includes('closing-soon')) {
+                console.log(`#${prNumber} — closing-soon, skipping`);
+                continue;
+              }
+
               // Check CI status on head commit
               const { data: status } = await github.rest.repos.getCombinedStatusForRef({
                 ...context.repo,
@@ -127,13 +133,6 @@ jobs:
                   ...context.repo,
                   issue_number: prNumber,
                   name: CONTRIBUTOR
-                }).catch(() => {});
-              }
-              if (labels.includes('closing-soon')) {
-                await github.rest.issues.removeLabel({
-                  ...context.repo,
-                  issue_number: prNumber,
-                  name: 'closing-soon'
                 }).catch(() => {});
               }
               console.log(`#${prNumber} — all clear, set ${MAINTAINER}`);


### PR DESCRIPTION
**Problem:** The `pending-maintainer` workflow adds `pending-maintainer` and removes `closing-soon` when a PR passes all checks (not draft, no conflicts, CI green, last commenter is author). This overrides the stale-close workflow's intent — `closing-soon` means the PR is inactive and pending-contributor.

**Fix:**
- Skip PRs with `closing-soon` label entirely (early return)
- Remove the `closing-soon` label removal block — this workflow should never touch it

Fixes the behavior seen in #1057 where `closing-soon` was incorrectly removed.