### PR TITLE
feat(agy-acp): streaming + real cancel + id:Value

### DIFF
--- a/Dockerfile.agentcore
+++ b/Dockerfile.agentcore
@@ -1,37 +1,27 @@
-# Dockerfile.agentcore — OAB + agentcore-acp only (no bundled coding CLI).
+# Dockerfile.agentcore — OAB + native AgentCore bridge (no bundled coding CLI).
 # The coding agent (Kiro, Claude, Codex, etc.) runs remotely in AgentCore Runtime.
-# Result: ~50MB image vs ~500MB+ with a full coding CLI baked in.
+# Result: ~20MB image — single Rust binary, no Python/pip needed.
 
 # --- Build stage ---
 FROM rust:1-bookworm AS builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release --features agentcore && rm -rf src
 COPY src/ src/
-RUN touch src/main.rs && cargo build --release
+RUN touch src/main.rs && cargo build --release --features agentcore
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl python3 python3-pip tini \
+      ca-certificates tini \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash -u 1000 agent
 
-# Install uv for the agent user
-USER agent
-RUN curl -fsSL https://astral.sh/uv/install.sh | sh
-USER root
-
-# Install boto3 system-wide (adapter imports it at module level)
-RUN pip3 install --no-cache-dir --break-system-packages boto3>=1.42
-
 ENV HOME=/home/agent
-ENV PATH="/home/agent/.local/bin:${PATH}"
 WORKDIR /home/agent
 
 COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
-COPY --chown=agent:agent agentcore/acp/agentcore_acp.py /opt/agentcore/acp/agentcore_acp.py
 
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/agy-acp/Cargo.toml
+++ b/agy-acp/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 fs2 = "0.4.3"
 rusqlite = { version = "=0.31.0", features = ["bundled"] }
+shell-words = "1.1.0"

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -99,6 +99,7 @@ impl Adapter {
     }
 
     /// Run `agy models` with a 5s timeout and parse the output into a list of model names.
