### PR TITLE
revert: release v0.8.5-beta.9 (#1097)

### DIFF
--- a/charts/openab/Chart.yaml
+++ b/charts/openab/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openab
 description: A lightweight, secure, cloud-native ACP harness that bridges Discord and any ACP-compatible coding CLI.
 type: application
-version: 0.8.5-beta.9
-appVersion: "0.8.5-beta.9"
+version: 0.8.5-beta.8
+appVersion: "0.8.5-beta.8"


### PR DESCRIPTION
Reverts #1097 to re-tag the release.