### PR TITLE
fix(ci): update closing-soon comment message

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -47,7 +47,7 @@ jobs:
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number: pr.number,
-                body: `🔒 Auto-closing: this PR has had the \`${label}\` label for more than ${staleDays} days without activity from the author.\n\nIf you'd like to continue working on this, feel free to reopen and leave a comment.`
+                body: `🔒 Auto-closing: this PR has had the \`${label}\` label for more than ${staleDays} days without activity from the author.\n\nIf you'd like to continue working on this, please submit a new PR and link to this one if necessary.`
               });
 
               await github.rest.pulls.update({


### PR DESCRIPTION
Changed closing comment to direct contributors to submit a new PR rather than reopen.