### PR TITLE
fix(ci): use app token for team membership API

### DIFF
--- a/.github/workflows/pr-discussion-check.yml
+++ b/.github/workflows/pr-discussion-check.yml
@@ -15,8 +15,14 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const pr = context.payload.pull_request;
             const body = pr.body || '';

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -12,8 +12,14 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const SLACK_LABEL = 'slack';
             const PENDING_COMMUNITY = 'pending-community-review';


### PR DESCRIPTION
Use `openab-app` token (with `Members:Read` org permission) for team membership lookups in:
- `pr-discussion-check.yml` — maintainer exemption
- `slack.yml` — slack reviewer list

No more hardcoded env vars. Team changes are reflected automatically.