### PR TITLE
docs: update Discord invite link to openab.dev/discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, Hermes, Grok Build, Antigravity, Pi, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](gateway/).
 
-🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://discord.gg/DmbhfDZjQS)** 🎉
+🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://openab.dev/discord)** 🎉
 
 ```
 ┌──────────────┐  Gateway WS   ┌──────────────┐  ACP stdio    ┌──────────────────┐


### PR DESCRIPTION
## Summary

Update the Discord community invite link in README.md from the raw Discord invite URL to the custom domain redirect `https://openab.dev/discord`.

## Changes

- Updated Discord link on line 9 of README.md from `https://discord.gg/DmbhfDZjQS` to `https://openab.dev/discord`

## Notes

- Uses the custom domain redirect for a cleaner, more memorable link that can be updated without changing docs