### PR TITLE
feat(charts): add openab-line Helm chart

### DIFF
--- a/charts/openab-line/Chart.yaml
+++ b/charts/openab-line/Chart.yaml
@@ -3,4 +3,4 @@ name: openab-line
 description: OpenAB + LINE — single-pod deployment with gateway sidecar and optional Cloudflare Tunnel.
 type: application
 version: 0.1.0
-appVersion: "0.8.5-beta.1"
+appVersion: "0.8.5-beta.9"

--- a/charts/openab-line/Chart.yaml
+++ b/charts/openab-line/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: openab-line
+description: OpenAB + LINE — single-pod deployment with gateway sidecar and optional Cloudflare Tunnel.
+type: application
+version: 0.1.0
+appVersion: "0.8.5-beta.1"

--- a/charts/openab-line/README.md
+++ b/charts/openab-line/README.md
@@ -131,19 +131,43 @@ helm upgrade --install my-bot ./charts/openab-line \
 |-----|---------|-------------|
 | `line.channelSecret` | `""` | **(required)** LINE channel secret |
 | `line.channelAccessToken` | `""` | **(required)** LINE channel access token |
-| `existingSecret` | `""` | Use pre-existing Secret |
+| `existingSecret` | `""` | Use a pre-existing Secret instead of creating one |
+| `channel` | `stable` | Agent release channel (`stable` or `beta`) |
 | `tunnel.enabled` | `false` | Enable cloudflared sidecar |
-| `tunnel.token` | `""` | Cloudflare Tunnel token |
-| `webhookDomain` | `""` | Used in install notes |
-| `image.repository` | `ghcr.io/openabdev/openab` | Agent image |
-| `image.tag` | `channel` | Agent image tag |
-| `gateway.image` | `ghcr.io/openabdev/openab-gateway` | Gateway image |
-| `gateway.tag` | `Chart.AppVersion` | Gateway image tag |
-| `agent.command` | `kiro-cli` | Agent command |
-| `agent.workingDir` | `/home/agent` | Shared HOME / PVC mount |
-| `platform.allowedUsers` | `[]` | Allowed LINE user IDs (empty = all) |
-| `platform.allowedChannels` | `[]` | Allowed LINE chat/group IDs (empty = all) |
+| `tunnel.token` | `""` | Cloudflare Tunnel token (required when `tunnel.enabled=true`) |
+| `tunnel.image` | `cloudflare/cloudflared` | Cloudflared image repository |
+| `tunnel.tag` | `2026.5.0` | Cloudflared image tag |
+| `webhookDomain` | `""` | Domain shown in post-install notes |
+| `image.repository` | `ghcr.io/openabdev/openab` | Agent image repository |
+| `image.tag` | `""` | Agent image tag (defaults to `channel` value) |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `gateway.image` | `ghcr.io/openabdev/openab-gateway` | Gateway image repository (override for air-gapped / private-registry installs) |
+| `gateway.tag` | `v0.5.1` | Gateway image tag. Pinned to version tested with this chart — change with care |
+| `agent.command` | `kiro-cli` | Agent entrypoint command |
+| `agent.args` | `["acp","--trust-all-tools"]` | Agent command arguments |
+| `agent.workingDir` | `/home/agent` | Shared HOME and PVC/emptyDir mount path |
+| `agent.env` | `{}` | Extra environment variables (map) |
+| `agent.envFrom` | `[]` | Extra envFrom sources (ConfigMaps/Secrets) |
+| `agent.secretEnv` | `[]` | Extra environment variables from Secrets |
+| `agent.pool.maxSessions` | `10` | Max concurrent sessions |
+| `agent.pool.sessionTtlHours` | `24` | Session TTL in hours |
+| `agent.reactions.enabled` | `false` | Enable reaction events (LINE does not support reactions) |
+| `agent.reactions.removeAfterReply` | `false` | Remove reaction after agent replies |
+| `platform.allowAllUsers` | `null` | Override allow-all-users (`null` = defer to `allowedUsers` list) |
+| `platform.allowAllChannels` | `null` | Override allow-all-channels (`null` = defer to `allowedChannels` list) |
+| `platform.allowedUsers` | `[]` | Allowed LINE user IDs (`Uxxx…`). Empty = allow all when `allowAllUsers` is null |
+| `platform.allowedChannels` | `[]` | Allowed LINE chat/group IDs. Empty = allow all when `allowAllChannels` is null |
 | `persistence.enabled` | `true` | Enable PVC for agent state and media |
+| `persistence.existingClaim` | `""` | Use an existing PVC instead of creating one |
+| `persistence.storageClass` | `""` | Storage class (`""` = cluster default) |
+| `persistence.size` | `1Gi` | PVC size |
+| `service.type` | `ClusterIP` | Service type |
+| `service.port` | `8080` | Service port |
+| `service.annotations` | `{}` | Extra annotations for the Service |
+| `resources` | `{}` | Container resource requests/limits |
+| `nodeSelector` | `{}` | Node selector |
+| `tolerations` | `[]` | Tolerations |
+| `affinity` | `{}` | Affinity rules |
 
 ## Troubleshooting
 

