### PR TITLE
feat(ci): Slack PR review workflow

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,0 +1,98 @@
+name: Slack PR Review Check
+
+on:
+  schedule:
+    - cron: '0 */3 * * *'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      members: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const SLACK_LABEL = 'slack';
+            const PENDING_COMMUNITY = 'pending-community-review';
+            const PENDING_MAINTAINER = 'pending-maintainer-review';
+
+            const prs = await github.rest.pulls.list({
+              ...context.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            // Get openab-slack-reviewers team members
+            const { data: members } = await github.rest.teams.listMembersInOrg({
+              org: 'openabdev',
+              team_slug: 'openab-slack-reviewers',
+              per_page: 100
+            });
+            const reviewerLogins = new Set(members.map(m => m.login));
+
+            for (const pr of prs.data) {
+              // 1. Check if title contains "slack" (case-insensitive)
+              if (!/slack/i.test(pr.title)) continue;
+
+              const labels = pr.labels.map(l => l.name);
+
+              // Apply slack label if not present
+              if (!labels.includes(SLACK_LABEL)) {
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: pr.number,
+                  labels: [SLACK_LABEL]
+                });
+              }
+
+              // 2. Check for approval from a slack reviewer
+              const { data: reviews } = await github.rest.pulls.listReviews({
+                ...context.repo,
+                pull_number: pr.number,
+                per_page: 100
+              });
+
+              const hasReviewerApproval = reviews.some(
+                r => r.state === 'APPROVED' && reviewerLogins.has(r.user.login)
+              );
+
+              if (hasReviewerApproval) {
+                // Flip to pending-maintainer-review
+                if (!labels.includes(PENDING_MAINTAINER)) {
+                  await github.rest.issues.addLabels({
+                    ...context.repo,
+                    issue_number: pr.number,
+                    labels: [PENDING_MAINTAINER]
+                  });
+                }
+                if (labels.includes(PENDING_COMMUNITY)) {
+                  await github.rest.issues.removeLabel({
+                    ...context.repo,
+                    issue_number: pr.number,
+                    name: PENDING_COMMUNITY
+                  }).catch(() => {});
+                }
+                console.log(`#${pr.number} — approved by slack reviewer, set ${PENDING_MAINTAINER}`);
+              } else {
+                // Flip to pending-community-review
+                if (!labels.includes(PENDING_COMMUNITY)) {
+                  await github.rest.issues.addLabels({
+                    ...context.repo,
+                    issue_number: pr.number,
+                    labels: [PENDING_COMMUNITY]
+                  });
+                }
+                if (labels.includes(PENDING_MAINTAINER)) {
+                  await github.rest.issues.removeLabel({
+                    ...context.repo,
+                    issue_number: pr.number,
+                    name: PENDING_MAINTAINER
+                  }).catch(() => {});
+                }
+                console.log(`#${pr.number} — no slack reviewer approval, set ${PENDING_COMMUNITY}`);
+              }
+            }


### PR DESCRIPTION
Adds a scheduled workflow (every 3h + manual dispatch) for Slack-related PRs:

1. If PR title contains `slack` (case-insensitive) → apply `slack` label
2. Check if any member of `openabdev/openab-slack-reviewers` has approved:
   - No → `pending-community-review`
   - Yes → `pending-maintainer-review`
3. Flips labels mutually exclusively