### PR TITLE
fix(ci): reduce closing-soon stale period to 1 day

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           script: |
             const label = 'closing-soon';
-            const staleDays = 3;
+            const staleDays = 1;
             const cutoff = new Date(Date.now() - staleDays * 24 * 60 * 60 * 1000);
 
             const prs = await github.rest.pulls.list({


### PR DESCRIPTION
The `closing-soon` label description says 'will auto-close in 24 hours' but the workflow was using `staleDays = 3`. This aligns the workflow with the label's stated behavior.