### PR TITLE
fix(discord): truncate select-menu option descriptions to Discord's 100-char limit

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1070,7 +1070,7 @@ impl Handler {
             .map(|o| {
                 let mut item = CreateSelectMenuOption::new(&o.name, &o.value);
                 if let Some(desc) = &o.description {
-                    item = item.description(desc);
+                    item = item.description(truncate_select_option_description(desc));
                 }
                 if o.value == opt.current_value {
                     item = item.default_selection(true);
@@ -1709,6 +1709,30 @@ impl Handler {
 
 // --- Discord-specific helpers ---
 
+/// Discord caps select-menu option descriptions at 100 characters. Exceeding it
+/// makes the API reject the *entire* interaction response with `Invalid Form
+/// Body (... description: Must be 100 or fewer in length.)`, which surfaces to
+/// the user as "This application did not respond".
+const SELECT_OPTION_DESCRIPTION_MAX: usize = 100;
+
+/// Truncate a select-menu option description to Discord's 100-char limit.
+///
+/// Truncates on a char boundary (via `char_indices`) so multi-byte text
+/// (中文 / emoji / accented Latin) never panics and never produces invalid
+/// UTF-8. Returns the input unchanged when it is already within the limit.
+fn truncate_select_option_description(desc: &str) -> &str {
+    if desc.chars().count() > SELECT_OPTION_DESCRIPTION_MAX {
+        let end = desc
+            .char_indices()
+            .nth(SELECT_OPTION_DESCRIPTION_MAX)
+            .map(|(i, _)| i)
+            .unwrap_or(desc.len());
+        &desc[..end]
+    } else {
+        desc
+    }
+}
+
 fn discord_msg_ref(msg: &Message) -> MessageRef {
     MessageRef {
         channel: ChannelRef {
@@ -2284,6 +2308,61 @@ fn turn_limit_warning_present(messages: &[(bool, &str)]) -> bool {
 mod tests {
     use super::*;
     use crate::bot_turns::{TurnResult, HARD_BOT_TURN_LIMIT, BOT_TURN_LIMIT_WARNING_PREFIX};
+
+    // --- truncate_select_option_description tests (regression for the
+    // `/agents` & `/models` "application did not respond" bug) ---
+
+    /// Short ASCII descriptions pass through unchanged.
+    #[test]
+    fn truncate_desc_short_ascii_unchanged() {
+        let s = "Read-only consultant — architecture analysis";
+        assert_eq!(truncate_select_option_description(s), s);
+    }
+
+    /// A description of exactly 100 chars is kept as-is (boundary).
+    #[test]
+    fn truncate_desc_exactly_100_unchanged() {
+        let s: String = "a".repeat(100);
+        assert_eq!(truncate_select_option_description(&s), s);
+        assert_eq!(truncate_select_option_description(&s).chars().count(), 100);
+    }
+
+    /// 101 ASCII chars are trimmed down to 100.
+    #[test]
+    fn truncate_desc_101_ascii_trimmed_to_100() {
+        let s: String = "b".repeat(101);
+        let out = truncate_select_option_description(&s);
+        assert_eq!(out.chars().count(), 100);
+        assert!(s.starts_with(out));
+    }
+
+    /// Multi-byte (CJK) descriptions over the limit are trimmed on a char
+    /// boundary — no panic, output stays valid UTF-8 and ≤100 chars.
+    #[test]
+    fn truncate_desc_multibyte_trimmed_on_char_boundary() {
+        // 200 CJK chars (3 bytes each in UTF-8) — far over the 100-char cap.
+        let s: String = "あ".repeat(200);
+        let out = truncate_select_option_description(&s);
+        assert_eq!(out.chars().count(), 100);
+        // Byte length is a multiple of 3 (clean char boundary), not a panic.
+        assert_eq!(out.len(), 300);
+        assert!(s.starts_with(out));
+    }
+
+    /// Emoji (4-byte scalar values) over the limit also trim cleanly.
+    #[test]
+    fn truncate_desc_emoji_trimmed_on_char_boundary() {
+        let s: String = "🚀".repeat(150);
+        let out = truncate_select_option_description(&s);
+        assert_eq!(out.chars().count(), 100);
+        assert!(s.starts_with(out));
+    }
+
+    /// Empty description is returned unchanged.
+    #[test]
+    fn truncate_desc_empty_unchanged() {
+        assert_eq!(truncate_select_option_description(""), "");
+    }
 
     // --- resolve_mentions tests ---
 


### PR DESCRIPTION
## What problem does this solve?

The `/agents` and `/models` Discord slash commands fail with **"This application did not respond"** whenever any option's `description` exceeds Discord's **100-character** limit for select-menu options.

`Handler::build_config_select` passed the raw ACP-provided description into `CreateSelectMenuOption::description()` with no length guard, so Discord rejected the **entire** interaction response:

```
ERROR openab::discord: failed to respond to slash command
error=Invalid Form Body (data.components.0.components.0.options.N.description:
Must be 100 or fewer in length.) category="agent"
```

A single agent/mode with a long description breaks the picker for the whole menu.

Closes #1075

Discord Discussion URL: N/A — no Discord thread; full context is in #1075 (server logs + repro).

## At a Glance

```
/agents  ──►  build_config_select()
                  │  for each ConfigOption value:
                  │     CreateSelectMenuOption::new(name, value)
                  │        .description(desc)        ◄── desc may be >100 chars
                  ▼
            Discord API  ──►  Invalid Form Body (whole response rejected)
                              "This application did not respond"

After:
            .description( truncate_select_option_description(desc) )  ◄── ≤100, char-boundary
                  ▼
            Discord API  ──►  menu renders
```

## Prior Art & Industry Research

Not applicable — trivial bug fix (enforce a documented Discord API limit). The same 100-char char-boundary truncation pattern already exists in this file for thread names (`rename_thread()`); this change simply applies the same guard to select-menu option descriptions.

## Proposed Solution

Add a small helper `truncate_select_option_description(&str) -> &str` and use it in `build_config_select`:

```rust
const SELECT_OPTION_DESCRIPTION_MAX: usize = 100;

fn truncate_select_option_description(desc: &str) -> &str {
    if desc.chars().count() > SELECT_OPTION_DESCRIPTION_MAX {
        let end = desc
            .char_indices()
            .nth(SELECT_OPTION_DESCRIPTION_MAX)
            .map(|(i, _)| i)
            .unwrap_or(desc.len());
        &desc[..end]
    } else {
        desc
    }
}
```

Truncation is on a **char boundary** (via `char_indices`), so multi-byte descriptions (CJK / emoji / accented Latin) never panic and stay valid UTF-8. Inputs already within the limit are returned unchanged.

## Why this approach?

- Mirrors the existing `rename_thread()` truncation already in `src/discord.rs`, keeping the codebase consistent.
- Fixes it on the rendering side, so it works for **any** ACP backend regardless of where descriptions come from (agents, models) — no per-backend config or upstream coordination required.
- Tradeoff: long descriptions are silently shortened in the picker. That is strictly better than the command being completely unusable, and the full description still lives in the agent/model config.

## Alternatives Considered

- **Shorten the agent/model `description` fields** (config side): pushes the burden onto every user/backend and doesn't prevent the crash for future long descriptions. Rejected — the broker should enforce the platform's own limit.
- **Skip options that exceed the limit**: hides valid agents from the picker; worse UX than truncating.
- **Truncate by bytes**: would panic / corrupt multi-byte UTF-8. Rejected in favor of char-boundary truncation.

## Validation

Rust changes:
- [x] `cargo check` passes
- [x] `cargo test` passes (6 new tests: `truncate_desc_*`)
- [x] `cargo clippy --bin openab` clean (no warnings)
- [x] `rustfmt` clean for the added code

All PRs:
- [x] Manual testing — built the patched binary, deployed it against a kiro-cli backend that previously failed, and confirmed `/agents` now renders the picker (agents with 321- and 132-char descriptions are truncated to 100 and the menu loads; no more `Invalid Form Body` in logs).

New unit tests cover: short ASCII (unchanged), exactly 100 chars (boundary, unchanged), 101 ASCII (trimmed to 100), CJK over limit (char-boundary, valid UTF-8), emoji over limit, and empty input.
