### PR TITLE
fix(ci): use env vars for team membership checks

### DIFF
--- a/.github/workflows/pr-discussion-check.yml
+++ b/.github/workflows/pr-discussion-check.yml
@@ -44,13 +44,8 @@ jobs:
               return;
             }
 
-            // Exempt maintainers (openabdev/openab-maintainers — team must be associated with repo)
-            const { data: maintainerMembers } = await github.rest.teams.listMembersInOrg({
-              org: 'openabdev',
-              team_slug: 'openab-maintainers',
-              per_page: 100
-            });
-            const maintainerLogins = new Set(maintainerMembers.map(m => m.login));
+            // Exempt maintainers
+            const maintainerLogins = new Set(process.env.MAINTAINERS.split(','));
             if (maintainerLogins.has(pr.user.login)) {
               console.log(`Skipping discussion check for maintainer ${pr.user.login}`);
               if (old) {
@@ -112,3 +107,5 @@ jobs:
                 });
               }
             }
+        env:
+          MAINTAINERS: neilkuan,JARVIS-coding-Agent,thepagent,CHC-Agent,shaun-agent,wangyuyan-agent,masami-agent,chaodu-agent

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -19,13 +19,7 @@ jobs:
             const PENDING_COMMUNITY = 'pending-community-review';
             const PENDING_MAINTAINER = 'pending-maintainer-review';
 
-            // Get openab-slack-reviewers team members (team must be associated with repo)
-            const { data: members } = await github.rest.teams.listMembersInOrg({
-              org: 'openabdev',
-              team_slug: 'openab-slack-reviewers',
-              per_page: 100
-            });
-            const SLACK_REVIEWERS = members.map(m => m.login);
+            const SLACK_REVIEWERS = process.env.SLACK_REVIEWERS.split(',');
 
             const prs = await github.rest.pulls.list({
               ...context.repo,
@@ -95,3 +89,5 @@ jobs:
                 console.log(`#${pr.number} — no slack reviewer approval, set ${PENDING_COMMUNITY}`);
               }
             }
+        env:
+          SLACK_REVIEWERS: MuLinForest


### PR DESCRIPTION
The `GITHUB_TOKEN` lacks `read:org` scope regardless of team-repo association. Revert to env var approach:

- `MAINTAINERS`: comma-separated list for discussion check exemption
- `SLACK_REVIEWERS`: comma-separated list for slack review check

Update the env vars when team membership changes.