--- a/charts/openab-line/README.md
+++ b/charts/openab-line/README.md
@@ -1,0 +1,156 @@
+# openab-line
+
+OpenAB + LINE in a single pod — OAB agent and gateway colocated, with optional Cloudflare Tunnel sidecar.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│ Pod: openab-line                                     │
+│                                                      │
+│  ┌──────────┐  ws://localhost:8080/ws  ┌──────────┐  │
+│  │  openab  │◄────────────────────────►│ gateway  │  │
+│  │ (agent)  │                          │  :8080   │  │
+│  └────┬─────┘                          └────┬─────┘  │
+│       │                                      │        │
+│       │ /home/agent (PVC, shared HOME)       │        │
+│       │ ~/.openab/media/inbound/<uuid>       │        │
+│       ▼                                      ▼        │
+│   shared filesystem                    /webhook/line  │
+│                                                      │
+│  optional: cloudflared sidecar                       │
+└──────────────────────────────────────────────────────┘
+```
+
+This chart follows OpenAB's current inbound-attachment model: the gateway stores media under the shared `$HOME`, and core reads `attachments[].path` from the same filesystem. That is why the agent and gateway run in the **same pod** and share the **same working directory / HOME**.
+
+## Quick Start
+
+### Option A: Cloudflare Tunnel
+
+```bash
+helm install my-bot ./charts/openab-line \
+  --set line.channelSecret="xxx" \
+  --set line.channelAccessToken="xxx" \
+  --set tunnel.enabled=true \
+  --set tunnel.token="eyJ..." \
+  --set webhookDomain=bot.example.com \
+  --namespace openab --create-namespace
+```
+
+### Option B: Existing Ingress / LoadBalancer
+
+```bash
+helm install my-bot ./charts/openab-line \
+  --set line.channelSecret="xxx" \
+  --set line.channelAccessToken="xxx" \
+  --namespace openab --create-namespace
+```
+
+Then expose the generated Service (`ClusterIP` by default) at:
+
+```text
+https://YOUR_DOMAIN/webhook/line
+```
+
+## LINE Setup
+
+### 1. Create a LINE Official Account
+
+1. Go to [LINE Official Account Manager](https://manager.line.biz)
+2. Create an account and enable **Messaging API**
+3. Open the channel in [LINE Developers Console](https://developers.line.biz)
+
+### 2. Get Credentials
+
+- **Channel secret** → `line.channelSecret`
+- **Channel access token** → `line.channelAccessToken`
+
+### 3. Configure the Webhook
+
+In LINE Developers Console → **Messaging API**:
+
+1. Set **Webhook URL** to `https://YOUR_DOMAIN/webhook/line`
+2. Turn **Use webhook** ON
+3. Turn **Auto-reply messages** OFF
+4. Click **Verify**
+
+## Credentials
+
+Three options from simplest to most secure:
+
+| # | Method | Security | Notes |
+|---|--------|----------|-------|
+| 1 | `--set line.channelSecret=... --set line.channelAccessToken=...` | ⚠️ Stored in Helm release | Good for dev/testing |
+| 2 | `kubectl create secret` + `--set existingSecret=name` | ✅ Out of Helm values | Good for production |
+| 3 | External secret manager → K8s Secret → `existingSecret` | ✅✅ Best for production | Recommended |
+
+### Option 2 example
+
+```bash
+kubectl create secret generic line-creds -n openab \
+  --from-literal=line-channel-secret="xxx" \
+  --from-literal=line-channel-access-token="xxx"
+
+helm install my-bot ./charts/openab-line \
+  --set existingSecret=line-creds \
+  --namespace openab --create-namespace
+```
+
+If you enable the tunnel sidecar, add:
+
+```bash
+  --from-literal=cloudflare-tunnel-token="eyJ..."
+```
+
+## Agent Images
+
+The chart keeps the agent side generic. You can swap the image/command/args, for example:
+
+```bash
+helm upgrade --install my-bot ./charts/openab-line \
+  --set image.repository=ghcr.io/openabdev/openab-copilot \
+  --set-string agent.command=copilot \
+  --set agent.args[0]=--acp \
+  --set agent.args[1]=--stdio \
+  --set agent.workingDir=/home/node \
+  --set existingSecret=line-creds \
+  --namespace openab
+```
+
+## LINE-specific Notes
+
+- LINE is **webhook-only**. This chart always creates a Service; either expose it yourself or enable `tunnel.enabled=true`.
+- LINE replies use Reply API first, then fall back to Push API when the reply token expires. Slow coding-agent responses can therefore consume push quota.
+- LINE reactions are not supported, so this chart defaults `agent.reactions.enabled=false`.
+- LINE-hosted inbound images are supported. `contentProvider.type = "external"` images are still skipped.
+
+## Values Reference
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `line.channelSecret` | `""` | **(required)** LINE channel secret |
+| `line.channelAccessToken` | `""` | **(required)** LINE channel access token |
+| `existingSecret` | `""` | Use pre-existing Secret |
+| `tunnel.enabled` | `false` | Enable cloudflared sidecar |
+| `tunnel.token` | `""` | Cloudflare Tunnel token |
+| `webhookDomain` | `""` | Used in install notes |
+| `image.repository` | `ghcr.io/openabdev/openab` | Agent image |
+| `image.tag` | `channel` | Agent image tag |
+| `gateway.image` | `ghcr.io/openabdev/openab-gateway` | Gateway image |
+| `gateway.tag` | `Chart.AppVersion` | Gateway image tag |
+| `agent.command` | `kiro-cli` | Agent command |
+| `agent.workingDir` | `/home/agent` | Shared HOME / PVC mount |
+| `platform.allowedUsers` | `[]` | Allowed LINE user IDs (empty = all) |
+| `platform.allowedChannels` | `[]` | Allowed LINE chat/group IDs (empty = all) |
+| `persistence.enabled` | `true` | Enable PVC for agent state and media |
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| Webhook verify fails | Ensure your public endpoint reaches the Service on port 8080 and the URL ends with `/webhook/line` |
+| Gateway logs show invalid signature | Re-check `line-channel-secret` |
+| Bot can reply to text but not see images | Verify the agent and gateway share the same `HOME` and PVC; this chart does by default |
+| Bot does not respond at all | Confirm **Use webhook** is ON and **Auto-reply messages** is OFF in LINE Developers Console |
+| Authenticated CLI lost session after restart | Keep `persistence.enabled=true` or mount an existing claim |

