### PR TITLE
fix(slack): debounce app_mention edit re-fires to one turn per message

### DIFF
--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -135,6 +135,10 @@ data:
     {{- if hasKey ($cfg.slack | default dict) "maxBatchTokens" }}
     max_batch_tokens = {{ ($cfg.slack).maxBatchTokens | int }}
     {{- end }}
+    {{- /* mentionDebounceSeconds: quiet window before a mention dispatches one turn (collapses app_mention edit re-fires) */ -}}
+    {{- if hasKey ($cfg.slack | default dict) "mentionDebounceSeconds" }}
+    mention_debounce_seconds = {{ ($cfg.slack).mentionDebounceSeconds | int }}
+    {{- end }}
     {{- if and (hasKey ($cfg.slack | default dict) "assistantMode") (not ($cfg.slack).assistantMode) }}
     assistant_mode = false
     {{- end }}

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -331,6 +331,13 @@ agents:
       # maxBufferedMessages: 10
       # maxBatchTokens: soft token cap per ACP turn for batching modes (default 24000)
       # maxBatchTokens: 24000
+      # mentionDebounceSeconds: quiet window before a mention dispatches one turn.
+      # Slack re-fires app_mention for every edit state of a mention-bearing
+      # message; the adapter holds only the latest state and dispatches once the
+      # message has been quiet this long. Default 4 (Rust-side
+      # `default_mention_debounce_seconds()`). Lower = less latency but higher
+      # risk of acting on a mid-stream edit; 0 dispatches on the first event.
+      # mentionDebounceSeconds: 4
     workingDir: /home/agent
     env: {}
     # Load env vars from existing Secrets or ConfigMaps, e.g. GH_TOKEN.

