### PR TITLE
fix(ci): remove invalid members permission from slack workflow

### DIFF
--- a/.github/workflows/pr-discussion-check.yml
+++ b/.github/workflows/pr-discussion-check.yml
@@ -14,7 +14,6 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
-      members: read
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -11,7 +11,6 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
-      members: read
     steps:
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
The `members: read` permission is not a valid workflow permission key. The team membership API works with the default GITHUB_TOKEN in org repos.