### PR TITLE
fix(slack): recover from half-open Socket Mode connections (keepalive + idle timeout)

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -717,10 +717,24 @@ pub async fn run_slack_adapter(
                 info!("Slack Socket Mode connected");
                 let (mut write, mut read) = ws_stream.split();
 
+                // Proactively ping Slack and bail out if the connection goes
+                // silent. Without this, a half-open socket (e.g. the peer is
+                // dropped by a NAT/firewall idle-timeout with no FIN/RST) leaves
+                // `read.next()` blocked forever, so the reconnect logic below
+                // never runs and the adapter stays silently dead. The idle timer
+                // is reset on every inbound frame (including Slack's Pong replies
+                // to our keepalive pings). See issue #1101.
+                let ping_interval = std::time::Duration::from_secs(30);
+                let idle_timeout = std::time::Duration::from_secs(90);
+                let mut last_activity = tokio::time::Instant::now();
+                let mut ping_timer = tokio::time::interval(ping_interval);
+                ping_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
                 loop {
                     tokio::select! {
                         msg_result = read.next() => {
                             let Some(msg_result) = msg_result else { break };
+                            last_activity = tokio::time::Instant::now();
                             match msg_result {
                                 Ok(tungstenite::Message::Text(text)) => {
                                     let envelope: serde_json::Value =
@@ -1062,6 +1076,23 @@ pub async fn run_slack_adapter(
                             info!("Slack adapter received shutdown signal");
                             let _ = write.send(tungstenite::Message::Close(None)).await;
                             return Ok(());
+                        }
+                        _ = ping_timer.tick() => {
+                            if last_activity.elapsed() > idle_timeout {
+                                warn!(
+                                    idle_secs = idle_timeout.as_secs(),
+                                    "no Slack frames within idle timeout; assuming a \
+                                     half-open connection and reconnecting"
+                                );
+                                break;
+                            }
+                            if let Err(e) = write
+                                .send(tungstenite::Message::Ping(Vec::new()))
+                                .await
+                            {
+                                warn!("failed to send Slack keepalive ping: {e}; reconnecting");
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## What

Adds an application-level keepalive + idle timeout to the Slack Socket Mode read loop in `src/slack.rs` so the adapter recovers from a **half-open WebSocket** instead of going silently dead.

Fixes #1101.

## Why

Today the read loop only reconnects when `read.next()` returns `Err`/`None`:

```rust
msg_result = read.next() => {
    let Some(msg_result) = msg_result else { break };
    ...
    Err(e) => { error!("Socket Mode read error: {e}"); break; }
}
```

There is no `SO_KEEPALIVE`, no read/idle timeout, and openab never sends its own pings (it only replies to Slack's). So if the underlying TCP flow dies *silently* — no FIN/RST, e.g. a NAT/firewall idle-timeout reaps the connection — `read.next()` blocks forever, the reconnect path never runs, and the bot stops receiving all events until the process is restarted.

Observed in production (openab 0.8.4, behind home NAT): after a normal `Slack Socket Mode connected` line, the usual ~5h reconnect cadence stopped and there were **zero** `openab::slack` log lines for ~23h while the container stayed "healthy". `/proc/<pid>/net/tcp` showed the socket still `ESTABLISHED` with no keepalive/retransmit timer running — a textbook half-open connection.

## How

A 30s ping timer drives a third `tokio::select!` arm:

- every 30s, send a WebSocket `Ping` to Slack;
- `last_activity` is reset on **every** inbound frame (Slack's `Pong` replies included);
- if no frame arrives for `idle_timeout` (90s), assume the connection is half-open and `break`, which falls through to the existing 5s reconnect.

This is backend-agnostic (no `socket2`/TLS-stream poking) and self-contained. On a healthy connection the ping→pong keeps `last_activity` fresh, so it never false-trips; on a dead connection recovery now takes ~90–120s instead of forever.

Worst case for a false positive is a single extra reconnect (~5s), which Slack already forces roughly every 5h.

## Testing

- `cargo check` passes on the patched tree (rustc 1.85).
- Verified the same recovery behavior out-of-band on the affected deployment by force-closing the half-open socket and confirming openab's existing reconnect fires and `Slack Socket Mode connected` returns.

I don't have a Slack Socket Mode integration test harness handy; happy to adjust the interval/timeout constants or wire them to config if you'd prefer.