--- a/charts/openab-line/README.md
+++ b/charts/openab-line/README.md
@@ -142,7 +142,7 @@ helm upgrade --install my-bot ./charts/openab-line \
 | `image.tag` | `""` | Agent image tag (defaults to `channel` value) |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `gateway.image` | `ghcr.io/openabdev/openab-gateway` | Gateway image repository (override for air-gapped / private-registry installs) |
-| `gateway.tag` | `v0.5.1` | Gateway image tag. Pinned to version tested with this chart — change with care |
+| `gateway.tag` | `v0.5.3` | Gateway image tag. Pinned to version tested with this chart — change with care |
 | `agent.command` | `kiro-cli` | Agent entrypoint command |
 | `agent.args` | `["acp","--trust-all-tools"]` | Agent command arguments |
 | `agent.workingDir` | `/home/agent` | Shared HOME and PVC/emptyDir mount path |

--- a/charts/openab-line/templates/NOTES.txt
+++ b/charts/openab-line/templates/NOTES.txt
@@ -1,11 +1,11 @@
 🎉 OpenAB LINE bot deployed!
 
 {{- if include "openab-line.tunnelEnabled" . }}
-Pod: {{ include "openab-line.fullname" . }} (3 containers: openab, gateway, cloudflared)
+Deployment: {{ include "openab-line.fullname" . }} (3 containers: openab, gateway, cloudflared)
 Exposure: Cloudflare Tunnel
 {{- else }}
-Pod: {{ include "openab-line.fullname" . }} (2 containers: openab, gateway)
-Exposure: bring your own Ingress / LoadBalancer to Service/{{ include "openab-line.fullname" . }}
+Deployment: {{ include "openab-line.fullname" . }} (2 containers: openab, gateway)
+Exposure: Service/{{ include "openab-line.fullname" . }} ({{ .Values.service.type }}) — route public traffic to it via Ingress, LoadBalancer, or NodePort
 {{- end }}
 
 ## Post-Install Steps
@@ -23,11 +23,14 @@ In Cloudflare Dashboard:
 {{- if not (include "openab-line.tunnelEnabled" .) }}
 ### Step 1: Expose the Service publicly
 
-Create an Ingress / LoadBalancer that routes:
-  https://{{ .Values.webhookDomain | default "YOUR_DOMAIN" }}/webhook/line
+Route public HTTPS traffic to Service/{{ include "openab-line.fullname" . }}:{{ .Values.service.port }}.
+Options depending on your cluster:
+  - Ingress: point your Ingress controller at the Service
+  - LoadBalancer: set service.type=LoadBalancer and use the external IP
+  - NodePort: set service.type=NodePort and expose via your load balancer
 
-to:
-  Service/{{ include "openab-line.fullname" . }}:{{ .Values.service.port }}
+Target URL:
+  https://{{ .Values.webhookDomain | default "YOUR_DOMAIN" }}/webhook/line
 {{- end }}
 
 ### Step 2: Set the LINE webhook