--- a/src/config.rs
+++ b/src/config.rs
@@ -355,6 +355,9 @@ fn default_max_buffered_messages() -> usize {
 fn default_max_batch_tokens() -> usize {
     24_000
 }
+fn default_mention_debounce_seconds() -> u64 {
+    4
+}
 
 /// Controls whether the bot responds to user messages in threads without @mention.
 ///
@@ -430,6 +433,14 @@ pub struct SlackConfig {
     /// that are not AI apps (no `assistant:write`) to keep emoji-reaction status.
     #[serde(default = "default_true")]
     pub assistant_mode: bool,
+    /// Quiet window (seconds) for per-message `app_mention` debouncing.
+    /// Slack re-fires `app_mention` for every edit state of a mention-bearing
+    /// message; the adapter holds only the latest state and dispatches one turn
+    /// once the message has been quiet for this long. Default: 4. Lower = less
+    /// latency but higher risk of acting on a mid-stream edit; 0 dispatches on
+    /// the first event (effectively disabling debounce).
+    #[serde(default = "default_mention_debounce_seconds")]
+    pub mention_debounce_seconds: u64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,6 +272,7 @@ async fn main() -> anyhow::Result<()> {
         let router = router.clone();
         let stt = cfg.stt.clone();
         let max_bot_turns = slack_cfg.max_bot_turns;
+        let mention_debounce_seconds = slack_cfg.mention_debounce_seconds;
         let slack_shutdown_rx = shutdown_rx.clone();
         let adapter = shared_slack_adapter
             .clone()
@@ -303,6 +304,7 @@ async fn main() -> anyhow::Result<()> {
                 slack_cfg.trusted_bot_ids.into_iter().collect(),
                 slack_cfg.allow_user_messages,
                 max_bot_turns,
+                mention_debounce_seconds,
                 stt,
                 slack_shutdown_rx,
                 slack_dispatcher,

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -674,7 +674,9 @@ impl ChatAdapter for SlackAdapter {
 /// Hard cap on consecutive bot messages in a thread. Prevents runaway loops.
 const MAX_CONSECUTIVE_BOT_TURNS: usize = 1000;
 
-/// Quiet window for per-message mention debouncing (see `MentionDebouncer`).
+/// Default quiet window for per-message mention debouncing (see
+/// `MentionDebouncer`), used when `[slack] mention_debounce_ms` is unset.
+/// Overridable per deployment; the live window is a `MentionDebouncer` field.
 const MENTION_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(4);
 /// Bounded memory for per-message dispatch history.
 const MENTION_HISTORY_CAP: usize = 512;
@@ -701,8 +703,10 @@ const MENTION_HISTORY_CAP: usize = 512;
 /// often a mid-stream fragment (observed in prod: a dispatch whose text was
 /// just `"<@U…>  -"`), and responding to fragments is worse than a few
 /// seconds of latency on turns that already take tens of seconds.
-#[derive(Default)]
 struct MentionDebouncer {
+    /// Quiet window each new event state must clear before dispatch. Sourced
+    /// from `[slack] mention_debounce_ms`; defaults to `MENTION_DEBOUNCE`.
+    window: tokio::time::Duration,
     /// key → (event payload, team_id, quiet deadline)
     pending: HashMap<String, (serde_json::Value, String, tokio::time::Instant)>,
     /// key → text of the last dispatched state (FIFO-bounded via `order`)
@@ -710,7 +714,22 @@ struct MentionDebouncer {
     order: std::collections::VecDeque<String>,
 }
 
+impl Default for MentionDebouncer {
+    fn default() -> Self {
+        Self::new(MENTION_DEBOUNCE)
+    }
+}
+
 impl MentionDebouncer {
+    fn new(window: tokio::time::Duration) -> Self {
+        Self {
+            window,
+            pending: HashMap::new(),
+            dispatched: HashMap::new(),
+            order: std::collections::VecDeque::new(),
+        }
+    }
+
     /// Record the latest state of a mention event. Returns true when the
     /// caller should spawn a waiter task for this key (i.e. the key was not
     /// already pending); later states just replace the payload and push the
@@ -719,7 +738,7 @@ impl MentionDebouncer {
         let fresh = !self.pending.contains_key(key);
         self.pending.insert(
             key.to_string(),
-            (event, team_id, tokio::time::Instant::now() + MENTION_DEBOUNCE),
+            (event, team_id, tokio::time::Instant::now() + self.window),
         );
         fresh
     }
@@ -801,13 +820,16 @@ pub async fn run_slack_adapter(
     trusted_bot_ids: HashSet<String>,
     allow_user_messages: AllowUsers,
     max_bot_turns: u32,
+    mention_debounce_seconds: u64,
     stt_config: SttConfig,
     mut shutdown_rx: watch::Receiver<bool>,
     dispatcher: Arc<crate::dispatch::Dispatcher>,
 ) -> Result<()> {
     let bot_token = adapter.bot_token().to_string();
     let bot_turns = Arc::new(tokio::sync::Mutex::new(BotTurnTracker::new(max_bot_turns)));
-    let mention_debounce = Arc::new(tokio::sync::Mutex::new(MentionDebouncer::default()));
+    let mention_debounce = Arc::new(tokio::sync::Mutex::new(MentionDebouncer::new(
+        tokio::time::Duration::from_secs(mention_debounce_seconds),
+    )));
 
     loop {
         // Check for shutdown before (re)connecting

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -674,6 +674,119 @@ impl ChatAdapter for SlackAdapter {
 /// Hard cap on consecutive bot messages in a thread. Prevents runaway loops.
 const MAX_CONSECUTIVE_BOT_TURNS: usize = 1000;
 
+/// Quiet window for per-message mention debouncing (see `MentionDebouncer`).
+const MENTION_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(4);
+/// Bounded memory for per-message dispatch history.
+const MENTION_HISTORY_CAP: usize = 512;
+
+/// Debounces `app_mention` events per (channel, message ts).
+///
+/// Slack re-fires `app_mention` for every edit state of a mention-bearing
+/// message, and openab's own native streaming (chat.startStream →
+/// N×appendStream → chat.stopStream → final chat.update) makes a single
+/// reply produce several such states. Each state used to dispatch a full
+/// agent turn; the duplicates resolved to no-op replies (one observed
+/// thread had 5 phantom turns for 2 real messages).
+///
+/// Strategy: hold only the *latest* state per message until the message has
+/// been quiet for `MENTION_DEBOUNCE` (each new state pushes the deadline),
+/// then dispatch it only if its text differs from the state last dispatched
+/// for that message. Identical re-fires drop; a material edit re-dispatches
+/// — fail-open, so a late final state is never lost.
+///
+/// Cost: this is trailing-edge, so **every** mention-triggered turn —
+/// including ordinary, never-edited human messages — starts
+/// `MENTION_DEBOUNCE` after the message arrives. Leading-edge dispatch was
+/// rejected deliberately: the first event state of a streamed message is
+/// often a mid-stream fragment (observed in prod: a dispatch whose text was
+/// just `"<@U…>  -"`), and responding to fragments is worse than a few
+/// seconds of latency on turns that already take tens of seconds.
+#[derive(Default)]
+struct MentionDebouncer {
+    /// key → (event payload, team_id, quiet deadline)
+    pending: HashMap<String, (serde_json::Value, String, tokio::time::Instant)>,
+    /// key → text of the last dispatched state (FIFO-bounded via `order`)
+    dispatched: HashMap<String, String>,
+    order: std::collections::VecDeque<String>,
+}
+
+impl MentionDebouncer {
+    /// Record the latest state of a mention event. Returns true when the
+    /// caller should spawn a waiter task for this key (i.e. the key was not
+    /// already pending); later states just replace the payload and push the
+    /// deadline forward.
+    fn note(&mut self, key: &str, event: serde_json::Value, team_id: String) -> bool {
+        let fresh = !self.pending.contains_key(key);
+        self.pending.insert(
+            key.to_string(),
+            (event, team_id, tokio::time::Instant::now() + MENTION_DEBOUNCE),
+        );
+        fresh
+    }
+
+    /// Atomically check the quiet deadline and drain the pending state.
+    /// Checking and taking under one lock closes the race where a new edit
+    /// state arrives (extending the deadline) between a deadline read and
+    /// the drain — the waiter would otherwise dispatch an unsettled state.
+    fn try_take(&mut self, key: &str, now: tokio::time::Instant) -> DebounceOutcome {
+        let Some((_, _, deadline)) = self.pending.get(key) else {
+            return DebounceOutcome::Done;
+        };
+        if now < *deadline {
+            return DebounceOutcome::Wait(*deadline);
+        }
+        match self.take_if_changed(key) {
+            Some((event, team_id)) => DebounceOutcome::Dispatch(event, team_id),
+            None => DebounceOutcome::Done,
+        }
+    }
+
+    /// Remove the pending state and return it for dispatch — unless it is
+    /// indistinguishable from what was already dispatched for this key.
+    fn take_if_changed(&mut self, key: &str) -> Option<(serde_json::Value, String)> {
+        let (event, team_id, _) = self.pending.remove(key)?;
+        let fingerprint = Self::fingerprint(&event);
+        if self.dispatched.get(key) == Some(&fingerprint) {
+            debug!(key, "mention debounce: identical re-fire dropped");
+            return None;
+        }
+        if !self.dispatched.contains_key(key) {
+            self.order.push_back(key.to_string());
+            if self.order.len() > MENTION_HISTORY_CAP {
+                if let Some(old) = self.order.pop_front() {
+                    self.dispatched.remove(&old);
+                }
+            }
+        }
+        self.dispatched.insert(key.to_string(), fingerprint);
+        Some((event, team_id))
+    }
+
+    /// What "the same message state" means for dedup purposes: the text plus
+    /// the attached file IDs. `handle_message` builds image/STT/text blocks
+    /// from `event["files"]`, so an edit that only adds an attachment is a
+    /// material change even when the text is byte-identical.
+    fn fingerprint(event: &serde_json::Value) -> String {
+        let text = event["text"].as_str().unwrap_or("");
+        let mut file_ids: Vec<&str> = event["files"]
+            .as_array()
+            .map(|files| files.iter().filter_map(|f| f["id"].as_str()).collect())
+            .unwrap_or_default();
+        file_ids.sort_unstable();
+        format!("{text}\u{0}{}", file_ids.join(","))
+    }
+}
+
+/// Result of `MentionDebouncer::try_take`.
+enum DebounceOutcome {
+    /// Quiet window satisfied and the state is new — dispatch it.
+    Dispatch(serde_json::Value, String),
+    /// Still pending — sleep until this deadline and re-check.
+    Wait(tokio::time::Instant),
+    /// Nothing to do (drained elsewhere, or an identical re-fire).
+    Done,
+}
+
 /// Run the Slack adapter using Socket Mode (persistent WebSocket, no public URL needed).
 /// Reconnects automatically on disconnect.
 #[allow(clippy::too_many_arguments)]
@@ -694,6 +807,7 @@ pub async fn run_slack_adapter(
 ) -> Result<()> {
     let bot_token = adapter.bot_token().to_string();
     let bot_turns = Arc::new(tokio::sync::Mutex::new(BotTurnTracker::new(max_bot_turns)));
+    let mention_debounce = Arc::new(tokio::sync::Mutex::new(MentionDebouncer::default()));
 
     loop {
         // Check for shutdown before (re)connecting
@@ -779,18 +893,59 @@ pub async fn run_slack_adapter(
                                                         }
                                                     }
                                                 }
-                                                let event = event.clone();
+                                                let team_id = envelope["payload"]["team_id"]
+                                                    .as_str()
+                                                    .unwrap_or("")
+                                                    .to_string();
+                                                // Debounce per (channel, ts): Slack re-fires
+                                                // app_mention for every edit state of a
+                                                // mention-bearing message (native streaming
+                                                // produces several). Hold the latest state
+                                                // until quiet, then dispatch once.
+                                                let debounce_key = format!(
+                                                    "{}:{}",
+                                                    event["channel"].as_str().unwrap_or(""),
+                                                    event["ts"].as_str().unwrap_or(""),
+                                                );
+                                                let spawn_waiter = mention_debounce
+                                                    .lock()
+                                                    .await
+                                                    .note(&debounce_key, event.clone(), team_id);
+                                                if !spawn_waiter {
+                                                    continue;
+                                                }
+                                                let mention_debounce = mention_debounce.clone();
                                                 let adapter = adapter.clone();
                                                 let bot_token = bot_token.clone();
                                                 let allowed_channels = allowed_channels.clone();
                                                 let allowed_users = allowed_users.clone();
                                                 let stt_config = stt_config.clone();
                                                 let dispatcher = dispatcher.clone();
-                                                let team_id = envelope["payload"]["team_id"]
-                                                    .as_str()
-                                                    .unwrap_or("")
-                                                    .to_string();
                                                 tokio::spawn(async move {
+                                                    // Wait until the message has been quiet for
+                                                    // the debounce window — each new edit state
+                                                    // pushes the deadline forward. Deadline check
+                                                    // and drain happen under one lock (try_take)
+                                                    // so a state arriving mid-check cannot leak
+                                                    // through unsettled.
+                                                    let (event, team_id) = loop {
+                                                        let outcome = mention_debounce
+                                                            .lock()
+                                                            .await
+                                                            .try_take(
+                                                                &debounce_key,
+                                                                tokio::time::Instant::now(),
+                                                            );
+                                                        match outcome {
+                                                            DebounceOutcome::Dispatch(event, team_id) => {
+                                                                break (event, team_id);
+                                                            }
+                                                            DebounceOutcome::Wait(deadline) => {
+                                                                tokio::time::sleep_until(deadline).await;
+                                                            }
+                                                            DebounceOutcome::Done => return,
+                                                        }
+                                                    };
                                                     handle_message(
                                                         &event,
                                                         &team_id,
@@ -1731,6 +1886,85 @@ fn build_set_status_body(channel_id: &str, thread_ts: &str, status: &str) -> ser
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- mention debounce tests ---
+
+    fn mention_event(text: &str) -> serde_json::Value {
+        serde_json::json!({"type": "app_mention", "channel": "C1", "ts": "1700.1", "text": text})
+    }
+
+    #[tokio::test]
+    async fn mention_debounce_latest_state_wins_and_refires_drop() {
+        let mut d = MentionDebouncer::default();
+        // First sighting spawns a waiter; edit states do not.
+        assert!(d.note("C1:1700.1", mention_event("<@U1> -"), "T1".into()));
+        assert!(!d.note("C1:1700.1", mention_event("<@U1> full review"), "T1".into()));
+
+        // Dispatch takes the latest state.
+        let (event, team) = d.take_if_changed("C1:1700.1").expect("first dispatch");
+        assert_eq!(event["text"], "<@U1> full review");
+        assert_eq!(team, "T1");
+
+        // Identical re-fire after dispatch: held, then dropped.
+        assert!(d.note("C1:1700.1", mention_event("<@U1> full review"), "T1".into()));
+        assert!(d.take_if_changed("C1:1700.1").is_none());
+
+        // Material edit after dispatch: re-dispatches (fail-open).
+        assert!(d.note("C1:1700.1", mention_event("<@U1> edited content"), "T1".into()));
+        assert!(d.take_if_changed("C1:1700.1").is_some());
+
+        // Attachment-only edit (same text, new file): also material.
+        let mut with_file = mention_event("<@U1> edited content");
+        with_file["files"] = serde_json::json!([{"id": "F123"}]);
+        assert!(d.note("C1:1700.1", with_file, "T1".into()));
+        assert!(d.take_if_changed("C1:1700.1").is_some());
+
+        // No pending entry → nothing to take.
+        assert!(d.take_if_changed("C1:1700.1").is_none());
+        assert!(matches!(
+            d.try_take("C1:1700.1", tokio::time::Instant::now()),
+            DebounceOutcome::Done
+        ));
+    }
+
+    #[tokio::test]
+    async fn mention_debounce_try_take_respects_extended_deadline() {
+        let mut d = MentionDebouncer::default();
+        let start = tokio::time::Instant::now();
+        d.note("C1:1700.1", mention_event("v1"), "T1".into());
+
+        // Before the quiet window elapses: wait, don't drain.
+        assert!(matches!(
+            d.try_take("C1:1700.1", start),
+            DebounceOutcome::Wait(_)
+        ));
+
+        // A new state arriving pushes the deadline — even a try_take issued
+        // "after" the original deadline must wait for the new one.
+        d.note("C1:1700.1", mention_event("v2"), "T1".into());
+        assert!(matches!(
+            d.try_take("C1:1700.1", start + MENTION_DEBOUNCE),
+            DebounceOutcome::Wait(_)
+        ));
+
+        // Once genuinely quiet, the latest state dispatches.
+        match d.try_take("C1:1700.1", start + MENTION_DEBOUNCE * 3) {
+            DebounceOutcome::Dispatch(event, _) => assert_eq!(event["text"], "v2"),
+            _ => panic!("expected dispatch of settled state"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mention_debounce_history_is_bounded() {
+        let mut d = MentionDebouncer::default();
+        for i in 0..(MENTION_HISTORY_CAP + 10) {
+            let key = format!("C1:{i}");
+            d.note(&key, mention_event("x"), "T1".into());
+            d.take_if_changed(&key);
+        }
+        assert!(d.dispatched.len() <= MENTION_HISTORY_CAP);
+        assert!(d.order.len() <= MENTION_HISTORY_CAP);
+    }
 
     // --- builder tests ---
 


### PR DESCRIPTION
Debounce Slack `app_mention` so one user message produces one agent turn.

## What problem does this solve?

`src/slack.rs` spawns a full `handle_message` (→ one agent turn) for **every** `app_mention` event, with no dedup by message `ts`. But a single logical mention arrives as several events: Slack re-delivers `app_mention` as a mention-bearing message moves through edit states, and openab's own native streaming drives a reply through several message states (`chat.startStream` → N×`appendStream` → `chat.stopStream` → final `chat.update`). One observed multi-agent thread produced **5 agent turns for 2 real messages** — duplicate LLM invocations, each forcing a no-op reply into the thread, and one dispatch even fired on a mid-stream fragment whose text was just `<@U…>  -`.

Closes #1103

## At a Glance

```
(before)  every app_mention event ─▶ tokio::spawn(handle_message) ─▶ full agent turn

          edit-state re-fires of the SAME (channel, ts):
            ts=170.1  "<@U  -"           ─▶ turn 1   ⚠ mid-stream fragment
            ts=170.1  "<@U review"       ─▶ turn 2
            ts=170.1  "<@U review this"  ─▶ turn 3        1 message ⇒ N turns ⇒ N noise replies

(after)   app_mention ─▶ MentionDebouncer.note((channel, ts), latest_state)
                          each new state pushes a quiet deadline (mention_debounce_seconds, default 4s)
              quiet ─▶ dispatch ONCE, only if fingerprint changed
                          (text + sorted file IDs)  ─▶ one turn on the settled message
```

## Prior Art & Industry Research

- **OpenClaw / Hermes Agent:** not applicable — this is a defect in OpenAB's own Slack Socket Mode event ingestion (`src/slack.rs`), upstream of any agent backend and independent of which ACP agent runs.
- **OpenAB turn-boundary batching** (`docs/adr/turn-boundary-batching.md`, the Dispatcher): the closest in-repo prior art. It coalesces **distinct** messages that arrive during an in-flight turn into one batch. This change is complementary and orthogonal — it dedupes **repeated edit states of the same message** at the adapter ingress, before a turn is ever dispatched, which the batching dispatcher does not cover.
- **OpenAB WeCom adapter** (`debounceSecs`): precedent for a per-adapter, seconds-valued "debounce quiet period before flushing" config — the naming/units of `mention_debounce_seconds` follow it.
- **Slack Events API:** `app_mention` delivery is at-least-once and re-fires as a message is edited (`message_changed`). Trailing-edge debounce keyed on `(channel, ts)` is the standard way to collapse such an event storm down to the message's settled state.

## Proposed Solution

Add `MentionDebouncer`, keyed on `(channel, ts)`:

- Hold only the **latest** event state per message; each new state pushes a quiet deadline.
- On quiet, dispatch **once**, and only if the settled state's fingerprint (`text` + sorted attached file IDs) differs from what was last dispatched for that message — so an attachment-only edit is still material, while an identical re-fire drops.
- The deadline check and the drain happen under **one lock** (`try_take`), closing the race where a new edit arriving mid-check would otherwise leak an unsettled state through.
- Fail-open: a late final state is never lost (a material edit re-dispatches). Dispatch history is FIFO-bounded (`MENTION_HISTORY_CAP`).

The quiet window is configurable via **`[slack] mention_debounce_seconds`** (Helm: `slack.mentionDebounceSeconds`), **default 4**. Set it lower to trade robustness for latency, or `0` to dispatch on the first event (effectively disabling debounce). The window defaults to `MENTION_DEBOUNCE` (4s) when unset.

Trailing-edge is deliberate: the first event state of a streamed/edited message is often a mid-stream fragment, and responding to fragments is worse than a few seconds of latency on turns that already take tens of seconds.

## Why this approach?

The bug is at the adapter ingress (one Slack message → many events), so the fix belongs there, before dispatch — not in the cross-platform batching Dispatcher, whose job (coalescing distinct messages at turn boundaries) is a different concern. Keying on `(channel, ts)` matches Slack's own identity for "the same message across its edit states". The change is contained to the Slack adapter plus a single, default-preserving config knob.

## Alternatives Considered

- **Leading-edge (dispatch the first event, ignore the rest):** rejected — the first state is often a mid-stream fragment (observed: text just `<@U…>  -`); responding to fragments is worse than trailing latency.
- **Dedup in the batching Dispatcher:** the Dispatcher batches *distinct* messages; same-`ts` edit states are not its model, and pushing per-message edit dedup down there would entangle a Slack-specific event quirk with the platform-agnostic batching logic.
- **Dedup by Slack `event_id` / `client_msg_id`:** wouldn't collapse genuine edit states (each edit is a fresh delivery of the same logical message); `(channel, ts)` + content fingerprint is the right grain.
- **`mention_debounce_ms` (millisecond units):** rejected for `_seconds` — this is a coarse, human-tuned window (3–5s), matching the repo's seconds-valued duration config (`timeout_seconds`, `*_secs`, WeCom `debounceSecs`) rather than the sub-second `ReactionTiming` `_ms` knobs.

## Validation

Built and tested locally against this branch:

- `cargo test --bin openab`: **501 passed, 1 failed**. The one failure (`secrets::tests::resolve_exec_nonzero_exit`) reproduces on a clean tree in this environment (asserts a shell error-message string) and is unrelated to this change — `src/secrets.rs` is untouched here.
- Debounce unit tests green: `mention_debounce_latest_state_wins_and_refires_drop`, `mention_debounce_try_take_respects_extended_deadline`, `mention_debounce_history_is_bounded` (latest-state-wins, identical-re-fire-drop, attachment-only-edit-is-material, the mid-check deadline race, and FIFO-bounded history).
- `cargo clippy --all-targets -- -D warnings`: clean on all changed files. (Two pre-existing `clippy::bool_assert_comparison` findings in the untouched `src/cron.rs` are surfaced only by a newer local clippy; not introduced here.)
- `helm template`: `slack.mentionDebounceSeconds=N` renders `mention_debounce_seconds = N` under `[slack]`; omitted when unset (Rust default applies).

Please re-verify via CI.
