### PR TITLE
feat(slack): keep the tool-used summary in assistant_mode messages

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -157,6 +157,10 @@ tables = "code"  # "code" (default) | "bullets" | "off"
 [reactions]
 enabled = true
 remove_after_reply = false
+# tool_display = "full"                 # "full" (default) | "compact" | "none"
+#                                       # Controls how tool calls appear in the final message.
+#                                       # Applies to both assistant_mode and post+edit mode.
+#                                       # Set "none" to hide the tool summary entirely.
 
 [reactions.emojis]
 queued = "👀"

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -736,6 +736,7 @@ impl AdapterRouter {
                                     }
                                 }
                                 AcpEvent::ToolStart { id, title } if !title.is_empty() => {
+                                    // Live indicator: assistant status line vs emoji reaction.
                                     if assistant_status {
                                         let _ = adapter
                                             .set_status(
@@ -745,63 +746,72 @@ impl AdapterRouter {
                                             .await;
                                     } else {
                                         reactions.set_tool(&title).await;
-                                        let title = sanitize_title(&title);
-                                        if let Some(slot) =
-                                            tool_lines.iter_mut().find(|e| e.id == id)
-                                        {
-                                            slot.title = title;
-                                            slot.state = ToolState::Running;
-                                        } else {
-                                            tool_lines.push(ToolEntry {
-                                                id,
-                                                title,
-                                                state: ToolState::Running,
-                                            });
-                                        }
-                                        if let Some(tx) = &buf_tx {
-                                            let _ = tx.send(compose_display(
-                                                &tool_lines,
-                                                &text_buf,
-                                                true,
-                                                tool_display,
-                                            ));
-                                        }
+                                    }
+                                    // Record the tool in BOTH modes so the finalized message keeps
+                                    // a tool summary (compose_display, gated by tool_display). In
+                                    // assistant_mode the status line is transient and cleared before
+                                    // the reply, so without this the message would retain no record
+                                    // of which tools ran.
+                                    let title = sanitize_title(&title);
+                                    if let Some(slot) =
+                                        tool_lines.iter_mut().find(|e| e.id == id)
+                                    {
+                                        slot.title = title;
+                                        slot.state = ToolState::Running;
+                                    } else {
+                                        tool_lines.push(ToolEntry {
+                                            id,
+                                            title,
+                                            state: ToolState::Running,
+                                        });
+                                    }
+                                    // Post+edit live update (no-op under native streaming: buf_tx is None).
+                                    if let Some(tx) = &buf_tx {
+                                        let _ = tx.send(compose_display(
+                                            &tool_lines,
+                                            &text_buf,
+                                            true,
+                                            tool_display,
+                                        ));
                                     }
                                 }
                                 AcpEvent::ToolDone { id, title, status } => {
+                                    // Live indicator: assistant status line vs emoji reaction.
                                     if assistant_status {
                                         let _ = adapter
                                             .set_status(&thread_channel, "Thinking…")
                                             .await;
                                     } else {
                                         reactions.set_thinking().await;
-                                        let new_state = if status == "completed" {
-                                            ToolState::Completed
-                                        } else {
-                                            ToolState::Failed
-                                        };
-                                        if let Some(slot) =
-                                            tool_lines.iter_mut().find(|e| e.id == id)
-                                        {
-                                            if !title.is_empty() {
-                                                slot.title = sanitize_title(&title);
-                                            }
-                                            slot.state = new_state;
-                                        } else if !title.is_empty() {
-                                            tool_lines.push(ToolEntry {
-                                                id,
-                                                title: sanitize_title(&title),
-                                                state: new_state,
-                                            });
+                                    }
+                                    // Update the tool's state in BOTH modes (see ToolStart) so the
+                                    // finalized message's tool summary reflects completion/failure.
+                                    let new_state = if status == "completed" {
+                                        ToolState::Completed
+                                    } else {
+                                        ToolState::Failed
+                                    };
+                                    if let Some(slot) =
+                                        tool_lines.iter_mut().find(|e| e.id == id)
+                                    {
+                                        if !title.is_empty() {
+                                            slot.title = sanitize_title(&title);
                                         }
-                                        if let Some(tx) = &buf_tx {
-                                            let _ = tx.send(compose_display(
-                                                &tool_lines,
-                                                &text_buf,
-                                                true,
-                                                tool_display,
-                                            ));
-                                        }
+                                        slot.state = new_state;
+                                    } else if !title.is_empty() {
+                                        tool_lines.push(ToolEntry {
+                                            id,
+                                            title: sanitize_title(&title),
+                                            state: new_state,
+                                        });
+                                    }
+                                    if let Some(tx) = &buf_tx {
+                                        let _ = tx.send(compose_display(
+                                            &tool_lines,
+                                            &text_buf,
+                                            true,
+                                            tool_display,
+                                        ));
                                     }
                                 }
                                 AcpEvent::ConfigUpdate { options } => {


### PR DESCRIPTION
## What problem does this solve?

In Slack `assistant_mode` (default since #995), tool usage is surfaced **only** via the transient `assistant.threads.setStatus` line ("Using <tool>…"), which is cleared before the final reply — so the **finalized message keeps no record of which tools ran**. Non-assistant (post+edit) mode renders a persistent tool summary in the message body (`compose_display`, gated by `[reactions] tool_display`), but `assistant_mode` doesn't: `tool_lines` is populated **only in the non-assistant `else` branch** of the `ToolStart`/`ToolDone` handlers, so `tool_display = "full"` has no effect under `assistant_mode`.

Closes #1078

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491969620754567270/1514120700175188121

## At a Glance

```
                       Before                                  After
  ┌───────────────────────────────────┐   ┌───────────────────────────────────┐
  │ assistant_mode reply:             │   │ assistant_mode reply:             │
  │  • live: "Using <tool>…" status   │   │  • live: "Using <tool>…" status   │
  │  • final message: text only       │   │  • final message: tool summary +  │
  │    (no tool record — status line  │   │    text (gated by tool_display)   │
  │     was cleared)                  │   │  → persistent record, like         │
  │                                   │   │    non-assistant mode              │
  └───────────────────────────────────┘   └───────────────────────────────────┘
```

## Proposed Solution

In the `AcpEvent::ToolStart` / `ToolDone` handlers, populate `tool_lines` in **both** modes; keep only the *live* indicator gated (assistant status line vs emoji reactions). The final `compose_display(&tool_lines, …)` then includes the summary in `assistant_mode` too, gated by the existing `[reactions] tool_display`. **Non-assistant behavior is byte-identical** (the tool-recording code is just de-nested out of the `else`).

## ⚠️ Behavior change (for release notes)

With the default `tool_display = "full"`, `assistant_mode` replies now carry a **persistent tool-used summary** in the finalized message — reversing #995's "clean assistant message, status-line-only" default. Operators who prefer the previous clean message set:

```toml
[reactions]
tool_display = "none"
```

The live "Using <tool>…" status line is unchanged either way. Non-assistant (post+edit) deployments are unaffected.

## Validation

Manual e2e (assistant_mode bot, alone in a thread → native streaming): asked it to perform a tool-using task → the finalized message now shows the tool summary (✅/❌ lines) **once**, alongside the answer, with the live "Using …" status line during the turn. Composes cleanly with #1056 (Block Kit finalize): the summary renders in the single replaced Block Kit message.

## Testing

- `cargo test --bin openab` — passing (the only failure is the pre-existing, environment-specific `secrets::resolve_exec_nonzero_exit`, unrelated).
- `cargo clippy --all-targets -- -D warnings` — clean.
- **Known gap:** the `assistant_status=true` `ToolStart`/`ToolDone` path isn't unit-tested — `AdapterRouter::stream_prompt_blocks` drives a real ACP subprocess with no event-injection seam, so the event loop is currently untestable without new mock infra (the whole loop shares this gap; `compose_display` output itself is covered). Worth a follow-up to add an event-loop test harness.

## Scope

Slack-only, one file (`src/adapter.rs`). Discord and gateway are unaffected.