--- a/charts/openab-line/templates/NOTES.txt
+++ b/charts/openab-line/templates/NOTES.txt
@@ -1,0 +1,63 @@
+🎉 OpenAB LINE bot deployed!
+
+{{- if include "openab-line.tunnelEnabled" . }}
+Pod: {{ include "openab-line.fullname" . }} (3 containers: openab, gateway, cloudflared)
+Exposure: Cloudflare Tunnel
+{{- else }}
+Pod: {{ include "openab-line.fullname" . }} (2 containers: openab, gateway)
+Exposure: bring your own Ingress / LoadBalancer to Service/{{ include "openab-line.fullname" . }}
+{{- end }}
+
+## Post-Install Steps
+
+{{- if include "openab-line.tunnelEnabled" . }}
+### Step 1: Configure Cloudflare Tunnel ingress
+
+In Cloudflare Dashboard:
+  https://one.dash.cloudflare.com/ → Networks → Tunnels → your tunnel → Public Hostname → Add:
+    Hostname: {{ .Values.webhookDomain | default "bot.example.com" }}
+    Type: HTTP
+    URL: localhost:8080
+{{- end }}
+
+{{- if not (include "openab-line.tunnelEnabled" .) }}
+### Step 1: Expose the Service publicly
+
+Create an Ingress / LoadBalancer that routes:
+  https://{{ .Values.webhookDomain | default "YOUR_DOMAIN" }}/webhook/line
+
+to:
+  Service/{{ include "openab-line.fullname" . }}:{{ .Values.service.port }}
+{{- end }}
+
+### Step 2: Set the LINE webhook
+
+In LINE Developers Console → Messaging API:
+  1. Set Webhook URL to:
+     https://{{ .Values.webhookDomain | default "YOUR_DOMAIN" }}/webhook/line
+  2. Turn "Use webhook" ON
+  3. Turn "Auto-reply messages" OFF
+  4. Click "Verify"
+
+### Step 3: Authenticate the agent if your CLI requires it
+
+Examples:
+  # Kiro
+  kubectl exec -it deployment/{{ include "openab-line.fullname" . }} -n {{ .Release.Namespace }} -c openab -- kiro-cli login --use-device-flow
+
+  # GitHub Copilot CLI
+  kubectl exec -it deployment/{{ include "openab-line.fullname" . }} -n {{ .Release.Namespace }} -c openab -- copilot auth login
+
+Then restart to pick up credentials:
+
+  kubectl rollout restart deployment/{{ include "openab-line.fullname" . }} -n {{ .Release.Namespace }}
+
+## Verify
+
+Check logs if the bot does not respond:
+
+  kubectl logs -n {{ .Release.Namespace }} deployment/{{ include "openab-line.fullname" . }} -c openab --tail=20
+  kubectl logs -n {{ .Release.Namespace }} deployment/{{ include "openab-line.fullname" . }} -c gateway --tail=20
+{{- if include "openab-line.tunnelEnabled" . }}
+  kubectl logs -n {{ .Release.Namespace }} deployment/{{ include "openab-line.fullname" . }} -c cloudflared --tail=20
+{{- end }}

--- a/charts/openab-line/templates/_helpers.tpl
+++ b/charts/openab-line/templates/_helpers.tpl
@@ -32,8 +32,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "openab-line.tunnelEnabled" -}}
-{{- if .Values.tunnel.enabled -}}
+{{- if and .Values.tunnel (kindIs "bool" .Values.tunnel.enabled) .Values.tunnel.enabled -}}
 true
-{{- else -}}
 {{- end -}}
 {{- end }}

--- a/charts/openab-line/templates/_helpers.tpl
+++ b/charts/openab-line/templates/_helpers.tpl
@@ -24,11 +24,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "openab-line.gatewayImage" -}}
-{{- $tag := .Values.gateway.tag -}}
-{{- if not $tag -}}
-  {{- $tag = .Chart.AppVersion -}}
-{{- end -}}
-{{- printf "%s:%s" .Values.gateway.image $tag -}}
+{{- printf "%s:%s" .Values.gateway.image .Values.gateway.tag -}}
 {{- end }}
 
 {{- define "openab-line.secretName" -}}

