### PR TITLE
fix(ci): exempt maintainers from Discord Discussion URL check

### DIFF
--- a/.github/workflows/pr-discussion-check.yml
+++ b/.github/workflows/pr-discussion-check.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      members: read
     steps:
       - uses: actions/github-script@v7
         with:
@@ -42,6 +43,26 @@ jobs:
                 try { await github.rest.issues.removeLabel({ ...context.repo, issue_number: pr.number, name: label }); } catch (e) { if (e.status !== 404) throw e; }
               }
               return;
+            }
+
+            // Exempt maintainers (openabdev/openab-maintainers team members)
+            try {
+              await github.rest.teams.getMembershipForUserInOrg({
+                org: 'openabdev',
+                team_slug: 'openab-maintainers',
+                username: pr.user.login
+              });
+              console.log(`Skipping discussion check for maintainer ${pr.user.login}`);
+              if (old) {
+                await github.rest.issues.deleteComment({ ...context.repo, comment_id: old.id });
+              }
+              if (labels.includes(label)) {
+                try { await github.rest.issues.removeLabel({ ...context.repo, issue_number: pr.number, name: label }); } catch (e) { if (e.status !== 404) throw e; }
+              }
+              return;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              // Not a maintainer, continue with check
             }
 
             if (!hasDiscordUrl) {


### PR DESCRIPTION
PR authors who are members of `openabdev/openab-maintainers` team are now exempt from the Discord Discussion URL requirement. If a maintainer opens a PR without the URL, no `closing-soon` label or warning comment is added.