### PR TITLE
fix(ci): discussion check use env var for maintainer list

### DIFF
--- a/.github/workflows/pr-discussion-check.yml
+++ b/.github/workflows/pr-discussion-check.yml
@@ -44,13 +44,9 @@ jobs:
               return;
             }
 
-            // Exempt maintainers (openabdev/openab-maintainers team members)
-            try {
-              await github.rest.teams.getMembershipForUserInOrg({
-                org: 'openabdev',
-                team_slug: 'openab-maintainers',
-                username: pr.user.login
-              });
+            // Exempt maintainers
+            const maintainers = process.env.MAINTAINERS.split(',').map(s => s.trim());
+            if (maintainers.includes(pr.user.login)) {
               console.log(`Skipping discussion check for maintainer ${pr.user.login}`);
               if (old) {
                 await github.rest.issues.deleteComment({ ...context.repo, comment_id: old.id });
@@ -59,9 +55,6 @@ jobs:
                 try { await github.rest.issues.removeLabel({ ...context.repo, issue_number: pr.number, name: label }); } catch (e) { if (e.status !== 404) throw e; }
               }
               return;
-            } catch (e) {
-              if (e.status !== 404) throw e;
-              // Not a maintainer, continue with check
             }
 
             if (!hasDiscordUrl) {
@@ -114,3 +107,5 @@ jobs:
                 });
               }
             }
+        env:
+          MAINTAINERS: neilkuan,JARVIS-coding-Agent,thepagent,CHC-Agent,shaun-agent,wangyuyan-agent,masami-agent,chaodu-agent


### PR DESCRIPTION
Same fix as #1064 — `GITHUB_TOKEN` can't access closed team membership. Replace `teams.getMembershipForUserInOrg` with env var lookup.

Current maintainers: `neilkuan, JARVIS-coding-Agent, thepagent, CHC-Agent, shaun-agent, wangyuyan-agent, masami-agent, chaodu-agent`