--- a/charts/openab-line/templates/_helpers.tpl
+++ b/charts/openab-line/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{- define "openab-line.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "openab-line.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "openab-line.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "openab-line.agentImage" -}}
+{{- $tag := .Values.image.tag -}}
+{{- if not $tag -}}
+  {{- $tag = .Values.channel | default "stable" -}}
+{{- end -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}
+
+{{- define "openab-line.gatewayImage" -}}
+{{- $tag := .Values.gateway.tag -}}
+{{- if not $tag -}}
+  {{- $tag = .Chart.AppVersion -}}
+{{- end -}}
+{{- printf "%s:%s" .Values.gateway.image $tag -}}
+{{- end }}
+
+{{- define "openab-line.secretName" -}}
+{{- .Values.existingSecret | default (include "openab-line.fullname" .) -}}
+{{- end }}
+
+{{- define "openab-line.tunnelEnabled" -}}
+{{- if .Values.tunnel.enabled -}}
+true
+{{- else -}}
+{{- end -}}
+{{- end }}

--- a/charts/openab-line/templates/configmap.yaml
+++ b/charts/openab-line/templates/configmap.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openab-line.fullname" . }}
+  labels:
+    {{- include "openab-line.labels" . | nindent 4 }}
+data:
+  config.toml: |
+    [agent]
+    command = {{ .Values.agent.command | toJson }}
+    args = {{ .Values.agent.args | default list | toJson }}
+    working_dir = {{ .Values.agent.workingDir | default "/home/agent" | toJson }}
+    {{- if .Values.agent.env }}
+    env = { {{ range $i, $k := (.Values.agent.env | keys | sortAlpha) }}{{ if gt $i 0 }}, {{ end }}{{ $k }} = {{ index $.Values.agent.env $k | toJson }}{{ end }} }
+    {{- end }}
+    {{- $secretEnvKeys := list }}
+    {{- range .Values.agent.secretEnv }}{{ $secretEnvKeys = append $secretEnvKeys .name }}{{ end }}
+    {{- if $secretEnvKeys }}
+    inherit_env = {{ $secretEnvKeys | toJson }}
+    {{- end }}
+
+    [pool]
+    max_sessions = {{ .Values.agent.pool.maxSessions | default 10 }}
+    session_ttl_hours = {{ .Values.agent.pool.sessionTtlHours | default 24 }}
+
+    [reactions]
+    enabled = {{ .Values.agent.reactions.enabled }}
+    remove_after_reply = {{ .Values.agent.reactions.removeAfterReply }}
+
+    [gateway]
+    url = "ws://localhost:8080/ws"
+    platform = "line"
+    allow_all_channels = {{ if .Values.platform.allowedChannels }}false{{ else }}true{{ end }}
+    allowed_channels = {{ .Values.platform.allowedChannels | default list | toJson }}
+    allow_all_users = {{ if .Values.platform.allowedUsers }}false{{ else }}true{{ end }}
+    allowed_users = {{ .Values.platform.allowedUsers | default list | toJson }}

--- a/charts/openab-line/templates/configmap.yaml
+++ b/charts/openab-line/templates/configmap.yaml
@@ -24,8 +24,8 @@ data:
     session_ttl_hours = {{ .Values.agent.pool.sessionTtlHours | default 24 }}
 
     [reactions]
-    enabled = {{ .Values.agent.reactions.enabled }}
-    remove_after_reply = {{ .Values.agent.reactions.removeAfterReply }}
+    enabled = {{ .Values.agent.reactions.enabled | default false }}
+    remove_after_reply = {{ .Values.agent.reactions.removeAfterReply | default false }}
 
     [gateway]
     url = "ws://localhost:8080/ws"

--- a/charts/openab-line/templates/configmap.yaml
+++ b/charts/openab-line/templates/configmap.yaml
@@ -30,7 +30,11 @@ data:
     [gateway]
     url = "ws://localhost:8080/ws"
     platform = "line"
-    allow_all_channels = {{ if .Values.platform.allowedChannels }}false{{ else }}true{{ end }}
+    {{- if not (kindIs "invalid" .Values.platform.allowAllChannels) }}
+    allow_all_channels = {{ .Values.platform.allowAllChannels }}
+    {{- end }}
     allowed_channels = {{ .Values.platform.allowedChannels | default list | toJson }}
-    allow_all_users = {{ if .Values.platform.allowedUsers }}false{{ else }}true{{ end }}
+    {{- if not (kindIs "invalid" .Values.platform.allowAllUsers) }}
+    allow_all_users = {{ .Values.platform.allowAllUsers }}
+    {{- end }}
     allowed_users = {{ .Values.platform.allowedUsers | default list | toJson }}

--- a/charts/openab-line/templates/deployment.yaml
+++ b/charts/openab-line/templates/deployment.yaml
@@ -36,9 +36,9 @@ spec:
           env:
             - name: HOME
               value: {{ .Values.agent.workingDir | default "/home/agent" }}
-            {{- range $k, $v := .Values.agent.env }}
+            {{- range $k := (.Values.agent.env | keys | sortAlpha) }}
             - name: {{ $k }}
-              value: {{ $v | quote }}
+              value: {{ get $.Values.agent.env $k | quote }}
             {{- end }}
             {{- range .Values.agent.secretEnv }}
             - name: {{ .name }}
@@ -59,10 +59,8 @@ spec:
             - name: config
               mountPath: /etc/openab
               readOnly: true
-            {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.agent.workingDir | default "/home/agent" }}
-            {{- end }}
             - name: tmp
               mountPath: /tmp
 
@@ -91,10 +89,8 @@ spec:
                   name: {{ include "openab-line.secretName" . }}
                   key: line-channel-access-token
           volumeMounts:
-            {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.agent.workingDir | default "/home/agent" }}
-            {{- end }}
             - name: tmp
               mountPath: /tmp
 
@@ -144,10 +140,12 @@ spec:
         - name: config
           configMap:
             name: {{ include "openab-line.fullname" . }}
-        {{- if .Values.persistence.enabled }}
         - name: data
