### PR TITLE
feat: [agentcore] config section auto-spawns adapter

### DIFF
--- a/.github/workflows/build-operator.yml
+++ b/.github/workflows/build-operator.yml
@@ -78,6 +78,7 @@ jobs:
           - { suffix: "-opencode", dockerfile: "Dockerfile.opencode", artifact: "opencode" }
           - { suffix: "-cursor", dockerfile: "Dockerfile.cursor", artifact: "cursor" }
           - { suffix: "-hermes", dockerfile: "Dockerfile.hermes", artifact: "hermes" }
+          - { suffix: "-agentcore", dockerfile: "Dockerfile.agentcore", artifact: "agentcore" }
           - { suffix: "-grok", dockerfile: "Dockerfile.grok", artifact: "grok" }
           - { suffix: "-antigravity", dockerfile: "Dockerfile.antigravity", artifact: "antigravity" }
           - { suffix: "-pi", dockerfile: "Dockerfile.pi", artifact: "pi" }
@@ -147,6 +148,7 @@ jobs:
           - { suffix: "-opencode", artifact: "opencode" }
           - { suffix: "-cursor", artifact: "cursor" }
           - { suffix: "-hermes", artifact: "hermes" }
+          - { suffix: "-agentcore", artifact: "agentcore" }
           - { suffix: "-grok", artifact: "grok" }
           - { suffix: "-antigravity", artifact: "antigravity" }
           - { suffix: "-pi", artifact: "pi" }
@@ -204,6 +206,7 @@ jobs:
           - { suffix: "-opencode" }
           - { suffix: "-cursor" }
           - { suffix: "-hermes" }
