### PR TITLE
fix(ci): use team API for maintainer/reviewer checks

### DIFF
--- a/.github/workflows/pr-discussion-check.yml
+++ b/.github/workflows/pr-discussion-check.yml
@@ -44,13 +44,14 @@ jobs:
               return;
             }
 
-            // Exempt maintainers (openabdev/openab-maintainers team members)
-            try {
-              await github.rest.teams.getMembershipForUserInOrg({
-                org: 'openabdev',
-                team_slug: 'openab-maintainers',
-                username: pr.user.login
-              });
+            // Exempt maintainers (openabdev/openab-maintainers — team must be associated with repo)
+            const { data: maintainerMembers } = await github.rest.teams.listMembersInOrg({
+              org: 'openabdev',
+              team_slug: 'openab-maintainers',
+              per_page: 100
+            });
+            const maintainerLogins = new Set(maintainerMembers.map(m => m.login));
+            if (maintainerLogins.has(pr.user.login)) {
               console.log(`Skipping discussion check for maintainer ${pr.user.login}`);
               if (old) {
                 await github.rest.issues.deleteComment({ ...context.repo, comment_id: old.id });
@@ -59,9 +60,6 @@ jobs:
                 try { await github.rest.issues.removeLabel({ ...context.repo, issue_number: pr.number, name: label }); } catch (e) { if (e.status !== 404) throw e; }
               }
               return;
-            } catch (e) {
-              if (e.status !== 404) throw e;
-              // Not a maintainer, continue with check
             }
 
             if (!hasDiscordUrl) {

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -19,9 +19,13 @@ jobs:
             const PENDING_COMMUNITY = 'pending-community-review';
             const PENDING_MAINTAINER = 'pending-maintainer-review';
 
-            // Hardcoded slack reviewer logins (team membership API requires read:org)
-            // Update this list when openab-slack-reviewers team changes.
-            const SLACK_REVIEWERS = process.env.SLACK_REVIEWERS.split(',').map(s => s.trim());
+            // Get openab-slack-reviewers team members (team must be associated with repo)
+            const { data: members } = await github.rest.teams.listMembersInOrg({
+              org: 'openabdev',
+              team_slug: 'openab-slack-reviewers',
+              per_page: 100
+            });
+            const SLACK_REVIEWERS = members.map(m => m.login);
 
             const prs = await github.rest.pulls.list({
               ...context.repo,
@@ -91,5 +95,3 @@ jobs:
                 console.log(`#${pr.number} — no slack reviewer approval, set ${PENDING_COMMUNITY}`);
               }
             }
-        env:
-          SLACK_REVIEWERS: MuLinForest


### PR DESCRIPTION
Now that `openab-maintainers` and `openab-slack-reviewers` teams are associated with the repo, the GITHUB_TOKEN can list members via `teams.listMembersInOrg`.

- `pr-discussion-check.yml`: dynamic maintainer lookup (no hardcoded list)
- `slack.yml`: dynamic slack reviewer lookup (no hardcoded list)

**Prerequisite**: also grant `openab-slack-reviewers` read access to the repo.