+          {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (include "openab-line.fullname" .) }}
-        {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         - name: tmp
           emptyDir: {}

--- a/charts/openab-line/templates/deployment.yaml
+++ b/charts/openab-line/templates/deployment.yaml
@@ -1,0 +1,153 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openab-line.fullname" . }}
+  labels:
+    {{- include "openab-line.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "openab-line.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.existingSecret }}
+        checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+      labels:
+        {{- include "openab-line.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: openab
+          image: {{ include "openab-line.agentImage" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: HOME
+              value: {{ .Values.agent.workingDir | default "/home/agent" }}
+            {{- range $k, $v := .Values.agent.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+            {{- range .Values.agent.secretEnv }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .secretKey }}
+            {{- end }}
+          {{- with .Values.agent.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/openab
+              readOnly: true
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.agent.workingDir | default "/home/agent" }}
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+
+        - name: gateway
+          image: {{ include "openab-line.gatewayImage" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: HOME
+              value: {{ .Values.agent.workingDir | default "/home/agent" }}
+            - name: LINE_CHANNEL_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab-line.secretName" . }}
+                  key: line-channel-secret
+            - name: LINE_CHANNEL_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab-line.secretName" . }}
+                  key: line-channel-access-token
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.agent.workingDir | default "/home/agent" }}
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+
+        {{- if include "openab-line.tunnelEnabled" . }}
+        {{- if and (not .Values.tunnel.token) (not .Values.existingSecret) }}
+        {{- fail "tunnel.token is required when tunnel.enabled=true (or provide existingSecret with cloudflare-tunnel-token)" }}
+        {{- end }}
+        - name: cloudflared
+          image: {{ printf "%s:%s" .Values.tunnel.image .Values.tunnel.tag }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          args:
+            - tunnel
+            - --no-autoupdate
+            - run
+            - --token
+            - $(TUNNEL_TOKEN)
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openab-line.secretName" . }}
+                  key: cloudflare-tunnel-token
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+        {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "openab-line.fullname" . }}
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "openab-line.fullname" .) }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}

--- a/charts/openab-line/templates/deployment.yaml
+++ b/charts/openab-line/templates/deployment.yaml
@@ -75,6 +75,18 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
           env:
             - name: HOME
               value: {{ .Values.agent.workingDir | default "/home/agent" }}
@@ -88,6 +100,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "openab-line.secretName" . }}
                   key: line-channel-access-token
+          {{- with .Values.gateway.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: {{ .Values.agent.workingDir | default "/home/agent" }}
@@ -111,14 +127,16 @@ spec:
             - tunnel
             - --no-autoupdate
             - run
-            - --token
-            - $(TUNNEL_TOKEN)
           env:
             - name: TUNNEL_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "openab-line.secretName" . }}
                   key: cloudflare-tunnel-token
+          {{- with .Values.tunnel.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/charts/openab-line/templates/deployment.yaml
+++ b/charts/openab-line/templates/deployment.yaml
@@ -77,13 +77,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /health
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /health
               port: http
             initialDelaySeconds: 3
             periodSeconds: 5

--- a/charts/openab-line/templates/pvc.yaml
+++ b/charts/openab-line/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "openab-line.fullname" . }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    {{- include "openab-line.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.persistence.storageClass }}
+  {{- if eq "-" .Values.persistence.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | default "1Gi" }}
+{{- end }}

--- a/charts/openab-line/templates/secret.yaml
+++ b/charts/openab-line/templates/secret.yaml
@@ -1,0 +1,24 @@
+{{- if not .Values.existingSecret }}
+{{- if not .Values.line.channelSecret }}
+{{- fail "line.channelSecret is required when existingSecret is not set (--set line.channelSecret=YOUR_CHANNEL_SECRET)" }}
+{{- end }}
+{{- if not .Values.line.channelAccessToken }}
+{{- fail "line.channelAccessToken is required when existingSecret is not set (--set line.channelAccessToken=YOUR_CHANNEL_ACCESS_TOKEN)" }}
+{{- end }}
+{{- if and .Values.tunnel.enabled (not .Values.tunnel.token) }}
+{{- fail "tunnel.token is required when tunnel.enabled=true (--set tunnel.token=YOUR_TUNNEL_TOKEN)" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openab-line.fullname" . }}
+  labels:
+    {{- include "openab-line.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  line-channel-secret: {{ .Values.line.channelSecret | quote }}
+  line-channel-access-token: {{ .Values.line.channelAccessToken | quote }}
+  {{- if .Values.tunnel.token }}
+  cloudflare-tunnel-token: {{ .Values.tunnel.token | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/openab-line/templates/service.yaml
+++ b/charts/openab-line/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openab-line.fullname" . }}
+  labels:
+    {{- include "openab-line.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "openab-line.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/openab-line/values.yaml
+++ b/charts/openab-line/values.yaml
@@ -21,7 +21,8 @@
 #
 # Optional:
 #   existingSecret            -- pre-existing K8s Secret with line-channel-secret,
-#                                line-channel-access-token, and optionally cloudflare-tunnel-token
+#                                line-channel-access-token (and cloudflare-tunnel-token
+#                                when tunnel.enabled=true)
 #   tunnel.enabled            -- run cloudflared sidecar
 #   tunnel.token              -- Cloudflare Tunnel token (required when tunnel.enabled=true)
 #   webhookDomain             -- shown in post-install notes for webhook setup
@@ -35,7 +36,7 @@ line:
 
 # -- Use a pre-existing K8s Secret instead of creating one from values.
 # Required keys: line-channel-secret, line-channel-access-token
-# Optional key: cloudflare-tunnel-token
+# Required when tunnel.enabled=true: cloudflare-tunnel-token
 existingSecret: ""
 
 # -- Optional Cloudflare Tunnel sidecar for webhook exposure
@@ -57,10 +58,12 @@ image:
   tag: ""  # defaults to channel
   pullPolicy: IfNotPresent
 
-# -- Gateway image
+# -- Gateway image (override repository for air-gapped / private-registry installs)
 gateway:
   image: ghcr.io/openabdev/openab-gateway
-  tag: ""  # defaults to Chart.AppVersion
+  # -- Gateway image tag. Pinned to the version tested with this chart release.
+  # Changing this may break compatibility — only override if you know what you are doing.
+  tag: "v0.5.1"
 
 # -- Agent configuration
 agent:
@@ -79,9 +82,18 @@ agent:
     enabled: false
     removeAfterReply: false
 
-# -- Gateway access control. Empty lists mean allow all.
+# -- Gateway access control.
 platform:
+  # allowAllUsers: override whether all users are allowed.
+  # null (default) → openab decides: allow all if allowedUsers is empty, restrict if non-empty.
+  # true  → allow all users regardless of allowedUsers list.
+  # false → restrict to allowedUsers list (useful to lock down even with an empty list).
+  allowAllUsers: null
+  # allowAllChannels: same override logic as allowAllUsers, applied to channels/groups.
+  allowAllChannels: null
+  # LINE user IDs allowed (format: Uxxxxxxxxxxxxx). Empty = allow all (when allowAllUsers is null).
   allowedUsers: []
+  # LINE channel/group/room IDs allowed. Empty = allow all (when allowAllChannels is null).
   allowedChannels: []
 
 # -- Persistence for shared agent working directory / inbound attachments

--- a/charts/openab-line/values.yaml
+++ b/charts/openab-line/values.yaml
@@ -1,0 +1,119 @@
+# openab-line values
+#
+# Install (with Cloudflare Tunnel):
+#   helm install my-bot ./charts/openab-line \
+#     --set line.channelSecret="xxx" \
+#     --set line.channelAccessToken="xxx" \
+#     --set tunnel.enabled=true \
+#     --set tunnel.token="eyJ..." \
+#     --set webhookDomain=bot.example.com \
+#     --namespace openab --create-namespace
+#
+# Install (bring your own Ingress / LoadBalancer):
+#   helm install my-bot ./charts/openab-line \
+#     --set line.channelSecret="xxx" \
+#     --set line.channelAccessToken="xxx" \
+#     --namespace openab --create-namespace
+#
+# Required:
+#   line.channelSecret        -- LINE channel secret
+#   line.channelAccessToken   -- LINE channel access token
+#
+# Optional:
+#   existingSecret            -- pre-existing K8s Secret with line-channel-secret,
+#                                line-channel-access-token, and optionally cloudflare-tunnel-token
+#   tunnel.enabled            -- run cloudflared sidecar
+#   tunnel.token              -- Cloudflare Tunnel token (required when tunnel.enabled=true)
+#   webhookDomain             -- shown in post-install notes for webhook setup
+
+# -- LINE Messaging API credentials
+line:
+  # -- (required unless existingSecret is set) Channel secret from LINE Developers Console
+  channelSecret: ""
+  # -- (required unless existingSecret is set) Channel access token
+  channelAccessToken: ""
+
+# -- Use a pre-existing K8s Secret instead of creating one from values.
+# Required keys: line-channel-secret, line-channel-access-token
+# Optional key: cloudflare-tunnel-token
+existingSecret: ""
+
+# -- Optional Cloudflare Tunnel sidecar for webhook exposure
+tunnel:
+  enabled: false
+  token: ""
+  image: cloudflare/cloudflared
+  tag: "2026.5.0"
+
+# -- Webhook domain shown in NOTES.txt (for tunnel or your own ingress)
+webhookDomain: ""
+
+# -- Release channel for the agent image: "stable" or "beta"
+channel: stable
+
+# -- OAB agent image
+image:
+  repository: ghcr.io/openabdev/openab
+  tag: ""  # defaults to channel
+  pullPolicy: IfNotPresent
+
+# -- Gateway image
+gateway:
+  image: ghcr.io/openabdev/openab-gateway
+  tag: ""  # defaults to Chart.AppVersion
+
+# -- Agent configuration
+agent:
+  command: kiro-cli
+  args:
+    - acp
+    - --trust-all-tools
+  workingDir: /home/agent
+  env: {}
+  envFrom: []
+  secretEnv: []
+  pool:
+    maxSessions: 10
+    sessionTtlHours: 24
+  reactions:
+    enabled: false
+    removeAfterReply: false
+
+# -- Gateway access control. Empty lists mean allow all.
+platform:
+  allowedUsers: []
+  allowedChannels: []
+
+# -- Persistence for shared agent working directory / inbound attachments
+persistence:
+  enabled: true
+  existingClaim: ""
+  storageClass: ""
+  size: 1Gi
+
+# -- Service for webhook exposure when using your own Ingress / LB
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+# -- Pod-level settings
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL

--- a/charts/openab-line/values.yaml
+++ b/charts/openab-line/values.yaml
@@ -63,7 +63,7 @@ gateway:
   image: ghcr.io/openabdev/openab-gateway
   # -- Gateway image tag. Pinned to the version tested with this chart release.
   # Changing this may break compatibility — only override if you know what you are doing.
-  tag: "v0.5.1"
+  tag: "v0.5.3"
 
 # -- Agent configuration
 agent:

--- a/charts/openab-line/values.yaml
+++ b/charts/openab-line/values.yaml
@@ -45,6 +45,8 @@ tunnel:
   token: ""
   image: cloudflare/cloudflared
   tag: "2026.5.0"
+  # -- Cloudflared container resource requests/limits
+  resources: {}
 
 # -- Webhook domain shown in NOTES.txt (for tunnel or your own ingress)
 webhookDomain: ""
@@ -64,6 +66,8 @@ gateway:
   # -- Gateway image tag. Pinned to the version tested with this chart release.
   # Changing this may break compatibility — only override if you know what you are doing.
   tag: "v0.5.3"
+  # -- Gateway container resource requests/limits
+  resources: {}
 
 # -- Agent configuration
 agent:


### PR DESCRIPTION
## What problem does this solve?

There is no official Helm chart for deploying OpenAB as a LINE Messaging API bot. Users who want to self-host a LINE bot have to manually compose Kubernetes manifests, wire up a gateway sidecar, and configure Cloudflare Tunnel — a significant barrier to adoption.

This PR adds `charts/openab-line`, a batteries-included Helm chart that deploys the OpenAB agent + gateway as a single unit with one `helm install`.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1511661981508305027/1512121004720394261

## At a Glance

```
LINE Messaging API
       │  HTTPS webhook
       ▼
┌─────────────────────────────────────────────────┐
│  Kubernetes Pod (openab-line)                   │
│                                                 │
│  ┌──────────────┐    WebSocket    ┌───────────┐ │
│  │  openab      │◄───────────────►│  gateway  │ │
│  │  (agent)     │  shared /home/agent   │ (sidecar) │ │
│  └──────────────┘  /.openab/media └───────────┘ │
│                                        ▲         │
│  ┌────────────┐                        │         │
│  │ cloudflared│────────────────────────┘         │
│  │ (sidecar)  │  forwards :443 → gateway:8080    │
│  └────────────┘                                  │
└─────────────────────────────────────────────────┘
```

**Why sidecar (not separate Deployment)?**
Gateway stores media files at `$HOME/.openab/media/inbound/` and passes the file *path* over the internal WebSocket. The agent reads the file and base64-encodes it before sending to the LLM. This requires gateway and agent to share the same filesystem — i.e. the same Pod. A separate-Deployment approach would break image delivery.

## Prior Art & Industry Research

**OpenClaw:**
OpenClaw uses a similar gateway-sidecar pattern for platform adapters. Platform-specific adapters run in the same process/container as the core agent, sharing memory for media payloads. See: https://github.com/openclaw/openclaw

**Hermes Agent:**
Hermes Agent handles multi-platform messaging but delivers all media as base64 inline in the message event — no local file storage. This avoids the filesystem-sharing constraint but increases WebSocket payload size significantly for images. See: https://github.com/NousResearch/hermes-agent

**Key design difference from both:**
OpenAB's gateway deliberately uses local file storage + path passing to keep the WebSocket protocol lean. This makes the sidecar colocation requirement explicit (as documented in `gateway/src/store.rs`).

## Proposed Solution

A new Helm chart `charts/openab-line` that:

- Deploys a single Pod with three containers: `openab` (agent), `gateway` (LINE adapter), `cloudflared` (Tunnel, optional)
- `data` volume (PVC or `emptyDir`) is always mounted to both `openab` and `gateway` containers, ensuring a writable `$HOME` even with `readOnlyRootFilesystem: true`
- `agent.env` iterates with `keys | sortAlpha` for deterministic ConfigMap output (GitOps-safe)
- `kindIs "invalid"` for null-checks on `platform.allowAllUsers` / `platform.allowAllChannels` (avoids nil-pointer panic from `eq ... nil`)
- `gateway.tag` exposed in `values.yaml` with a warning comment — gateway versions independently from the agent
- Cloudflare Tunnel token accepts either inline value or `existingSecret`

## Why this approach?

**Sidecar vs separate Deployment:** The shared-filesystem requirement for media delivery makes sidecar the only viable option without introducing a ReadWriteMany PVC (which adds significant operational complexity). Verified experimentally — switching to separate Deployment causes `gateway → line (reply API)` to succeed but the agent replies "no content received" because `tokio::fs::read(path)` fails on a path that only exists on the gateway pod.

**Cloudflare Tunnel as the exposure default:** LINE requires a public HTTPS webhook with a valid TLS certificate. Cloudflare Tunnel satisfies this without requiring an Ingress controller or public LoadBalancer IP, matching the pattern used in `charts/openab-telegram`.

**Known limitations:**
- `add_reaction` / `remove_reaction` commands are not supported by LINE Messaging API and are silently ignored by the gateway (logged at INFO).
- Single-bot-per-chart design — one LINE channel per Helm release.

## Alternatives Considered

1. **Extend `charts/openab` (base chart)** — the base chart supports `gateway.deploy: true` with a separate Deployment. This works for text but breaks image delivery due to filesystem isolation. Rejected.

2. **Inline base64 in gateway WebSocket message** — would remove the filesystem dependency. Rejected because it significantly increases WebSocket payload size for images and would require changes to the core gateway protocol, which is out of scope for a chart PR.

3. **ReadWriteMany PVC shared between gateway and agent Deployments** — technically feasible but requires NFS/CephFS/EFS storage class, which is not available in most default Kubernetes clusters. Rejected.

## Validation

- [x] `helm lint charts/openab-line` passes (0 chart(s) failed)
- [x] `helm template` renders correctly (verified deterministic output with `sortAlpha`)
- [x] Manual E2E — deployed to live Kubernetes cluster:
  - Text message: LINE → gateway → agent → reply ✅
  - Image message: LINE → gateway (download + store at `/home/node/.openab/media/inbound/`) → agent (read + base64 → LLM) → reply describing image content ✅
  - Cloudflare Tunnel: webhook reachable from LINE platform ✅
  - `readOnlyRootFilesystem: true`: containers start without crash ✅