### PR TITLE
feat: agentcore-acp adapter + ADR for AgentCore Runtime backend

### DIFF
--- a/agentcore-acp/Dockerfile
+++ b/agentcore-acp/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY pyproject.toml agentcore_acp.py ./
+RUN pip install --no-cache-dir .
+
+ENTRYPOINT ["agentcore-acp"]

--- a/agentcore-acp/README.md
+++ b/agentcore-acp/README.md
@@ -1,0 +1,64 @@
+# agentcore-acp
+
+ACP stdio adapter for [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime.html).
+
+Bridges OAB's ACP JSON-RPC protocol to AgentCore's `InvokeAgentRuntime` streaming API. **Zero OAB code changes required.**
+
+## Architecture
+
+```
+OAB ──ACP stdio──► agentcore-acp ──AWS SDK──► AgentCore Runtime (microVM)
+```
+
+## Usage
+
+### With OpenAB (config.toml)
+
+```toml
+[agent]
+command = "agentcore-acp"
+args = ["--runtime-arn", "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-agent", "--region", "us-west-2"]
+working_dir = "/home/agent"
+```
+
+### Standalone (for testing)
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/"}}' | \
+  agentcore-acp --runtime-arn arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-agent
+```
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+Or with Docker:
+
+```bash
+docker build -t agentcore-acp .
+```
+
+## CLI Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--runtime-arn` | (required) | AgentCore Runtime ARN |
+| `--region` | `us-west-2` | AWS region |
+| `--cancel-strategy` | `stop` | `noop` (ignore cancel) or `stop` (terminate session) |
+
+## How It Works
+
+1. OAB spawns `agentcore-acp` as a subprocess
+2. On `session/prompt`, the adapter parses `<sender_context>` from the prompt to extract `thread_id`
+3. Builds a deterministic `runtimeSessionId` (`oab-{platform}-thread-{thread_id}`, ≥33 chars)
+4. Calls `InvokeAgentRuntime` with streaming response
+5. Translates SSE `data:` lines → ACP `notifications/content` JSON-RPC notifications
+6. OAB displays the response in Discord/Slack as usual
+
+## Requirements
+
+- Python ≥ 3.11
+- AWS credentials (IRSA, instance profile, or env vars)
+- `bedrock-agentcore:InvokeAgentRuntime` IAM permission

