### PR TITLE
fix(agentcore/kiro): prevent argument injection in run.sh

### DIFF
--- a/agentcore/runtimes/kiro/run.sh
+++ b/agentcore/runtimes/kiro/run.sh
@@ -40,25 +40,17 @@ else
   exec kiro-cli login --use-device-flow
 fi
 
-# Parse args: ACTION [--flags...] "prompt"
+# Parse args: ACTION "prompt"
+# Note: Extra flags are sourced from KIRO_EXTRA_FLAGS env var (operator-controlled)
+# rather than from argv, to prevent argument injection from untrusted prompts.
 ACTION="${1:-interactive}"
 shift 2>/dev/null || true
-
-EXTRA_FLAGS=()
-PROMPT_PARTS=()
-for arg in "$@"; do
-  if [[ "$arg" == --* ]]; then
-    EXTRA_FLAGS+=("$arg")
-  else
-    PROMPT_PARTS+=("$arg")
-  fi
-done
-PROMPT="${PROMPT_PARTS[*]}"
+PROMPT="$*"
 
 cd "$HOME"
 
 case "$ACTION" in
   interactive) exec kiro-cli ;;
-  chat) exec kiro-cli chat --no-interactive --trust-all-tools "${EXTRA_FLAGS[@]}" "$PROMPT" ;;
-  *) exec kiro-cli "$ACTION" "${EXTRA_FLAGS[@]}" "$PROMPT" ;;
+  chat) exec kiro-cli chat --no-interactive --trust-all-tools ${KIRO_EXTRA_FLAGS:-} -- "$PROMPT" ;;
+  *) exec kiro-cli "$ACTION" ${KIRO_EXTRA_FLAGS:-} -- "$PROMPT" ;;
 esac


### PR DESCRIPTION
## Summary

Fixes #1080 — argument injection (argv flag smuggling) in `agentcore/runtimes/kiro/run.sh`.

## Changes

- **Removed** the `--*` flag promotion loop that classified untrusted prompt tokens as kiro-cli options
- **Added** `--` end-of-options separator before `$PROMPT` so the prompt is always positional text
- **Added** `KIRO_EXTRA_FLAGS` env var as the trusted channel for operators who need to pass extra flags

## Before (vulnerable)

```bash
for arg in "$@"; do
  if [[ "$arg" == --* ]]; then
    EXTRA_FLAGS+=("$arg")   # attacker-controlled prompt promoted to flags
  fi
done
exec kiro-cli chat --trust-all-tools "${EXTRA_FLAGS[@]}" "$PROMPT"
```

A `POST /invocations` with `{"prompt": "--version"}` would inject `--version` as a kiro-cli flag.

## After (fixed)

```bash
PROMPT="$*"
exec kiro-cli chat --no-interactive --trust-all-tools ${KIRO_EXTRA_FLAGS:-} -- "$PROMPT"
```

The `--` separator ensures anything after it is treated as positional text, regardless of leading dashes.

## Testing

- `bash -n run.sh` — syntax check passes
- Prompt starting with `--` is now correctly treated as text, not an option