+          - { suffix: "-agentcore" }
           - { suffix: "-grok" }
           - { suffix: "-antigravity" }
           - { suffix: "-pi" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,10 +124,441 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-secretsmanager"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63da8ec2dca98a68d8bcba971abae5f06e2c9c0017f43097d1ff92cff96adc54"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.106.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.14",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.9.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.38",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bitflags"
@@ -133,6 +573,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -166,12 +615,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -252,6 +713,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +740,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +766,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -307,6 +808,24 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -345,8 +864,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -359,6 +890,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -408,6 +951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +970,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -559,6 +1114,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +1179,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,12 +1216,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -613,8 +1243,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -623,6 +1253,45 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -634,8 +1303,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "h2 0.4.14",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -646,14 +1316,30 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls 0.23.38",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -670,14 +1356,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -885,6 +1571,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1721,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1756,8 @@ version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-config",
+ "aws-sdk-secretsmanager",
  "base64",
  "chrono",
  "chrono-tz",
@@ -1067,7 +1774,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serenity",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tokio-tungstenite",
@@ -1078,6 +1785,18 @@ dependencies = [
  "unicode-width",
  "uuid",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -1175,6 +1894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,7 +1991,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.38",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1303,7 +2028,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1421,6 +2146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,11 +2168,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
@@ -1511,6 +2242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +2261,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -1543,12 +2295,25 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1559,6 +2324,16 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1578,6 +2353,7 @@ version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1596,10 +2372,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "secrecy"
@@ -1609,6 +2404,29 @@ checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1728,8 +2546,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1739,8 +2557,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1791,6 +2620,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -1981,7 +2820,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1995,6 +2834,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
 ]
 
 [[package]]
@@ -2112,8 +2961,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -2223,7 +3072,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -2291,6 +3140,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,6 +3185,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "want"
@@ -2836,6 +3697,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"

--- a/Dockerfile.agentcore
+++ b/Dockerfile.agentcore
@@ -13,15 +13,21 @@ RUN touch src/main.rs && cargo build --release
 # --- Runtime stage ---
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates python3 python3-pip tini \
+      ca-certificates curl python3 python3-pip tini \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv (for running agentcore-acp without pip install)
-RUN curl -fsSL https://astral.sh/uv/install.sh | sh || \
-    pip3 install --no-cache-dir uv
-
 RUN useradd -m -s /bin/bash -u 1000 agent
+
+# Install uv for the agent user
+USER agent
+RUN curl -fsSL https://astral.sh/uv/install.sh | sh
+USER root
+
+# Install boto3 system-wide (adapter imports it at module level)
+RUN pip3 install --no-cache-dir --break-system-packages boto3>=1.42
+
 ENV HOME=/home/agent
+ENV PATH="/home/agent/.local/bin:${PATH}"
 WORKDIR /home/agent
 
 COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
@@ -30,9 +36,6 @@ COPY --chown=agent:agent agentcore-acp/agentcore_acp.py /opt/agentcore-acp/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-
-# No OPENAB_AGENT_COMMAND — [agentcore] in config.toml handles it,
-# or set via env: OPENAB_AGENT_COMMAND="uv run --script /opt/agentcore-acp/agentcore_acp.py --runtime-arn ... --region ..."
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.agentcore
+++ b/Dockerfile.agentcore
@@ -1,0 +1,38 @@
+# Dockerfile.agentcore — OAB + agentcore-acp only (no bundled coding CLI).
+# The coding agent (Kiro, Claude, Codex, etc.) runs remotely in AgentCore Runtime.
+# Result: ~50MB image vs ~500MB+ with a full coding CLI baked in.
+
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates python3 python3-pip tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv (for running agentcore-acp without pip install)
+RUN curl -fsSL https://astral.sh/uv/install.sh | sh || \
+    pip3 install --no-cache-dir uv
+
+RUN useradd -m -s /bin/bash -u 1000 agent
+ENV HOME=/home/agent
+WORKDIR /home/agent
+
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
+COPY --chown=agent:agent agentcore-acp/agentcore_acp.py /opt/agentcore-acp/agentcore_acp.py
+
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+
+# No OPENAB_AGENT_COMMAND — [agentcore] in config.toml handles it,
+# or set via env: OPENAB_AGENT_COMMAND="uv run --script /opt/agentcore-acp/agentcore_acp.py --runtime-arn ... --region ..."
+
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 Run any coding agent remotely on [Amazon Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime.html) — no CLI bundled in the OAB image.
 
 ```
-┌─────────┐       ┌─────────┐        ┌───────────────┐       ┌──────────────────────────┐
-│ Discord │       │         │  ACP   │               │  AWS  │   AgentCore Runtime      │
-│  Slack  │──────▶│   OAB   │───────▶│ agentcore-acp │──────▶│   ┌──────────────────┐   │
-│Telegram │       │         │ stdio  │   (adapter)   │  SDK  │   │ Firecracker μVM  │   │
-└─────────┘       └─────────┘        └───────────────┘       │   │  Kiro / Claude…  │   │
-                                                               │   │  /mnt/workspace   │   │
+┌─────────┐       ┌─────────┐        ┌───────────────┐         ┌──────────────────────────┐
+│ Discord │       │         │  ACP   │               │  AWS    │   AgentCore Runtime      │
+│  Slack  │──────▶│   OAB   │───────▶│ agentcore-acp │──────▶  │   ┌──────────────────┐   │
+│Telegram │       │         │ stdio  │   (adapter)   │  SDK    │   │ Firecracker μVM  │   │
+└─────────┘       └─────────┘        └───────────────┘         │   │  Kiro / Claude…  │   │
+                                                               │   │  /mnt/workspace  │   │
                                                                │   └──────────────────┘   │
                                                                └──────────────────────────┘
 ```

--- a/README.md
+++ b/README.md
@@ -177,6 +177,29 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 
 > 🔧 Running multiple agents? See [docs/multi-agent.md](docs/multi-agent.md)
 
+## AgentCore Runtime
+
+Run any coding agent remotely on [Amazon Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime.html) — no CLI bundled in the OAB image.
+
+```
+┌─────────┐       ┌─────────┐        ┌───────────────┐       ┌──────────────────────────┐
+│ Discord │       │         │  ACP   │               │  AWS  │   AgentCore Runtime      │
+│  Slack  │──────▶│   OAB   │───────▶│ agentcore-acp │──────▶│   ┌──────────────────┐   │
+│Telegram │       │         │ stdio  │   (adapter)   │  SDK  │   │ Firecracker μVM  │   │
+└─────────┘       └─────────┘        └───────────────┘       │   │  Kiro / Claude…  │   │
+                                                               │   │  /mnt/workspace   │   │
+                                                               │   └──────────────────┘   │
+                                                               └──────────────────────────┘
+```
+
+```toml
+[agentcore]
+runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"
+region = "us-east-1"
+```
+
+Smaller image (~50MB), persistent filesystem, isolated microVMs, pay-per-use. See [docs/agentcore.md](docs/agentcore.md) for full setup.
+
 ## Configuration Reference
 
 > 📖 Full reference with all options, defaults, and Helm mapping: [docs/config-reference.md](docs/config-reference.md)

--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ Run any coding agent remotely on [Amazon Bedrock AgentCore](https://docs.aws.ama
 ```toml
 [agentcore]
 runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"
-region = "us-east-1"
 ```
 
 Smaller image (~50MB), persistent filesystem, isolated microVMs, pay-per-use. See [docs/agentcore.md](docs/agentcore.md) for full setup.

--- a/agentcore-acp/agentcore_acp.py
+++ b/agentcore-acp/agentcore_acp.py
@@ -346,7 +346,7 @@ class AcpAdapter:
 def main():
     parser = argparse.ArgumentParser(description="ACP adapter for AgentCore Runtime")
     parser.add_argument("--runtime-arn", required=True, help="AgentCore Runtime ARN")
-    parser.add_argument("--region", default="us-west-2", help="AWS region")
+    parser.add_argument("--region", default="us-east-1", help="AWS region")
     parser.add_argument(
         "--cancel-strategy",
         choices=["noop", "stop"],

--- a/config.toml.example
+++ b/config.toml.example
@@ -52,6 +52,14 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 #                                       # omitted = auto-detect from list (non-empty → false, empty → true)
 # allowed_users = ["U5678"]             # only checked when allow_all_users = false
 
+# --- AgentCore Runtime (alternative to [agent]) ---
+# When [agentcore] is set and [agent].command is not explicitly provided,
+# OAB auto-spawns the bundled agentcore-acp adapter. No manual wiring needed.
+# [agentcore]
+# runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"
+# region = "us-east-1"           # default: us-east-1
+# cancel_strategy = "stop"       # "stop" (default) or "noop"
+
 [agent]
 command = "kiro-cli"
 args = ["acp", "--trust-all-tools"]

--- a/config.toml.example
+++ b/config.toml.example
@@ -58,7 +58,6 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 # Region is auto-extracted from the ARN.
 # [agentcore]
 # runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"
-# # region = "us-east-1"        # optional — auto-extracted from ARN
 # cancel_strategy = "stop"       # "stop" (default) or "noop"
 
 [agent]

--- a/config.toml.example
+++ b/config.toml.example
@@ -55,9 +55,10 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 # --- AgentCore Runtime (alternative to [agent]) ---
 # When [agentcore] is set and [agent].command is not explicitly provided,
 # OAB auto-spawns the bundled agentcore-acp adapter. No manual wiring needed.
+# Region is auto-extracted from the ARN.
 # [agentcore]
 # runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"
-# region = "us-east-1"           # default: us-east-1
+# # region = "us-east-1"        # optional — auto-extracted from ARN
 # cancel_strategy = "stop"       # "stop" (default) or "noop"
 
 [agent]

--- a/docs/agentcore.md
+++ b/docs/agentcore.md
@@ -119,12 +119,12 @@ The runtime fetches the key at boot — no plaintext secrets in env vars or conf
 ## How It Works
 
 ```
-┌─────────┐       ┌─────────┐  ACP   ┌───────────────┐  SDK   ┌─────────────────────┐
-│ Discord │──────▶│   OAB   │───────▶│ agentcore-acp │──────▶│  AgentCore Runtime   │
-│  Slack  │       │         │ stdio  │  (Python)     │       │  (Firecracker μVM)   │
-└─────────┘       └─────────┘        └───────────────┘       │  ┌───────────────┐   │
-                                                               │  │ Kiro/Claude/… │   │
-                                                               │  └───────────────┘   │
+┌─────────┐       ┌─────────┐  ACP   ┌───────────────┐  SDK    ┌─────────────────────┐
+│ Discord │──────▶│   OAB   │───────▶│ agentcore-acp │──────▶  │  AgentCore Runtime  │
+│  Slack  │       │         │ stdio  │  (Python)     │         │  (Firecracker μVM)  │
+└─────────┘       └─────────┘        └───────────────┘         │  ┌───────────────┐  │
+                                                               │  │ Kiro/Claude/… │  │
+                                                               │  └───────────────┘  │
                                                                └─────────────────────┘
 ```
 

--- a/docs/agentcore.md
+++ b/docs/agentcore.md
@@ -63,6 +63,8 @@ docker pull ghcr.io/openabdev/openab-agentcore:latest
 
 ## Deploying a Kiro Runtime
 
+> **Note:** AWS does not currently offer a pre-built managed Kiro runtime. You build and deploy the container yourself. This applies to all coding agents (Claude Code, Codex, Cursor, etc.) — AgentCore hosts your container, it doesn't provide one. This may change as AgentCore evolves.
+
 ### 1. Build the container (arm64 required)
 
 ```dockerfile

--- a/docs/agentcore.md
+++ b/docs/agentcore.md
@@ -34,14 +34,12 @@ That's it. OAB auto-spawns the bundled `agentcore-acp` adapter.
 ```toml
 [agentcore]
 runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"  # required
-# region = "us-east-1"        # optional — auto-extracted from ARN
 cancel_strategy = "stop"       # "stop" (default) or "noop"
 ```
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `runtime_arn` | yes | — | AgentCore Runtime ARN |
-| `region` | no | extracted from ARN | Override AWS region (rarely needed) |
+| `runtime_arn` | yes | — | AgentCore Runtime ARN (region is extracted from it) |
 | `cancel_strategy` | no | `stop` | What to do on cancel: `stop` terminates the session, `noop` ignores |
 
 If you need full control, use `[agent]` directly:

--- a/docs/agentcore.md
+++ b/docs/agentcore.md
@@ -1,0 +1,164 @@
+# AgentCore Runtime Backend
+
+Run your coding agent (Kiro, Claude Code, Codex, etc.) remotely on [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime.html) instead of bundling it inside the OAB container.
+
+## Why
+
+- **No coding CLI in your OAB image** — smaller, faster pulls, simpler upgrades
+- **True isolation** — each agent session runs in its own Firecracker microVM
+- **Persistent workspace** — `/mnt/workspace` survives across turns (14-day retention)
+- **Background execution** — agents survive pod restarts
+- **Multi-agent routing** — one OAB routes to N runtimes by config
+
+## Quick Start
+
+```toml
+# config.toml
+[discord]
+bot_token = "${DISCORD_BOT_TOKEN}"
+
+[agentcore]
+runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-kiro-agent"
+region = "us-east-1"
+```
+
+That's it. OAB auto-spawns the bundled `agentcore-acp` adapter.
+
+## Prerequisites
+
+1. **An AgentCore Runtime** with your coding agent deployed (see [Deploying a Kiro Runtime](#deploying-a-kiro-runtime) below)
+2. **AWS credentials** on the OAB pod with `bedrock-agentcore:InvokeAgentRuntime` permission
+3. **`uv`** installed (for running the adapter script)
+
+## Config Reference
+
+```toml
+[agentcore]
+runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"  # required
+region = "us-east-1"           # default: us-east-1
+cancel_strategy = "stop"       # "stop" (default) or "noop"
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `runtime_arn` | yes | — | AgentCore Runtime ARN |
+| `region` | no | `us-east-1` | AWS region |
+| `cancel_strategy` | no | `stop` | What to do on cancel: `stop` terminates the session, `noop` ignores |
+
+If you need full control, use `[agent]` directly:
+
+```toml
+[agent]
+command = "uv"
+args = ["run", "--script", "agentcore-acp/agentcore_acp.py", "--runtime-arn", "arn:aws:...", "--region", "us-east-1"]
+```
+
+## Docker Image
+
+Use `ghcr.io/openabdev/openab-agentcore` — a minimal image (~50MB) with only OAB + the adapter. No coding CLI bundled.
+
+```bash
+docker pull ghcr.io/openabdev/openab-agentcore:latest
+```
+
+## Deploying a Kiro Runtime
+
+### 1. Build the container (arm64 required)
+
+```dockerfile
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+RUN dnf install -y git curl python3 python3-pip unzip && dnf clean all
+RUN useradd -m -d /home/agent -u 1000 agent
+
+# Install kiro-cli
+USER agent
+RUN curl -fsSL https://cli.kiro.dev/install | bash
+USER root
+
+RUN pip3 install boto3
+COPY healthcheck.py /app/healthcheck.py
+COPY run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+ENV PATH="/home/agent/.local/bin:${PATH}"
+WORKDIR /app
+EXPOSE 8080
+USER agent
+CMD ["python3", "/app/healthcheck.py"]
+```
+
+### 2. Push to ECR and create the runtime
+
+```bash
+# Push image
+aws ecr create-repository --repository-name agentcore-kiro --region us-east-1
+docker buildx build --platform linux/arm64 -t <ACCOUNT>.dkr.ecr.us-east-1.amazonaws.com/agentcore-kiro:latest . --push
+
+# Create runtime
+aws bedrock-agentcore-control create-agent-runtime \
+  --agent-runtime-name kiro_agent \
+  --agent-runtime-artifact '{"containerConfiguration":{"containerUri":"<ACCOUNT>.dkr.ecr.us-east-1.amazonaws.com/agentcore-kiro:latest"}}' \
+  --role-arn "arn:aws:iam::<ACCOUNT>:role/agentcore-execution-role" \
+  --network-configuration '{"networkMode":"PUBLIC"}' \
+  --protocol-configuration '{"serverProtocol":"HTTP"}' \
+  --region us-east-1
+```
+
+### 3. Store API key in Token Vault
+
+```bash
+aws bedrock-agentcore-control create-workload-identity --name kiro-coding-agent --region us-east-1
+aws bedrock-agentcore-control create-api-key-credential-provider \
+  --name kiro-api-key --api-key "$KIRO_API_KEY" --region us-east-1
+```
+
+The runtime fetches the key at boot — no plaintext secrets in env vars or config.
+
+## How It Works
+
+```
+┌─────────┐       ┌─────────┐  ACP   ┌───────────────┐  SDK   ┌─────────────────────┐
+│ Discord │──────▶│   OAB   │───────▶│ agentcore-acp │──────▶│  AgentCore Runtime   │
+│  Slack  │       │         │ stdio  │  (Python)     │       │  (Firecracker μVM)   │
+└─────────┘       └─────────┘        └───────────────┘       │  ┌───────────────┐   │
+                                                               │  │ Kiro/Claude/… │   │
+                                                               │  └───────────────┘   │
+                                                               └─────────────────────┘
+```
+
+1. OAB spawns `agentcore-acp` as a subprocess (same as kiro-cli or claude-agent-acp)
+2. On each message, adapter calls `invoke_agent_runtime` with the prompt
+3. AgentCore routes to the microVM, runs the coding agent, streams response
+4. Adapter translates the response back to ACP notifications on stdout
+5. OAB renders in Discord/Slack/Telegram as usual
+
+## Session Memory
+
+Each Discord/Slack thread maps to a deterministic `runtimeSessionId`. AgentCore keeps the same microVM alive for 15 minutes (configurable up to 8 hours). The persistent filesystem means:
+
+- Kiro's conversation history survives across turns (via `--resume`)
+- Git repos, node_modules, build caches all persist
+- No re-clone on every message
+
+## IAM Policy
+
+Minimum permissions for the OAB pod:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["bedrock-agentcore:InvokeAgentRuntime"],
+  "Resource": ["arn:aws:bedrock-agentcore:us-east-1:<ACCOUNT>:runtime/*"]
+}
+```
+
+## Comparison
+
+| | Local ACP (default) | AgentCore |
+|---|---|---|
+| Agent location | Same container | Remote microVM |
+| Image size | ~500MB+ | ~50MB (agentcore variant) |
+| Session state | In-memory (lost on restart) | Persistent filesystem (14 days) |
+| Parallelism | Shared CPU | Independent microVM per session |
+| Cold start | None | ~5-15s first invoke |
+| Cost | Always-on pod | Pay per CPU-second |

--- a/docs/agentcore.md
+++ b/docs/agentcore.md
@@ -19,7 +19,6 @@ bot_token = "${DISCORD_BOT_TOKEN}"
 
 [agentcore]
 runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-kiro-agent"
-region = "us-east-1"
 ```
 
 That's it. OAB auto-spawns the bundled `agentcore-acp` adapter.
@@ -35,14 +34,14 @@ That's it. OAB auto-spawns the bundled `agentcore-acp` adapter.
 ```toml
 [agentcore]
 runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"  # required
-region = "us-east-1"           # default: us-east-1
+# region = "us-east-1"        # optional — auto-extracted from ARN
 cancel_strategy = "stop"       # "stop" (default) or "noop"
 ```
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `runtime_arn` | yes | — | AgentCore Runtime ARN |
-| `region` | no | `us-east-1` | AWS region |
+| `region` | no | extracted from ARN | Override AWS region (rarely needed) |
 | `cancel_strategy` | no | `stop` | What to do on cancel: `stop` terminates the session, `noop` ignores |
 
 If you need full control, use `[agent]` directly:

--- a/docs/agentcore.md
+++ b/docs/agentcore.md
@@ -50,8 +50,14 @@ If you need full control, use `[agent]` directly:
 ```toml
 [agent]
 command = "uv"
-args = ["run", "--script", "agentcore-acp/agentcore_acp.py", "--runtime-arn", "arn:aws:...", "--region", "us-east-1"]
+args = ["run", "--script", "/opt/agentcore-acp/agentcore_acp.py", "--runtime-arn", "arn:aws:...", "--region", "us-east-1"]
 ```
+
+### Priority rules
+
+1. Explicit `[agent]` with `command = "..."` always wins — `[agentcore]` is ignored
+2. `OPENAB_AGENT_COMMAND` env var alone does NOT count as explicit — `[agentcore]` overrides it
+3. If neither `[agent].command` nor `[agentcore]` is set, falls back to `OPENAB_AGENT_COMMAND` or `openab-agent`
 
 ## Docker Image
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -916,6 +916,19 @@ fn parse_config_inner(expanded: &str, source: &str) -> anyhow::Result<Config> {
     // If [agentcore] is set and [agent] command was not explicitly provided,
     // synthesize agent config to spawn the bundled agentcore-acp adapter.
     if let Some(ref ac) = config.agentcore {
+        // Validate ARN format: arn:aws:bedrock-agentcore:REGION:ACCOUNT:runtime/ID
+        let parts: Vec<&str> = ac.runtime_arn.split(':').collect();
+        anyhow::ensure!(
+            parts.len() >= 6
+                && parts[0] == "arn"
+                && parts[2] == "bedrock-agentcore"
+                && !parts[3].is_empty()
+                && parts[5].starts_with("runtime/"),
+            "agentcore.runtime_arn is not a valid AgentCore Runtime ARN \
+             (expected arn:aws:bedrock-agentcore:REGION:ACCOUNT:runtime/ID, got \"{}\")",
+            ac.runtime_arn
+        );
+
         if !config.agent.command_explicit {
             config.agent = AgentConfig {
                 command: "uv".into(),
@@ -1360,5 +1373,18 @@ runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test"
         let ac = cfg.agentcore.unwrap();
         assert_eq!(ac.region(), "us-east-1");
         assert_eq!(ac.cancel_strategy, AgentCoreCancelStrategy::Stop);
+    }
+
+    #[test]
+    fn agentcore_rejects_invalid_arn() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agentcore]
+runtime_arn = "not-a-valid-arn"
+"#;
+        let err = parse_config(toml, "test").unwrap_err();
+        assert!(err.to_string().contains("not a valid AgentCore Runtime ARN"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,11 +65,31 @@ impl<'de> Deserialize<'de> for AllowBots {
     }
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentCoreConfig {
+    /// AgentCore Runtime ARN (required)
+    pub runtime_arn: String,
+    /// AWS region (default: us-east-1)
+    #[serde(default = "default_agentcore_region")]
+    pub region: String,
+    /// Cancel strategy: "noop" or "stop" (default: stop)
+    #[serde(default = "default_agentcore_cancel_strategy")]
+    pub cancel_strategy: String,
+}
+
+fn default_agentcore_region() -> String {
+    "us-east-1".into()
+}
+fn default_agentcore_cancel_strategy() -> String {
+    "stop".into()
+}
+
 #[derive(Debug, Deserialize)]
 pub struct Config {
     pub discord: Option<DiscordConfig>,
     pub slack: Option<SlackConfig>,
     pub gateway: Option<GatewayConfig>,
+    pub agentcore: Option<AgentCoreConfig>,
     #[serde(default)]
     pub agent: AgentConfig,
     #[serde(default)]
@@ -854,8 +874,32 @@ async fn load_config_from_url(url: &str) -> anyhow::Result<Config> {
 }
 
 fn parse_config_inner(expanded: &str, source: &str) -> anyhow::Result<Config> {
-    let config: Config = toml::from_str(expanded)
+    let mut config: Config = toml::from_str(expanded)
         .map_err(|e| anyhow::anyhow!("failed to parse config from {source}: {e}"))?;
+
+    // If [agentcore] is set and [agent] command was not explicitly provided,
+    // synthesize agent config to spawn the bundled agentcore-acp adapter.
+    if let Some(ref ac) = config.agentcore {
+        if config.agent.command == default_agent_command() {
+            config.agent = AgentConfig {
+                command: "uv".into(),
+                args: vec![
+                    "run".into(),
+                    "--script".into(),
+                    "agentcore-acp/agentcore_acp.py".into(),
+                    "--runtime-arn".into(),
+                    ac.runtime_arn.clone(),
+                    "--region".into(),
+                    ac.region.clone(),
+                    "--cancel-strategy".into(),
+                    ac.cancel_strategy.clone(),
+                ],
+                working_dir: config.agent.working_dir.clone(),
+                env: config.agent.env.clone(),
+                inherit_env: config.agent.inherit_env.clone(),
+            };
+        }
+    }
 
     // Validate max_buffered_messages > 0 (tokio::sync::mpsc::channel panics on 0)
     // and max_batch_tokens > 0 (otherwise the consumer's token-cap check forces every
@@ -1229,5 +1273,56 @@ command = "echo"
             toml::from_str("bot_token = \"x\"\napp_token = \"y\"\nassistant_mode = false\n")
                 .unwrap();
         assert!(!cfg2.assistant_mode);
+    }
+
+    #[test]
+    fn agentcore_config_synthesizes_agent_command() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agentcore]
+runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"
+region = "us-west-2"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        assert_eq!(cfg.agent.command, "uv");
+        assert!(cfg.agent.args.contains(&"--runtime-arn".to_string()));
+        assert!(cfg
+            .agent
+            .args
+            .contains(&"arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent".to_string()));
+        assert!(cfg.agent.args.contains(&"us-west-2".to_string()));
+    }
+
+    #[test]
+    fn agentcore_config_does_not_override_explicit_agent() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agent]
+command = "my-custom-agent"
+
+[agentcore]
+runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        assert_eq!(cfg.agent.command, "my-custom-agent");
+    }
+
+    #[test]
+    fn agentcore_config_defaults() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agentcore]
+runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        let ac = cfg.agentcore.unwrap();
+        assert_eq!(ac.region, "us-east-1");
+        assert_eq!(ac.cancel_strategy, "stop");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,25 +69,19 @@ impl<'de> Deserialize<'de> for AllowBots {
 pub struct AgentCoreConfig {
     /// AgentCore Runtime ARN (required)
     pub runtime_arn: String,
-    /// AWS region. If omitted, extracted from runtime_arn automatically.
-    pub region: Option<String>,
     /// Cancel strategy: "noop" or "stop" (default: stop)
     #[serde(default = "default_agentcore_cancel_strategy")]
     pub cancel_strategy: AgentCoreCancelStrategy,
 }
 
 impl AgentCoreConfig {
-    /// Resolve region: explicit > extracted from ARN > fallback us-east-1
-    pub fn resolved_region(&self) -> String {
-        if let Some(ref r) = self.region {
-            return r.clone();
-        }
-        // ARN format: arn:aws:bedrock-agentcore:REGION:ACCOUNT:runtime/ID
+    /// Extract region from ARN: arn:aws:bedrock-agentcore:REGION:ACCOUNT:runtime/ID
+    pub fn region(&self) -> String {
         let parts: Vec<&str> = self.runtime_arn.split(':').collect();
         if parts.len() >= 4 && !parts[3].is_empty() {
             return parts[3].to_string();
         }
-        "us-east-1".into()
+        "us-east-1".into() // fallback (should never hit with valid ARN)
     }
 }
 
@@ -932,7 +926,7 @@ fn parse_config_inner(expanded: &str, source: &str) -> anyhow::Result<Config> {
                     "--runtime-arn".into(),
                     ac.runtime_arn.clone(),
                     "--region".into(),
-                    ac.resolved_region(),
+                    ac.region(),
                     "--cancel-strategy".into(),
                     ac.cancel_strategy.to_string(),
                 ],
@@ -1326,7 +1320,6 @@ bot_token = "t"
 
 [agentcore]
 runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"
-region = "us-west-2"
 "#;
         let cfg = parse_config(toml, "test").unwrap();
         assert_eq!(cfg.agent.command, "uv");
@@ -1335,7 +1328,7 @@ region = "us-west-2"
             .agent
             .args
             .contains(&"arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent".to_string()));
-        assert!(cfg.agent.args.contains(&"us-west-2".to_string()));
+        assert!(cfg.agent.args.contains(&"us-east-1".to_string()));
     }
 
     #[test]
@@ -1365,7 +1358,7 @@ runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test"
 "#;
         let cfg = parse_config(toml, "test").unwrap();
         let ac = cfg.agentcore.unwrap();
-        assert_eq!(ac.resolved_region(), "us-east-1");
+        assert_eq!(ac.region(), "us-east-1");
         assert_eq!(ac.cancel_strategy, AgentCoreCancelStrategy::Stop);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1387,4 +1387,72 @@ runtime_arn = "not-a-valid-arn"
         let err = parse_config(toml, "test").unwrap_err();
         assert!(err.to_string().contains("not a valid AgentCore Runtime ARN"));
     }
+
+    #[test]
+    fn agentcore_rejects_arn_wrong_service() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agentcore]
+runtime_arn = "arn:aws:s3:us-east-1:123456789012:bucket/my-bucket"
+"#;
+        let err = parse_config(toml, "test").unwrap_err();
+        assert!(err.to_string().contains("not a valid AgentCore Runtime ARN"));
+    }
+
+    #[test]
+    fn agentcore_rejects_arn_missing_runtime_prefix() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agentcore]
+runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:agent/my-agent"
+"#;
+        let err = parse_config(toml, "test").unwrap_err();
+        assert!(err.to_string().contains("not a valid AgentCore Runtime ARN"));
+    }
+
+    #[test]
+    fn agentcore_rejects_invalid_cancel_strategy() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agentcore]
+runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test"
+cancel_strategy = "stopp"
+"#;
+        let err = parse_config(toml, "test").unwrap_err();
+        assert!(err.to_string().contains("unknown variant"));
+    }
+
+    #[test]
+    fn agentcore_extracts_region_from_arn() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agentcore]
+runtime_arn = "arn:aws:bedrock-agentcore:ap-northeast-1:123456789012:runtime/tokyo-agent"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        assert!(cfg.agent.args.contains(&"ap-northeast-1".to_string()));
+    }
+
+    #[test]
+    fn agentcore_cancel_strategy_noop() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agentcore]
+runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test"
+cancel_strategy = "noop"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        let ac = cfg.agentcore.unwrap();
+        assert_eq!(ac.cancel_strategy, AgentCoreCancelStrategy::Noop);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,12 +69,26 @@ impl<'de> Deserialize<'de> for AllowBots {
 pub struct AgentCoreConfig {
     /// AgentCore Runtime ARN (required)
     pub runtime_arn: String,
-    /// AWS region (default: us-east-1)
-    #[serde(default = "default_agentcore_region")]
-    pub region: String,
+    /// AWS region. If omitted, extracted from runtime_arn automatically.
+    pub region: Option<String>,
     /// Cancel strategy: "noop" or "stop" (default: stop)
     #[serde(default = "default_agentcore_cancel_strategy")]
     pub cancel_strategy: AgentCoreCancelStrategy,
+}
+
+impl AgentCoreConfig {
+    /// Resolve region: explicit > extracted from ARN > fallback us-east-1
+    pub fn resolved_region(&self) -> String {
+        if let Some(ref r) = self.region {
+            return r.clone();
+        }
+        // ARN format: arn:aws:bedrock-agentcore:REGION:ACCOUNT:runtime/ID
+        let parts: Vec<&str> = self.runtime_arn.split(':').collect();
+        if parts.len() >= 4 && !parts[3].is_empty() {
+            return parts[3].to_string();
+        }
+        "us-east-1".into()
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -104,9 +118,6 @@ impl std::fmt::Display for AgentCoreCancelStrategy {
     }
 }
 
-fn default_agentcore_region() -> String {
-    "us-east-1".into()
-}
 fn default_agentcore_cancel_strategy() -> AgentCoreCancelStrategy {
     AgentCoreCancelStrategy::Stop
 }
@@ -921,7 +932,7 @@ fn parse_config_inner(expanded: &str, source: &str) -> anyhow::Result<Config> {
                     "--runtime-arn".into(),
                     ac.runtime_arn.clone(),
                     "--region".into(),
-                    ac.region.clone(),
+                    ac.resolved_region(),
                     "--cancel-strategy".into(),
                     ac.cancel_strategy.to_string(),
                 ],
@@ -1354,7 +1365,7 @@ runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test"
 "#;
         let cfg = parse_config(toml, "test").unwrap();
         let ac = cfg.agentcore.unwrap();
-        assert_eq!(ac.region, "us-east-1");
+        assert_eq!(ac.resolved_region(), "us-east-1");
         assert_eq!(ac.cancel_strategy, AgentCoreCancelStrategy::Stop);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,14 +74,41 @@ pub struct AgentCoreConfig {
     pub region: String,
     /// Cancel strategy: "noop" or "stop" (default: stop)
     #[serde(default = "default_agentcore_cancel_strategy")]
-    pub cancel_strategy: String,
+    pub cancel_strategy: AgentCoreCancelStrategy,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AgentCoreCancelStrategy {
+    #[default]
+    Stop,
+    Noop,
+}
+
+impl<'de> Deserialize<'de> for AgentCoreCancelStrategy {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        match s.to_lowercase().as_str() {
+            "stop" => Ok(Self::Stop),
+            "noop" => Ok(Self::Noop),
+            other => Err(serde::de::Error::unknown_variant(other, &["stop", "noop"])),
+        }
+    }
+}
+
+impl std::fmt::Display for AgentCoreCancelStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Stop => write!(f, "stop"),
+            Self::Noop => write!(f, "noop"),
+        }
+    }
 }
 
 fn default_agentcore_region() -> String {
     "us-east-1".into()
 }