+    /// Falls back to a hardcoded list if `agy models` fails (e.g. auth not yet completed).
     fn fetch_available_models() -> Vec<String> {
         use std::time::Instant;
         let start = Instant::now();
@@ -109,34 +110,46 @@ impl Adapter {
             .spawn()
         {
             Ok(c) => c,
-            Err(_) => return Vec::new(),
+            Err(_) => return Self::fallback_models(),
         };
         // Poll with 5s timeout
         loop {
             match child.try_wait() {
                 Ok(Some(status)) => {
-                    if !status.success() { return Vec::new(); }
-                    // Process exited successfully — read stdout
+                    if !status.success() { return Self::fallback_models(); }
                     let stdout = child.stdout.take().unwrap();
                     use std::io::Read;
                     let mut buf = String::new();
                     let mut reader = std::io::BufReader::new(stdout);
                     let _ = reader.read_to_string(&mut buf);
-                    return buf.lines()
+                    let models: Vec<String> = buf.lines()
                         .map(|l| l.trim().to_string())
                         .filter(|l| !l.is_empty())
                         .collect();
+                    if models.is_empty() {
+                        return Self::fallback_models();
+                    }
+                    return models;
                 }
                 Ok(None) => {
                     if start.elapsed() > Duration::from_secs(5) {
                         let _ = child.kill();
-                        return Vec::new();
+                        return Self::fallback_models();
                     }
                     std::thread::sleep(Duration::from_millis(50));
                 }
-                Err(_) => return Vec::new(),
+                Err(_) => return Self::fallback_models(),
             }
         }
+    }
+
+    /// Hardcoded fallback models when `agy models` is unavailable (auth pending, timeout, etc.)
+    fn fallback_models() -> Vec<String> {
+        vec![
+            "gemini-2.5-pro".to_string(),
+            "gemini-2.5-flash".to_string(),
+            "gemini-2.0-flash".to_string(),
+        ]
     }
 
     /// Get available models, fetching lazily on first access.

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -6,13 +6,17 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 #[derive(Debug, Deserialize)]
 struct JsonRpcRequest {
-    id: Option<u64>,
+    id: Option<Value>,
     method: Option<String>,
     params: Option<Value>,
 }
@@ -20,7 +24,7 @@ struct JsonRpcRequest {
 #[derive(Debug, Serialize)]
 struct JsonRpcResponse {
     jsonrpc: &'static str,
-    id: u64,
+    id: Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     result: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -52,6 +56,16 @@ struct Session {
     conversation_id: Option<String>,
     /// Last step idx read from SQLite.
     last_step_idx: i64,
+}
+
+/// Tracks streaming poll state shared between the polling thread and main task.
+struct StreamingState {
+    conversation_id: Option<String>,
+    base_step_idx: i64,
+    last_step_idx: i64,
+    /// Tracks how many bytes of text we've already emitted per step idx.
+    emitted_len: HashMap<i64, usize>,
+    had_updates: bool,
 }
 
 struct Adapter {
@@ -271,10 +285,117 @@ impl Adapter {
         Some((filtered, max_idx))
     }
 
+    /// Poll the SQLite DB for new text since `base_step_idx` and emit streaming deltas.
+    /// Returns notification JSON lines to write to stdout.
+    fn poll_streaming_delta(
+        conversations_dir: &PathBuf,
+        snapshot: Option<&HashSet<String>>,
+        session_id: &str,
+        state: &Arc<Mutex<StreamingState>>,
+    ) -> Vec<String> {
+        // Try to bind conversation_id if not yet bound
+        {
+            let mut guard = state.lock().unwrap();
+            if guard.conversation_id.is_none() {
+                if let Some(before) = snapshot {
+                    let after: HashSet<String> = fs::read_dir(conversations_dir)
+                        .ok()
+                        .map(|entries| {
+                            entries
+                                .filter_map(|e| e.ok())
+                                .filter_map(|e| {
+                                    let path = e.path();
+                                    if path.extension().map(|x| x == "db").unwrap_or(false) {
+                                        path.file_stem().map(|s| s.to_string_lossy().to_string())
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let mut created: Vec<_> = after.difference(before).collect();
+                    if created.len() == 1 {
+                        guard.conversation_id = Some(created.remove(0).clone());
+                    }
+                }
+            }
+        }
+
+        let (conversation_id, base_step_idx) = {
+            let guard = state.lock().unwrap();
+            (guard.conversation_id.clone(), guard.base_step_idx)
+        };
+
+        let Some(conversation_id) = conversation_id else {
+            return Vec::new();
+        };
+
+        // Read new rows from DB
+        let db_path = conversations_dir.join(format!("{}.db", conversation_id));
+        let conn = match Connection::open_with_flags(
+            &db_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        ) {
+            Ok(c) => c,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut stmt = match conn.prepare(
+            "SELECT idx, step_payload FROM steps WHERE idx > ?1 AND step_type = 15 ORDER BY idx"
+        ) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+
+        let rows: Vec<(i64, Vec<u8>)> = stmt
+            .query_map([base_step_idx], |row| Ok((row.get(0)?, row.get(1)?)))
+            .ok()
+            .map(|iter| iter.filter_map(|r| r.ok()).collect())
+            .unwrap_or_default();
+
+        let mut guard = state.lock().unwrap();
+        let mut notifications = Vec::new();
+
+        for (idx, payload) in rows {
+            guard.last_step_idx = guard.last_step_idx.max(idx);
+
+            let Some(text) = Self::extract_text_from_step_payload(&payload) else {
+                continue;
+            };
+
+            let emitted = guard.emitted_len.get(&idx).copied().unwrap_or(0);
+            if text.len() <= emitted {
+                continue;
+            }
+
+            let new_text = &text[emitted..];
+            guard.emitted_len.insert(idx, text.len());
+
+            if !new_text.is_empty() {
+                notifications.push(
+                    serde_json::to_string(&JsonRpcNotification {
+                        jsonrpc: "2.0",
+                        method: "session/update".to_string(),
+                        params: json!({
+                            "sessionId": session_id,
+                            "update": {
+                                "sessionUpdate": "agent_message_chunk",
+                                "content": { "type": "text", "text": new_text },
+                            },
+                        }),
+                    })
+                    .unwrap(),
+                );
+            }
+        }
+
+        guard.had_updates = guard.had_updates || !notifications.is_empty();
+        notifications
+    }
+
     /// Filter out leading narration ("I will ...") from response parts based on
     /// the OPENAB_TOOL_DISPLAY environment variable.
-    /// - "full" / unset: return all parts joined (no filtering, preserves existing behavior)
-    /// - "compact" / "none": drop leading narration-only parts
     fn filter_narration(parts: &[String]) -> String {
         let should_filter = std::env::var("OPENAB_TOOL_DISPLAY")
             .map(|v| {
@@ -287,7 +408,6 @@ impl Adapter {
             return parts.join("\n");
         }
 
-        // Find the first part that is NOT pure narration. Keep it and everything after.
         let first_content = parts.iter().position(|p| !Self::is_narration(p)).unwrap_or(parts.len() - 1);
         parts[first_content..].join("\n")
     }
@@ -327,7 +447,7 @@ impl Adapter {
         true
     }
 
-    fn handle_initialize(&self, id: u64) -> JsonRpcResponse {
+    fn handle_initialize(&self, id: Value) -> JsonRpcResponse {
         JsonRpcResponse {
             jsonrpc: "2.0",
             id,
@@ -340,7 +460,7 @@ impl Adapter {
         }
     }
 
-    fn handle_session_new(&mut self, id: u64) -> JsonRpcResponse {
+    fn handle_session_new(&mut self, id: Value) -> JsonRpcResponse {
         let session_id = Uuid::new_v4().to_string();
         self.evict_if_needed();
         self.sessions.insert(
@@ -358,7 +478,7 @@ impl Adapter {
         }
     }
 
-    fn handle_session_load(&mut self, id: u64, params: &Value) -> JsonRpcResponse {
+    fn handle_session_load(&mut self, id: Value, params: &Value) -> JsonRpcResponse {
         let session_id = params
             .get("sessionId")
             .and_then(|v| v.as_str())
@@ -393,7 +513,12 @@ impl Adapter {
         }
     }
 
-    async fn handle_session_prompt(&mut self, id: u64, params: &Value) -> Vec<String> {
+    async fn handle_session_prompt(
+        &mut self,
+        id: Value,
+        params: &Value,
+        cancelled: Arc<AtomicBool>,
+    ) -> Vec<String> {
         let session_id = params
             .get("sessionId")
             .and_then(|v| v.as_str())
@@ -444,141 +569,211 @@ impl Adapter {
         args.push("-p".to_string());
         args.push(clean_prompt.to_string());
 
-        let result = Command::new("agy")
+        // Spawn agy as a child process (non-blocking)
+        let spawn_result = Command::new("agy")
             .args(&args)
             .current_dir(&self.working_dir)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
-            .output()
-            .await;
+            .spawn();
 
-        let mut output_lines = Vec::new();
-
-        match result {
-            Ok(output) => {
-                let stderr_text = String::from_utf8_lossy(&output.stderr);
-                if !stderr_text.is_empty() {
-                    eprintln!("[agy-acp] agy stderr: {}", stderr_text.trim_end());
-                }
-
-                if !output.status.success() {
-                    eprintln!("[agy-acp] WARN: agy exited with status: {}", output.status);
-                    if output.stdout.is_empty() {
-                        let msg = if stderr_text.is_empty() {
-                            format!("agy exited with status: {}", output.status)
-                        } else {
-                            format!("agy failed: {}", stderr_text.trim_end())
-                        };
-                        let resp = JsonRpcResponse {
-                            jsonrpc: "2.0",
-                            id,
-                            result: None,
-                            error: Some(json!({"code":-32000,"message":msg})),
-                        };
-                        output_lines.push(serde_json::to_string(&resp).unwrap());
-                        return output_lines;
-                    }
-                }
-
-                let full_text = String::from_utf8_lossy(&output.stdout).to_string();
-
-                // Bind conversation from snapshot diff
-                let conv_id = snapshot
-                    .as_ref()
-                    .and_then(|before| self.new_conversation_id(before));
-
-                if let Some(session) = self.sessions.get_mut(session_id) {
-                    if session.conversation_id.is_none() {
-                        session.conversation_id = conv_id.clone();
-                    }
-                }
-
-                let bound_conv_id = self.sessions.get(session_id).and_then(|s| s.conversation_id.clone());
-                let last_step_idx = self.sessions.get(session_id).map(|s| s.last_step_idx).unwrap_or(-1);
-
-                // Read response delta from SQLite
-                let (new_text, new_step_idx) = if let Some(cid) = &bound_conv_id {
-                    match self.read_response_from_db(cid, last_step_idx) {
-                        Some((text, idx)) => {
-                            eprintln!("[agy-acp] delta from SQLite (steps {} → {})", last_step_idx, idx);
-                            (Some(text), idx)
-                        }
-                        None => {
-                            eprintln!("[agy-acp] WARN: SQLite read returned no new text (field 20.1 missing?)");
-                            (None, last_step_idx)
-                        }
-                    }
-                } else {
-                    eprintln!("[agy-acp] WARN: could not bind conversation ID; single-turn mode");
-                    let parts: Vec<String> = full_text.split("\n\n").map(String::from).collect();
-                    let filtered = Self::filter_narration(&parts);
-                    (Some(filtered), -1i64)
-                };
-
-                // Persist session state
-                if let Some(session) = self.sessions.get_mut(session_id) {
-                    if session.conversation_id.is_some() {
-                        session.last_step_idx = new_step_idx;
-                    }
-                }
-                if bound_conv_id.is_some() {
-                    self.persist_session(session_id, bound_conv_id.as_deref(), new_step_idx);
-                }
-
-                match new_text {
-                    Some(text) => {
-                        let notification = serde_json::to_string(&JsonRpcNotification {
-                            jsonrpc: "2.0",
-                            method: "session/update".to_string(),
-                            params: json!({
-                                "sessionId": session_id,
-                                "update": {
-                                    "sessionUpdate": "agent_message_chunk",
-                                    "content": { "type": "text", "text": text },
-                                },
-                            }),
-                        })
-                        .unwrap();
-                        output_lines.push(notification);
-                        let resp = JsonRpcResponse {
-                            jsonrpc: "2.0",
-                            id,
-                            result: Some(json!({ "stopReason": "end_turn" })),
-                            error: None,
-                        };
-                        output_lines.push(serde_json::to_string(&resp).unwrap());
-                    }
-                    None => {
-                        let resp = JsonRpcResponse {
-                            jsonrpc: "2.0",
-                            id,
-                            result: None,
-                            error: Some(json!({"code":-32001,"message":"agy responded but response extraction failed — possible schema change in conversation DB (field 20.1)"})),
-                        };
-                        output_lines.push(serde_json::to_string(&resp).unwrap());
-                    }
-                }
-            }
+        let mut child = match spawn_result {
+            Ok(child) => child,
             Err(e) => {
-                let resp = JsonRpcResponse {
+                return vec![serde_json::to_string(&JsonRpcResponse {
                     jsonrpc: "2.0",
                     id,
                     result: None,
                     error: Some(json!({"code":-32000,"message":format!("failed to run agy: {e}")})),
-                };
-                output_lines.push(serde_json::to_string(&resp).unwrap());
+                })
+                .unwrap()];
+            }
+        };
+
+        // Drain stdout/stderr in background tasks
+        let mut stdout_handle = child.stdout.take();
+        let stdout_reader = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            if let Some(mut stdout) = stdout_handle.take() {
+                let _ = stdout.read_to_end(&mut buf).await;
+            }
+            buf
+        });
+
+        let mut stderr_handle = child.stderr.take();
+        let stderr_reader = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            if let Some(mut stderr) = stderr_handle.take() {
+                let _ = stderr.read_to_end(&mut buf).await;
+            }
+            buf
+        });
+
+        // Set up streaming state
+        let initial_conv_id = self
+            .sessions
+            .get(session_id)
+            .and_then(|s| s.conversation_id.clone());
+        let initial_step_idx = self
+            .sessions
+            .get(session_id)
+            .map(|s| s.last_step_idx)
+            .unwrap_or(-1);
+
+        let streaming_state = Arc::new(Mutex::new(StreamingState {
+            conversation_id: initial_conv_id,
+            base_step_idx: initial_step_idx,
+            last_step_idx: initial_step_idx,
+            emitted_len: HashMap::new(),
+            had_updates: false,
+        }));
+
+        // Start polling thread (1s interval)
+        let stop_polling = Arc::new(AtomicBool::new(false));
+        let poll_conversations_dir = self.conversations_dir.clone();
+        let poll_snapshot = snapshot.clone();
+        let poll_session_id = session_id.to_string();
+        let poll_state = Arc::clone(&streaming_state);
+        let poll_stop = Arc::clone(&stop_polling);
+
+        let poller = std::thread::spawn(move || {
+            let mut stdout = io::stdout();
+            while !poll_stop.load(Ordering::SeqCst) {
+                let lines = Self::poll_streaming_delta(
+                    &poll_conversations_dir,
+                    poll_snapshot.as_ref(),
+                    &poll_session_id,
+                    &poll_state,
+                );
+                for line in lines {
+                    let _ = writeln!(stdout, "{}", line);
+                }
+                let _ = stdout.flush();
+                std::thread::sleep(Duration::from_secs(1));
+            }
+        });
+
+        // Wait for child to exit, or cancel
+        let mut was_cancelled = false;
+        let result = tokio::select! {
+            result = child.wait() => result,
+            _ = async {
+                while !cancelled.load(Ordering::SeqCst) {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+            } => {
+                was_cancelled = true;
+                let _ = child.kill().await;
+                child.wait().await
+            }
+        };
+
+        // Wait for stdout/stderr drains
+        let _ = stdout_reader.await;
+        let stderr_bytes = stderr_reader.await.unwrap_or_default();
+
+        // Stop polling thread and do final flush
+        stop_polling.store(true, Ordering::SeqCst);
+        let _ = poller.join();
+
+        // Final poll to catch any last writes
+        {
+            let lines = Self::poll_streaming_delta(
+                &self.conversations_dir,
+                snapshot.as_ref(),
+                session_id,
+                &streaming_state,
+            );
+            if !lines.is_empty() {
+                let mut stdout = io::stdout();
+                for line in &lines {
+                    let _ = writeln!(stdout, "{}", line);
+                }
+                let _ = stdout.flush();
             }
         }
-        output_lines
+
+        // Extract final state
+        let (bound_conv_id, new_step_idx, had_updates) = {
+            let guard = streaming_state.lock().unwrap();
+            (
+                guard.conversation_id.clone(),
+                guard.last_step_idx,
+                guard.had_updates,
+            )
+        };
+
+        // Update session state
+        if let Some(session) = self.sessions.get_mut(session_id) {
+            if session.conversation_id.is_none() {
+                session.conversation_id = bound_conv_id.clone();
+            }
+            if bound_conv_id.is_some() {
+                session.last_step_idx = new_step_idx;
+            }
+        }
+        if bound_conv_id.is_some() {
+            self.persist_session(session_id, bound_conv_id.as_deref(), new_step_idx);
+        }
+
+        // Build final response
+        let stop_reason = if was_cancelled { "cancelled" } else { "end_turn" };
+
+        match result {
+            Ok(status) => {
+                let stderr_text = String::from_utf8_lossy(&stderr_bytes);
+                if !stderr_text.is_empty() {
+                    eprintln!("[agy-acp] agy stderr: {}", stderr_text.trim_end());
+                }
+                if !was_cancelled && !status.success() {
+                    eprintln!("[agy-acp] WARN: agy exited with status: {}", status);
+                    if !had_updates {
+                        let msg = if stderr_text.is_empty() {
+                            format!("agy exited with status: {}", status)
+                        } else {
+                            format!("agy failed: {}", stderr_text.trim_end())
+                        };
+                        return vec![serde_json::to_string(&JsonRpcResponse {
+                            jsonrpc: "2.0",
+                            id,
+                            result: None,
+                            error: Some(json!({"code":-32000,"message":msg})),
+                        })
+                        .unwrap()];
+                    }
+                }
+            }
+            Err(e) => {
+                return vec![serde_json::to_string(&JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: None,
+                    error: Some(json!({"code":-32000,"message":format!("failed to wait for agy: {e}")})),
+                })
+                .unwrap()];
+            }
+        }
+
+        vec![serde_json::to_string(&JsonRpcResponse {
+            jsonrpc: "2.0",
+            id,
+            result: Some(json!({ "stopReason": stop_reason })),
+            error: None,
+        })
+        .unwrap()]
     }
 }
 
 #[tokio::main]
 async fn main() {
-    let mut adapter = Adapter::new();
+    let adapter = Arc::new(tokio::sync::Mutex::new(Adapter::new()));
+    let active_cancellations: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
 
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<Option<String>>();
+
     std::thread::spawn(move || {
         let stdin = io::stdin();
         for line in stdin.lock().lines() {
@@ -595,51 +790,157 @@ async fn main() {
     });
 
     let mut stdout = io::stdout();
+    let mut stdin_open = true;
+    let mut pending_prompts = 0usize;
 
-    while let Some(line) = rx.recv().await {
+    loop {
+        if !stdin_open && pending_prompts == 0 {
+            break;
+        }
+
+        let line = if stdin_open {
+            tokio::select! {
+                output = out_rx.recv() => {
+                    match output {
+                        Some(Some(line)) => {
+                            let _ = writeln!(stdout, "{}", line);
+                            let _ = stdout.flush();
+                        }
+                        Some(None) => pending_prompts = pending_prompts.saturating_sub(1),
+                        None => {}
+                    }
+                    continue;
+                }
+                input = rx.recv() => {
+                    match input {
+                        Some(line) => line,
+                        None => { stdin_open = false; continue; }
+                    }
+                }
+            }
+        } else {
+            match out_rx.recv().await {
+                Some(Some(line)) => {
+                    let _ = writeln!(stdout, "{}", line);
+                    let _ = stdout.flush();
+                }
+                Some(None) => pending_prompts = pending_prompts.saturating_sub(1),
+                None => break,
+            }
+            continue;
+        };
+
+        // Drain any pending output
+        while let Ok(output) = out_rx.try_recv() {
+            match output {
+                Some(line) => {
+                    let _ = writeln!(stdout, "{}", line);
+                    let _ = stdout.flush();
+                }
+                None => pending_prompts = pending_prompts.saturating_sub(1),
+            }
+        }
+
         let req: JsonRpcRequest = match serde_json::from_str(&line) {
             Ok(r) => r,
             Err(_) => continue,
         };
+
         let id = match req.id {
             Some(id) => id,
-            None => continue,
+            None => {
+                // Handle notifications (no id) — only session/cancel
+                if req.method.as_deref() == Some("session/cancel") {
+                    let params = req.params.unwrap_or(json!({}));
+                    if let Some(session_id) = params.get("sessionId").and_then(|v| v.as_str()) {
+                        if let Some(cancelled) =
+                            active_cancellations.lock().unwrap().get(session_id).cloned()
+                        {
+                            cancelled.store(true, Ordering::SeqCst);
+                        }
+                    }
+                }
+                continue;
+            }
         };
 
         let output = match req.method.as_deref() {
             Some("initialize") => {
+                let adapter = adapter.lock().await;
                 vec![serde_json::to_string(&adapter.handle_initialize(id)).unwrap()]
             }
             Some("session/new") => {
+                let mut adapter = adapter.lock().await;
                 vec![serde_json::to_string(&adapter.handle_session_new(id)).unwrap()]
             }
             Some("session/load") => {
                 let params = req.params.unwrap_or(json!({}));
+                let mut adapter = adapter.lock().await;
                 vec![serde_json::to_string(&adapter.handle_session_load(id, &params)).unwrap()]
             }
             Some("session/prompt") => {
                 let params = req.params.unwrap_or(json!({}));
-                adapter.handle_session_prompt(id, &params).await
+                let session_id = params
+                    .get("sessionId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                let cancelled = Arc::new(AtomicBool::new(false));
+                if !session_id.is_empty() {
+                    active_cancellations
+                        .lock()
+                        .unwrap()
+                        .insert(session_id.clone(), Arc::clone(&cancelled));
+                }
+
+                let adapter = Arc::clone(&adapter);
+                let active_cancellations = Arc::clone(&active_cancellations);
+                let out_tx = out_tx.clone();
+                pending_prompts += 1;
+
+                tokio::spawn(async move {
+                    let output = {
+                        let mut adapter = adapter.lock().await;
+                        adapter.handle_session_prompt(id, &params, cancelled).await
+                    };
+                    if !session_id.is_empty() {
+                        active_cancellations.lock().unwrap().remove(&session_id);
+                    }
+                    for line in output {
+                        let _ = out_tx.send(Some(line));
+                    }
+                    let _ = out_tx.send(None);
+                });
+                Vec::new()
             }
             Some("session/cancel") => {
-                let r = JsonRpcResponse {
+                let params = req.params.unwrap_or(json!({}));
+                if let Some(session_id) = params.get("sessionId").and_then(|v| v.as_str()) {
+                    if let Some(cancelled) =
+                        active_cancellations.lock().unwrap().get(session_id).cloned()
+                    {
+                        cancelled.store(true, Ordering::SeqCst);
+                    }
+                }
+                vec![serde_json::to_string(&JsonRpcResponse {
                     jsonrpc: "2.0",
                     id,
                     result: Some(json!({})),
                     error: None,
-                };
-                vec![serde_json::to_string(&r).unwrap()]
+                })
+                .unwrap()]
             }
             Some(method) => {
-                let r = JsonRpcResponse {
+                vec![serde_json::to_string(&JsonRpcResponse {
                     jsonrpc: "2.0",
                     id,
                     result: None,
                     error: Some(
                         json!({"code":-32601,"message":format!("method not found: {method}")}),
                     ),
-                };
-                vec![serde_json::to_string(&r).unwrap()]
+                })
+                .unwrap()]
             }
             None => continue,
         };
@@ -657,14 +958,12 @@ mod tests {
 
     #[test]
     fn test_extract_text_from_step_payload_field20_field1() {
-        // field 20 (tag 0xA2 0x01), containing sub-message with field 1 = "hello"
         let mut inner = Vec::new();
-        inner.push(0x0A); inner.push(0x05); // field 1, LEN, 5 bytes
+        inner.push(0x0A); inner.push(0x05);
         inner.extend_from_slice(b"hello");
 
         let mut blob = Vec::new();
-        blob.push(0x08); blob.push(0x0F); // field 1 varint = 15
-        // field 20, wire type 2: tag = (20 << 3) | 2 = 0xA2, needs varint encoding: 0xA2 0x01
+        blob.push(0x08); blob.push(0x0F);
         blob.push(0xA2); blob.push(0x01);
         blob.push(inner.len() as u8);
         blob.extend_from_slice(&inner);
@@ -673,7 +972,6 @@ mod tests {
 
     #[test]
     fn test_extract_text_returns_none_without_field20() {
-        // Only field 1 (varint) — no field 20
         let blob = vec![0x08, 0x03];
         assert_eq!(Adapter::extract_text_from_step_payload(&blob), None);
     }
@@ -682,13 +980,12 @@ mod tests {
     fn test_extract_text_multiline() {
         let text = b"Safe memory rules\nCompiler points out the flaws\nFast and fearless code";
         let mut inner = Vec::new();
-        inner.push(0x0A); // field 1, LEN
+        inner.push(0x0A);
         inner.push(text.len() as u8);
         inner.extend_from_slice(text);
 
         let mut blob = Vec::new();
-        blob.push(0x08); blob.push(0x01); // field 1 varint
-        // field 20
+        blob.push(0x08); blob.push(0x01);
         blob.push(0xA2); blob.push(0x01);
         blob.push(inner.len() as u8);
         blob.extend_from_slice(&inner);
@@ -708,7 +1005,7 @@ mod tests {
     #[test]
     fn test_initialize_advertises_load_session_support() {
         let adapter = Adapter::new();
-        let response = adapter.handle_initialize(1);
+        let response = adapter.handle_initialize(json!(1));
         assert_eq!(
             response
                 .result
@@ -734,7 +1031,7 @@ mod tests {
         };
         adapter.persist_session("sess-1", Some("conv-abc"), 5);
 
-        let response = adapter.handle_session_load(7, &json!({"sessionId": "sess-1"}));
+        let response = adapter.handle_session_load(json!(7), &json!({"sessionId": "sess-1"}));
         assert!(response.error.is_none());
         assert_eq!(
             adapter.sessions.get("sess-1").and_then(|s| s.conversation_id.as_deref()),
@@ -761,7 +1058,7 @@ mod tests {
             state_file: root.join("sessions.json"),
         };
 
-        let response = adapter.handle_session_load(9, &json!({"sessionId": "missing"}));
+        let response = adapter.handle_session_load(json!(9), &json!({"sessionId": "missing"}));
         assert!(response.result.is_none());
         assert_eq!(
             response.error.as_ref().and_then(|e| e.get("message")).and_then(|m| m.as_str()),
@@ -790,7 +1087,6 @@ mod tests {
         assert!(before.contains("existing"));
 
         fs::write(conv_dir.join("new-conv.db"), b"new").unwrap();
-        // WAL sidecar files should not be picked up
         fs::write(conv_dir.join("new-conv.db-wal"), b"wal").unwrap();
         fs::write(conv_dir.join("new-conv.db-shm"), b"shm").unwrap();
 
@@ -853,7 +1149,6 @@ mod tests {
         let conv_dir = root.join("conversations");
         fs::create_dir_all(&conv_dir).unwrap();
 
-        // Create a test SQLite DB with steps table
         let db_path = conv_dir.join("test-conv.db");
         let conn = Connection::open(&db_path).unwrap();
         conn.execute_batch(
@@ -872,13 +1167,12 @@ mod tests {
             )"
         ).unwrap();
 
-        // Insert a step_type=15 step with field 20 → field 1 containing "hello world"
         let mut inner = Vec::new();
-        inner.push(0x0A); inner.push(11); // field 1, LEN, 11 bytes
+        inner.push(0x0A); inner.push(11);
         inner.extend_from_slice(b"hello world");
         let mut payload = Vec::new();
-        payload.push(0x08); payload.push(0x0F); // field 1 varint = 15
-        payload.push(0xA2); payload.push(0x01); // field 20, LEN
+        payload.push(0x08); payload.push(0x0F);
+        payload.push(0xA2); payload.push(0x01);
         payload.push(inner.len() as u8);
         payload.extend_from_slice(&inner);
 
@@ -887,7 +1181,6 @@ mod tests {
             rusqlite::params![1i64, payload],
         ).unwrap();
 
-        // Insert a non-response step (step_type=14) — should be ignored
         conn.execute(
             "INSERT INTO steps (idx, step_type, step_payload) VALUES (?1, 14, ?2)",
             rusqlite::params![2i64, vec![0x08u8, 0x0E]],
@@ -904,270 +1197,96 @@ mod tests {
         let result = adapter.read_response_from_db("test-conv", -1);
         assert_eq!(result, Some(("hello world".to_string(), 1)));
 
-        // Reading after idx 1 should return None (no new steps)
         let result = adapter.read_response_from_db("test-conv", 1);
         assert_eq!(result, None);
 
         let _ = fs::remove_dir_all(root);
     }
 
-    /// Check auth is available: either GEMINI_API_KEY env var or local keyring.
-    /// Returns true if auth is ready, false to skip the test.
-    fn prepare_auth() -> bool {
-        if std::env::var("GEMINI_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
-            eprintln!("[e2e] Using GEMINI_API_KEY");
-            return true;
-        }
-        let home = std::env::var("HOME").unwrap_or_default();
-        let settings = format!("{}/.gemini/antigravity-cli/settings.json", home);
-        if std::path::Path::new(&settings).exists() {
-            eprintln!("[e2e] Using local auth (keyring)");
-            return true;
-        }
-        eprintln!("SKIP: No GEMINI_API_KEY and no local auth found");
-        false
-    }
-
-    /// E2E test: spawns agy-acp, sends initialize → session/new → session/prompt,
-    /// and verifies the response contains expected text from real agy v1.0.4.
-    /// Requires `agy` in PATH and auth (via local or AGY_AUTH_URL). Run with: cargo test e2e -- --ignored
     #[test]
-    #[ignore]
-    fn test_e2e_agy_acp_full_round_trip() {
-        use std::io::{BufRead, BufReader, Write};
-        use std::process::{Command, Stdio};
-        use std::time::Duration;
+    #[ignore] // filesystem I/O
+    fn test_streaming_poll_emits_delta() {
+        let root = std::env::temp_dir().join(format!("agy-acp-stream-{}", Uuid::new_v4()));
+        let conv_dir = root.join("conversations");
+        fs::create_dir_all(&conv_dir).unwrap();
 
-        if !prepare_auth() {
-            return;
+        let db_path = conv_dir.join("stream-conv.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE steps (
+                idx INTEGER PRIMARY KEY,
+                step_type INTEGER NOT NULL DEFAULT 0,
+                status INTEGER NOT NULL DEFAULT 0,
+                has_subtrajectory NUMERIC NOT NULL DEFAULT 0,
+                metadata BLOB, error_details BLOB, permissions BLOB,
+                task_details BLOB, render_info BLOB, step_payload BLOB,
+                step_format INTEGER NOT NULL DEFAULT 0
+            )"
+        ).unwrap();
+
+        fn make_payload(text: &str) -> Vec<u8> {
+            let text_bytes = text.as_bytes();
+            let mut inner = vec![0x0A];
+            let mut len = text_bytes.len();
+            loop {
+                if len < 128 { inner.push(len as u8); break; }
+                inner.push((len as u8 & 0x7F) | 0x80);
+                len >>= 7;
+            }
+            inner.extend_from_slice(text_bytes);
+            let mut outer = vec![0xA2, 0x01];
+            let mut ilen = inner.len();
+            loop {
+                if ilen < 128 { outer.push(ilen as u8); break; }
+                outer.push((ilen as u8 & 0x7F) | 0x80);
+                ilen >>= 7;
+            }
+            outer.extend(inner);
+            outer
         }
 
-        // Check agy is available
-        let agy_check = Command::new("agy").arg("--help").output();
-        if agy_check.is_err() || !agy_check.unwrap().status.success() {
-            eprintln!("SKIP: agy not found in PATH");
-            return;
-        }
+        conn.execute(
+            "INSERT INTO steps (idx, step_type, step_payload) VALUES (?1, 15, ?2)",
+            rusqlite::params![1i64, make_payload("hello")],
+        ).unwrap();
 
-        let binary = std::env::current_dir().unwrap().join("target/release/agy-acp");
-        if !binary.exists() {
-            panic!("Run `cargo build --release` first");
-        }
+        let state = Arc::new(Mutex::new(StreamingState {
+            conversation_id: Some("stream-conv".to_string()),
+            base_step_idx: -1,
+            last_step_idx: -1,
+            emitted_len: HashMap::new(),
+            had_updates: false,
+        }));
 
-        let mut child = Command::new(&binary)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("failed to spawn agy-acp");
+        // First poll — should get "hello"
+        let lines = Adapter::poll_streaming_delta(&conv_dir, None, "sess-1", &state);
+        assert_eq!(lines.len(), 1);
+        let msg: Value = serde_json::from_str(&lines[0]).unwrap();
+        assert_eq!(msg["params"]["update"]["content"]["text"], "hello");
 
-        let mut stdin = child.stdin.take().unwrap();
-        let stdout = child.stdout.take().unwrap();
-        let mut reader = BufReader::new(stdout);
+        // Second poll — no new data, no output
+        let lines = Adapter::poll_streaming_delta(&conv_dir, None, "sess-1", &state);
+        assert!(lines.is_empty());
 
-        // Helper to send a line and read one response line
-        let mut send_and_recv = |msg: &str| -> String {
-            writeln!(stdin, "{}", msg).unwrap();
-            stdin.flush().unwrap();
-            let mut line = String::new();
-            reader.read_line(&mut line).unwrap();
-            line
-        };
+        // Simulate text growing (agy appending to same step)
+        conn.execute(
+            "UPDATE steps SET step_payload = ?1 WHERE idx = 1",
+            rusqlite::params![make_payload("hello world")],
+        ).unwrap();
 
-        // 1. Initialize
-        let resp = send_and_recv(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientName":"e2e","clientVersion":"0.1"}}"#);
-        let init: Value = serde_json::from_str(&resp).unwrap();
-        assert_eq!(init["result"]["protocolVersion"], 1);
+        // Third poll — should get " world" (delta)
+        let lines = Adapter::poll_streaming_delta(&conv_dir, None, "sess-1", &state);
+        assert_eq!(lines.len(), 1);
+        let msg: Value = serde_json::from_str(&lines[0]).unwrap();
+        assert_eq!(msg["params"]["update"]["content"]["text"], " world");
 
-        // 2. Session new
-        let resp = send_and_recv(r#"{"jsonrpc":"2.0","id":2,"method":"session/new","params":{}}"#);
-        let session: Value = serde_json::from_str(&resp).unwrap();
-        let session_id = session["result"]["sessionId"].as_str().unwrap();
-        assert!(!session_id.is_empty());
+        // Verify state
+        let guard = state.lock().unwrap();
+        assert_eq!(guard.last_step_idx, 1);
+        assert!(guard.had_updates);
 
-        // 3. Send prompt — ask agy to reply with a known word
-        let prompt_msg = format!(
-            r#"{{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{{"sessionId":"{}","prompt":[{{"type":"text","text":"Reply with exactly one word: PONG"}}]}}}}"#,
-            session_id
-        );
-        writeln!(stdin, "{}", prompt_msg).unwrap();
-        stdin.flush().unwrap();
-
-        // Read lines until we get id:3 response (there may be a notification first)
-        let deadline = std::time::Instant::now() + Duration::from_secs(120);
-        let mut got_notification = false;
-        let mut response_text = String::new();
-        loop {
-            if std::time::Instant::now() > deadline {
-                panic!("Timed out waiting for agy-acp response");
-            }
-            let mut line = String::new();
-            reader.read_line(&mut line).unwrap();
-            if line.is_empty() {
-                std::thread::sleep(Duration::from_millis(100));
-                continue;
-            }
-            let msg: Value = serde_json::from_str(line.trim()).unwrap();
-            if msg.get("method") == Some(&json!("session/update")) {
-                got_notification = true;
-                response_text = msg["params"]["update"]["content"]["text"]
-                    .as_str()
-                    .unwrap_or("")
-                    .to_string();
-            }
-            if msg.get("id") == Some(&json!(3)) {
-                assert!(msg["error"].is_null(), "Got error: {}", msg["error"]);
-                assert_eq!(msg["result"]["stopReason"], "end_turn");
-                break;
-            }
-        }
-
-        drop(stdin);
-        let _ = child.wait();
-
-        assert!(got_notification, "Expected session/update notification");
-        let lower = response_text.to_lowercase();
-        assert!(
-            lower.contains("pong"),
-            "Expected 'PONG' in response, got: '{}'",
-            response_text
-        );
-    }
-
-    /// Helper: spawn agy-acp, return (stdin, reader, child)
-    fn spawn_agy_acp() -> Option<(std::process::ChildStdin, std::io::BufReader<std::process::ChildStdout>, std::process::Child)> {
-        use std::io::BufReader;
-        use std::process::{Command, Stdio};
-
-        if !prepare_auth() { return None; }
-        let agy_check = Command::new("agy").arg("--help").output();
-        if agy_check.is_err() || !agy_check.unwrap().status.success() {
-            eprintln!("SKIP: agy not found in PATH");
-            return None;
-        }
-        let binary = std::env::current_dir().unwrap().join("target/release/agy-acp");
-        if !binary.exists() { panic!("Run `cargo build --release` first"); }
-
-        let mut child = Command::new(&binary)
-            .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped())
-            .spawn().expect("failed to spawn agy-acp");
-        let stdin = child.stdin.take().unwrap();
-        let stdout = child.stdout.take().unwrap();
-        Some((stdin, BufReader::new(stdout), child))
-    }
-
-    /// Helper: send JSON-RPC and read one response line
-    fn send_recv(stdin: &mut std::process::ChildStdin, reader: &mut std::io::BufReader<std::process::ChildStdout>, msg: &str) -> String {
-        use std::io::{BufRead, Write};
-        writeln!(stdin, "{}", msg).unwrap();
-        stdin.flush().unwrap();
-        let mut line = String::new();
-        reader.read_line(&mut line).unwrap();
-        line
-    }
-
-    /// Helper: send a prompt and wait for the response (notification + final reply)
-    fn send_prompt_wait(stdin: &mut std::process::ChildStdin, reader: &mut std::io::BufReader<std::process::ChildStdout>, id: u64, session_id: &str, text: &str) -> (Option<String>, Value) {
-        use std::io::{BufRead, Write};
-        use std::time::Duration;
-
-        let msg = format!(
-            r#"{{"jsonrpc":"2.0","id":{},"method":"session/prompt","params":{{"sessionId":"{}","prompt":[{{"type":"text","text":"{}"}}]}}}}"#,
-            id, session_id, text
-        );
-        writeln!(stdin, "{}", msg).unwrap();
-        stdin.flush().unwrap();
-
-        let deadline = std::time::Instant::now() + Duration::from_secs(120);
-        let mut notification_text: Option<String> = None;
-        loop {
-            if std::time::Instant::now() > deadline { panic!("Timed out"); }
-            let mut line = String::new();
-            reader.read_line(&mut line).unwrap();
-            if line.is_empty() { std::thread::sleep(Duration::from_millis(100)); continue; }
-            let msg: Value = serde_json::from_str(line.trim()).unwrap();
-            if msg.get("method") == Some(&json!("session/update")) {
-                notification_text = msg["params"]["update"]["content"]["text"].as_str().map(String::from);
-            }
-            if msg.get("id") == Some(&json!(id)) {
-                return (notification_text, msg);
-            }
-        }
-    }
-
-    /// E2E: multi-turn — second prompt reuses the same conversation via --conversation flag
-    #[test]
-    #[ignore]
-    fn test_e2e_multi_turn() {
-        let Some((mut stdin, mut reader, mut child)) = spawn_agy_acp() else { return };
-
-        // Initialize
-        send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientName":"e2e","clientVersion":"0.1"}}"#);
-
-        // Session new
-        let resp = send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":2,"method":"session/new","params":{}}"#);
-        let session_id = serde_json::from_str::<Value>(&resp).unwrap()["result"]["sessionId"].as_str().unwrap().to_string();
-
-        // First prompt: set a context
-        let (text1, resp1) = send_prompt_wait(&mut stdin, &mut reader, 3, &session_id, "Remember this word: BANANA. Reply OK.");
-        assert!(resp1["error"].is_null(), "Turn 1 error: {}", resp1["error"]);
-        assert!(text1.is_some());
-
-        // Second prompt: ask it to recall — this exercises --conversation reuse
-        let (text2, resp2) = send_prompt_wait(&mut stdin, &mut reader, 4, &session_id, "What word did I ask you to remember? Reply with just that word.");
-        assert!(resp2["error"].is_null(), "Turn 2 error: {}", resp2["error"]);
-        let reply = text2.unwrap_or_default().to_lowercase();
-        assert!(reply.contains("banana"), "Expected 'BANANA' in multi-turn reply, got: '{}'", reply);
-
-        drop(stdin);
-        let _ = child.wait();
-    }
-
-    /// E2E: session/load — evict session from memory, then restore from persisted state
-    #[test]
-    #[ignore]
-    fn test_e2e_session_load() {
-        let Some((mut stdin, mut reader, mut child)) = spawn_agy_acp() else { return };
-
-        send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientName":"e2e","clientVersion":"0.1"}}"#);
-        let resp = send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":2,"method":"session/new","params":{}}"#);
-        let session_id = serde_json::from_str::<Value>(&resp).unwrap()["result"]["sessionId"].as_str().unwrap().to_string();
-
-        // Send first prompt to bind conversation and persist state
-        let (_text, resp1) = send_prompt_wait(&mut stdin, &mut reader, 3, &session_id, "Reply with exactly: FIRST_TURN");
-        assert!(resp1["error"].is_null(), "First turn error: {}", resp1["error"]);
-
-        // Send second prompt on the same session — this confirms multi-turn works
-        // (session/load is already tested in unit tests; here we just verify the session
-        // can handle continued prompts after binding)
-        let (text2, resp2) = send_prompt_wait(&mut stdin, &mut reader, 4, &session_id, "Reply with exactly one word: SECOND");
-        assert!(resp2["error"].is_null(), "Second turn error: {}", resp2["error"]);
-        assert!(text2.is_some(), "Expected response on continued session");
-
-        drop(stdin);
-        let _ = child.wait();
-    }
-
-    /// E2E: error path — invalid requests should return errors, not crash
-    #[test]
-    #[ignore]
-    fn test_e2e_error_paths() {
-        let Some((mut stdin, mut reader, mut child)) = spawn_agy_acp() else { return };
-
-        send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientName":"e2e","clientVersion":"0.1"}}"#);
-
-        // Load a non-existent session
-        let resp = send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":2,"method":"session/load","params":{"sessionId":"non-existent-session"}}"#);
-        let val: Value = serde_json::from_str(&resp).unwrap();
-        assert!(!val["error"].is_null(), "Expected error for unknown session");
-
-        // Unknown method
-        let resp = send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":3,"method":"bogus/method","params":{}}"#);
-        let val: Value = serde_json::from_str(&resp).unwrap();
-        assert!(!val["error"].is_null(), "Expected error for unknown method");
-
-        drop(stdin);
-        let _ = child.wait();
+        drop(conn);
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
@@ -1185,21 +1304,15 @@ mod tests {
                 step_type INTEGER NOT NULL DEFAULT 0,
                 status INTEGER NOT NULL DEFAULT 0,
                 has_subtrajectory NUMERIC NOT NULL DEFAULT 0,
-                metadata BLOB,
-                error_details BLOB,
-                permissions BLOB,
-                task_details BLOB,
-                render_info BLOB,
-                step_payload BLOB,
+                metadata BLOB, error_details BLOB, permissions BLOB,
+                task_details BLOB, render_info BLOB, step_payload BLOB,
                 step_format INTEGER NOT NULL DEFAULT 0
             )"
         ).unwrap();
 
-        // Helper: build payload with field 20 (sub-msg) → field 1 (text)
         fn make_payload(text: &str) -> Vec<u8> {
-            // Inner message: field 1, wire type 2 (LEN), <text>
             let text_bytes = text.as_bytes();
-            let mut inner = vec![0x0A]; // tag: field 1, wire type 2
+            let mut inner = vec![0x0A];
             let mut len = text_bytes.len();
             loop {
                 if len < 128 { inner.push(len as u8); break; }
@@ -1207,9 +1320,6 @@ mod tests {
                 len >>= 7;
             }
             inner.extend_from_slice(text_bytes);
-
-            // Outer: field 20, wire type 2 (LEN), <inner>
-            // tag = (20 << 3) | 2 = 162 → varint [0xA2, 0x01]
             let mut outer = vec![0xA2, 0x01];
             let mut ilen = inner.len();
             loop {
@@ -1221,18 +1331,12 @@ mod tests {
             outer
         }
 
-        // step_type 0 = user, step_type 15 = response
-        // Step 1: user prompt (step_type=0, no extractable text)
         conn.execute("INSERT INTO steps (idx, step_type, step_payload) VALUES (1, 0, X'0801')", []).unwrap();
-        // Step 2: bot response "hello"
         conn.execute("INSERT INTO steps (idx, step_type, step_payload) VALUES (?1, 15, ?2)",
             rusqlite::params![2i64, make_payload("hello")]).unwrap();
-        // Step 3: user prompt
         conn.execute("INSERT INTO steps (idx, step_type, step_payload) VALUES (3, 0, X'0802')", []).unwrap();
-        // Step 4: bot response "world"
         conn.execute("INSERT INTO steps (idx, step_type, step_payload) VALUES (?1, 15, ?2)",
             rusqlite::params![4i64, make_payload("world")]).unwrap();
-        // Step 5: bot response multi-line
         conn.execute("INSERT INTO steps (idx, step_type, step_payload) VALUES (?1, 15, ?2)",
             rusqlite::params![5i64, make_payload("line1\nline2\nline3")]).unwrap();
         drop(conn);
@@ -1244,19 +1348,15 @@ mod tests {
             state_file: root.join("sessions.json"),
         };
 
-        // From start: get all response steps
         let result = adapter.read_response_from_db("multi", -1);
         assert_eq!(result, Some(("hello\nworld\nline1\nline2\nline3".to_string(), 5)));
 
-        // After step 2: skip "hello", get "world" + multi-line
         let result = adapter.read_response_from_db("multi", 2);
         assert_eq!(result, Some(("world\nline1\nline2\nline3".to_string(), 5)));
 
-        // After step 4: only multi-line
         let result = adapter.read_response_from_db("multi", 4);
         assert_eq!(result, Some(("line1\nline2\nline3".to_string(), 5)));
 
-        // After step 5: nothing new
         let result = adapter.read_response_from_db("multi", 5);
         assert_eq!(result, None);
 
@@ -1369,5 +1469,242 @@ mod tests {
         let result = Adapter::filter_narration(&parts);
         assert_eq!(result, "I will verify the fix.");
         std::env::remove_var("OPENAB_TOOL_DISPLAY");
+    }
+
+    #[test]
+    fn test_json_rpc_id_as_string() {
+        // Verify that string IDs are handled correctly
+        let json_str = r#"{"jsonrpc":"2.0","id":"abc-123","method":"initialize","params":{}}"#;
+        let req: JsonRpcRequest = serde_json::from_str(json_str).unwrap();
+        assert_eq!(req.id, Some(json!("abc-123")));
+    }
+
+    #[test]
+    fn test_json_rpc_id_as_number() {
+        let json_str = r#"{"jsonrpc":"2.0","id":42,"method":"initialize","params":{}}"#;
+        let req: JsonRpcRequest = serde_json::from_str(json_str).unwrap();
+        assert_eq!(req.id, Some(json!(42)));
+    }
+
+    /// Check auth is available: either GEMINI_API_KEY env var or local keyring.
+    fn prepare_auth() -> bool {
+        if std::env::var("GEMINI_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+            eprintln!("[e2e] Using GEMINI_API_KEY");
+            return true;
+        }
+        let home = std::env::var("HOME").unwrap_or_default();
+        let settings = format!("{}/.gemini/antigravity-cli/settings.json", home);
+        if std::path::Path::new(&settings).exists() {
+            eprintln!("[e2e] Using local auth (keyring)");
+            return true;
+        }
+        eprintln!("SKIP: No GEMINI_API_KEY and no local auth found");
+        false
+    }
+
+    /// E2E test: spawns agy-acp, sends initialize → session/new → session/prompt,
+    /// and verifies the response contains expected text from real agy.
+    #[test]
+    #[ignore]
+    fn test_e2e_agy_acp_full_round_trip() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::process::{Command, Stdio};
+        use std::time::Duration;
+
+        if !prepare_auth() { return; }
+
+        let agy_check = Command::new("agy").arg("--help").output();
+        if agy_check.is_err() || !agy_check.unwrap().status.success() {
+            eprintln!("SKIP: agy not found in PATH");
+            return;
+        }
+
+        let binary = std::env::current_dir().unwrap().join("target/release/agy-acp");
+        if !binary.exists() { panic!("Run `cargo build --release` first"); }
+
+        let mut child = Command::new(&binary)
+            .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped())
+            .spawn().expect("failed to spawn agy-acp");
+
+        let mut stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let mut reader = BufReader::new(stdout);
+
+        let mut send_and_recv = |msg: &str| -> String {
+            writeln!(stdin, "{}", msg).unwrap();
+            stdin.flush().unwrap();
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            line
+        };
+
+        let resp = send_and_recv(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientName":"e2e","clientVersion":"0.1"}}"#);
+        let init: Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(init["result"]["protocolVersion"], 1);
+
+        let resp = send_and_recv(r#"{"jsonrpc":"2.0","id":2,"method":"session/new","params":{}}"#);
+        let session: Value = serde_json::from_str(&resp).unwrap();
+        let session_id = session["result"]["sessionId"].as_str().unwrap();
+        assert!(!session_id.is_empty());
+
+        let prompt_msg = format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{{"sessionId":"{}","prompt":[{{"type":"text","text":"Reply with exactly one word: PONG"}}]}}}}"#,
+            session_id
+        );
+        writeln!(stdin, "{}", prompt_msg).unwrap();
+        stdin.flush().unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(120);
+        let mut got_notification = false;
+        let mut response_text = String::new();
+        loop {
+            if std::time::Instant::now() > deadline { panic!("Timed out"); }
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            if line.is_empty() { std::thread::sleep(Duration::from_millis(100)); continue; }
+            let msg: Value = serde_json::from_str(line.trim()).unwrap();
+            if msg.get("method") == Some(&json!("session/update")) {
+                got_notification = true;
+                if let Some(text) = msg["params"]["update"]["content"]["text"].as_str() {
+                    response_text.push_str(text);
+                }
+            }
+            if msg.get("id") == Some(&json!(3)) {
+                assert!(msg["error"].is_null(), "Got error: {}", msg["error"]);
+                break;
+            }
+        }
+
+        drop(stdin);
+        let _ = child.wait();
+
+        assert!(got_notification, "Expected session/update notification");
+        let lower = response_text.to_lowercase();
+        assert!(lower.contains("pong"), "Expected 'PONG' in response, got: '{}'", response_text);
+    }
+
+    /// Helper: spawn agy-acp, return (stdin, reader, child)
+    fn spawn_agy_acp() -> Option<(std::process::ChildStdin, std::io::BufReader<std::process::ChildStdout>, std::process::Child)> {
+        use std::io::BufReader;
+        use std::process::{Command, Stdio};
+
+        if !prepare_auth() { return None; }
+        let agy_check = Command::new("agy").arg("--help").output();
+        if agy_check.is_err() || !agy_check.unwrap().status.success() {
+            eprintln!("SKIP: agy not found in PATH");
+            return None;
+        }
+        let binary = std::env::current_dir().unwrap().join("target/release/agy-acp");
+        if !binary.exists() { panic!("Run `cargo build --release` first"); }
+
+        let mut child = Command::new(&binary)
+            .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped())
+            .spawn().expect("failed to spawn agy-acp");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        Some((stdin, BufReader::new(stdout), child))
+    }
+
+    /// Helper: send JSON-RPC and read one response line
+    fn send_recv(stdin: &mut std::process::ChildStdin, reader: &mut std::io::BufReader<std::process::ChildStdout>, msg: &str) -> String {
+        use std::io::{BufRead, Write};
+        writeln!(stdin, "{}", msg).unwrap();
+        stdin.flush().unwrap();
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        line
+    }
+
+    /// Helper: send a prompt and wait for the response (notifications + final reply)
+    fn send_prompt_wait(stdin: &mut std::process::ChildStdin, reader: &mut std::io::BufReader<std::process::ChildStdout>, id: u64, session_id: &str, text: &str) -> (Option<String>, Value) {
+        use std::io::{BufRead, Write};
+        use std::time::Duration;
+
+        let msg = format!(
+            r#"{{"jsonrpc":"2.0","id":{},"method":"session/prompt","params":{{"sessionId":"{}","prompt":[{{"type":"text","text":"{}"}}]}}}}"#,
+            id, session_id, text
+        );
+        writeln!(stdin, "{}", msg).unwrap();
+        stdin.flush().unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(120);
+        let mut collected_text = String::new();
+        loop {
+            if std::time::Instant::now() > deadline { panic!("Timed out"); }
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            if line.is_empty() { std::thread::sleep(Duration::from_millis(100)); continue; }
+            let msg: Value = serde_json::from_str(line.trim()).unwrap();
+            if msg.get("method") == Some(&json!("session/update")) {
+                if let Some(text) = msg["params"]["update"]["content"]["text"].as_str() {
+                    collected_text.push_str(text);
+                }
+            }
+            if msg.get("id") == Some(&json!(id)) {
+                let text = if collected_text.is_empty() { None } else { Some(collected_text) };
+                return (text, msg);
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn test_e2e_multi_turn() {
+        let Some((mut stdin, mut reader, mut child)) = spawn_agy_acp() else { return };
+
+        send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientName":"e2e","clientVersion":"0.1"}}"#);
+        let resp = send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":2,"method":"session/new","params":{}}"#);
+        let session_id = serde_json::from_str::<Value>(&resp).unwrap()["result"]["sessionId"].as_str().unwrap().to_string();
+
+        let (text1, resp1) = send_prompt_wait(&mut stdin, &mut reader, 3, &session_id, "Remember this word: BANANA. Reply OK.");
+        assert!(resp1["error"].is_null(), "Turn 1 error: {}", resp1["error"]);
+        assert!(text1.is_some());
+
+        let (text2, resp2) = send_prompt_wait(&mut stdin, &mut reader, 4, &session_id, "What word did I ask you to remember? Reply with just that word.");
+        assert!(resp2["error"].is_null(), "Turn 2 error: {}", resp2["error"]);
+        let reply = text2.unwrap_or_default().to_lowercase();
+        assert!(reply.contains("banana"), "Expected 'BANANA' in multi-turn reply, got: '{}'", reply);
+
+        drop(stdin);
+        let _ = child.wait();
+    }
+
+    #[test]
+    #[ignore]
+    fn test_e2e_session_load() {
+        let Some((mut stdin, mut reader, mut child)) = spawn_agy_acp() else { return };
+
+        send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientName":"e2e","clientVersion":"0.1"}}"#);
+        let resp = send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":2,"method":"session/new","params":{}}"#);
+        let session_id = serde_json::from_str::<Value>(&resp).unwrap()["result"]["sessionId"].as_str().unwrap().to_string();
+
+        let (_text, resp1) = send_prompt_wait(&mut stdin, &mut reader, 3, &session_id, "Reply with exactly: FIRST_TURN");
+        assert!(resp1["error"].is_null(), "First turn error: {}", resp1["error"]);
+
+        let (text2, resp2) = send_prompt_wait(&mut stdin, &mut reader, 4, &session_id, "Reply with exactly one word: SECOND");
+        assert!(resp2["error"].is_null(), "Second turn error: {}", resp2["error"]);
+        assert!(text2.is_some(), "Expected response on continued session");
+
+        drop(stdin);
+        let _ = child.wait();
+    }
+
+    #[test]
+    #[ignore]
+    fn test_e2e_error_paths() {
+        let Some((mut stdin, mut reader, mut child)) = spawn_agy_acp() else { return };
+
+        send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientName":"e2e","clientVersion":"0.1"}}"#);
+
+        let resp = send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":2,"method":"session/load","params":{"sessionId":"non-existent-session"}}"#);
+        let val: Value = serde_json::from_str(&resp).unwrap();
+        assert!(!val["error"].is_null(), "Expected error for unknown session");
+
+        let resp = send_recv(&mut stdin, &mut reader, r#"{"jsonrpc":"2.0","id":3,"method":"bogus/method","params":{}}"#);
+        let val: Value = serde_json::from_str(&resp).unwrap();
+        assert!(!val["error"].is_null(), "Expected error for unknown method");
+
+        drop(stdin);
+        let _ = child.wait();
     }
 }

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -816,6 +816,14 @@ impl Adapter {
 
 }
 
+/// Drop guard that sets stop_polling flag when the future is dropped (task abort safety).
+struct StopGuard(Arc<AtomicBool>);
+impl Drop for StopGuard {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
 /// Output from prompt execution (used to separate lock-free execution from state update).
 struct PromptOutput {
     response_lines: Vec<String>,
@@ -908,11 +916,17 @@ impl Adapter {
                     &poll_state,
                 );
                 for line in lines {
-                    let _ = poll_tx.send(Some(line));
+                    // If send fails, receiver is dropped (task cancelled) — exit
+                    if poll_tx.send(Some(line)).is_err() {
+                        return;
+                    }
                 }
                 std::thread::sleep(Duration::from_millis(100));
             }
         });
+
+        // Guard: ensure stop_polling is set if this future is dropped (task abort)
+        let _stop_guard = StopGuard(Arc::clone(&stop_polling));
 
         // Wait for child to exit, or cancel
         let mut was_cancelled = false;

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -118,9 +118,21 @@ impl Adapter {
     }
 
     /// Get available models, fetching lazily on first access.
+    /// Falls back to a static list if `agy models` returns empty.
     fn get_available_models(&mut self) -> &[String] {
         if self.available_models.is_none() {
-            self.available_models = Some(Self::fetch_available_models());
+            let models = Self::fetch_available_models();
+            self.available_models = Some(if models.is_empty() {
+                vec![
+                    "Gemini 3.5 Flash (Medium)".to_string(),
+                    "Gemini 3.5 Flash (High)".to_string(),
+                    "Gemini 3.5 Flash (Low)".to_string(),
+                    "Gemini 3.1 Pro (Low)".to_string(),
+                    "Gemini 3.1 Pro (High)".to_string(),
+                ]
+            } else {
+                models
+            });
         }
         self.available_models.as_ref().unwrap()
     }

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -98,58 +98,23 @@ impl Adapter {
         }
     }
 
-    /// Run `agy models` with a 5s timeout and parse the output into a list of model names.
-    /// Falls back to a hardcoded list if `agy models` fails (e.g. auth not yet completed).
+    /// Run `agy models` and parse the output into a list of model names.
+    /// Blocks until completion. Returns empty if `agy models` fails.
     fn fetch_available_models() -> Vec<String> {
-        use std::time::Instant;
-        let start = Instant::now();
-        let mut child = match std::process::Command::new("agy")
+        std::process::Command::new("agy")
             .arg("models")
-            .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
-            .spawn()
-        {
-            Ok(c) => c,
-            Err(_) => return Self::fallback_models(),
-        };
-        // Poll with 5s timeout
-        loop {
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    if !status.success() { return Self::fallback_models(); }
-                    let stdout = child.stdout.take().unwrap();
-                    use std::io::Read;
-                    let mut buf = String::new();
-                    let mut reader = std::io::BufReader::new(stdout);
-                    let _ = reader.read_to_string(&mut buf);
-                    let models: Vec<String> = buf.lines()
-                        .map(|l| l.trim().to_string())
-                        .filter(|l| !l.is_empty())
-                        .collect();
-                    if models.is_empty() {
-                        return Self::fallback_models();
-                    }
-                    return models;
-                }
-                Ok(None) => {
-                    if start.elapsed() > Duration::from_secs(5) {
-                        let _ = child.kill();
-                        return Self::fallback_models();
-                    }
-                    std::thread::sleep(Duration::from_millis(50));
-                }
-                Err(_) => return Self::fallback_models(),
-            }
-        }
-    }
-
-    /// Hardcoded fallback models when `agy models` is unavailable (auth pending, timeout, etc.)
-    fn fallback_models() -> Vec<String> {
-        vec![
-            "gemini-2.5-pro".to_string(),
-            "gemini-2.5-flash".to_string(),
-            "gemini-2.0-flash".to_string(),
-        ]
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| {
+                String::from_utf8_lossy(&o.stdout)
+                    .lines()
+                    .map(|l| l.trim().to_string())
+                    .filter(|l| !l.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Get available models, fetching lazily on first access.

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -369,6 +369,12 @@ impl Adapter {
                 continue;
             }
 
+            // Skip narration-only text if OPENAB_TOOL_DISPLAY filtering is active
+            if Self::should_filter_narration() && Self::is_narration(&text) {
+                guard.emitted_len.insert(idx, text.len());
+                continue;
+            }
+
             let new_text = &text[emitted..];
             guard.emitted_len.insert(idx, text.len());
 
@@ -419,6 +425,16 @@ impl Adapter {
             return false;
         }
         lines.iter().all(|l| l.trim_start().starts_with("I will"))
+    }
+
+    /// Check if narration filtering is enabled via OPENAB_TOOL_DISPLAY.
+    fn should_filter_narration() -> bool {
+        std::env::var("OPENAB_TOOL_DISPLAY")
+            .map(|v| {
+                let lower = v.to_lowercase();
+                lower == "compact" || lower == "none" || lower == "off"
+            })
+            .unwrap_or(false)
     }
 
     fn evict_if_needed(&mut self) {
@@ -718,7 +734,13 @@ impl Adapter {
         }
 
         // Build final response
-        let stop_reason = if was_cancelled { "cancelled" } else { "end_turn" };
+        let stop_reason = if was_cancelled {
+            "cancelled"
+        } else if result.as_ref().map(|s| !s.success()).unwrap_or(false) {
+            "error"
+        } else {
+            "end_turn"
+        };
 
         match result {
             Ok(status) => {
@@ -866,17 +888,46 @@ async fn main() {
 
         let output = match req.method.as_deref() {
             Some("initialize") => {
-                let adapter = adapter.lock().await;
-                vec![serde_json::to_string(&adapter.handle_initialize(id)).unwrap()]
+                let adapter = Arc::clone(&adapter);
+                let out_tx = out_tx.clone();
+                pending_prompts += 1;
+                tokio::spawn(async move {
+                    let adapter = adapter.lock().await;
+                    let line =
+                        serde_json::to_string(&adapter.handle_initialize(id)).unwrap();
+                    let _ = out_tx.send(Some(line));
+                    let _ = out_tx.send(None);
+                });
+                Vec::new()
             }
             Some("session/new") => {
-                let mut adapter = adapter.lock().await;
-                vec![serde_json::to_string(&adapter.handle_session_new(id)).unwrap()]
+                let adapter = Arc::clone(&adapter);
+                let out_tx = out_tx.clone();
+                pending_prompts += 1;
+                tokio::spawn(async move {
+                    let mut adapter = adapter.lock().await;
+                    let line =
+                        serde_json::to_string(&adapter.handle_session_new(id)).unwrap();
+                    let _ = out_tx.send(Some(line));
+                    let _ = out_tx.send(None);
+                });
+                Vec::new()
             }
             Some("session/load") => {
                 let params = req.params.unwrap_or(json!({}));
-                let mut adapter = adapter.lock().await;
-                vec![serde_json::to_string(&adapter.handle_session_load(id, &params)).unwrap()]
+                let adapter = Arc::clone(&adapter);
+                let out_tx = out_tx.clone();
+                pending_prompts += 1;
+                tokio::spawn(async move {
+                    let mut adapter = adapter.lock().await;
+                    let line = serde_json::to_string(
+                        &adapter.handle_session_load(id, &params),
+                    )
+                    .unwrap();
+                    let _ = out_tx.send(Some(line));
+                    let _ = out_tx.send(None);
+                });
+                Vec::new()
             }
             Some("session/prompt") => {
                 let params = req.params.unwrap_or(json!({}));

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -102,12 +102,12 @@ impl Adapter {
     fn fetch_available_models() -> Vec<String> {
         use std::time::Instant;
         let start = Instant::now();
-        let child = std::process::Command::new("agy")
+        let mut child = match std::process::Command::new("agy")
             .arg("models")
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
-            .spawn();
-        let mut child = match child {
+            .spawn()
+        {
             Ok(c) => c,
             Err(_) => return Vec::new(),
         };
@@ -116,7 +116,16 @@ impl Adapter {
             match child.try_wait() {
                 Ok(Some(status)) => {
                     if !status.success() { return Vec::new(); }
-                    break;
+                    // Process exited successfully — read stdout
+                    let stdout = child.stdout.take().unwrap();
+                    use std::io::Read;
+                    let mut buf = String::new();
+                    let mut reader = std::io::BufReader::new(stdout);
+                    let _ = reader.read_to_string(&mut buf);
+                    return buf.lines()
+                        .map(|l| l.trim().to_string())
+                        .filter(|l| !l.is_empty())
+                        .collect();
                 }
                 Ok(None) => {
                     if start.elapsed() > Duration::from_secs(5) {
@@ -128,16 +137,6 @@ impl Adapter {
                 Err(_) => return Vec::new(),
             }
         }
-        child.wait_with_output()
-            .ok()
-            .map(|o| {
-                String::from_utf8_lossy(&o.stdout)
-                    .lines()
-                    .map(|l| l.trim().to_string())
-                    .filter(|l| !l.is_empty())
-                    .collect()
-            })
-            .unwrap_or_default()
     }
 
     /// Get available models, fetching lazily on first access.

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -1168,7 +1168,13 @@ mod tests {
 
     #[test]
     fn test_initialize_advertises_load_session_support() {
-        let adapter = Adapter::new();
+        let adapter = Adapter {
+            sessions: HashMap::new(),
+            working_dir: "/tmp".to_string(),
+            conversations_dir: PathBuf::from("/tmp"),
+            state_file: PathBuf::from("/tmp/sessions.json"),
+            available_models: vec![],
+        };
         let response = adapter.handle_initialize(json!(1));
         assert_eq!(
             response

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -814,22 +814,30 @@ impl Adapter {
         (session_id, clean_prompt, args, snapshot, initial_conv_id, initial_step_idx)
     }
 
-    async fn handle_session_prompt(
-        &mut self,
+}
+
+/// Output from prompt execution (used to separate lock-free execution from state update).
+struct PromptOutput {
+    response_lines: Vec<String>,
+    /// If Some, contains (bound_conv_id, new_step_idx) for session state update.
+    session_update: Option<(Option<String>, i64)>,
+}
+
+impl Adapter {
+    /// Execute prompt subprocess without holding any adapter lock.
+    /// This is a static method — all needed state is passed in as parameters.
+    async fn execute_prompt(
         id: Value,
-        params: &Value,
+        session_id: &str,
+        args: Vec<String>,
+        snapshot: Option<HashSet<String>>,
+        initial_conv_id: Option<String>,
+        initial_step_idx: i64,
+        working_dir: String,
+        conversations_dir: PathBuf,
         cancelled: Arc<AtomicBool>,
         out_tx: mpsc::UnboundedSender<Option<String>>,
-    ) -> Vec<String> {
-        // --- Phase 1: extract state under lock (lock released after this method returns to caller) ---
-        let (session_id, _clean_prompt, args, snapshot, initial_conv_id, initial_step_idx) =
-            self.prepare_prompt_state(params);
-        let working_dir = self.working_dir.clone();
-        let conversations_dir = self.conversations_dir.clone();
-
-        // --- Phase 2: subprocess execution (no adapter lock held) ---
-        // We drop &mut self usage here; the spawn + poll happens with extracted data only.
-
+    ) -> PromptOutput {
         let spawn_result = Command::new("agy")
             .args(&args)
             .current_dir(&working_dir)
@@ -841,13 +849,15 @@ impl Adapter {
         let mut child = match spawn_result {
             Ok(child) => child,
             Err(e) => {
-                return vec![serde_json::to_string(&JsonRpcResponse {
-                    jsonrpc: "2.0",
-                    id,
-                    result: None,
-                    error: Some(json!({"code":-32000,"message":format!("failed to run agy: {e}")})),
-                })
-                .unwrap()];
+                return PromptOutput {
+                    response_lines: vec![serde_json::to_string(&JsonRpcResponse {
+                        jsonrpc: "2.0",
+                        id,
+                        result: None,
+                        error: Some(json!({"code":-32000,"message":format!("failed to run agy: {e}")})),
+                    }).unwrap()],
+                    session_update: None,
+                };
             }
         };
 
@@ -880,11 +890,11 @@ impl Adapter {
             had_updates: false,
         }));
 
-        // Start polling thread — 100ms interval (F2 fix), writes through channel (F3 fix)
+        // Start polling thread — 100ms interval, writes through channel
         let stop_polling = Arc::new(AtomicBool::new(false));
         let poll_conversations_dir = conversations_dir.clone();
         let poll_snapshot = snapshot.clone();
-        let poll_session_id = session_id.clone();
+        let poll_session_id = session_id.to_string();
         let poll_state = Arc::clone(&streaming_state);
         let poll_stop = Arc::clone(&stop_polling);
         let poll_tx = out_tx.clone();
@@ -927,12 +937,12 @@ impl Adapter {
         stop_polling.store(true, Ordering::SeqCst);
         let _ = poller.join();
 
-        // Final poll to catch any last writes — routed through channel (F3)
+        // Final poll to catch any last writes
         {
             let lines = Self::poll_streaming_delta(
                 &conversations_dir,
                 snapshot.as_ref(),
-                &session_id,
+                session_id,
                 &streaming_state,
             );
             for line in lines {
@@ -950,19 +960,7 @@ impl Adapter {
             )
         };
 
-        // --- Phase 3: update session state (re-acquire lock briefly) ---
-        if let Some(session) = self.sessions.get_mut(&session_id) {
-            if session.conversation_id.is_none() {
-                session.conversation_id = bound_conv_id.clone();
-            }
-            if bound_conv_id.is_some() {
-                session.last_step_idx = new_step_idx;
-            }
-        }
-        if bound_conv_id.is_some() {
-            let model_id = self.sessions.get(&session_id).and_then(|s| s.model_id.clone());
-            self.persist_session(&session_id, bound_conv_id.as_deref(), new_step_idx, model_id.as_deref());
-        }
+        let session_update = Some((bound_conv_id.clone(), new_step_idx));
 
         // Build final response
         let stop_reason = if was_cancelled {
@@ -987,34 +985,40 @@ impl Adapter {
                         } else {
                             format!("agy failed: {}", stderr_text.trim_end())
                         };
-                        return vec![serde_json::to_string(&JsonRpcResponse {
-                            jsonrpc: "2.0",
-                            id,
-                            result: None,
-                            error: Some(json!({"code":-32000,"message":msg})),
-                        })
-                        .unwrap()];
+                        return PromptOutput {
+                            response_lines: vec![serde_json::to_string(&JsonRpcResponse {
+                                jsonrpc: "2.0",
+                                id,
+                                result: None,
+                                error: Some(json!({"code":-32000,"message":msg})),
+                            }).unwrap()],
+                            session_update,
+                        };
                     }
                 }
             }
             Err(e) => {
-                return vec![serde_json::to_string(&JsonRpcResponse {
-                    jsonrpc: "2.0",
-                    id,
-                    result: None,
-                    error: Some(json!({"code":-32000,"message":format!("failed to wait for agy: {e}")})),
-                })
-                .unwrap()];
+                return PromptOutput {
+                    response_lines: vec![serde_json::to_string(&JsonRpcResponse {
+                        jsonrpc: "2.0",
+                        id,
+                        result: None,
+                        error: Some(json!({"code":-32000,"message":format!("failed to wait for agy: {e}")})),
+                    }).unwrap()],
+                    session_update,
+                };
             }
         }
 
-        vec![serde_json::to_string(&JsonRpcResponse {
-            jsonrpc: "2.0",
-            id,
-            result: Some(json!({ "stopReason": stop_reason })),
-            error: None,
-        })
-        .unwrap()]
+        PromptOutput {
+            response_lines: vec![serde_json::to_string(&JsonRpcResponse {
+                jsonrpc: "2.0",
+                id,
+                result: Some(json!({ "stopReason": stop_reason })),
+                error: None,
+            }).unwrap()],
+            session_update,
+        }
     }
 }
 
@@ -1182,14 +1186,42 @@ async fn main() {
                 pending_prompts += 1;
 
                 tokio::spawn(async move {
-                    let output = {
+                    // Phase 1: acquire lock briefly to prepare state
+                    let (session_id_inner, args, snapshot, initial_conv_id, initial_step_idx, working_dir, conversations_dir) = {
                         let mut adapter = adapter.lock().await;
-                        adapter.handle_session_prompt(id, &params, cancelled, out_tx.clone()).await
+                        let (sid, _prompt, args, snapshot, init_conv, init_idx) =
+                            adapter.prepare_prompt_state(&params);
+                        let wd = adapter.working_dir.clone();
+                        let cd = adapter.conversations_dir.clone();
+                        (sid, args, snapshot, init_conv, init_idx, wd, cd)
                     };
+                    // Lock released — Phase 2: run subprocess without holding lock
+                    let output = Adapter::execute_prompt(
+                        id, &session_id_inner, args, snapshot, initial_conv_id, initial_step_idx,
+                        working_dir, conversations_dir, cancelled, out_tx.clone(),
+                    ).await;
+
+                    // Phase 3: acquire lock briefly to update session state
+                    if let Some((bound_conv_id, new_step_idx)) = output.session_update {
+                        let mut adapter = adapter.lock().await;
+                        if let Some(session) = adapter.sessions.get_mut(&session_id_inner) {
+                            if session.conversation_id.is_none() {
+                                session.conversation_id = bound_conv_id.clone();
+                            }
+                            if bound_conv_id.is_some() {
+                                session.last_step_idx = new_step_idx;
+                            }
+                        }
+                        if bound_conv_id.is_some() {
+                            let model_id = adapter.sessions.get(&session_id_inner).and_then(|s| s.model_id.clone());
+                            adapter.persist_session(&session_id_inner, bound_conv_id.as_deref(), new_step_idx, model_id.as_deref());
+                        }
+                    }
+
                     if !session_id.is_empty() {
                         active_cancellations.lock().unwrap().remove(&session_id);
                     }
-                    for line in output {
+                    for line in output.response_lines {
                         let _ = out_tx.send(Some(line));
                     }
                     let _ = out_tx.send(None);

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -80,7 +80,7 @@ struct Adapter {
     working_dir: String,
     conversations_dir: PathBuf,
     state_file: PathBuf,
-    available_models: Vec<String>,
+    available_models: Option<Vec<String>>,
 }
 
 impl Adapter {
@@ -94,17 +94,42 @@ impl Adapter {
                 .unwrap_or_else(|_| "/tmp".to_string()),
             conversations_dir: PathBuf::from(&home).join(".gemini/antigravity-cli/conversations"),
             state_file: state_dir.join("sessions.json"),
-            available_models: Self::fetch_available_models(),
+            available_models: None,
         }
     }
 
-    /// Run `agy models` and parse the output into a list of model names.
+    /// Run `agy models` with a 5s timeout and parse the output into a list of model names.
     fn fetch_available_models() -> Vec<String> {
-        std::process::Command::new("agy")
+        use std::time::Instant;
+        let start = Instant::now();
+        let child = std::process::Command::new("agy")
             .arg("models")
-            .output()
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+        let mut child = match child {
+            Ok(c) => c,
+            Err(_) => return Vec::new(),
+        };
+        // Poll with 5s timeout
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    if !status.success() { return Vec::new(); }
+                    break;
+                }
+                Ok(None) => {
+                    if start.elapsed() > Duration::from_secs(5) {
+                        let _ = child.kill();
+                        return Vec::new();
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                Err(_) => return Vec::new(),
+            }
+        }
+        child.wait_with_output()
             .ok()
-            .filter(|o| o.status.success())
             .map(|o| {
                 String::from_utf8_lossy(&o.stdout)
                     .lines()
@@ -115,16 +140,24 @@ impl Adapter {
             .unwrap_or_default()
     }
 
+    /// Get available models, fetching lazily on first access.
+    fn get_available_models(&mut self) -> &[String] {
+        if self.available_models.is_none() {
+            self.available_models = Some(Self::fetch_available_models());
+        }
+        self.available_models.as_ref().unwrap()
+    }
+
     /// Build the ACP configOptions JSON for the model selector.
-    fn config_options_json(&self, model_id: Option<&str>) -> Value {
-        if self.available_models.is_empty() {
+    fn config_options_json(&mut self, model_id: Option<&str>) -> Value {
+        let models = self.get_available_models();
+        if models.is_empty() {
             return json!([]);
         }
         let current = model_id
-            .or_else(|| self.available_models.first().map(|s| s.as_str()))
+            .or_else(|| models.first().map(|s| s.as_str()))
             .unwrap_or("");
-        let options: Vec<Value> = self
-            .available_models
+        let options: Vec<Value> = models
             .iter()
             .map(|name| json!({ "value": name, "name": name }))
             .collect();
@@ -760,7 +793,11 @@ impl Adapter {
         args.push("--add-dir".to_string());
         args.push(self.working_dir.clone());
         if let Ok(extra) = std::env::var("AGY_EXTRA_ARGS") {
-            args.extend(extra.split_whitespace().map(String::from));
+            if let Ok(parsed) = shell_words::split(&extra) {
+                args.extend(parsed);
+            } else {
+                eprintln!("[agy-acp] WARN: failed to parse AGY_EXTRA_ARGS, ignoring");
+            }
         }
         if let Some(session) = self.sessions.get(&session_id) {
             if let Some(conv_id) = &session.conversation_id {
@@ -1281,7 +1318,7 @@ mod tests {
             working_dir: "/tmp".to_string(),
             conversations_dir: PathBuf::from("/tmp"),
             state_file: PathBuf::from("/tmp/sessions.json"),
-            available_models: vec![],
+            available_models: Some(vec![]),
         };
         let response = adapter.handle_initialize(json!(1));
         assert_eq!(
@@ -1306,7 +1343,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: root.join("conversations"),
             state_file: root.join("sessions.json"),
-            available_models: vec![],
+            available_models: Some(vec![]),
         };
         adapter.persist_session("sess-1", Some("conv-abc"), 5, None);
 
@@ -1335,7 +1372,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: root.join("conversations"),
             state_file: root.join("sessions.json"),
-            available_models: vec![],
+            available_models: Some(vec![]),
         };
 
         let response = adapter.handle_session_load(json!(9), &json!({"sessionId": "missing"}));
@@ -1361,7 +1398,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: conv_dir.clone(),
             state_file: root.join("sessions.json"),
-            available_models: vec![],
+            available_models: Some(vec![]),
         };
 
         let before = adapter.conversation_snapshot();
@@ -1390,7 +1427,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: conv_dir.clone(),
             state_file: root.join("sessions.json"),
-            available_models: vec![],
+            available_models: Some(vec![]),
         };
 
         let before = adapter.conversation_snapshot();
@@ -1412,7 +1449,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: root.join("conversations"),
             state_file: root.join("sessions.json"),
-            available_models: vec![],
+            available_models: Some(vec![]),
         };
 
         adapter.persist_session("sess-1", Some("conv-abc"), 7, None);
@@ -1475,7 +1512,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: conv_dir,
             state_file: root.join("sessions.json"),
-            available_models: vec![],
+            available_models: Some(vec![]),
         };
 
         let result = adapter.read_response_from_db("test-conv", -1);
@@ -1631,7 +1668,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: conv_dir,
             state_file: root.join("sessions.json"),
-            available_models: vec![],
+            available_models: Some(vec![]),
         };
 
         let result = adapter.read_response_from_db("multi", -1);
@@ -1666,7 +1703,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: conv_dir,
             state_file: root.join("sessions.json"),
-            available_models: vec![],
+            available_models: Some(vec![]),
         };
 
         let result = adapter.read_response_from_db("empty", -1);

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -327,11 +327,19 @@ impl Adapter {
         name.to_string()
     }
 
-    /// Check if narration should be shown (opt-in via OPENAB_SHOW_NARRATION=1).
+    /// Check if narration should be shown.
+    /// - OPENAB_SHOW_NARRATION=1 → show (opt-in)
+    /// - OPENAB_TOOL_DISPLAY=full → show (backward compat)
+    /// - Default (neither set) → skip narration
     fn show_narration() -> bool {
-        std::env::var("OPENAB_SHOW_NARRATION")
-            .map(|v| v == "1" || v.to_lowercase() == "true")
-            .unwrap_or(false)
+        if let Ok(v) = std::env::var("OPENAB_SHOW_NARRATION") {
+            return v == "1" || v.to_lowercase() == "true";
+        }
+        // Backward compat: OPENAB_TOOL_DISPLAY=full means show everything
+        if let Ok(v) = std::env::var("OPENAB_TOOL_DISPLAY") {
+            return v.to_lowercase() == "full";
+        }
+        false
     }
 
     /// Read the latest response from the SQLite conversation DB.
@@ -503,14 +511,15 @@ impl Adapter {
                     guard.emitted_tool_steps.insert(idx);
                     let title = Self::tool_call_title(&name, &input);
                     let tool_call_id = format!("agy-{}-{}", idx, step_type);
-                    let mut update = json!({
+
+                    // Emit tool_call (start)
+                    let mut start_update = json!({
                         "sessionUpdate": "tool_call",
                         "toolCallId": tool_call_id,
                         "title": title,
-                        "status": "completed",
                     });
                     if let Some(input) = &input {
-                        update["rawInput"] = input.clone();
+                        start_update["rawInput"] = input.clone();
                     }
                     notifications.push(
                         serde_json::to_string(&JsonRpcNotification {
@@ -518,7 +527,25 @@ impl Adapter {
                             method: "session/update".to_string(),
                             params: json!({
                                 "sessionId": session_id,
-                                "update": update,
+                                "update": start_update,
+                            }),
+                        })
+                        .unwrap(),
+                    );
+
+                    // Emit tool_call_update (completed)
+                    notifications.push(
+                        serde_json::to_string(&JsonRpcNotification {
+                            jsonrpc: "2.0",
+                            method: "session/update".to_string(),
+                            params: json!({
+                                "sessionId": session_id,
+                                "update": {
+                                    "sessionUpdate": "tool_call_update",
+                                    "toolCallId": tool_call_id,
+                                    "title": title,
+                                    "status": "completed",
+                                },
                             }),
                         })
                         .unwrap(),

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -98,41 +98,96 @@ impl Adapter {
         }
     }
 
-    /// Run `agy models` and parse the output into a list of model names.
-    /// Blocks until completion. Returns empty if `agy models` fails.
-    fn fetch_available_models() -> Vec<String> {
-        std::process::Command::new("agy")
-            .arg("models")
-            .stderr(std::process::Stdio::null())
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| {
-                String::from_utf8_lossy(&o.stdout)
-                    .lines()
-                    .map(|l| l.trim().to_string())
-                    .filter(|l| !l.is_empty())
-                    .collect()
-            })
-            .unwrap_or_default()
+    /// Cache file path for model list.
+    fn models_cache_path(&self) -> PathBuf {
+        self.state_file.with_file_name("models_cache.json")
     }
 
-    /// Get available models, fetching lazily on first access.
-    /// Falls back to a static list if `agy models` returns empty.
+    /// Load cached models (any age — cache is never deleted).
+    fn load_cached_models(&self) -> Option<Vec<String>> {
+        let path = self.models_cache_path();
+        let content = fs::read_to_string(&path).ok()?;
+        serde_json::from_str::<Vec<String>>(&content).ok().filter(|v| !v.is_empty())
+    }
+
+    /// Persist model list to cache file.
+    fn save_models_cache(&self, models: &[String]) {
+        if let Some(parent) = self.models_cache_path().parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        if let Ok(json) = serde_json::to_string(models) {
+            let tmp = self.models_cache_path().with_extension("tmp");
+            if fs::write(&tmp, &json).is_ok() {
+                let _ = fs::rename(&tmp, self.models_cache_path());
+            }
+        }
+    }
+
+    /// Hardcoded static fallback (last resort).
+    fn static_fallback_models() -> Vec<String> {
+        vec![
+            "gemini-2.5-pro".to_string(),
+            "gemini-2.5-flash".to_string(),
+            "gemini-2.0-flash".to_string(),
+        ]
+    }
+
+    /// Run `agy models` with 5s timeout and parse the output.
+    fn fetch_available_models() -> Vec<String> {
+        use std::time::Instant;
+        let start = Instant::now();
+        let mut child = match std::process::Command::new("agy")
+            .arg("models")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(_) => return Vec::new(),
+        };
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    if !status.success() { return Vec::new(); }
+                    let stdout = child.stdout.take().unwrap();
+                    use std::io::Read;
+                    let mut buf = String::new();
+                    let _ = std::io::BufReader::new(stdout).read_to_string(&mut buf);
+                    return buf.lines()
+                        .map(|l| l.trim().to_string())
+                        .filter(|l| !l.is_empty())
+                        .collect();
+                }
+                Ok(None) => {
+                    if start.elapsed() > Duration::from_secs(5) {
+                        let _ = child.kill();
+                        return Vec::new();
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                Err(_) => return Vec::new(),
+            }
+        }
+    }
+
+    /// Get available models — always attempts fresh fetch (5s timeout):
+    /// 1. Fetch `agy models` → success → use + always update cache
+    /// 2. Fetch failed → cache (any age, never deleted) → use
+    /// 3. No cache → static hardcoded list (last resort)
     fn get_available_models(&mut self) -> &[String] {
         if self.available_models.is_none() {
             let models = Self::fetch_available_models();
-            self.available_models = Some(if models.is_empty() {
-                vec![
-                    "Gemini 3.5 Flash (Medium)".to_string(),
-                    "Gemini 3.5 Flash (High)".to_string(),
-                    "Gemini 3.5 Flash (Low)".to_string(),
-                    "Gemini 3.1 Pro (Low)".to_string(),
-                    "Gemini 3.1 Pro (High)".to_string(),
-                ]
+            if !models.is_empty() {
+                eprintln!("[agy-acp] fetched {} models from `agy models`, updating cache", models.len());
+                self.save_models_cache(&models);
+                self.available_models = Some(models);
+            } else if let Some(cached) = self.load_cached_models() {
+                eprintln!("[agy-acp] `agy models` failed, using cached model list ({} models)", cached.len());
+                self.available_models = Some(cached);
             } else {
-                models
-            });
+                eprintln!("[agy-acp] `agy models` failed and no cache found, using hardcoded fallback");
+                self.available_models = Some(Self::static_fallback_models());
+            }
         }
         self.available_models.as_ref().unwrap()
     }
@@ -1038,7 +1093,27 @@ impl Adapter {
 
 #[tokio::main]
 async fn main() {
+    // Prefetch models in background to avoid blocking tokio worker on first session/new
+    let prefetch = tokio::task::spawn_blocking(Adapter::fetch_available_models);
+
     let adapter = Arc::new(tokio::sync::Mutex::new(Adapter::new()));
+
+    // Apply prefetched models
+    if let Ok(models) = prefetch.await {
+        let mut guard = adapter.lock().await;
+        if !models.is_empty() {
+            eprintln!("[agy-acp] fetched {} models from `agy models`, updating cache", models.len());
+            guard.save_models_cache(&models);
+            guard.available_models = Some(models);
+        } else if let Some(cached) = guard.load_cached_models() {
+            eprintln!("[agy-acp] `agy models` failed, using cached model list ({} models)", cached.len());
+            guard.available_models = Some(cached);
+        } else {
+            eprintln!("[agy-acp] `agy models` failed and no cache found, using hardcoded fallback");
+            guard.available_models = Some(Adapter::static_fallback_models());
+        }
+    }
+
     let active_cancellations: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>> =
         Arc::new(Mutex::new(HashMap::new()));
 

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -70,6 +70,8 @@ struct StreamingState {
     last_step_idx: i64,
     /// Tracks how many bytes of text we've already emitted per step idx.
     emitted_len: HashMap<i64, usize>,
+    /// Tracks which tool steps we've already emitted notifications for.
+    emitted_tool_steps: HashSet<i64>,
     had_updates: bool,
 }
 
@@ -281,6 +283,57 @@ impl Adapter {
         None
     }
 
+    /// Get a text (UTF-8 string) from a protobuf field.
+    fn get_proto_text(blob: &[u8], target: u64) -> Option<String> {
+        let bytes = Self::get_proto_field(blob, target)?;
+        String::from_utf8(bytes).ok()
+    }
+
+    /// Check if a step_type represents a tool call.
+    fn is_tool_step_type(step_type: i64) -> bool {
+        matches!(step_type, 5 | 7 | 8 | 9 | 17 | 21 | 33 | 101 | 138)
+    }
+
+    /// Extract tool name and input from a tool step payload.
+    /// Parses: field 5 (tool sub-message) → field 4 (call) → field 2 or 9 (name), field 3 (input JSON).
+    fn extract_tool_from_step_payload(blob: &[u8]) -> Option<(String, Option<Value>)> {
+        let tool = Self::get_proto_field(blob, 5)?;
+        let call = Self::get_proto_field(&tool, 4)?;
+        let name = Self::get_proto_text(&call, 2)
+            .or_else(|| Self::get_proto_text(&call, 9))
+            .filter(|n| !n.is_empty())?;
+        let input = Self::get_proto_text(&call, 3)
+            .and_then(|s| serde_json::from_str::<Value>(&s).ok());
+        Some((name, input))
+    }
+
+    /// Derive a short title for a tool call based on name and input.
+    fn tool_call_title(name: &str, input: &Option<Value>) -> String {
+        if let Some(input) = input {
+            // Try common path fields
+            for key in ["path", "file", "AbsolutePath", "FilePath"] {
+                if let Some(path) = input.get(key).and_then(|v| v.as_str()) {
+                    return format!("{}: {}", name, path);
+                }
+            }
+            // Try query/command fields
+            for key in ["query", "command", "text"] {
+                if let Some(val) = input.get(key).and_then(|v| v.as_str()) {
+                    let truncated: String = val.chars().take(60).collect();
+                    return format!("{}: {}", name, truncated);
+                }
+            }
+        }
+        name.to_string()
+    }
+
+    /// Check if narration should be shown (opt-in via OPENAB_SHOW_NARRATION=1).
+    fn show_narration() -> bool {
+        std::env::var("OPENAB_SHOW_NARRATION")
+            .map(|v| v == "1" || v.to_lowercase() == "true")
+            .unwrap_or(false)
+    }
+
     /// Read the latest response from the SQLite conversation DB.
     /// Returns (response_text, max_step_idx) or None if reading fails.
     fn read_response_from_db(&self, conversation_id: &str, after_step_idx: i64) -> Option<(String, i64)> {
@@ -390,14 +443,14 @@ impl Adapter {
         };
 
         let mut stmt = match conn.prepare(
-            "SELECT idx, step_payload FROM steps WHERE idx > ?1 AND step_type = 15 ORDER BY idx"
+            "SELECT idx, step_type, step_payload FROM steps WHERE idx > ?1 AND (step_type = 15 OR step_type IN (5,7,8,9,17,21,33,101,138)) ORDER BY idx"
         ) {
             Ok(s) => s,
             Err(_) => return Vec::new(),
         };
 
-        let rows: Vec<(i64, Vec<u8>)> = stmt
-            .query_map([base_step_idx], |row| Ok((row.get(0)?, row.get(1)?)))
+        let rows: Vec<(i64, i64, Vec<u8>)> = stmt
+            .query_map([base_step_idx], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
             .ok()
             .map(|iter| iter.filter_map(|r| r.ok()).collect())
             .unwrap_or_default();
@@ -405,42 +458,72 @@ impl Adapter {
         let mut guard = state.lock().unwrap();
         let mut notifications = Vec::new();
 
-        for (idx, payload) in rows {
+        for (idx, step_type, payload) in rows {
             guard.last_step_idx = guard.last_step_idx.max(idx);
 
-            let Some(text) = Self::extract_text_from_step_payload(&payload) else {
-                continue;
-            };
+            if step_type == 15 {
+                // Text response
+                let Some(text) = Self::extract_text_from_step_payload(&payload) else {
+                    continue;
+                };
 
-            let emitted = guard.emitted_len.get(&idx).copied().unwrap_or(0);
-            if text.len() <= emitted {
-                continue;
-            }
+                let emitted = guard.emitted_len.get(&idx).copied().unwrap_or(0);
+                if text.len() <= emitted {
+                    continue;
+                }
 
-            // Skip narration-only text if OPENAB_TOOL_DISPLAY filtering is active
-            if Self::should_filter_narration() && Self::is_narration(&text) {
+                // Skip narration by default (unless OPENAB_SHOW_NARRATION=1)
+                if !Self::show_narration() && Self::is_narration(&text) {
+                    guard.emitted_len.insert(idx, text.len());
+                    continue;
+                }
+
+                let new_text = &text[emitted..];
                 guard.emitted_len.insert(idx, text.len());
-                continue;
-            }
 
-            let new_text = &text[emitted..];
-            guard.emitted_len.insert(idx, text.len());
-
-            if !new_text.is_empty() {
-                notifications.push(
-                    serde_json::to_string(&JsonRpcNotification {
-                        jsonrpc: "2.0",
-                        method: "session/update".to_string(),
-                        params: json!({
-                            "sessionId": session_id,
-                            "update": {
-                                "sessionUpdate": "agent_message_chunk",
-                                "content": { "type": "text", "text": new_text },
-                            },
-                        }),
-                    })
-                    .unwrap(),
-                );
+                if !new_text.is_empty() {
+                    notifications.push(
+                        serde_json::to_string(&JsonRpcNotification {
+                            jsonrpc: "2.0",
+                            method: "session/update".to_string(),
+                            params: json!({
+                                "sessionId": session_id,
+                                "update": {
+                                    "sessionUpdate": "agent_message_chunk",
+                                    "content": { "type": "text", "text": new_text },
+                                },
+                            }),
+                        })
+                        .unwrap(),
+                    );
+                }
+            } else if Self::is_tool_step_type(step_type) && !guard.emitted_tool_steps.contains(&idx) {
+                // Tool call
+                if let Some((name, input)) = Self::extract_tool_from_step_payload(&payload) {
+                    guard.emitted_tool_steps.insert(idx);
+                    let title = Self::tool_call_title(&name, &input);
+                    let tool_call_id = format!("agy-{}-{}", idx, step_type);
+                    let mut update = json!({
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": tool_call_id,
+                        "title": title,
+                        "status": "completed",
+                    });
+                    if let Some(input) = &input {
+                        update["rawInput"] = input.clone();
+                    }
+                    notifications.push(
+                        serde_json::to_string(&JsonRpcNotification {
+                            jsonrpc: "2.0",
+                            method: "session/update".to_string(),
+                            params: json!({
+                                "sessionId": session_id,
+                                "update": update,
+                            }),
+                        })
+                        .unwrap(),
+                    );
+                }
             }
         }
 
@@ -448,17 +531,10 @@ impl Adapter {
         notifications
     }
 
-    /// Filter out leading narration ("I will ...") from response parts based on
-    /// the OPENAB_TOOL_DISPLAY environment variable.
+    /// Filter out leading narration ("I will ...") from response parts.
+    /// Narration is skipped by default; set OPENAB_SHOW_NARRATION=1 to keep it.
     fn filter_narration(parts: &[String]) -> String {
-        let should_filter = std::env::var("OPENAB_TOOL_DISPLAY")
-            .map(|v| {
-                let lower = v.to_lowercase();
-                lower == "compact" || lower == "none" || lower == "off"
-            })
-            .unwrap_or(false);
-
-        if !should_filter || parts.len() <= 1 {
+        if Self::show_narration() || parts.len() <= 1 {
             return parts.join("\n");
         }
 
@@ -473,16 +549,6 @@ impl Adapter {
             return false;
         }
         lines.iter().all(|l| l.trim_start().starts_with("I will"))
-    }
-
-    /// Check if narration filtering is enabled via OPENAB_TOOL_DISPLAY.
-    fn should_filter_narration() -> bool {
-        std::env::var("OPENAB_TOOL_DISPLAY")
-            .map(|v| {
-                let lower = v.to_lowercase();
-                lower == "compact" || lower == "none" || lower == "off"
-            })
-            .unwrap_or(false)
     }
 
     fn evict_if_needed(&mut self) {
@@ -738,6 +804,7 @@ impl Adapter {
             base_step_idx: initial_step_idx,
             last_step_idx: initial_step_idx,
             emitted_len: HashMap::new(),
+            emitted_tool_steps: HashSet::new(),
             had_updates: false,
         }));
 
@@ -1431,6 +1498,7 @@ mod tests {
             base_step_idx: -1,
             last_step_idx: -1,
             emitted_len: HashMap::new(),
+            emitted_tool_steps: HashSet::new(),
             had_updates: false,
         }));
 
@@ -1582,7 +1650,8 @@ mod tests {
 
     #[test]
     fn test_filter_narration_drops_leading_narration() {
-        std::env::set_var("OPENAB_TOOL_DISPLAY", "compact");
+        // Narration is now skipped by default
+        std::env::remove_var("OPENAB_SHOW_NARRATION");
         let parts = vec![
             "I will fetch the latest commits.\nI will check the diff.".to_string(),
             "I will read the file.".to_string(),
@@ -1590,12 +1659,11 @@ mod tests {
         ];
         let result = Adapter::filter_narration(&parts);
         assert_eq!(result, "The fix is confirmed! LGTM ✅");
-        std::env::remove_var("OPENAB_TOOL_DISPLAY");
     }
 
     #[test]
     fn test_filter_narration_preserves_content_after_first_non_narration() {
-        std::env::set_var("OPENAB_TOOL_DISPLAY", "none");
+        std::env::remove_var("OPENAB_SHOW_NARRATION");
         let parts = vec![
             "I will check things.".to_string(),
             "Here is my analysis.".to_string(),
@@ -1603,42 +1671,42 @@ mod tests {
         ];
         let result = Adapter::filter_narration(&parts);
         assert_eq!(result, "Here is my analysis.\nI will also note this is fine.");
-        std::env::remove_var("OPENAB_TOOL_DISPLAY");
     }
 
     #[test]
-    fn test_filter_narration_full_mode() {
-        std::env::set_var("OPENAB_TOOL_DISPLAY", "full");
+    fn test_filter_narration_show_mode() {
+        std::env::set_var("OPENAB_SHOW_NARRATION", "1");
         let parts = vec![
             "I will fetch commits.".to_string(),
             "Final answer here.".to_string(),
         ];
         let result = Adapter::filter_narration(&parts);
         assert_eq!(result, "I will fetch commits.\nFinal answer here.");
-        std::env::remove_var("OPENAB_TOOL_DISPLAY");
+        std::env::remove_var("OPENAB_SHOW_NARRATION");
     }
 
     #[test]
-    fn test_filter_narration_unset_defaults_to_full() {
-        std::env::remove_var("OPENAB_TOOL_DISPLAY");
+    fn test_filter_narration_default_skips() {
+        std::env::remove_var("OPENAB_SHOW_NARRATION");
         let parts = vec![
             "I will fetch commits.".to_string(),
             "Final answer here.".to_string(),
         ];
         let result = Adapter::filter_narration(&parts);
-        assert_eq!(result, "I will fetch commits.\nFinal answer here.");
+        assert_eq!(result, "Final answer here.");
     }
 
     #[test]
     fn test_filter_narration_single_part_unchanged() {
         let parts = vec!["I will do something.".to_string()];
         let result = Adapter::filter_narration(&parts);
+        // Single part is never filtered (would leave nothing)
         assert_eq!(result, "I will do something.");
     }
 
     #[test]
     fn test_filter_narration_all_narration_keeps_last() {
-        std::env::set_var("OPENAB_TOOL_DISPLAY", "compact");
+        std::env::remove_var("OPENAB_SHOW_NARRATION");
         let parts = vec![
             "I will fetch the file.".to_string(),
             "I will check the output.".to_string(),
@@ -1646,7 +1714,6 @@ mod tests {
         ];
         let result = Adapter::filter_narration(&parts);
         assert_eq!(result, "I will verify the fix.");
-        std::env::remove_var("OPENAB_TOOL_DISPLAY");
     }
 
     #[test]

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -50,12 +50,17 @@ struct StoredSession {
     /// Last step idx read from SQLite; used for delta extraction.
     #[serde(default)]
     last_step_idx: i64,
+    /// Selected model ID for this session.
+    #[serde(default)]
+    model_id: Option<String>,
 }
 
 struct Session {
     conversation_id: Option<String>,
     /// Last step idx read from SQLite.
     last_step_idx: i64,
+    /// Selected model ID for this session.
+    model_id: Option<String>,
 }
 
 /// Tracks streaming poll state shared between the polling thread and main task.
@@ -73,6 +78,7 @@ struct Adapter {
     working_dir: String,
     conversations_dir: PathBuf,
     state_file: PathBuf,
+    available_models: Vec<String>,
 }
 
 impl Adapter {
@@ -86,7 +92,48 @@ impl Adapter {
                 .unwrap_or_else(|_| "/tmp".to_string()),
             conversations_dir: PathBuf::from(&home).join(".gemini/antigravity-cli/conversations"),
             state_file: state_dir.join("sessions.json"),
+            available_models: Self::fetch_available_models(),
         }
+    }
+
+    /// Run `agy models` and parse the output into a list of model names.
+    fn fetch_available_models() -> Vec<String> {
+        std::process::Command::new("agy")
+            .arg("models")
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| {
+                String::from_utf8_lossy(&o.stdout)
+                    .lines()
+                    .map(|l| l.trim().to_string())
+                    .filter(|l| !l.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Build the ACP configOptions JSON for the model selector.
+    fn config_options_json(&self, model_id: Option<&str>) -> Value {
+        if self.available_models.is_empty() {
+            return json!([]);
+        }
+        let current = model_id
+            .or_else(|| self.available_models.first().map(|s| s.as_str()))
+            .unwrap_or("");
+        let options: Vec<Value> = self
+            .available_models
+            .iter()
+            .map(|name| json!({ "value": name, "name": name }))
+            .collect();
+        json!([{
+            "id": "model",
+            "name": "Model",
+            "category": "model",
+            "type": "select",
+            "currentValue": current,
+            "options": options,
+        }])
     }
 
     /// Acquire exclusive lock on a dedicated lock file for read-write mutual exclusion.
@@ -119,16 +166,16 @@ impl Adapter {
         self.load_store_inner()
     }
 
-    /// Try to restore conversation_id and last_step_idx from persisted state.
-    fn restore_session(&self, session_id: &str) -> Option<(String, i64)> {
+    /// Try to restore conversation_id, last_step_idx, and model_id from persisted state.
+    fn restore_session(&self, session_id: &str) -> Option<(String, i64, Option<String>)> {
         let store = self.load_store();
         store.sessions.get(session_id).and_then(|s| {
-            s.conversation_id.clone().map(|cid| (cid, s.last_step_idx))
+            s.conversation_id.clone().map(|cid| (cid, s.last_step_idx, s.model_id.clone()))
         })
     }
 
     /// Persist a session binding (read-modify-write under single lock).
-    fn persist_session(&self, session_id: &str, conversation_id: Option<&str>, last_step_idx: i64) {
+    fn persist_session(&self, session_id: &str, conversation_id: Option<&str>, last_step_idx: i64, model_id: Option<&str>) {
         let Some(_lock) = self.lock_state_file() else {
             return;
         };
@@ -138,6 +185,7 @@ impl Adapter {
             StoredSession {
                 conversation_id: conversation_id.map(String::from),
                 last_step_idx,
+                model_id: model_id.map(String::from),
             },
         );
         let tmp = self.state_file.with_extension("tmp");
@@ -447,7 +495,7 @@ impl Adapter {
     }
 
     fn restore_session_state(&mut self, session_id: &str) -> bool {
-        let Some((conversation_id, last_step_idx)) = self.restore_session(session_id) else {
+        let Some((conversation_id, last_step_idx, model_id)) = self.restore_session(session_id) else {
             return false;
         };
         if !self.sessions.contains_key(session_id) {
@@ -458,6 +506,7 @@ impl Adapter {
             Session {
                 conversation_id: Some(conversation_id),
                 last_step_idx,
+                model_id,
             },
         );
         true
@@ -484,12 +533,14 @@ impl Adapter {
             Session {
                 conversation_id: None,
                 last_step_idx: -1,
+                model_id: None,
             },
         );
+        let config_options = self.config_options_json(None);
         JsonRpcResponse {
             jsonrpc: "2.0",
             id,
-            result: Some(json!({ "sessionId": session_id })),
+            result: Some(json!({ "sessionId": session_id, "configOptions": config_options })),
             error: None,
         }
     }
@@ -526,6 +577,47 @@ impl Adapter {
                 "code": -32000,
                 "message": format!("unknown sessionId: {session_id}"),
             })),
+        }
+    }
+
+    fn handle_session_set_config_option(&mut self, id: Value, params: &Value) -> JsonRpcResponse {
+        let session_id = params.get("sessionId").and_then(|v| v.as_str()).unwrap_or("");
+        let config_id = params.get("configId").and_then(|v| v.as_str()).unwrap_or("");
+        let value = params.get("value").and_then(|v| v.as_str()).unwrap_or("");
+
+        if session_id.is_empty() || config_id != "model" || value.is_empty() {
+            return JsonRpcResponse {
+                jsonrpc: "2.0",
+                id,
+                result: None,
+                error: Some(json!({"code":-32602,"message":"missing sessionId, configId, or value"})),
+            };
+        }
+
+        if !self.sessions.contains_key(session_id) {
+            let _ = self.restore_session_state(session_id);
+        }
+
+        let Some(session) = self.sessions.get_mut(session_id) else {
+            return JsonRpcResponse {
+                jsonrpc: "2.0",
+                id,
+                result: None,
+                error: Some(json!({"code":-32000,"message":format!("unknown sessionId: {session_id}")})),
+            };
+        };
+
+        session.model_id = Some(value.to_string());
+        let conv_id = session.conversation_id.clone();
+        let last_step_idx = session.last_step_idx;
+        self.persist_session(session_id, conv_id.as_deref(), last_step_idx, Some(value));
+
+        let config_options = self.config_options_json(Some(value));
+        JsonRpcResponse {
+            jsonrpc: "2.0",
+            id,
+            result: Some(json!({ "configOptions": config_options })),
+            error: None,
         }
     }
 
@@ -580,6 +672,10 @@ impl Adapter {
             if let Some(conv_id) = &session.conversation_id {
                 args.push("--conversation".to_string());
                 args.push(conv_id.clone());
+            }
+            if let Some(model_id) = &session.model_id {
+                args.push("--model".to_string());
+                args.push(model_id.clone());
             }
         }
         args.push("-p".to_string());
@@ -730,7 +826,8 @@ impl Adapter {
             }
         }
         if bound_conv_id.is_some() {
-            self.persist_session(session_id, bound_conv_id.as_deref(), new_step_idx);
+            let model_id = self.sessions.get(session_id).and_then(|s| s.model_id.clone());
+            self.persist_session(session_id, bound_conv_id.as_deref(), new_step_idx, model_id.as_deref());
         }
 
         // Build final response
@@ -965,6 +1062,22 @@ async fn main() {
                 });
                 Vec::new()
             }
+            Some("session/setConfigOption") | Some("session/set_config_option") => {
+                let params = req.params.unwrap_or(json!({}));
+                let adapter = Arc::clone(&adapter);
+                let out_tx = out_tx.clone();
+                pending_prompts += 1;
+                tokio::spawn(async move {
+                    let mut adapter = adapter.lock().await;
+                    let line = serde_json::to_string(
+                        &adapter.handle_session_set_config_option(id, &params),
+                    )
+                    .unwrap();
+                    let _ = out_tx.send(Some(line));
+                    let _ = out_tx.send(None);
+                });
+                Vec::new()
+            }
             Some("session/cancel") => {
                 let params = req.params.unwrap_or(json!({}));
                 if let Some(session_id) = params.get("sessionId").and_then(|v| v.as_str()) {
@@ -1079,8 +1192,9 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: root.join("conversations"),
             state_file: root.join("sessions.json"),
+            available_models: vec![],
         };
-        adapter.persist_session("sess-1", Some("conv-abc"), 5);
+        adapter.persist_session("sess-1", Some("conv-abc"), 5, None);
 
         let response = adapter.handle_session_load(json!(7), &json!({"sessionId": "sess-1"}));
         assert!(response.error.is_none());
@@ -1107,6 +1221,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: root.join("conversations"),
             state_file: root.join("sessions.json"),
+            available_models: vec![],
         };
 
         let response = adapter.handle_session_load(json!(9), &json!({"sessionId": "missing"}));
@@ -1132,6 +1247,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: conv_dir.clone(),
             state_file: root.join("sessions.json"),
+            available_models: vec![],
         };
 
         let before = adapter.conversation_snapshot();
@@ -1160,6 +1276,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: conv_dir.clone(),
             state_file: root.join("sessions.json"),
+            available_models: vec![],
         };
 
         let before = adapter.conversation_snapshot();
@@ -1181,11 +1298,12 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: root.join("conversations"),
             state_file: root.join("sessions.json"),
+            available_models: vec![],
         };
 
-        adapter.persist_session("sess-1", Some("conv-abc"), 7);
+        adapter.persist_session("sess-1", Some("conv-abc"), 7, None);
         let restored = adapter.restore_session("sess-1");
-        assert_eq!(restored, Some(("conv-abc".to_string(), 7)));
+        assert_eq!(restored, Some(("conv-abc".to_string(), 7, None)));
 
         let missing = adapter.restore_session("sess-unknown");
         assert_eq!(missing, None);
@@ -1243,6 +1361,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: conv_dir,
             state_file: root.join("sessions.json"),
+            available_models: vec![],
         };
 
         let result = adapter.read_response_from_db("test-conv", -1);
@@ -1397,6 +1516,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: conv_dir,
             state_file: root.join("sessions.json"),
+            available_models: vec![],
         };
 
         let result = adapter.read_response_from_db("multi", -1);
@@ -1431,6 +1551,7 @@ mod tests {
             working_dir: root.to_string_lossy().to_string(),
             conversations_dir: conv_dir,
             state_file: root.join("sessions.json"),
+            available_models: vec![],
         };
 
         let result = adapter.read_response_from_db("empty", -1);

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -714,20 +714,21 @@ impl Adapter {
         }
     }
 
-    async fn handle_session_prompt(
+    /// Gather session state needed for prompt execution (under lock),
+    /// returning extracted data so the lock can be released before subprocess spawn.
+    fn prepare_prompt_state(
         &mut self,
-        id: Value,
         params: &Value,
-        cancelled: Arc<AtomicBool>,
-    ) -> Vec<String> {
+    ) -> (String, String, Vec<String>, Option<HashSet<String>>, Option<String>, i64) {
         let session_id = params
             .get("sessionId")
             .and_then(|v| v.as_str())
-            .unwrap_or("");
+            .unwrap_or("")
+            .to_string();
 
         // Restore evicted session from state file if needed
-        if !session_id.is_empty() && !self.sessions.contains_key(session_id) {
-            let _ = self.restore_session_state(session_id);
+        if !session_id.is_empty() && !self.sessions.contains_key(&session_id) {
+            let _ = self.restore_session_state(&session_id);
         }
 
         let prompt_text = params
@@ -740,12 +741,12 @@ impl Adapter {
                     .join("\n")
             })
             .unwrap_or_default();
-        let clean_prompt = prompt_text.trim();
+        let clean_prompt = prompt_text.trim().to_string();
 
         // Take snapshot before spawning agy if we need to bind a conversation
         let snapshot = if self
             .sessions
-            .get(session_id)
+            .get(&session_id)
             .map(|s| s.conversation_id.is_none())
             .unwrap_or(false)
         {
@@ -761,7 +762,7 @@ impl Adapter {
         if let Ok(extra) = std::env::var("AGY_EXTRA_ARGS") {
             args.extend(extra.split_whitespace().map(String::from));
         }
-        if let Some(session) = self.sessions.get(session_id) {
+        if let Some(session) = self.sessions.get(&session_id) {
             if let Some(conv_id) = &session.conversation_id {
                 args.push("--conversation".to_string());
                 args.push(conv_id.clone());
@@ -772,12 +773,40 @@ impl Adapter {
             }
         }
         args.push("-p".to_string());
-        args.push(clean_prompt.to_string());
+        args.push(clean_prompt.clone());
 
-        // Spawn agy as a child process (non-blocking)
+        let initial_conv_id = self
+            .sessions
+            .get(&session_id)
+            .and_then(|s| s.conversation_id.clone());
+        let initial_step_idx = self
+            .sessions
+            .get(&session_id)
+            .map(|s| s.last_step_idx)
+            .unwrap_or(-1);
+
+        (session_id, clean_prompt, args, snapshot, initial_conv_id, initial_step_idx)
+    }
+
+    async fn handle_session_prompt(
+        &mut self,
+        id: Value,
+        params: &Value,
+        cancelled: Arc<AtomicBool>,
+        out_tx: mpsc::UnboundedSender<Option<String>>,
+    ) -> Vec<String> {
+        // --- Phase 1: extract state under lock (lock released after this method returns to caller) ---
+        let (session_id, _clean_prompt, args, snapshot, initial_conv_id, initial_step_idx) =
+            self.prepare_prompt_state(params);
+        let working_dir = self.working_dir.clone();
+        let conversations_dir = self.conversations_dir.clone();
+
+        // --- Phase 2: subprocess execution (no adapter lock held) ---
+        // We drop &mut self usage here; the spawn + poll happens with extracted data only.
+
         let spawn_result = Command::new("agy")
             .args(&args)
-            .current_dir(&self.working_dir)
+            .current_dir(&working_dir)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
@@ -816,16 +845,6 @@ impl Adapter {
         });
 
         // Set up streaming state
-        let initial_conv_id = self
-            .sessions
-            .get(session_id)
-            .and_then(|s| s.conversation_id.clone());
-        let initial_step_idx = self
-            .sessions
-            .get(session_id)
-            .map(|s| s.last_step_idx)
-            .unwrap_or(-1);
-
         let streaming_state = Arc::new(Mutex::new(StreamingState {
             conversation_id: initial_conv_id,
             base_step_idx: initial_step_idx,
@@ -835,16 +854,16 @@ impl Adapter {
             had_updates: false,
         }));
 
-        // Start polling thread (1s interval)
+        // Start polling thread — 100ms interval (F2 fix), writes through channel (F3 fix)
         let stop_polling = Arc::new(AtomicBool::new(false));
-        let poll_conversations_dir = self.conversations_dir.clone();
+        let poll_conversations_dir = conversations_dir.clone();
         let poll_snapshot = snapshot.clone();
-        let poll_session_id = session_id.to_string();
+        let poll_session_id = session_id.clone();
         let poll_state = Arc::clone(&streaming_state);
         let poll_stop = Arc::clone(&stop_polling);
+        let poll_tx = out_tx.clone();
 
         let poller = std::thread::spawn(move || {
-            let mut stdout = io::stdout();
             while !poll_stop.load(Ordering::SeqCst) {
                 let lines = Self::poll_streaming_delta(
                     &poll_conversations_dir,
@@ -853,10 +872,9 @@ impl Adapter {
                     &poll_state,
                 );
                 for line in lines {
-                    let _ = writeln!(stdout, "{}", line);
+                    let _ = poll_tx.send(Some(line));
                 }
-                let _ = stdout.flush();
-                std::thread::sleep(Duration::from_secs(1));
+                std::thread::sleep(Duration::from_millis(100));
             }
         });
 
@@ -883,20 +901,16 @@ impl Adapter {
         stop_polling.store(true, Ordering::SeqCst);
         let _ = poller.join();
 
-        // Final poll to catch any last writes
+        // Final poll to catch any last writes — routed through channel (F3)
         {
             let lines = Self::poll_streaming_delta(
-                &self.conversations_dir,
+                &conversations_dir,
                 snapshot.as_ref(),
-                session_id,
+                &session_id,
                 &streaming_state,
             );
-            if !lines.is_empty() {
-                let mut stdout = io::stdout();
-                for line in &lines {
-                    let _ = writeln!(stdout, "{}", line);
-                }
-                let _ = stdout.flush();
+            for line in lines {
+                let _ = out_tx.send(Some(line));
             }
         }
 
@@ -910,8 +924,8 @@ impl Adapter {
             )
         };
 
-        // Update session state
-        if let Some(session) = self.sessions.get_mut(session_id) {
+        // --- Phase 3: update session state (re-acquire lock briefly) ---
+        if let Some(session) = self.sessions.get_mut(&session_id) {
             if session.conversation_id.is_none() {
                 session.conversation_id = bound_conv_id.clone();
             }
@@ -920,8 +934,8 @@ impl Adapter {
             }
         }
         if bound_conv_id.is_some() {
-            let model_id = self.sessions.get(session_id).and_then(|s| s.model_id.clone());
-            self.persist_session(session_id, bound_conv_id.as_deref(), new_step_idx, model_id.as_deref());
+            let model_id = self.sessions.get(&session_id).and_then(|s| s.model_id.clone());
+            self.persist_session(&session_id, bound_conv_id.as_deref(), new_step_idx, model_id.as_deref());
         }
 
         // Build final response
@@ -1144,7 +1158,7 @@ async fn main() {
                 tokio::spawn(async move {
                     let output = {
                         let mut adapter = adapter.lock().await;
-                        adapter.handle_session_prompt(id, &params, cancelled).await
+                        adapter.handle_session_prompt(id, &params, cancelled, out_tx.clone()).await
                     };
                     if !session_id.is_empty() {
                         active_cancellations.lock().unwrap().remove(&session_id);

--- a/docs/agentcore.md
+++ b/docs/agentcore.md
@@ -21,13 +21,13 @@ bot_token = "${DISCORD_BOT_TOKEN}"
 runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-kiro-agent"
 ```
 
-That's it. OAB auto-spawns the bundled `agentcore-acp` adapter.
+That's it. OAB auto-spawns the native AgentCore bridge.
 
 ## Prerequisites
 
 1. **An AgentCore Runtime** with your coding agent deployed (see [Deploying a Kiro Runtime](#deploying-a-kiro-runtime) below)
-2. **AWS credentials** on the OAB pod with `bedrock-agentcore:InvokeAgentRuntime` permission
-3. **`uv`** installed (for running the adapter script)
+2. **AWS credentials** on the OAB pod with `bedrock-agentcore:InvokeAgentRuntimeCommandShell` permission
+3. **Runtime deployed after June 5, 2026** (interactive shells support required)
 
 ## Config Reference
 
@@ -46,8 +46,8 @@ If you need full control, use `[agent]` directly:
 
 ```toml
 [agent]
-command = "uv"
-args = ["run", "--script", "/opt/agentcore/acp/agentcore_acp.py", "--runtime-arn", "arn:aws:...", "--region", "us-east-1"]
+command = "openab"
+args = ["agentcore-bridge", "--runtime-arn", "arn:aws:...", "--region", "us-east-1"]
 ```
 
 ### Priority rules
@@ -58,7 +58,7 @@ args = ["run", "--script", "/opt/agentcore/acp/agentcore_acp.py", "--runtime-arn
 
 ## Docker Image
 
-Use `ghcr.io/openabdev/openab-agentcore` — a minimal image (~50MB) with only OAB + the adapter. No coding CLI bundled.
+Use `ghcr.io/openabdev/openab-agentcore` — a minimal image (~20MB) with only the OAB binary. No Python, no coding CLI bundled.
 
 ```bash
 docker pull ghcr.io/openabdev/openab-agentcore:latest
@@ -124,20 +124,21 @@ The runtime fetches the key at boot — no plaintext secrets in env vars or conf
 ## How It Works
 
 ```
-┌─────────┐       ┌─────────┐  ACP   ┌───────────────┐  SDK    ┌─────────────────────┐
-│ Discord │──────▶│   OAB   │───────▶│ agentcore-acp │──────▶  │  AgentCore Runtime  │
-│  Slack  │       │         │ stdio  │  (Python)     │         │  (Firecracker μVM)  │
-└─────────┘       └─────────┘        └───────────────┘         │  ┌───────────────┐  │
-                                                               │  │ Kiro/Claude/… │  │
-                                                               │  └───────────────┘  │
-                                                               └─────────────────────┘
+┌─────────┐       ┌─────────┐  ACP   ┌───────────────────┐  WebSocket  ┌─────────────────────┐
+│ Discord │──────▶│   OAB   │───────▶│ agentcore-bridge  │────────────▶│  AgentCore Runtime  │
+│  Slack  │       │         │ stdio  │  (Rust, in-tree)  │  (PTY/WS)  │  (Firecracker μVM)  │
+└─────────┘       └─────────┘        └───────────────────┘            │  ┌───────────────┐  │
+                                                                      │  │ kiro-cli acp  │  │
+                                                                      │  │ (long-lived)  │  │
+                                                                      │  └───────────────┘  │
+                                                                      └─────────────────────┘
 ```
 
-1. OAB spawns `agentcore-acp` as a subprocess (same as kiro-cli or claude-agent-acp)
-2. On each message, adapter calls `invoke_agent_runtime` with the prompt
-3. AgentCore routes to the microVM, runs the coding agent, streams response
-4. Adapter translates the response back to ACP notifications on stdout
-5. OAB renders in Discord/Slack/Telegram as usual
+1. OAB spawns `openab agentcore-bridge` as a subprocess (ACP stdio protocol)
+2. Bridge opens a SigV4-signed WebSocket to AgentCore (`InvokeAgentRuntimeCommandShell`)
+3. Inside the persistent PTY shell, `kiro-cli acp --trust-all-tools` runs as a long-lived process
+4. JSON-RPC messages flow bidirectionally: OAB ↔ bridge ↔ WebSocket ↔ kiro-cli
+5. Same `shell_id` per thread ensures session continuity across messages
 
 ## Session Memory
 
@@ -154,7 +155,7 @@ Minimum permissions for the OAB pod:
 ```json
 {
   "Effect": "Allow",
-  "Action": ["bedrock-agentcore:InvokeAgentRuntime"],
+  "Action": ["bedrock-agentcore:InvokeAgentRuntimeCommandShell"],
   "Resource": ["arn:aws:bedrock-agentcore:us-east-1:<ACCOUNT>:runtime/*"]
 }
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -1335,13 +1335,20 @@ bot_token = "t"
 runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"
 "#;
         let cfg = parse_config(toml, "test").unwrap();
-        assert_eq!(cfg.agent.command, "uv");
+        #[cfg(feature = "agentcore")]
+        {
+            // With agentcore feature, spawns self with agentcore-bridge subcommand
+            assert!(cfg.agent.args.contains(&"agentcore-bridge".to_string()));
+        }
+        #[cfg(not(feature = "agentcore"))]
+        {
+            assert_eq!(cfg.agent.command, "uv");
+        }
         assert!(cfg.agent.args.contains(&"--runtime-arn".to_string()));
         assert!(cfg
             .agent
             .args
             .contains(&"arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent".to_string()));
-        assert!(cfg.agent.args.contains(&"us-east-1".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Comprehensive upgrade to agy-acp, inspired by [hicder/agy-acp](https://github.com/hicder/agy-acp) fork.

### Changes

**1. Streaming (1s SQLite polling)**
- Spawns agy as subprocess, polls SQLite DB every 1 second
- Emits incremental `session/update` notifications as text arrives
- Users see responses progressively instead of waiting for completion

**2. Tool Call Parsing**
- Parses step_type 5/7/8/9/17/21/33/101/138 from SQLite (protobuf field 5.4)
- Extracts tool name + input JSON
- Emits `tool_call` sessionUpdate with title, toolCallId, rawInput
- OAB can use `OPENAB_TOOL_DISPLAY` to control verbosity

**3. Narration Default Skip**
- "I will ..." narration is now SKIPPED by default
- Set `OPENAB_SHOW_NARRATION=1` to opt-in showing narration
- Removes old `OPENAB_TOOL_DISPLAY` dependency for narration

**4. Real Cancel**
- `session/cancel` kills the agy child process via AtomicBool + child.kill()
- Returns `stopReason: "cancelled"`

**5. Model Selector**
- Runs `agy models` at startup, exposes as ACP `configOptions`
- Handles `session/setConfigOption` to persist model per session
- Passes `--model` to agy subprocess

**6. JSON-RPC id: Value**
- Supports string or number IDs per spec

**7. Non-blocking Main Loop**
- All adapter-lock handlers spawned into background tasks
- Main loop stays responsive to cancel during long prompts

### Environment Variables
| Variable | Default | Description |
|----------|---------|-------------|
| `OPENAB_SHOW_NARRATION` | unset (skip) | Set to `1` to show "I will..." narration |
| `OPENAB_TOOL_DISPLAY` | — | Used by OAB to control tool call verbosity |
| `AGY_EXTRA_ARGS` | — | Extra args passed to every agy invocation |

### Tests
- All 28 tests pass (15 unit + 13 filesystem I/O)
- New: streaming delta, JSON-RPC id type tests