### PR TITLE
ci: add agentcore variant to PR preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -13,6 +13,7 @@ on:
         type: choice
         options:
           - default
+          - agentcore
           - antigravity
           - claude
           - codex


### PR DESCRIPTION
Add `agentcore` to the Dockerfile variant selector in the PR Preview Build workflow dispatch.