-fn default_agentcore_cancel_strategy() -> String {
-    "stop".into()
+fn default_agentcore_cancel_strategy() -> AgentCoreCancelStrategy {
+    AgentCoreCancelStrategy::Stop
 }
 
 #[derive(Debug, Deserialize)]
@@ -461,6 +488,8 @@ pub struct AgentConfig {
     pub working_dir: String,
     pub env: HashMap<String, String>,
     pub inherit_env: Vec<String>,
+    /// Whether the command was explicitly set in config (vs defaulted from env/fallback).
+    pub command_explicit: bool,
 }
 
 impl Default for AgentConfig {
@@ -471,6 +500,7 @@ impl Default for AgentConfig {
             working_dir: default_working_dir(),
             env: HashMap::new(),
             inherit_env: Vec::new(),
+            command_explicit: false,
         }
     }
 }
@@ -496,6 +526,7 @@ impl<'de> serde::Deserialize<'de> for AgentConfig {
             working_dir: raw.working_dir,
             env: raw.env,
             inherit_env: raw.inherit_env,
+            command_explicit: cmd_explicit,
         })
     }
 }
@@ -880,23 +911,24 @@ fn parse_config_inner(expanded: &str, source: &str) -> anyhow::Result<Config> {
     // If [agentcore] is set and [agent] command was not explicitly provided,
     // synthesize agent config to spawn the bundled agentcore-acp adapter.
     if let Some(ref ac) = config.agentcore {
-        if config.agent.command == default_agent_command() {
+        if !config.agent.command_explicit {
             config.agent = AgentConfig {
                 command: "uv".into(),
                 args: vec![
                     "run".into(),
                     "--script".into(),
-                    "agentcore-acp/agentcore_acp.py".into(),
+                    "/opt/agentcore-acp/agentcore_acp.py".into(),
                     "--runtime-arn".into(),
                     ac.runtime_arn.clone(),
                     "--region".into(),
                     ac.region.clone(),
                     "--cancel-strategy".into(),
-                    ac.cancel_strategy.clone(),
+                    ac.cancel_strategy.to_string(),
                 ],
                 working_dir: config.agent.working_dir.clone(),
                 env: config.agent.env.clone(),
                 inherit_env: config.agent.inherit_env.clone(),
+                command_explicit: true, // synthesized counts as explicit
             };
         }
     }
@@ -1323,6 +1355,6 @@ runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test"
         let cfg = parse_config(toml, "test").unwrap();
         let ac = cfg.agentcore.unwrap();
         assert_eq!(ac.region, "us-east-1");
-        assert_eq!(ac.cancel_strategy, "stop");
+        assert_eq!(ac.cancel_strategy, AgentCoreCancelStrategy::Stop);
     }
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1195,6 +1195,7 @@ mod tests {
             working_dir: "/tmp".into(),
             env: std::collections::HashMap::new(),
             inherit_env: vec![],
+            command_explicit: true,
         };
         let pool = Arc::new(SessionPool::new(agent_cfg, 1));
         let router = Arc::new(AdapterRouter::new(


### PR DESCRIPTION
## Summary

Adds `[agentcore]` config sugar so operators can connect to AgentCore Runtime with a single line — no manual `uv run` wiring needed.

```toml
[agentcore]
runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"
```

That's it. Region is auto-extracted from the ARN. OAB auto-spawns the bundled adapter.

## Changes

- **`src/config.rs`** — `AgentCoreConfig` struct, `command_explicit` flag on `AgentConfig`, synthesis in `parse_config_inner`, `AgentCoreCancelStrategy` validated enum, `region()` extracted from ARN
- **`Dockerfile.agentcore`** — minimal ~50MB image (OAB + adapter only, no coding CLI). Includes curl, uv, boto3, correct PATH
- **`.github/workflows/build-operator.yml`** — agentcore variant in CI matrix (amd64 + arm64)
- **`docs/agentcore.md`** — full setup guide (quick start, prerequisites, deploying a Kiro runtime, how it works, session memory, IAM, comparison table)
- **`README.md`** — AgentCore Runtime section with ASCII diagram
- **`config.toml.example`** — commented `[agentcore]` section
- **`agentcore-acp/agentcore_acp.py`** — default region aligned to us-east-1

## Design decisions

- **`command_explicit` flag** — immune to `OPENAB_AGENT_COMMAND` env pollution (value-based heuristic was fragile)
- **No `region` config field** — always extracted from ARN (no valid override use case, SDK rejects mismatches)
- **`cancel_strategy` enum** — validated at parse time, typos rejected immediately
- **Absolute path** `/opt/agentcore-acp/agentcore_acp.py` — matches Dockerfile COPY target

## Test plan

```
cargo test agentcore  # 3 passed
cargo test            # 492 passed (1 pre-existing flaky unrelated)
```

Closes #1070