--- a/agentcore-acp/agentcore_acp.py
+++ b/agentcore-acp/agentcore_acp.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""agentcore-acp: ACP stdio adapter for Amazon Bedrock AgentCore Runtime.
+
+Bridges OAB's ACP JSON-RPC protocol to AgentCore's InvokeAgentRuntime API.
+OAB spawns this as a subprocess — zero OAB code changes required.
+
+Usage:
+    agentcore-acp --runtime-arn ARN --region REGION [--cancel-strategy noop|stop]
+"""
+
+import argparse
+import json
+import re
+import sys
+import threading
+import time
+
+import boto3
+
+# ---------------------------------------------------------------------------
+# ACP stdio helpers
+# ---------------------------------------------------------------------------
+
+
+def write_response(id: int, result=None, error=None):
+    """Write a JSON-RPC response to stdout."""
+    msg = {"jsonrpc": "2.0", "id": id}
+    if error is not None:
+        msg["error"] = error
+    else:
+        msg["result"] = result if result is not None else {}
+    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.flush()
+
+
+def write_notification(method: str, params: dict):
+    """Write a JSON-RPC notification to stdout."""
+    msg = {"jsonrpc": "2.0", "method": method, "params": params}
+    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Sender context parsing
+# ---------------------------------------------------------------------------
+
+SENDER_CTX_RE = re.compile(
+    r"<sender_context>\s*(\{.*?\})\s*</sender_context>", re.DOTALL
+)
+
+
+def extract_session_id_from_prompt(blocks: list) -> str | None:
+    """Parse <sender_context> from prompt blocks to build deterministic session ID."""
+    for block in blocks:
+        if isinstance(block, dict) and block.get("type") == "text":
+            m = SENDER_CTX_RE.search(block.get("text", ""))
+            if m:
+                try:
+                    ctx = json.loads(m.group(1))
+                    platform = ctx.get("channel", "unknown")
+                    thread_id = ctx.get("thread_id") or ctx.get("channel_id", "")
+                    sid = f"oab-{platform}-thread-{thread_id}"
+                    # Guarantee ≥33 chars
+                    if len(sid) < 33:
+                        sid = sid + "0" * (33 - len(sid))
+                    return sid
+                except (json.JSONDecodeError, KeyError):
+                    pass
+    return None
+
+
+def strip_sender_context(blocks: list) -> str:
+    """Extract plain prompt text from blocks, stripping sender_context."""
+    parts = []
+    for block in blocks:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text", "")
+            # Remove sender_context block
+            text = SENDER_CTX_RE.sub("", text).strip()
+            if text:
+                parts.append(text)
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# AgentCore client
+# ---------------------------------------------------------------------------
+
+
+class AgentCoreClient:
+    def __init__(self, runtime_arn: str, region: str, cancel_strategy: str):
+        self.runtime_arn = runtime_arn
+        self.region = region
+        self.cancel_strategy = cancel_strategy
+        self.client = boto3.client("bedrock-agentcore", region_name=region)
+        self._active_session: str | None = None
+
+    def invoke_streaming(self, session_id: str, prompt: str):
+        """Call InvokeAgentRuntime and yield response text chunks."""
+        self._active_session = session_id
+        payload = json.dumps({"prompt": prompt}).encode()
+
+        response = self.client.invoke_agent_runtime(
+            agentRuntimeArn=self.runtime_arn,
+            runtimeSessionId=session_id,
+            payload=payload,
+        )
+
+        content_type = response.get("contentType", "")
+
+        if "text/event-stream" in content_type:
+            # SSE streaming response
+            for line in response["response"].iter_lines(chunk_size=1024):
+                if not line:
+                    continue
+                decoded = line.decode("utf-8") if isinstance(line, bytes) else line
+                # SSE format: "data: <content>"
+                if decoded.startswith("data: "):
+                    yield decoded[6:]
+                elif decoded.startswith("data:"):
+                    yield decoded[5:]
+                # Skip SSE comments (:) and event/id lines
+        elif content_type == "application/json":
+            # Non-streaming JSON response
+            chunks = []
+            for chunk in response.get("response", []):
+                chunks.append(
+                    chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+                )
+            full = "".join(chunks)
+            try:
+                data = json.loads(full)
+                yield data.get("message", data.get("response", full))
+            except json.JSONDecodeError:
+                yield full
+        else:
+            # Raw response
+            for chunk in response.get("response", []):
+                yield chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+
+        self._active_session = None
+
+    def cancel(self, session_id: str):
+        """Cancel based on configured strategy."""
+        if self.cancel_strategy == "noop":
+            return
+        # strategy == "stop": terminate the session
+        try:
+            self.client.stop_runtime_session(
+                agentRuntimeArn=self.runtime_arn,
+                runtimeSessionId=session_id,
+            )
+        except Exception:
+            pass  # Best-effort
+
+
+# ---------------------------------------------------------------------------
+# ACP Adapter
+# ---------------------------------------------------------------------------
+
+
+class AcpAdapter:
+    def __init__(self, client: AgentCoreClient):
+        self.client = client
+        self.sessions: dict[str, str] = {}  # acp_session_id → runtime_session_id
+        self._lock = threading.Lock()  # per-session invoke serialization
+
+    def handle_session_new(self, id: int, params: dict):
+        acp_sid = f"agentcore-{int(time.time() * 1000)}"
+        self.sessions[acp_sid] = ""  # runtime session ID determined on first prompt
+        write_response(id, {"sessionId": acp_sid})
+
+    def handle_session_prompt(self, id: int, params: dict):
+        acp_sid = params.get("sessionId", "")
+        blocks = params.get("prompt", [])
+
+        # Determine runtime session ID from sender_context
+        runtime_sid = self.sessions.get(acp_sid, "")
+        if not runtime_sid:
+            runtime_sid = extract_session_id_from_prompt(blocks)
+            if not runtime_sid:
+                # Fallback: use ACP session ID padded to 33 chars
+                runtime_sid = f"oab-fallback-{acp_sid}"
+                if len(runtime_sid) < 33:
+                    runtime_sid = runtime_sid + "0" * (33 - len(runtime_sid))
+            self.sessions[acp_sid] = runtime_sid
+
+        # Extract plain prompt text
+        prompt_text = strip_sender_context(blocks)
+        if not prompt_text:
+            prompt_text = "hello"
+
+        # Invoke with serialization
+        with self._lock:
+            cold_start_notified = False
+            start_time = time.time()
+
+            try:
+                for chunk in self.client.invoke_streaming(runtime_sid, prompt_text):
+                    if not cold_start_notified and time.time() - start_time > 3:
+                        write_notification(
+                            "notifications/content",
+                            {"type": "text", "text": "⏳ Starting agent environment..."},
+                        )
+                        cold_start_notified = True
+
+                    write_notification(
+                        "notifications/content",
+                        {"type": "text", "text": chunk},
+                    )
+            except self.client.client.exceptions.ResourceNotFoundException:
+                # Session expired — re-invoke (AgentCore auto-provisions new microVM)
+                try:
+                    for chunk in self.client.invoke_streaming(runtime_sid, prompt_text):
+                        write_notification(
+                            "notifications/content",
+                            {"type": "text", "text": chunk},
+                        )
+                except Exception as e:
+                    write_response(id, error={"code": -32603, "message": str(e)})
+                    return
+            except Exception as e:
+                error_code = -32000
+                msg = str(e)
+                if "Throttling" in msg:
+                    error_code = -32000
+                    msg = "rate limited, retry later"
+                elif "ValidationException" in msg:
+                    error_code = -32602
+                write_response(id, error={"code": error_code, "message": msg})
+                return
+
+        # Success response (marks end of turn)
+        write_response(id, {"type": "success"})
+
+    def handle_cancel(self, params: dict):
+        acp_sid = params.get("sessionId", "")
+        runtime_sid = self.sessions.get(acp_sid, "")
+        if runtime_sid:
+            self.client.cancel(runtime_sid)
+
+    def handle_session_load(self, id: int, params: dict):
+        """Resume a session — with deterministic IDs, just store the mapping."""
+        acp_sid = params.get("sessionId", "")
+        if acp_sid not in self.sessions:
+            self.sessions[acp_sid] = ""  # Will be resolved on next prompt
+        write_response(id, {"sessionId": acp_sid})
+
+    def run(self):
+        """Main loop: read JSON-RPC from stdin, dispatch."""
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            method = msg.get("method")
+            params = msg.get("params", {})
+            msg_id = msg.get("id")
+
+            if method == "session/new":
+                self.handle_session_new(msg_id, params)
+            elif method == "session/prompt":
+                self.handle_session_prompt(msg_id, params)
+            elif method == "session/cancel":
+                self.handle_cancel(params)
+            elif method == "session/load":
+                self.handle_session_load(msg_id, params)
+            elif method == "session/request_permission":
+                # Auto-approve all tool calls (AgentCore agents run autonomously)
+                if msg_id is not None:
+                    write_response(msg_id, {"approved": True})
+            elif msg_id is not None:
+                # Unknown method with id — respond with method not found
+                write_response(
+                    msg_id, error={"code": -32601, "message": f"unknown method: {method}"}
+                )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description="ACP adapter for AgentCore Runtime")
+    parser.add_argument("--runtime-arn", required=True, help="AgentCore Runtime ARN")
+    parser.add_argument("--region", default="us-west-2", help="AWS region")
+    parser.add_argument(
+        "--cancel-strategy",
+        choices=["noop", "stop"],
+        default="stop",
+        help="Cancel behavior: noop (ignore) or stop (terminate session)",
+    )
+    args = parser.parse_args()
+
+    client = AgentCoreClient(
+        runtime_arn=args.runtime_arn,
+        region=args.region,
+        cancel_strategy=args.cancel_strategy,
+    )
+    adapter = AcpAdapter(client)
+    adapter.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/agentcore-acp/agentcore_acp.py
+++ b/agentcore-acp/agentcore_acp.py
@@ -40,6 +40,20 @@ def write_notification(method: str, params: dict):
     sys.stdout.flush()
 
 
+def emit_text_chunk(text: str):
+    """Emit a text chunk in the format OAB's classify_notification expects.
+
+    OAB parses: params.update.sessionUpdate == "agent_message_chunk"
+                params.update.content.text == <the text>
+    """
+    write_notification("session/update", {
+        "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"text": text},
+        }
+    })
+
+
 # ---------------------------------------------------------------------------
 # Sender context parsing
 # ---------------------------------------------------------------------------
@@ -238,30 +252,26 @@ class AcpAdapter:
         # Invoke with per-session serialization
         session_lock = self._get_session_lock(acp_sid)
         with session_lock:
-            cold_start_notified = False
-            start_time = time.time()
+            first_chunk_received = threading.Event()
+
+            # Cold start timer: if no chunk arrives within 3s, notify user
+            def _cold_start_timer():
+                if not first_chunk_received.wait(timeout=3.0):
+                    emit_text_chunk("⏳ Starting agent environment...")
+
+            timer = threading.Thread(target=_cold_start_timer, daemon=True)
+            timer.start()
 
             try:
                 for chunk in self.client.invoke_streaming(runtime_sid, prompt_text):
-                    if not cold_start_notified and time.time() - start_time > 3:
-                        write_notification(
-                            "notifications/content",
-                            {"type": "text", "text": "⏳ Starting agent environment..."},
-                        )
-                        cold_start_notified = True
-
-                    write_notification(
-                        "notifications/content",
-                        {"type": "text", "text": chunk},
-                    )
+                    first_chunk_received.set()
+                    emit_text_chunk(chunk)
             except self.client.client.exceptions.ResourceNotFoundException:
+                first_chunk_received.set()
                 # Session expired — re-invoke (AgentCore auto-provisions new microVM)
                 try:
                     for chunk in self.client.invoke_streaming(runtime_sid, prompt_text):
-                        write_notification(
-                            "notifications/content",
-                            {"type": "text", "text": chunk},
-                        )
+                        emit_text_chunk(chunk)
                 except Exception as e:
                     write_response(id, error={"code": -32603, "message": str(e)})
                     return

--- a/agentcore-acp/agentcore_acp.py
+++ b/agentcore-acp/agentcore_acp.py
@@ -45,8 +45,41 @@ def write_notification(method: str, params: dict):
 # ---------------------------------------------------------------------------
 
 SENDER_CTX_RE = re.compile(
-    r"<sender_context>\s*(\{.*?\})\s*</sender_context>", re.DOTALL
+    r"<sender_context>\s*(.*?)\s*</sender_context>", re.DOTALL
 )
+
+
+def _extract_json_object(text: str) -> dict | None:
+    """Extract the first complete JSON object from text using brace counting."""
+    start = text.find("{")
+    if start == -1:
+        return None
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(text)):
+        c = text[i]
+        if escape:
+            escape = False
+            continue
+        if c == "\\":
+            escape = True
+            continue
+        if c == '"' and not escape:
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(text[start : i + 1])
+                except json.JSONDecodeError:
+                    return None
+    return None
 
 
 def extract_session_id_from_prompt(blocks: list) -> str | None:
@@ -55,8 +88,8 @@ def extract_session_id_from_prompt(blocks: list) -> str | None:
         if isinstance(block, dict) and block.get("type") == "text":
             m = SENDER_CTX_RE.search(block.get("text", ""))
             if m:
-                try:
-                    ctx = json.loads(m.group(1))
+                ctx = _extract_json_object(m.group(1))
+                if ctx:
                     platform = ctx.get("channel", "unknown")
                     thread_id = ctx.get("thread_id") or ctx.get("channel_id", "")
                     sid = f"oab-{platform}-thread-{thread_id}"
@@ -64,8 +97,6 @@ def extract_session_id_from_prompt(blocks: list) -> str | None:
                     if len(sid) < 33:
                         sid = sid + "0" * (33 - len(sid))
                     return sid
-                except (json.JSONDecodeError, KeyError):
-                    pass
     return None
 
 
@@ -110,6 +141,9 @@ class AgentCoreClient:
 
         if "text/event-stream" in content_type:
             # SSE streaming response
+            # TODO(phase2): Replace iter_lines() with proper SSE parser (httpx-sse)
+            # to handle TCP chunk boundaries correctly. Acceptable for PoC since
+            # AgentCore likely flushes complete lines per event.
             for line in response["response"].iter_lines(chunk_size=1024):
                 if not line:
                     continue
@@ -163,11 +197,20 @@ class AcpAdapter:
     def __init__(self, client: AgentCoreClient):
         self.client = client
         self.sessions: dict[str, str] = {}  # acp_session_id → runtime_session_id
-        self._lock = threading.Lock()  # per-session invoke serialization
+        self._sessions_lock = threading.Lock()  # protects self.sessions dict
+        self._session_locks: dict[str, threading.Lock] = {}  # per-session invoke mutex
+
+    def _get_session_lock(self, acp_sid: str) -> threading.Lock:
+        """Get or create a per-session lock for invoke serialization."""
+        with self._sessions_lock:
+            if acp_sid not in self._session_locks:
+                self._session_locks[acp_sid] = threading.Lock()
+            return self._session_locks[acp_sid]
 
     def handle_session_new(self, id: int, params: dict):
         acp_sid = f"agentcore-{int(time.time() * 1000)}"
-        self.sessions[acp_sid] = ""  # runtime session ID determined on first prompt
+        with self._sessions_lock:
+            self.sessions[acp_sid] = ""  # runtime session ID determined on first prompt
         write_response(id, {"sessionId": acp_sid})
 
     def handle_session_prompt(self, id: int, params: dict):
@@ -175,7 +218,8 @@ class AcpAdapter:
         blocks = params.get("prompt", [])
 
         # Determine runtime session ID from sender_context
-        runtime_sid = self.sessions.get(acp_sid, "")
+        with self._sessions_lock:
+            runtime_sid = self.sessions.get(acp_sid, "")
         if not runtime_sid:
             runtime_sid = extract_session_id_from_prompt(blocks)
             if not runtime_sid:
@@ -183,15 +227,17 @@ class AcpAdapter:
                 runtime_sid = f"oab-fallback-{acp_sid}"
                 if len(runtime_sid) < 33:
                     runtime_sid = runtime_sid + "0" * (33 - len(runtime_sid))
-            self.sessions[acp_sid] = runtime_sid
+            with self._sessions_lock:
+                self.sessions[acp_sid] = runtime_sid
 
         # Extract plain prompt text
         prompt_text = strip_sender_context(blocks)
         if not prompt_text:
             prompt_text = "hello"
 
-        # Invoke with serialization
-        with self._lock:
+        # Invoke with per-session serialization
+        session_lock = self._get_session_lock(acp_sid)
+        with session_lock:
             cold_start_notified = False
             start_time = time.time()
 
@@ -235,15 +281,17 @@ class AcpAdapter:
 
     def handle_cancel(self, params: dict):
         acp_sid = params.get("sessionId", "")
-        runtime_sid = self.sessions.get(acp_sid, "")
+        with self._sessions_lock:
+            runtime_sid = self.sessions.get(acp_sid, "")
         if runtime_sid:
             self.client.cancel(runtime_sid)
 
     def handle_session_load(self, id: int, params: dict):
         """Resume a session — with deterministic IDs, just store the mapping."""
         acp_sid = params.get("sessionId", "")
-        if acp_sid not in self.sessions:
-            self.sessions[acp_sid] = ""  # Will be resolved on next prompt
+        with self._sessions_lock:
+            if acp_sid not in self.sessions:
+                self.sessions[acp_sid] = ""  # Will be resolved on next prompt
         write_response(id, {"sessionId": acp_sid})
 
     def run(self):
@@ -265,7 +313,7 @@ class AcpAdapter:
                 self.handle_session_new(msg_id, params)
             elif method == "session/prompt":
                 self.handle_session_prompt(msg_id, params)
-            elif method == "session/cancel":
+            elif method in ("session/cancel", "cancel"):
                 self.handle_cancel(params)
             elif method == "session/load":
                 self.handle_session_load(msg_id, params)

--- a/agentcore-acp/pyproject.toml
+++ b/agentcore-acp/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "agentcore-acp"
+version = "0.1.0"
+description = "ACP stdio adapter for Amazon Bedrock AgentCore Runtime"
+requires-python = ">=3.11"
+dependencies = [
+    "boto3==1.38.34",
+]
+
+[project.scripts]
+agentcore-acp = "agentcore_acp:main"

--- a/docs/adr/agentcore-runtime-backend.md
+++ b/docs/adr/agentcore-runtime-backend.md
@@ -1,0 +1,271 @@
+# ADR: AgentCore Runtime Backend
+
+- **Status:** Proposed
+- **Date:** 2026-06-10
+- **Author:** @chaodu-agent
+
+---
+
+## 1. Context & Motivation
+
+Today, OpenAB dispatches messages exclusively via ACP (Agent Client Protocol) — JSON-RPC over stdio to a co-located subprocess:
+
+```
+Discord/Slack msg ──► OpenAB ──stdio──► coding CLI (kiro, claude, codex…)
+```
+
+This means:
+- **One agent per container.** The coding CLI binary must be bundled inside the same pod as OpenAB.
+- **No parallelism across agents.** Running Claude Code *and* Kiro simultaneously requires deploying two full OpenAB stacks.
+- **Pod-bound lifecycle.** If the pod restarts, the agent process (and any in-flight work) dies with it.
+- **Resource coupling.** The agent shares CPU/memory/disk with OpenAB — a 90-minute refactor starves the broker.
+
+AWS recently launched **Amazon Bedrock AgentCore Runtime**, which hosts coding agents (Kiro, Claude Code, Codex, etc.) in isolated Firecracker microVMs with persistent filesystems, session management, and streaming invoke APIs. This creates an opportunity: OpenAB can route messages to remote AgentCore sessions via SDK instead of local subprocesses, decoupling the agent lifecycle from the broker.
+
+### What this unlocks
+
+1. **Dynamic multi-agent routing** — one OpenAB instance routes to N different AgentCore runtimes based on @mention or config.
+2. **True isolation** — each agent runs in its own microVM; no shared localhost, no credential leakage.
+3. **Background execution** — agents survive pod restarts, laptop lid closures, and network drops.
+4. **Cost efficiency** — microVMs spin down when idle (pay per use), no always-on pod per agent.
+
+---
+
+## 2. Design
+
+### Architecture Overview
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  OpenAB (Rust, always-on pod)                                      │
+│                                                                    │
+│  Discord/Slack ──► Dispatch ──┬── backend=acp ──► local subprocess │
+│                               │                                    │
+│                               └── backend=agentcore ──► AWS SDK    │
+│                                         │                          │
+└─────────────────────────────────────────┼──────────────────────────┘
+                                          │
+                              ┌────────────▼────────────────┐
+                              │  AgentCore Runtime (AWS)     │
+                              │                             │
+                              │  ┌─────────────────────┐    │
+                              │  │ microVM (Kiro)      │    │
+                              │  │ /mnt/workspace      │    │
+                              │  │ session: oab-thread1│    │
+                              │  └─────────────────────┘    │
+                              │                             │
+                              │  ┌─────────────────────┐    │
+                              │  │ microVM (Claude)    │    │
+                              │  │ /mnt/workspace      │    │
+                              │  │ session: oab-thread2│    │
+                              │  └─────────────────────┘    │
+                              └─────────────────────────────┘
+```
+
+### Message Flow
+
+```
+Inbound:
+  1. User sends message in Discord thread
+  2. OpenAB dispatch selects backend based on config (or @mention routing)
+  3. If backend=agentcore:
+     a. Build runtimeSessionId from thread key (≥33 chars)
+     b. Serialize prompt + sender context into JSON payload
+     c. Call InvokeAgentRuntime (streaming)
+  4. Stream response chunks back to Discord (same edit loop as ACP)
+
+Session Lifecycle:
+  - Discord thread ID → runtimeSessionId (deterministic mapping)
+  - First invoke on new session → cold start (microVM boot, ~5-15s)
+  - Subsequent invokes → reuse existing microVM (idle timer reset)
+  - Idle 15min (configurable) → microVM terminates, filesystem persists
+  - Next invoke → new microVM mounts same filesystem, agent resumes
+```
+
+### Two Invoke APIs
+
+AgentCore provides two complementary APIs. OpenAB uses primarily `InvokeAgentRuntime`:
+
+| API | Purpose | Response | OpenAB Use |
+|-----|---------|----------|------------|
+| `InvokeAgentRuntime` | Send prompt, get agent reasoning output | Streaming `text/event-stream` | Primary: Discord msg → agent → streaming reply |
+| `InvokeAgentRuntimeCommand` | Run shell command in same microVM | Streaming stdout/stderr events | Optional: deterministic ops (git push, npm test) |
+
+### Streaming Response Handling
+
+`InvokeAgentRuntime` returns `text/event-stream` with `data:` lines:
+
+```
+data: Starting analysis of the code...
+data: I can see the issue is in line 42...
+data: Here's my proposed fix:
+data: ```rust
+data: fn main() { ... }
+data: ```
+```
+
+OpenAB consumes this identically to ACP streaming — progressive Discord message edits via the existing `AdapterRouter::edit_message` path.
+
+---
+
+## 3. Configuration
+
+### Single agent (simple)
+
+```toml
+[agent]
+backend = "agentcore"
+runtime_arn = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/kiro-agent"
+region = "us-west-2"
+```
+
+### Multi-agent routing
+
+```toml
+[agent]
+backend = "agentcore"
+runtime_arn = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/kiro-agent"
+region = "us-west-2"
+
+# Future: route by @mention to different runtimes
+# [agent.routes]
+# kiro = "arn:aws:...:runtime/kiro-agent"
+# claude = "arn:aws:...:runtime/claude-agent"
+# codex = "arn:aws:...:runtime/codex-agent"
+```
+
+### Hybrid (ACP + AgentCore coexist)
+
+In a future multi-agent config, some agents could be local ACP while others are remote AgentCore. This ADR focuses on the single-agent case first.
+
+---
+
+## 4. Session ID Mapping
+
+AgentCore requires `runtimeSessionId` ≥ 33 characters. OpenAB thread keys are platform-specific (Discord: 18-20 digit snowflake, Slack: channel.thread_ts).
+
+**Strategy:** Prefix with `oab-` and pad/hash to guarantee length:
+
+```
+Discord thread 1514294613853208667
+  → runtimeSessionId = "oab-discord-1514294613853208667"  (34 chars ✓)
+
+Slack thread C0123456789.1234567890.123456
+  → runtimeSessionId = "oab-slack-C0123456789-1234567890-123456"  (43 chars ✓)
+```
+
+The mapping is deterministic (no persistent state needed). Same thread always maps to same session. This enables:
+- Resume after OpenAB restart (no `thread_map.json` needed for AgentCore backend)
+- Multiple OpenAB replicas sharing the same AgentCore sessions
+
+---
+
+## 5. Implementation Plan
+
+### Phase 1: Minimal viable backend
+
+1. Add `backend` field to `AgentConfig` (`"acp"` default, `"agentcore"` new)
+2. Define `AgentBackend` trait:
+   ```rust
+   #[async_trait]
+   trait AgentBackend: Send + Sync {
+       /// Send a prompt and stream response blocks back.
+       async fn stream_prompt(
+           &self,
+           session_key: &str,
+           prompt: &str,
+           extra_blocks: &[ContentBlock],
+           tx: mpsc::Sender<ContentBlock>,
+       ) -> Result<()>;
+
+       /// Cancel an in-flight turn (best-effort).
+       async fn cancel(&self, session_key: &str) -> Result<()>;
+   }
+   ```
+3. Implement `AcpBackend` (wraps existing `SessionPool` logic)
+4. Implement `AgentCoreBackend`:
+   - Uses `aws-sdk-bedrockagentcore` crate
+   - `stream_prompt` → `invoke_agent_runtime` with streaming response
+   - Parses `text/event-stream` lines into `ContentBlock::Text`
+   - Maps session_key → runtimeSessionId with prefix scheme
+5. Wire into dispatcher — replace direct `SessionPool` usage with `dyn AgentBackend`
+
+### Phase 2: Cold start UX
+
+- Detect first-invoke latency (no streaming data for >3s)
+- Show ⏳ or "Starting agent environment..." reaction
+- Once streaming begins, switch to normal 🤔 thinking reaction
+
+### Phase 3: Multi-runtime routing (future)
+
+- Config-driven routing table (per @mention, per channel, per pattern)
+- Parallel invoke to multiple runtimes (race mode)
+
+---
+
+## 6. Differences from ACP Backend
+
+| Concern | ACP (current) | AgentCore (proposed) |
+|---------|--------------|---------------------|
+| Agent location | Same container | Remote microVM |
+| Startup | Already running (subprocess) | Cold start on first invoke (~5-15s) |
+| Session state | In-memory (process) | Persistent filesystem (/mnt/workspace) |
+| Credential isolation | Shared pod env | Fully isolated (IAM + Gateway) |
+| Tool permission prompt | Supported (mid-turn stdin) | Not supported — must trust all tools |
+| Streaming format | ACP JSON-RPC notifications | HTTP/2 event-stream (`data:` lines) |
+| Max session duration | Unlimited (until pod dies) | 8 hours (configurable) |
+| Idle behavior | Stays alive (in pool) | Auto-terminates after idle timeout |
+| Resume after kill | Lost (unless session/save) | Automatic (filesystem persists 14 days) |
+| Parallelism | One process per thread, shared CPU | One microVM per session, independent |
+| Cost model | Always-on pod cost | Pay per CPU-second + peak memory |
+
+---
+
+## 7. Open Questions
+
+1. **Payload format standardization** — Different AgentCore runtimes may expect different payload schemas (`{"prompt": "..."}` vs raw text vs MCP). Do we need a `payload_template` config field?
+
+2. **Response format parsing** — If the agent runtime returns structured JSON (not plain text streaming), how do we extract the "message" portion? May need a configurable response extractor.
+
+3. **OAuth-based invocation** — AgentCore docs state that OAuth-integrated runtimes cannot use the SDK; they require raw HTTPS. If a runtime uses AgentCore Identity/Gateway with OAuth, OpenAB would need to use `reqwest` directly instead of the AWS SDK. How common is this pattern?
+
+4. **Human-in-the-loop** — ACP supports mid-turn tool permission prompts (agent asks user "can I run this command?"). AgentCore agents run autonomously. Is this acceptable, or do we need a callback mechanism?
+
+5. **Multi-agent routing UX** — How should users specify which agent handles which message? Options: @mention, channel binding, slash command, or auto-detect.
+
+6. **Error recovery** — If `InvokeAgentRuntime` fails (throttling, session terminated), should OpenAB auto-retry with a new session, or surface the error to the user?
+
+---
+
+## 8. Alternatives Considered
+
+### A. Keep ACP-only, run OpenAB on AgentCore
+
+Deploy the entire OpenAB + agent container on AgentCore Runtime instead. This works but:
+- Still couples agent to container
+- Doesn't leverage AgentCore's multi-session isolation
+- Doesn't enable multi-agent routing from one OpenAB instance
+- Loses the "thin bridge" philosophy — OpenAB becomes the thing being hosted, not the router
+
+### B. WebSocket relay to AgentCore
+
+Instead of SDK invoke, have a persistent WebSocket between OpenAB and a custom proxy that talks to AgentCore. Rejected because:
+- Adds another service to deploy and maintain
+- `InvokeAgentRuntime` already supports streaming; no need for an intermediary
+- Increases complexity without clear benefit
+
+### C. MCP-based integration via AgentCore Gateway
+
+Use AgentCore Gateway's MCP endpoint as the tool layer, keeping agents local. This is complementary (we could support it for tools) but doesn't solve the core problem of agent lifecycle coupling.
+
+---
+
+## 9. References
+
+- [AWS Blog: Hosting Coding Agents on AgentCore](https://aws.amazon.com/blogs/machine-learning/its-safe-to-close-your-laptop-now-hosting-coding-agents-on-amazon-bedrock-agentcore/)
+- [InvokeAgentRuntime API Reference](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_InvokeAgentRuntime.html)
+- [InvokeAgentRuntimeCommand API Reference](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_InvokeAgentRuntimeCommand.html)
+- [AgentCore Runtime Lifecycle Settings](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-lifecycle-settings.html)
+- [AgentCore Session Storage (Preview)](https://aws.amazon.com/about-aws/whats-new/2026/03/bedrock-agentcore-runtime-session-storage/)
+- [Handle Long-Running Agents](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-long-run.html)
+- [OpenAB DESIGN.md](../../DESIGN.md) — "Thin Bridge" philosophy

--- a/docs/adr/agentcore-runtime-backend.md
+++ b/docs/adr/agentcore-runtime-backend.md
@@ -113,28 +113,51 @@ Option A remains viable for future consideration if we find the ACP translation 
 | `session/new` | Generate `runtimeSessionId` from thread key, return session_id |
 | `session/prompt` | `invoke_agent_runtime(payload={"prompt": text})` → stream response → emit ACP `notifications/content` blocks on stdout |
 | `session/load` | Resume with same `runtimeSessionId` (AgentCore auto-mounts filesystem) |
-| `cancel` | Best-effort: no direct cancel API; can `stop_runtime_session` if needed |
+| `cancel` | **Known limitation:** no mid-invoke cancel in AgentCore. Adapter responds with acknowledgement but the remote invocation continues. See §Known Limitations. |
+
+### Concurrency Control
+
+AgentCore's behavior with concurrent `InvokeAgentRuntime` calls to the same session is undefined. The adapter **must** serialize invocations per session:
+
+```
+Thread A prompt arrives → acquire per-session mutex → invoke → release
+Thread A prompt 2 arrives (while invoke in-flight) → wait for mutex → invoke
+```
+
+This matches OAB's existing invariant (I2: at most one in-flight ACP turn per thread), so in practice the mutex is a safety net, not a bottleneck.
+
+### Error Code Mapping
+
+| AgentCore Error | ACP Behavior |
+|-----------------|-------------|
+| `ThrottlingException` (429) | ACP error response `{"code": -32000, "message": "rate limited, retry later"}` |
+| `ResourceNotFoundException` (404) | ACP error `{"code": -32001, "message": "session not found"}` → OAB shows error to user |
+| `ValidationException` (400) | ACP error `{"code": -32602, "message": "invalid params: ..."}` |
+| `ServiceQuotaExceededException` (402) | ACP error `{"code": -32000, "message": "quota exceeded"}` |
+| `RuntimeClientError` (424) | ACP error `{"code": -32603, "message": "agent runtime error: ..."}` |
+| Network timeout / connection drop | Adapter emits ACP error, does NOT crash (OAB sees error, not a dead process) |
 
 ### Streaming Translation
 
-AgentCore returns `text/event-stream`:
-```
-data: I'll analyze the code...
-data: The issue is in line 42...
-data: Here's my fix:
-```
+AgentCore returns `text/event-stream` (SSE). The adapter **must** use a proper SSE parser (e.g., `httpx-sse`, `aiohttp` SSE support) — not naive `iter_lines()` — because:
+- SSE chunks may split across TCP packets (partial `data:` lines)
+- Multiple events may arrive in a single chunk
+- Keep-alive comments (`:`) must be filtered
 
-`agentcore-acp` translates each chunk to ACP JSON-RPC notification:
-```json
-{"jsonrpc":"2.0","method":"notifications/content","params":{"type":"text","text":"I'll analyze the code..."}}
-{"jsonrpc":"2.0","method":"notifications/content","params":{"type":"text","text":"The issue is in line 42..."}}
+Parsed SSE events are translated to ACP JSON-RPC notifications:
+```
+SSE:  data: I'll analyze the code...
+ACP:  {"jsonrpc":"2.0","method":"notifications/content","params":{"type":"text","text":"I'll analyze the code..."}}
+
+SSE:  data: The issue is in line 42...
+ACP:  {"jsonrpc":"2.0","method":"notifications/content","params":{"type":"text","text":"The issue is in line 42..."}}
 ```
 
 This is the same format OAB already consumes from kiro-cli, claude-agent-acp, etc. — zero changes needed in OAB's streaming/edit logic.
 
 ### Session ID Mapping
 
-AgentCore requires `runtimeSessionId` ≥ 33 characters. The adapter builds this deterministically from the ACP session context:
+AgentCore requires `runtimeSessionId` ≥ 33 characters. The adapter builds this deterministically from the ACP session context, **with guaranteed minimum length**:
 
 ```
 ACP session for Discord thread 1514294613853208667
@@ -142,7 +165,12 @@ ACP session for Discord thread 1514294613853208667
 
 ACP session for Slack thread C0123456789.1234567890.123456
   → runtimeSessionId = "oab-slack-C0123456789-1234567890-123456"  (43 chars ✓)
+
+Short thread ID (edge case): "thread-123"
+  → runtimeSessionId = "oab-discord-thread-123-000000000"  (padded to 33 chars ✓)
 ```
+
+**Length guarantee:** If the constructed ID is < 33 chars, the adapter pads with zero suffix. Alternatively, use a UUID v5 namespace hash of the thread key (always 36 chars).
 
 Deterministic mapping means:
 - No persistent state file needed in the adapter
@@ -241,7 +269,17 @@ Minimal `agentcore-acp` in Python (fastest path to validation):
 
 ---
 
-## 7. Open Questions
+## 7. Known Limitations
+
+1. **Cancel is a no-op.** AgentCore has no mid-invoke cancel API. When OAB sends `cancel`, the adapter acknowledges it but the remote invocation continues until completion. The user sees the cancel reaction (✓) but the agent keeps working. If full cancellation is needed, the adapter can call `StopRuntimeSession` — but this kills the entire session (and any in-progress filesystem writes). This is documented as a known tradeoff; operators must choose between "cancel does nothing" and "cancel nukes the session."
+
+2. **Cold start latency.** First invoke per session takes ~5-15s (microVM boot). Users see this as a pause before streaming begins. The adapter mitigates by emitting an early "Starting environment..." ACP notification.
+
+3. **8-hour max lifetime.** Sessions cannot exceed `maxLifetime` (default 8hr). Long-running work needs the adapter to transparently rotate to a new session and re-mount the same filesystem.
+
+---
+
+## 8. Open Questions
 
 1. **Payload format** — Different AgentCore runtimes may expect different payload schemas (`{"prompt": "..."}` vs raw text vs MCP). Do we need a `--payload-template` flag?
 
@@ -251,15 +289,13 @@ Minimal `agentcore-acp` in Python (fastest path to validation):
 
 4. **Cold start notification** — How should the adapter signal to OAB that the agent is booting? Options: immediate ACP notification ("Starting environment..."), or let OAB's existing stall detection handle it.
 
-5. **Cancel semantics** — AgentCore has `StopRuntimeSession` but no mid-invoke cancel. Should `cancel` kill the entire session (losing state), or just be a no-op?
+5. **Multi-agent routing** — Single adapter routing to multiple runtimes, or multiple adapter instances? Former is more convenient, latter is simpler.
 
-6. **Multi-agent routing** — Single adapter routing to multiple runtimes, or multiple adapter instances? Former is more convenient, latter is simpler.
-
-7. **Language choice for production** — Python (fast to write, boto3 native), Rust (single binary, matches OAB ecosystem), or Node.js (middle ground)?
+6. **Language choice for production** — Python (fast to write, boto3 native), Rust (single binary, matches OAB ecosystem), or Node.js (middle ground)?
 
 ---
 
-## 8. Alternatives Considered
+## 9. Alternatives Considered
 
 ### A. OAB native SDK backend (not recommended for now)
 
@@ -292,7 +328,7 @@ Use Gateway's MCP endpoint as a tool layer for local agents. Complementary (coul
 
 ---
 
-## 9. References
+## 10. References
 
 - [AWS Blog: Hosting Coding Agents on AgentCore](https://aws.amazon.com/blogs/machine-learning/its-safe-to-close-your-laptop-now-hosting-coding-agents-on-amazon-bedrock-agentcore/)
 - [InvokeAgentRuntime API Reference](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_InvokeAgentRuntime.html)

--- a/docs/adr/agentcore-runtime-backend.md
+++ b/docs/adr/agentcore-runtime-backend.md
@@ -20,7 +20,7 @@ This means:
 - **Pod-bound lifecycle.** If the pod restarts, the agent process (and any in-flight work) dies with it.
 - **Resource coupling.** The agent shares CPU/memory/disk with OpenAB — a 90-minute refactor starves the broker.
 
-AWS recently launched **Amazon Bedrock AgentCore Runtime**, which hosts coding agents (Kiro, Claude Code, Codex, etc.) in isolated Firecracker microVMs with persistent filesystems, session management, and streaming invoke APIs. This creates an opportunity: OpenAB can route messages to remote AgentCore sessions via SDK instead of local subprocesses, decoupling the agent lifecycle from the broker.
+AWS recently launched **Amazon Bedrock AgentCore Runtime**, which hosts coding agents (Kiro, Claude Code, Codex, etc.) in isolated Firecracker microVMs with persistent filesystems, session management, and streaming invoke APIs. This creates an opportunity: OpenAB can route messages to remote AgentCore sessions, decoupling the agent lifecycle from the broker.
 
 ### What this unlocks
 
@@ -31,232 +31,264 @@ AWS recently launched **Amazon Bedrock AgentCore Runtime**, which hosts coding a
 
 ---
 
-## 2. Design
+## 2. Integration Approaches
 
-### Architecture Overview
+Two viable approaches exist. We recommend **Option B**.
 
-```
-┌────────────────────────────────────────────────────────────────────┐
-│  OpenAB (Rust, always-on pod)                                      │
-│                                                                    │
-│  Discord/Slack ──► Dispatch ──┬── backend=acp ──► local subprocess │
-│                               │                                    │
-│                               └── backend=agentcore ──► AWS SDK    │
-│                                         │                          │
-└─────────────────────────────────────────┼──────────────────────────┘
-                                          │
-                              ┌────────────▼────────────────┐
-                              │  AgentCore Runtime (AWS)     │
-                              │                             │
-                              │  ┌─────────────────────┐    │
-                              │  │ microVM (Kiro)      │    │
-                              │  │ /mnt/workspace      │    │
-                              │  │ session: oab-thread1│    │
-                              │  └─────────────────────┘    │
-                              │                             │
-                              │  ┌─────────────────────┐    │
-                              │  │ microVM (Claude)    │    │
-                              │  │ /mnt/workspace      │    │
-                              │  │ session: oab-thread2│    │
-                              │  └─────────────────────┘    │
-                              └─────────────────────────────┘
-```
+### Option A: OAB native SDK backend
 
-### Message Flow
+Add a new `backend = "agentcore"` inside OAB that calls `InvokeAgentRuntime` directly via the AWS SDK.
 
 ```
-Inbound:
-  1. User sends message in Discord thread
-  2. OpenAB dispatch selects backend based on config (or @mention routing)
-  3. If backend=agentcore:
-     a. Build runtimeSessionId from thread key (≥33 chars)
-     b. Serialize prompt + sender context into JSON payload
-     c. Call InvokeAgentRuntime (streaming)
-  4. Stream response chunks back to Discord (same edit loop as ACP)
-
-Session Lifecycle:
-  - Discord thread ID → runtimeSessionId (deterministic mapping)
-  - First invoke on new session → cold start (microVM boot, ~5-15s)
-  - Subsequent invokes → reuse existing microVM (idle timer reset)
-  - Idle 15min (configurable) → microVM terminates, filesystem persists
-  - Next invoke → new microVM mounts same filesystem, agent resumes
+Discord → OAB ──AWS SDK──► AgentCore Runtime (microVM)
 ```
 
-### Two Invoke APIs
+### Option B: `agentcore-acp` adapter (recommended)
 
-AgentCore provides two complementary APIs. OpenAB uses primarily `InvokeAgentRuntime`:
-
-| API | Purpose | Response | OpenAB Use |
-|-----|---------|----------|------------|
-| `InvokeAgentRuntime` | Send prompt, get agent reasoning output | Streaming `text/event-stream` | Primary: Discord msg → agent → streaming reply |
-| `InvokeAgentRuntimeCommand` | Run shell command in same microVM | Streaming stdout/stderr events | Optional: deterministic ops (git push, npm test) |
-
-### Streaming Response Handling
-
-`InvokeAgentRuntime` returns `text/event-stream` with `data:` lines:
+Write a standalone ACP-compatible adapter binary that bridges ACP stdio to AgentCore SDK calls. OAB treats it like any other coding CLI — zero OAB changes.
 
 ```
-data: Starting analysis of the code...
-data: I can see the issue is in line 42...
-data: Here's my proposed fix:
-data: ```rust
-data: fn main() { ... }
-data: ```
+Discord → OAB ──ACP stdio──► agentcore-acp ──AWS SDK──► AgentCore Runtime (microVM)
 ```
 
-OpenAB consumes this identically to ACP streaming — progressive Discord message edits via the existing `AdapterRouter::edit_message` path.
+### Why Option B wins
+
+| Dimension | A. OAB native SDK | B. agentcore-acp adapter |
+|-----------|-------------------|--------------------------|
+| OAB code changes | Large — new trait, new backend, AWS SDK dep | **Zero** |
+| Thin bridge philosophy | Violated — OAB learns AWS specifics | **Preserved** — OAB only speaks ACP |
+| Onboarding pattern | New pattern for operators | **Same as kiro/claude/codex** |
+| Independent dev/test | Coupled to OAB release cycle | **Standalone binary**, own repo/release |
+| Language flexibility | Must be Rust (inside OAB) | **Any language** — Python PoC in hours |
+| Multi-runtime routing | Requires OAB routing logic | Multiple OAB instances or adapter-level routing |
+| Deployment | OAB pod needs IRSA for AgentCore | Adapter subprocess needs IRSA (same pod, same SA) |
+| Streaming fidelity | Direct event-stream consumption | Adapter translates to ACP notifications (tiny overhead) |
+
+Option A remains viable for future consideration if we find the ACP translation layer adds unacceptable latency or loses information. But given that every other agent integration (kiro-cli, claude-agent-acp, codex --acp, gemini --acp, opencode acp) follows the adapter pattern, Option B is the natural extension.
 
 ---
 
-## 3. Configuration
+## 3. Design: `agentcore-acp`
 
-### Single agent (simple)
-
-```toml
-[agent]
-backend = "agentcore"
-runtime_arn = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/kiro-agent"
-region = "us-west-2"
-```
-
-### Multi-agent routing
-
-```toml
-[agent]
-backend = "agentcore"
-runtime_arn = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/kiro-agent"
-region = "us-west-2"
-
-# Future: route by @mention to different runtimes
-# [agent.routes]
-# kiro = "arn:aws:...:runtime/kiro-agent"
-# claude = "arn:aws:...:runtime/claude-agent"
-# codex = "arn:aws:...:runtime/codex-agent"
-```
-
-### Hybrid (ACP + AgentCore coexist)
-
-In a future multi-agent config, some agents could be local ACP while others are remote AgentCore. This ADR focuses on the single-agent case first.
-
----
-
-## 4. Session ID Mapping
-
-AgentCore requires `runtimeSessionId` ≥ 33 characters. OpenAB thread keys are platform-specific (Discord: 18-20 digit snowflake, Slack: channel.thread_ts).
-
-**Strategy:** Prefix with `oab-` and pad/hash to guarantee length:
+### Architecture
 
 ```
-Discord thread 1514294613853208667
+┌─ agentcore-acp (subprocess, started by OAB) ─────────────────────┐
+│                                                                   │
+│  stdin ◄── ACP JSON-RPC from OAB                                  │
+│  stdout ──► ACP JSON-RPC notifications to OAB                     │
+│                                                                   │
+│  ┌─────────────────────────────────────────────────────────────┐  │
+│  │  ACP Server Layer                                           │  │
+│  │  - session/new → create/resume AgentCore session            │  │
+│  │  - session/prompt → InvokeAgentRuntime (streaming)          │  │
+│  │  - cancel → StopRuntimeSession (best-effort)               │  │
+│  └──────────────────────┬──────────────────────────────────────┘  │
+│                         │                                         │
+│  ┌──────────────────────▼──────────────────────────────────────┐  │
+│  │  AgentCore Client                                           │  │
+│  │  - boto3 / aws-sdk-rust / JS SDK                            │  │
+│  │  - invoke_agent_runtime(runtimeArn, sessionId, payload)     │  │
+│  │  - Stream text/event-stream → ACP content notifications     │  │
+│  └─────────────────────────────────────────────────────────────┘  │
+│                                                                   │
+└───────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+                ┌──────────────────────────┐
+                │  AgentCore Runtime (AWS)  │
+                │  ┌────────────────────┐  │
+                │  │ microVM            │  │
+                │  │ Kiro / Claude /    │  │
+                │  │ Codex / etc.       │  │
+                │  │ /mnt/workspace     │  │
+                │  └────────────────────┘  │
+                └──────────────────────────┘
+```
+
+### ACP Protocol Mapping
+
+| ACP Method (from OAB) | agentcore-acp Action |
+|------------------------|---------------------|
+| `session/new` | Generate `runtimeSessionId` from thread key, return session_id |
+| `session/prompt` | `invoke_agent_runtime(payload={"prompt": text})` → stream response → emit ACP `notifications/content` blocks on stdout |
+| `session/load` | Resume with same `runtimeSessionId` (AgentCore auto-mounts filesystem) |
+| `cancel` | Best-effort: no direct cancel API; can `stop_runtime_session` if needed |
+
+### Streaming Translation
+
+AgentCore returns `text/event-stream`:
+```
+data: I'll analyze the code...
+data: The issue is in line 42...
+data: Here's my fix:
+```
+
+`agentcore-acp` translates each chunk to ACP JSON-RPC notification:
+```json
+{"jsonrpc":"2.0","method":"notifications/content","params":{"type":"text","text":"I'll analyze the code..."}}
+{"jsonrpc":"2.0","method":"notifications/content","params":{"type":"text","text":"The issue is in line 42..."}}
+```
+
+This is the same format OAB already consumes from kiro-cli, claude-agent-acp, etc. — zero changes needed in OAB's streaming/edit logic.
+
+### Session ID Mapping
+
+AgentCore requires `runtimeSessionId` ≥ 33 characters. The adapter builds this deterministically from the ACP session context:
+
+```
+ACP session for Discord thread 1514294613853208667
   → runtimeSessionId = "oab-discord-1514294613853208667"  (34 chars ✓)
 
-Slack thread C0123456789.1234567890.123456
+ACP session for Slack thread C0123456789.1234567890.123456
   → runtimeSessionId = "oab-slack-C0123456789-1234567890-123456"  (43 chars ✓)
 ```
 
-The mapping is deterministic (no persistent state needed). Same thread always maps to same session. This enables:
-- Resume after OpenAB restart (no `thread_map.json` needed for AgentCore backend)
-- Multiple OpenAB replicas sharing the same AgentCore sessions
+Deterministic mapping means:
+- No persistent state file needed in the adapter
+- Resume works automatically after adapter restart
+- Multiple adapter instances can share the same AgentCore sessions
 
 ---
 
-## 5. Implementation Plan
+## 4. Configuration
 
-### Phase 1: Minimal viable backend
+From the OAB operator's perspective, `agentcore-acp` is just another agent command:
 
-1. Add `backend` field to `AgentConfig` (`"acp"` default, `"agentcore"` new)
-2. Define `AgentBackend` trait:
-   ```rust
-   #[async_trait]
-   trait AgentBackend: Send + Sync {
-       /// Send a prompt and stream response blocks back.
-       async fn stream_prompt(
-           &self,
-           session_key: &str,
-           prompt: &str,
-           extra_blocks: &[ContentBlock],
-           tx: mpsc::Sender<ContentBlock>,
-       ) -> Result<()>;
+```toml
+[agent]
+command = "agentcore-acp"
+args = ["--runtime-arn", "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/kiro-agent", "--region", "us-west-2"]
+working_dir = "/home/agent"
+# IAM credentials come from pod's service account (IRSA) — no env vars needed
+```
 
-       /// Cancel an in-flight turn (best-effort).
-       async fn cancel(&self, session_key: &str) -> Result<()>;
-   }
-   ```
-3. Implement `AcpBackend` (wraps existing `SessionPool` logic)
-4. Implement `AgentCoreBackend`:
-   - Uses `aws-sdk-bedrockagentcore` crate
-   - `stream_prompt` → `invoke_agent_runtime` with streaming response
-   - Parses `text/event-stream` lines into `ContentBlock::Text`
-   - Maps session_key → runtimeSessionId with prefix scheme
-5. Wire into dispatcher — replace direct `SessionPool` usage with `dyn AgentBackend`
+For multi-agent setups, deploy multiple OAB instances each pointing to a different runtime:
 
-### Phase 2: Cold start UX
+```toml
+# Instance 1: Kiro
+[agent]
+command = "agentcore-acp"
+args = ["--runtime-arn", "arn:aws:...:runtime/kiro-agent"]
 
-- Detect first-invoke latency (no streaming data for >3s)
-- Show ⏳ or "Starting agent environment..." reaction
-- Once streaming begins, switch to normal 🤔 thinking reaction
+# Instance 2: Claude Code
+[agent]
+command = "agentcore-acp"
+args = ["--runtime-arn", "arn:aws:...:runtime/claude-agent"]
+```
 
-### Phase 3: Multi-runtime routing (future)
-
-- Config-driven routing table (per @mention, per channel, per pattern)
-- Parallel invoke to multiple runtimes (race mode)
+Or, if the adapter supports it, a single adapter could route based on hints in the prompt/sender context (future enhancement).
 
 ---
 
-## 6. Differences from ACP Backend
+## 5. AgentCore Runtime Characteristics
 
-| Concern | ACP (current) | AgentCore (proposed) |
-|---------|--------------|---------------------|
+Key properties that the adapter must handle:
+
+| Property | Value | Implication |
+|----------|-------|-------------|
+| Session idle timeout | 15 min (configurable, up to 8hr) | Each invoke resets the timer; long gaps = cold start |
+| Max session lifetime | 8 hours | Long-running work needs session rotation |
+| Cold start | ~5-15s (microVM boot) | First invoke per session has visible latency |
+| Filesystem persistence | 14 days after last use | Agent state survives across session restarts |
+| Streaming response | `text/event-stream` over HTTP/2 | Real-time token delivery, translatable to ACP |
+| Parallelism | Independent microVM per session | No resource contention between sessions |
+| Cost model | CPU-seconds + peak memory | Idle sessions cost nothing after termination |
+
+### Comparison with local ACP
+
+| Concern | ACP (local subprocess) | agentcore-acp (remote) |
+|---------|----------------------|------------------------|
 | Agent location | Same container | Remote microVM |
-| Startup | Already running (subprocess) | Cold start on first invoke (~5-15s) |
+| Startup | Already running | Cold start on first invoke (~5-15s) |
 | Session state | In-memory (process) | Persistent filesystem (/mnt/workspace) |
-| Credential isolation | Shared pod env | Fully isolated (IAM + Gateway) |
-| Tool permission prompt | Supported (mid-turn stdin) | Not supported — must trust all tools |
-| Streaming format | ACP JSON-RPC notifications | HTTP/2 event-stream (`data:` lines) |
+| Credential isolation | Shared pod env | Fully isolated (IAM + AgentCore Gateway) |
+| Tool permission prompt | Supported (mid-turn) | Not supported — agents run autonomously |
 | Max session duration | Unlimited (until pod dies) | 8 hours (configurable) |
-| Idle behavior | Stays alive (in pool) | Auto-terminates after idle timeout |
-| Resume after kill | Lost (unless session/save) | Automatic (filesystem persists 14 days) |
-| Parallelism | One process per thread, shared CPU | One microVM per session, independent |
-| Cost model | Always-on pod cost | Pay per CPU-second + peak memory |
+| Resume after restart | Lost (unless session/save) | Automatic (filesystem persists) |
+| Parallelism | Shared CPU per pod | One microVM per session |
+
+---
+
+## 6. Implementation Plan
+
+### Phase 1: Python PoC
+
+Minimal `agentcore-acp` in Python (fastest path to validation):
+
+1. ACP stdio server (read JSON-RPC from stdin, write to stdout)
+2. `session/new` → generate runtimeSessionId
+3. `session/prompt` → `boto3.client('bedrock-agentcore').invoke_agent_runtime()` with streaming
+4. Parse `response["response"].iter_lines()` → emit ACP content notifications
+5. Package as a single script or small pip package
+
+**Deliverable:** Working end-to-end demo: Discord message → OAB → agentcore-acp → AgentCore → streaming reply in Discord.
+
+### Phase 2: Production hardening
+
+1. Proper error handling (throttling, session terminated, cold start detection)
+2. Cold start UX: emit a "⏳ Starting agent environment..." notification before streaming begins
+3. Session resume logic (detect if session was idle-terminated, re-invoke transparently)
+4. Config file support (runtime ARN, region, payload template, timeout)
+5. Logging and observability (structured logs, latency metrics)
+
+### Phase 3: Advanced features
+
+1. Multi-runtime routing within a single adapter instance
+2. `InvokeAgentRuntimeCommand` support for deterministic operations (exposed as an ACP tool?)
+3. Rust rewrite for performance/single-binary distribution (if Python overhead is measurable)
+4. Integration with AgentCore Gateway MCP for tool access
 
 ---
 
 ## 7. Open Questions
 
-1. **Payload format standardization** — Different AgentCore runtimes may expect different payload schemas (`{"prompt": "..."}` vs raw text vs MCP). Do we need a `payload_template` config field?
+1. **Payload format** — Different AgentCore runtimes may expect different payload schemas (`{"prompt": "..."}` vs raw text vs MCP). Do we need a `--payload-template` flag?
 
-2. **Response format parsing** — If the agent runtime returns structured JSON (not plain text streaming), how do we extract the "message" portion? May need a configurable response extractor.
+2. **Session context passthrough** — Should the adapter forward OAB's sender context (user name, channel, etc.) in the payload so the remote agent knows who's asking?
 
-3. **OAuth-based invocation** — AgentCore docs state that OAuth-integrated runtimes cannot use the SDK; they require raw HTTPS. If a runtime uses AgentCore Identity/Gateway with OAuth, OpenAB would need to use `reqwest` directly instead of the AWS SDK. How common is this pattern?
+3. **Human-in-the-loop** — ACP supports mid-turn tool permission prompts. AgentCore agents run autonomously. Is this acceptable, or do we need a callback mechanism via the adapter?
 
-4. **Human-in-the-loop** — ACP supports mid-turn tool permission prompts (agent asks user "can I run this command?"). AgentCore agents run autonomously. Is this acceptable, or do we need a callback mechanism?
+4. **Cold start notification** — How should the adapter signal to OAB that the agent is booting? Options: immediate ACP notification ("Starting environment..."), or let OAB's existing stall detection handle it.
 
-5. **Multi-agent routing UX** — How should users specify which agent handles which message? Options: @mention, channel binding, slash command, or auto-detect.
+5. **Cancel semantics** — AgentCore has `StopRuntimeSession` but no mid-invoke cancel. Should `cancel` kill the entire session (losing state), or just be a no-op?
 
-6. **Error recovery** — If `InvokeAgentRuntime` fails (throttling, session terminated), should OpenAB auto-retry with a new session, or surface the error to the user?
+6. **Multi-agent routing** — Single adapter routing to multiple runtimes, or multiple adapter instances? Former is more convenient, latter is simpler.
+
+7. **Language choice for production** — Python (fast to write, boto3 native), Rust (single binary, matches OAB ecosystem), or Node.js (middle ground)?
 
 ---
 
 ## 8. Alternatives Considered
 
-### A. Keep ACP-only, run OpenAB on AgentCore
+### A. OAB native SDK backend (not recommended for now)
 
-Deploy the entire OpenAB + agent container on AgentCore Runtime instead. This works but:
+Add `backend = "agentcore"` directly inside OAB with AWS SDK calls. This works but:
+- Violates the "thin bridge" philosophy — OAB shouldn't understand AWS specifics
+- Adds `aws-sdk-bedrockagentcore` as a compile-time dependency to OAB
+- Different release cycle (AgentCore API changes shouldn't require OAB rebuild)
+- Breaks the consistent "all agents are ACP subprocesses" mental model
+
+May revisit if the ACP translation layer proves to be a bottleneck.
+
+### B. Deploy OAB itself on AgentCore
+
+Run the entire OpenAB + agent container on AgentCore Runtime. This works but:
 - Still couples agent to container
 - Doesn't leverage AgentCore's multi-session isolation
-- Doesn't enable multi-agent routing from one OpenAB instance
-- Loses the "thin bridge" philosophy — OpenAB becomes the thing being hosted, not the router
+- Doesn't enable dynamic routing from one OAB instance
+- Loses the thin bridge role
 
-### B. WebSocket relay to AgentCore
+### C. WebSocket relay to AgentCore
 
-Instead of SDK invoke, have a persistent WebSocket between OpenAB and a custom proxy that talks to AgentCore. Rejected because:
-- Adds another service to deploy and maintain
-- `InvokeAgentRuntime` already supports streaming; no need for an intermediary
-- Increases complexity without clear benefit
+Persistent WebSocket between OAB and a custom proxy. Rejected:
+- Adds another service to deploy
+- `InvokeAgentRuntime` already streams; no intermediary needed
+- More moving parts, same result
 
-### C. MCP-based integration via AgentCore Gateway
+### D. MCP-based integration via AgentCore Gateway
 
-Use AgentCore Gateway's MCP endpoint as the tool layer, keeping agents local. This is complementary (we could support it for tools) but doesn't solve the core problem of agent lifecycle coupling.
+Use Gateway's MCP endpoint as a tool layer for local agents. Complementary (could add for tools) but doesn't solve the agent lifecycle coupling problem.
 
 ---
 
@@ -269,3 +301,4 @@ Use AgentCore Gateway's MCP endpoint as the tool layer, keeping agents local. Th
 - [AgentCore Session Storage (Preview)](https://aws.amazon.com/about-aws/whats-new/2026/03/bedrock-agentcore-runtime-session-storage/)
 - [Handle Long-Running Agents](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-long-run.html)
 - [OpenAB DESIGN.md](../../DESIGN.md) — "Thin Bridge" philosophy
+- [ADR: openab-agent](./openab-agent.md) — Native agent pattern (similar standalone approach)

--- a/docs/adr/agentcore-runtime-backend.md
+++ b/docs/adr/agentcore-runtime-backend.md
@@ -271,9 +271,13 @@ Minimal `agentcore-acp` in Python (fastest path to validation):
 
 ## 7. Known Limitations
 
-1. **Cancel is a no-op.** AgentCore has no mid-invoke cancel API. When OAB sends `cancel`, the adapter acknowledges it but the remote invocation continues until completion. The user sees the cancel reaction (✓) but the agent keeps working. If full cancellation is needed, the adapter can call `StopRuntimeSession` — but this kills the entire session (and any in-progress filesystem writes). This is documented as a known tradeoff; operators must choose between "cancel does nothing" and "cancel nukes the session."
+1. **Cancel is safe for filesystem, destructive for in-memory state.** AgentCore has no mid-invoke cancel API. When OAB sends `cancel`, the adapter can call `StopRuntimeSession` which terminates the microVM. **Filesystem (`/mnt/workspace`) persists for 14 days** — files, git history, installed packages are all safe. What is lost: in-memory agent state (conversation context, running processes, partial computations). The next invoke on the same session ID mounts the same filesystem on a fresh microVM. This makes cancel = stop session a reasonable default for most coding workflows.
 
-2. **Cold start latency.** First invoke per session takes ~5-15s (microVM boot). Users see this as a pause before streaming begins. The adapter mitigates by emitting an early "Starting environment..." ACP notification.
+2. **Cold start latency (~5-15s).** First invoke per session requires microVM boot. The adapter handles this proactively: if no SSE event arrives within 3 seconds of invoking, the adapter emits an early ACP notification:
+   ```json
+   {"jsonrpc":"2.0","method":"notifications/content","params":{"type":"text","text":"⏳ Starting agent environment..."}}
+   ```
+   OAB displays this immediately, so the user knows the system is working. Once streaming begins, normal content flow takes over. This is defined behavior, not dependent on OAB's stall detection.
 
 3. **8-hour max lifetime.** Sessions cannot exceed `maxLifetime` (default 8hr). Long-running work needs the adapter to transparently rotate to a new session and re-mount the same filesystem.
 
@@ -287,11 +291,9 @@ Minimal `agentcore-acp` in Python (fastest path to validation):
 
 3. **Human-in-the-loop** — ACP supports mid-turn tool permission prompts. AgentCore agents run autonomously. Is this acceptable, or do we need a callback mechanism via the adapter?
 
-4. **Cold start notification** — How should the adapter signal to OAB that the agent is booting? Options: immediate ACP notification ("Starting environment..."), or let OAB's existing stall detection handle it.
+4. **Multi-agent routing** — Single adapter routing to multiple runtimes, or multiple adapter instances? Former is more convenient, latter is simpler.
 
-5. **Multi-agent routing** — Single adapter routing to multiple runtimes, or multiple adapter instances? Former is more convenient, latter is simpler.
-
-6. **Language choice for production** — Python (fast to write, boto3 native), Rust (single binary, matches OAB ecosystem), or Node.js (middle ground)?
+5. **Language choice for production** — Python (fast to write, boto3 native), Rust (single binary, matches OAB ecosystem), or Node.js (middle ground)?
 
 ---
 

--- a/docs/adr/agentcore-runtime-backend.md
+++ b/docs/adr/agentcore-runtime-backend.md
@@ -174,13 +174,13 @@ The adapter parses this on the first `session/prompt` to extract `thread_id` (or
 
 ```
 Discord thread 1514294613853208667
-  → runtimeSessionId = "oab-discord-1514294613853208667"  (34 chars ✓)
+  → runtimeSessionId = "oab-discord-thread-1514294613853208667"  (38 chars ✓)
 
 Slack thread C0123456789.1234567890.123456
-  → runtimeSessionId = "oab-slack-C0123456789-1234567890-123456"  (43 chars ✓)
+  → runtimeSessionId = "oab-slack-thread-C0123456789-1234567890-123456"  (47 chars ✓)
 
 Short/missing thread ID (edge case): channel_id only "1490282656913559673"
-  → runtimeSessionId = "oab-discord-ch-1490282656913559673"  (37 chars ✓)
+  → runtimeSessionId = "oab-discord-channel-1490282656913559673"  (39 chars ✓)
 ```
 
 **Length guarantee:** If the constructed ID is < 33 chars, the adapter pads with zero suffix. Alternatively, use a UUID v5 namespace hash of the thread key (always 36 chars).

--- a/docs/adr/agentcore-runtime-backend.md
+++ b/docs/adr/agentcore-runtime-backend.md
@@ -112,8 +112,8 @@ Option A remains viable for future consideration if we find the ACP translation 
 |------------------------|---------------------|
 | `session/new` | Generate `runtimeSessionId` from thread key, return session_id |
 | `session/prompt` | `invoke_agent_runtime(payload={"prompt": text})` → stream response → emit ACP `notifications/content` blocks on stdout |
-| `session/load` | Resume with same `runtimeSessionId` (AgentCore auto-mounts filesystem) |
-| `cancel` | **Known limitation:** no mid-invoke cancel in AgentCore. Adapter responds with acknowledgement but the remote invocation continues. See §Known Limitations. |
+| `session/load` | Resume with same `runtimeSessionId`. If session was idle-terminated (404 `ResourceNotFoundException`), transparently invoke as new — AgentCore auto-provisions a new microVM and mounts the persisted filesystem. Return success either way. |
+| `cancel` | **Known limitation:** see §Known Limitations. Default: call `StopRuntimeSession`. Configurable via `--cancel-strategy=noop|stop`. |
 
 ### Concurrency Control
 
@@ -157,20 +157,35 @@ This is the same format OAB already consumes from kiro-cli, claude-agent-acp, et
 
 ### Session ID Mapping
 
-AgentCore requires `runtimeSessionId` ≥ 33 characters. The adapter builds this deterministically from the ACP session context, **with guaranteed minimum length**:
+AgentCore requires `runtimeSessionId` ≥ 33 characters. The adapter builds this deterministically from the **sender context embedded in each prompt**.
+
+**How the adapter gets the thread ID (no OAB changes needed):**
+
+OAB wraps every prompt with a `<sender_context>` block containing the full routing metadata:
+```json
+<sender_context>
+{"schema":"openab.sender.v1","channel_id":"1490282656913559673","thread_id":"1514294613853208667",...}
+</sender_context>
+```
+
+The adapter parses this on the first `session/prompt` to extract `thread_id` (or `channel_id` if no thread). This is the same sender context that all ACP agents already receive — no protocol changes needed.
+
+**Mapping examples (guaranteed ≥33 chars):**
 
 ```
-ACP session for Discord thread 1514294613853208667
+Discord thread 1514294613853208667
   → runtimeSessionId = "oab-discord-1514294613853208667"  (34 chars ✓)
 
-ACP session for Slack thread C0123456789.1234567890.123456
+Slack thread C0123456789.1234567890.123456
   → runtimeSessionId = "oab-slack-C0123456789-1234567890-123456"  (43 chars ✓)
 
-Short thread ID (edge case): "thread-123"
-  → runtimeSessionId = "oab-discord-thread-123-000000000"  (padded to 33 chars ✓)
+Short/missing thread ID (edge case): channel_id only "1490282656913559673"
+  → runtimeSessionId = "oab-discord-ch-1490282656913559673"  (37 chars ✓)
 ```
 
 **Length guarantee:** If the constructed ID is < 33 chars, the adapter pads with zero suffix. Alternatively, use a UUID v5 namespace hash of the thread key (always 36 chars).
+
+**Fallback:** If `<sender_context>` is absent (e.g., non-OAB usage), the adapter falls back to a per-process monotonic session ID. This loses cross-restart resume but still functions.
 
 Deterministic mapping means:
 - No persistent state file needed in the adapter


### PR DESCRIPTION
## Summary

Proposes `agentcore-acp` — a standalone ACP adapter that bridges OpenAB to **Amazon Bedrock AgentCore Runtime** via SDK invoke. OAB stays unchanged (zero code modifications).

```
┌─────────┐       ┌─────────────────┐       ┌────────────────────────────────────────────┐
│ Discord │       │                 │  ACP   │            agentcore-acp                   │
│  Slack  │──────▶│      OAB        │───────▶│  (Python, single-file, spawned by OAB)     │
│Telegram │       │  (thin bridge)  │ stdio  │                                            │
└─────────┘       └─────────────────┘        └────────────────────┬───────────────────────┘
                                                                   │ AWS SDK
                                                                   │ invoke_agent_runtime
                                                                   ▼
                                              ┌────────────────────────────────────────────┐
                                              │        AgentCore Runtime (us-east-1)        │
                                              │                                            │
                                              │  ┌──────────────────────────────────────┐  │
                                              │  │        Firecracker microVM            │  │
                                              │  │                                      │  │
                                              │  │  ┌──────────────────────────────┐    │  │
                                              │  │  │  Kiro / Claude / Codex / ...  │    │  │
                                              │  │  │  /mnt/workspace (persistent)  │    │  │
                                              │  │  └──────────────────────────────┘    │  │
                                              │  │                                      │  │
                                              │  │  • Token Vault auth (no plaintext)   │  │
                                              │  │  • Session memory across turns        │  │
                                              │  │  • 14-day filesystem persistence      │  │
                                              │  └──────────────────────────────────────┘  │
                                              └────────────────────────────────────────────┘
```

## Motivation

Inspired by [this AWS blog post](https://aws.amazon.com/blogs/machine-learning/its-safe-to-close-your-laptop-now-hosting-coding-agents-on-amazon-bedrock-agentcore/) — AgentCore Runtime hosts coding agents in isolated Firecracker microVMs with persistent filesystems and streaming APIs.

This unlocks:
- **Dynamic multi-agent routing** — one OAB routes to N runtimes by @mention
- **True isolation** — each agent in its own microVM, no shared localhost
- **Background execution** — agents survive pod restarts, lid closes
- **Pay-per-use** — no always-on pod per agent

## Why an adapter (Option B) instead of native SDK in OAB (Option A)

```
┌─────┐          ┌──────────────┐          ┌──────────────┐
│ OAB │──ACP────▶│agentcore-acp │──SDK────▶│  AgentCore   │   ← Option B (chosen)
└─────┘  stdio   └──────────────┘          └──────────────┘

┌─────┐                                    ┌──────────────┐
│ OAB │────────────────SDK────────────────▶│  AgentCore   │   ← Option A (rejected)
└─────┘                                    └──────────────┘
```

- **Zero OAB changes** — same onboarding as any other coding CLI
- **Thin bridge preserved** — OAB only speaks ACP, doesn't learn AWS specifics
- **Independent release cycle** — adapter ships separately
- **Any language** — Python PoC in hours, Rust later if needed

## Usage

```toml
[agent]
command = "uv"
args = ["run", "./agentcore-acp/agentcore_acp.py", "--runtime-arn", "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent", "--region", "us-east-1"]
```

## ADR Contents

1. Two approaches compared (A vs B) with recommendation
2. Adapter architecture + ACP protocol mapping
3. Streaming translation (event-stream → ACP notifications)
4. Session ID mapping (deterministic, no persistent state)
5. Config example
6. Implementation plan (3 phases: Python PoC → Production → Advanced)
7. Open questions + alternatives considered

## E2E Validated

- ✅ Full round trip: Discord → OAB → agentcore-acp → AgentCore → Kiro CLI → response
- ✅ Token Vault auth (no plaintext keys)
- ✅ Session memory with `--resume` on persistent filesystem
- ✅ `invoke_agent_runtime_command` available in boto3 (Phase 2 path)
- ✅ Works with `uv run` — single file, no install needed

## Follow-up

- #1070 — `[agentcore]` config sugar