### PR TITLE
feat(gateway): Telegram Bot API 10.1 Rich Messages support

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -46,6 +46,8 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 # allow_all_users = true                # true = any user; false = only allowed_users
 #                                       # omitted = auto-detect from list (non-empty → false, empty → true)
 # allowed_users = ["U5678"]             # only checked when allow_all_users = false
+# streaming = true                      # enable streaming (typewriter) mode
+# streaming_placeholder = false         # set false for draft-based platforms (e.g. Telegram Rich Messages)
 
 [agent]
 command = "kiro-cli"

--- a/docs/adr/telegram-rich-messages.md
+++ b/docs/adr/telegram-rich-messages.md
@@ -1,0 +1,107 @@
+# ADR: Telegram Rich Messages Support
+
+**Status:** Proposed  
+**Date:** 2026-06-14  
+**Author:** 超渡法師  
+**Bot API Version:** 10.1 (June 11, 2026)
+
+## Context
+
+Telegram Bot API 10.1 introduced **Rich Messages** — a structured formatting system that allows bots to send highly formatted content (headings, tables, code blocks, collages, math formulas, etc.) and **stream AI-generated replies** with seamless rich formatting.
+
+Currently, the OAB Telegram adapter in `gateway/src/adapters/telegram.rs` uses `sendMessage` with `parse_mode: MarkdownV2` for all replies. This limits formatting to basic inline styles and has known escaping pain points.
+
+## Decision
+
+Add Rich Message support to the Telegram gateway adapter with three capabilities:
+
+### 1. `sendRichMessage` for structured replies
+
+When the agent output contains complex formatting (tables, code blocks, headings, long-form content), use `sendRichMessage` with `InputRichMessage.markdown` instead of `sendMessage`.
+
+### 2. `sendRichMessageDraft` for AI streaming
+
+Implement streaming UX via the draft → final pattern:
+
+```
+sendRichMessageDraft(draft_id=N, rich_message={markdown: partial})  // updates animate
+   ... repeat as content grows ...
+sendRichMessage(rich_message={markdown: final})                     // persist
+```
+
+### 3. `editMessageText` with `rich_message` param
+
+For editing existing rich messages (e.g., updating a streaming reply).
+
+## Architecture
+
+```
+Agent output (markdown)
+       │
+       ▼
+┌─────────────────────────────┐
+│  TG Adapter (gateway)       │
+│                             │
+│  classify_reply(content) →  │
+│    Simple  → sendMessage    │
+│    Complex → sendRichMessage│
+│    Stream  → Draft → Final  │
+└─────────────────────────────┘
+```
+
+### Classification heuristic
+
+A reply is "complex" if it contains any of:
+- Markdown table (`|---|`)
+- Fenced code block (triple backtick)
+- ATX headings (`# `, `## `)
+- Content > 4096 chars (sendMessage limit)
+
+Otherwise, fall back to `sendMessage` with `MarkdownV2` for maximum client compatibility.
+
+### Rich Message Limits (from API docs)
+
+| Limit | Value |
+|-------|-------|
+| Text length | 32,768 UTF-8 chars |
+| Blocks | 500 |
+| Nesting | 16 levels |
+| Media | 50 attachments |
+| Table columns | 20 |
+
+## Implementation Plan
+
+### Phase 1: `sendRichMessage` (basic)
+
+- Add `send_rich_message()` function to `telegram.rs`
+- Add classification logic in `handle_reply()`
+- Pass markdown directly to `InputRichMessage.markdown` (no conversion needed — Rich Markdown is GitHub Flavored Markdown compatible)
+
+### Phase 2: Streaming via `sendRichMessageDraft`
+
+- Add `send_rich_message_draft()` function
+- Integrate with existing gateway streaming infrastructure
+- Use `RichBlockThinking` for "thinking" animation during agent processing
+
+### Phase 3: Fallback & compatibility
+
+- Detect API errors (old clients / bot API version mismatch) and fall back to `sendMessage`
+- Feature-gate behind config: `[telegram] rich_messages = true`
+
+## Consequences
+
+**Positive:**
+- Much better formatting for PR reviews, code analysis, structured reports
+- Native streaming UX for AI responses (no more "typing..." placeholder)
+- No conversion layer needed — agent markdown passes through directly
+
+**Negative:**
+- Requires Bot API 10.1+ (June 2026) — older Telegram clients may not render correctly
+- Two code paths to maintain (sendMessage vs sendRichMessage)
+
+## References
+
+- [Bot API 10.1 Changelog](https://core.telegram.org/bots/api#june-11-2026)
+- [Rich Message Formatting Options](https://core.telegram.org/bots/api#rich-message-formatting-options)
+- [sendRichMessage](https://core.telegram.org/bots/api#sendrichmessage)
+- [sendRichMessageDraft](https://core.telegram.org/bots/api#sendrichmessagedraft)

--- a/docs/adr/telegram-rich-messages.md
+++ b/docs/adr/telegram-rich-messages.md
@@ -1,6 +1,6 @@
 # ADR: Telegram Rich Messages Support
 
-**Status:** Proposed  
+**Status:** Accepted  
 **Date:** 2026-06-14  
 **Author:** 超渡法師  
 **Bot API Version:** 10.1 (June 11, 2026)
@@ -9,7 +9,7 @@
 
 Telegram Bot API 10.1 introduced **Rich Messages** — a structured formatting system that allows bots to send highly formatted content (headings, tables, code blocks, collages, math formulas, etc.) and **stream AI-generated replies** with seamless rich formatting.
 
-Currently, the OAB Telegram adapter in `gateway/src/adapters/telegram.rs` uses `sendMessage` with `parse_mode: MarkdownV2` for all replies. This limits formatting to basic inline styles and has known escaping pain points.
+Currently, the OAB Telegram adapter in `gateway/src/adapters/telegram.rs` uses `sendMessage` with `parse_mode: Markdown` for all replies. This limits formatting to basic inline styles and lacks support for tables and headings.
 
 ## Decision
 

--- a/docs/adr/telegram-rich-messages.md
+++ b/docs/adr/telegram-rich-messages.md
@@ -17,7 +17,7 @@ Add Rich Message support to the Telegram gateway adapter with three capabilities
 
 ### 1. `sendRichMessage` for structured replies
 
-When the agent output contains complex formatting (tables, code blocks, headings, long-form content), use `sendRichMessage` with `InputRichMessage.markdown` instead of `sendMessage`.
+When the agent output contains complex formatting (tables, headings, long-form content), use `sendRichMessage` with `InputRichMessage.markdown` instead of `sendMessage`.
 
 ### 2. `sendRichMessageDraft` for AI streaming
 
@@ -53,11 +53,12 @@ Agent output (markdown)
 
 A reply is "complex" if it contains any of:
 - Markdown table (`|---|`)
-- Fenced code block (triple backtick)
 - ATX headings (`# `, `## `)
 - Content > 4096 chars (sendMessage limit)
 
-Otherwise, fall back to `sendMessage` with `MarkdownV2` for maximum client compatibility.
+Code blocks (triple backtick) are intentionally **not** classified as complex — `sendMessage` preserves syntax highlighting with language headers and copy buttons, which `RichBlockPreformatted` currently lacks.
+
+Otherwise, fall back to `sendMessage` with `Markdown` parse mode for maximum client compatibility.
 
 ### Rich Message Limits (from API docs)
 
@@ -86,7 +87,7 @@ Otherwise, fall back to `sendMessage` with `MarkdownV2` for maximum client compa
 ### Phase 3: Fallback & compatibility
 
 - Detect API errors (old clients / bot API version mismatch) and fall back to `sendMessage`
-- Feature-gate behind config: `[telegram] rich_messages = true`
+- Feature-gate behind env var: `TELEGRAM_RICH_MESSAGES=true` (default on, set `=false` to opt out)
 
 ## Consequences
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -83,6 +83,8 @@ Custom Gateway adapter for platforms like Telegram, LINE, Feishu/Lark, and Googl
 | `allowed_channels` | string[] | `[]` | Chat/group IDs to allow. Only checked when `allow_all_channels` resolves to false. |
 | `allow_all_users` | bool \| omit | auto-detect | `true` = any user; `false` = only `allowed_users`. Omitted = inferred from list. |
 | `allowed_users` | string[] | `[]` | User IDs to allow. Only checked when `allow_all_users` resolves to false. |
+| `streaming` | bool | `false` | Enable streaming (typewriter) mode — requires the gateway platform to support message editing. |
+| `streaming_placeholder` | bool | `true` | Show "…" placeholder at streaming start. Set `false` for platforms using drafts (e.g. Telegram Rich Messages). |
 | `message_processing_mode` | string | `"per-message"` | Same as Discord. See [Message Dispatch Modes](message-dispatch-modes.md). |
 | `max_buffered_messages` | u32 | `10` | Same as Discord. |
 | `max_batch_tokens` | u32 | `24000` | Same as Discord. |

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -199,7 +199,11 @@ In supergroups with topics enabled, each new conversation auto-creates a forum t
 
 ### Markdown rendering
 
-Agent replies are rendered with Telegram Markdown: **bold**, `code`, and code blocks work. Headers (`##`) and tables render as plain text (Telegram limitation).
+Agent replies are rendered with Telegram Markdown: **bold**, `code`, and code blocks work natively.
+
+With **Rich Messages** enabled (default, requires Bot API 10.1+), headings (`##`) and tables render with full formatting via `sendRichMessage`. Code blocks remain on the legacy path for syntax highlighting and copy-button support. Content exceeding 4096 characters is automatically handled via rich messages (up to 32768 chars).
+
+Set `TELEGRAM_RICH_MESSAGES=false` to disable rich messages and use legacy `sendMessage` for all replies.
 
 ## Environment Variables (Gateway)
 
@@ -207,6 +211,7 @@ Agent replies are rendered with Telegram Markdown: **bold**, `code`, and code bl
 |---|---|---|---|
 | `TELEGRAM_BOT_TOKEN` | Yes | — | Bot API token from @BotFather |
 | `TELEGRAM_SECRET_TOKEN` | No | — | Webhook signature validation |
+| `TELEGRAM_RICH_MESSAGES` | No | `true` | Use `sendRichMessage` for tables/headings/long content (Bot API 10.1+). Set `false` to opt out. |
 | `GATEWAY_WS_TOKEN` | No | — | WebSocket auth token |
 | `GATEWAY_LISTEN` | No | `0.0.0.0:8080` | Listen address |
 | `TELEGRAM_WEBHOOK_PATH` | No | `/webhook/telegram` | Webhook endpoint path |

--- a/gateway/src/adapters/line.rs
+++ b/gateway/src/adapters/line.rs
@@ -643,6 +643,7 @@ mod tests {
         let state = Arc::new(crate::AppState {
             telegram_bot_token: None,
             telegram_secret_token: None,
+            telegram_rich_messages: false,
             line_channel_secret: None,
             line_access_token: None,
             teams: None,

--- a/gateway/src/adapters/teams.rs
+++ b/gateway/src/adapters/teams.rs
@@ -654,6 +654,7 @@ mod tests {
         Arc::new(crate::AppState {
             telegram_bot_token: None,
             telegram_secret_token: None,
+            telegram_rich_messages: false,
             line_channel_secret: None,
             line_access_token: None,
             teams: Some(TeamsAdapter::new(make_config(vec![]))),

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -394,12 +394,15 @@ pub async fn handle_reply(
 
     // Handle edit_message → stream via sendRichMessageDraft
     if reply.command.as_deref() == Some("edit_message") && rich_messages {
+        // Skip short updates — let thinking animation show until meaningful content arrives
+        if reply.content.text.len() < 30 {
+            return;
+        }
         let text = if reply.content.text.len() > 32768 {
             &reply.content.text[..reply.content.text.floor_char_boundary(32768)]
         } else {
             &reply.content.text
         };
-        // Use chat_id hash as stable draft_id for animated transitions
         let draft_id: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs() % 1_000_000 + 1;
         let _ = send_rich_message_draft(client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id, text).await;
         return;

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -474,16 +474,6 @@ pub async fn handle_reply(
     }
 
     // Normal send_message
-    // Suppress streaming placeholder "…" — the thinking draft handles this
-    if rich_messages && (reply.content.text.trim() == "…" || reply.content.text.trim() == "...") {
-        let draft_id: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs() % 1_000_000 + 1;
-        let _ = send_rich_message_draft(
-            client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id,
-            "<tg-thinking>Thinking...</tg-thinking>",
-        ).await;
-        return;
-    }
-
     info!(
         chat_id = %reply.channel.id,
         thread_id = ?reply.channel.thread_id,

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -737,9 +737,9 @@ mod tests {
         assert!(is_complex_markdown("| Col1 | Col2 |\n|---|---|\n| a | b |"));
         assert!(is_complex_markdown("| Col1 | Col2 |\n| :--- | ---: |\n| a | b |"));
         assert!(is_complex_markdown("| A | B |\n| :---: | :---: |\n| x | y |"));
-        // Code blocks
-        assert!(is_complex_markdown("```rust\nfn main() {}\n```"));
-        assert!(is_complex_markdown("~~~\ncode\n~~~"));
+        // Code blocks — intentionally NOT complex (preserves syntax highlighting on legacy path)
+        assert!(!is_complex_markdown("```rust\nfn main() {}\n```"));
+        assert!(!is_complex_markdown("~~~\ncode\n~~~"));
         // Headings
         assert!(is_complex_markdown("# Heading\n\nSome text"));
         assert!(is_complex_markdown("## Heading 2 at start"));

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -213,6 +213,38 @@ pub async fn webhook(
     axum::http::StatusCode::OK
 }
 
+/// Split text into chunks of at most `limit` characters, breaking at newlines when possible.
+fn chunk_text(text: &str, limit: usize) -> Vec<String> {
+    if text.chars().count() <= limit {
+        return vec![text.to_string()];
+    }
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+    for line in text.lines() {
+        if !current.is_empty() && current.chars().count() + line.chars().count() + 1 > limit {
+            chunks.push(std::mem::take(&mut current));
+        }
+        if !current.is_empty() {
+            current.push('\n');
+        }
+        if line.chars().count() > limit {
+            // Line itself exceeds limit — hard split
+            for ch in line.chars() {
+                current.push(ch);
+                if current.chars().count() >= limit {
+                    chunks.push(std::mem::take(&mut current));
+                }
+            }
+        } else {
+            current.push_str(line);
+        }
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
 fn is_markdown_parse_error(description: &str) -> bool {
     let desc_lower = description.to_lowercase();
     desc_lower.contains("can't find end")
@@ -229,20 +261,16 @@ fn is_markdown_parse_error(description: &str) -> bool {
 ///   unnecessary API switches for plain prose to reduce risk surface.
 /// - LaTeX and blockquotes are intentionally omitted for now (Phase 2).
 fn is_complex_markdown(text: &str) -> bool {
-    // Fenced code blocks (backtick or tilde) — sendMessage can't syntax-highlight.
-    // We check both ``` and ~~~ since LLM outputs vary.
-    if text.contains("```") || text.contains("~~~") {
-        return true;
-    }
+    // 🟡 Code blocks intentionally NOT routed to rich — sendMessage preserves
+    // syntax highlighting (language header + copy button) which RichBlockPreformatted lacks.
+
     // sendMessage hard limit is 4096 chars. Rich messages support 32768.
-    // Rather than chunking (which breaks tables/code mid-block), prefer rich.
-    if text.len() > 4096 {
+    if text.chars().count() > 4096 {
         return true;
     }
     text.lines().any(|line| {
         let trimmed = line.trim_start();
         // ATX headings (h1-h6): sendMessage has zero heading support.
-        // We require "# " (with space) to avoid matching "#hashtag".
         if trimmed.starts_with("# ")
             || trimmed.starts_with("## ")
             || trimmed.starts_with("### ")
@@ -253,9 +281,6 @@ fn is_complex_markdown(text: &str) -> bool {
             return true;
         }
         // GFM table separator row detection.
-        // Must start and end with |, and every cell between pipes must be
-        // only dashes (optionally wrapped in colons for alignment).
-        // This avoids false positives on lines like "| just | pipes |".
         if trimmed.starts_with('|') && trimmed.ends_with('|') {
             let inner = &trimmed[1..trimmed.len() - 1];
             if inner.split('|').all(|cell| {
@@ -483,71 +508,74 @@ pub async fn handle_reply(
     // --- Rich Message routing ---
     // Design: try sendRichMessage first for complex content. On ANY failure
     // (unsupported client, API version mismatch, network error), fall back to
-    // legacy sendMessage. This ensures zero-downtime rollout — the worst case
-    // is one extra round-trip, not a failed delivery.
+    // legacy sendMessage (chunked). This ensures zero-downtime rollout.
     if rich_messages && is_complex_markdown(&reply.content.text) {
-        // Bot API limit: 32768 UTF-8 chars for rich messages.
-        // Truncate here to avoid sending oversized payloads that will always fail.
-        let rich_text = if reply.content.text.len() > 32768 {
-            &reply.content.text[..reply.content.text.floor_char_boundary(32768)]
+        // Bot API limit: 32768 UTF-8 characters (not bytes).
+        let text = &reply.content.text;
+        let rich_text: String = if text.chars().count() > 32768 {
+            text.chars().take(32768).collect()
         } else {
-            &reply.content.text
+            text.to_string()
         };
-        match send_rich_message(client, bot_token, &reply.channel.id, &reply.channel.thread_id, rich_text).await {
+        match send_rich_message(client, bot_token, &reply.channel.id, &reply.channel.thread_id, &rich_text).await {
             Ok(_) => return,
             Err(e) => warn!("sendRichMessage failed ({e}), falling back to sendMessage"),
         }
     }
 
-    let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage");
-    let resp = client
-        .post(&url)
-        .json(&serde_json::json!({
-            "chat_id": reply.channel.id,
-            "text": &reply.content.text,
-            "message_thread_id": reply.channel.thread_id,
-            "parse_mode": "Markdown",
-        }))
-        .send()
-        .await;
+    // Legacy sendMessage — chunk at 4096 chars to avoid rejection.
+    let chunks = chunk_text(&reply.content.text, 4096);
+    for chunk in &chunks {
+        let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage");
+        let resp = client
+            .post(&url)
+            .json(&serde_json::json!({
+                "chat_id": reply.channel.id,
+                "text": chunk,
+                "message_thread_id": reply.channel.thread_id,
+                "parse_mode": "Markdown",
+            }))
+            .send()
+            .await;
 
-    match resp {
-        Ok(r) => {
-            let body: serde_json::Value = r.json().await.unwrap_or_default();
-            if body["ok"].as_bool() != Some(true) {
-                let desc = body["description"].as_str().unwrap_or("unknown error");
-                if is_markdown_parse_error(desc) {
-                    warn!("Markdown send failed: {desc}, retrying as plain text");
-                    match client
-                        .post(&url)
-                        .json(&serde_json::json!({
-                            "chat_id": reply.channel.id,
-                            "text": &reply.content.text,
-                            "message_thread_id": reply.channel.thread_id,
-                        }))
-                        .send()
-                        .await
-                    {
-                        Ok(retry_r) => {
-                            let retry_body: serde_json::Value =
-                                retry_r.json().await.unwrap_or_default();
-                            if retry_body["ok"].as_bool() != Some(true) {
-                                error!(
-                                    "telegram plain-text retry failed: {}",
-                                    retry_body["description"]
-                                        .as_str()
-                                        .unwrap_or("unknown error")
-                                );
+        match resp {
+            Ok(r) => {
+                let body: serde_json::Value = r.json().await.unwrap_or_default();
+                if body["ok"].as_bool() != Some(true) {
+                    let desc = body["description"].as_str().unwrap_or("unknown error");
+                    if is_markdown_parse_error(desc) {
+                        warn!("Markdown send failed: {desc}, retrying as plain text");
+                        match client
+                            .post(&url)
+                            .json(&serde_json::json!({
+                                "chat_id": reply.channel.id,
+                                "text": chunk,
+                                "message_thread_id": reply.channel.thread_id,
+                            }))
+                            .send()
+                            .await
+                        {
+                            Ok(retry_r) => {
+                                let retry_body: serde_json::Value =
+                                    retry_r.json().await.unwrap_or_default();
+                                if retry_body["ok"].as_bool() != Some(true) {
+                                    error!(
+                                        "telegram plain-text retry failed: {}",
+                                        retry_body["description"]
+                                            .as_str()
+                                            .unwrap_or("unknown error")
+                                    );
+                                }
                             }
+                            Err(e) => error!("telegram plain-text send error: {e}"),
                         }
-                        Err(e) => error!("telegram plain-text send error: {e}"),
+                    } else {
+                        error!("telegram send failed: {desc}");
                     }
-                } else {
-                    error!("telegram send failed: {desc}");
                 }
             }
+            Err(e) => error!("telegram send error: {e}"),
         }
-        Err(e) => error!("telegram send error: {e}"),
     }
 }
 

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -417,27 +417,41 @@ pub async fn handle_reply(
         return;
     }
 
-    // Handle edit_message → stream via sendRichMessageDraft
+    // Handle edit_message
     if reply.command.as_deref() == Some("edit_message") {
-        if !rich_messages {
-            // Without rich messages, "draft" placeholder has no real message_id to edit.
-            // Silently drop — the final reply will be sent as a new message via send_message.
+        if reply.reply_to == "draft" {
+            // Dummy "draft" ref from streaming without placeholder.
+            if rich_messages {
+                // Skip short updates — let thinking animation show until meaningful content arrives
+                if reply.content.text.len() < 30 {
+                    return;
+                }
+                let text = if reply.content.text.len() > 32768 {
+                    &reply.content.text[..reply.content.text.floor_char_boundary(32768)]
+                } else {
+                    &reply.content.text
+                };
+                // Combine channel + thread to avoid draft_id collision in forum topics
+                let chan: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs();
+                let tid: i64 = reply.channel.thread_id.as_deref().and_then(|t| t.parse::<i64>().ok()).unwrap_or(0).abs();
+                let draft_id: i64 = (chan.wrapping_add(tid)) % 1_000_000 + 1;
+                let _ = send_rich_message_draft(client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id, text).await;
+            }
+            // else: rich_messages=false with dummy ref — silently drop (no real msg to edit)
             return;
         }
-        // Skip short updates — let thinking animation show until meaningful content arrives
-        if reply.content.text.len() < 30 {
-            return;
-        }
-        let text = if reply.content.text.len() > 32768 {
-            &reply.content.text[..reply.content.text.floor_char_boundary(32768)]
-        } else {
-            &reply.content.text
-        };
-        // Combine channel + thread to avoid draft_id collision in forum topics
-        let chan: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs();
-        let tid: i64 = reply.channel.thread_id.as_deref().and_then(|t| t.parse::<i64>().ok()).unwrap_or(0).abs();
-        let draft_id: i64 = (chan.wrapping_add(tid)) % 1_000_000 + 1;
-        let _ = send_rich_message_draft(client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id, text).await;
+        // Real message_id — perform actual editMessageText (legacy streaming path)
+        let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/editMessageText");
+        let _ = client
+            .post(&url)
+            .json(&serde_json::json!({
+                "chat_id": reply.channel.id,
+                "message_id": reply.reply_to,
+                "text": &reply.content.text,
+                "parse_mode": "Markdown",
+            }))
+            .send()
+            .await;
         return;
     }
 

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -408,7 +408,13 @@ pub async fn handle_reply(
 
     // Try sendRichMessage for complex content when enabled
     if rich_messages && is_complex_markdown(&reply.content.text) {
-        match send_rich_message(client, bot_token, &reply.channel.id, &reply.channel.thread_id, &reply.content.text).await {
+        // Bot API limit: 32768 UTF-8 chars for rich messages
+        let rich_text = if reply.content.text.len() > 32768 {
+            &reply.content.text[..reply.content.text.floor_char_boundary(32768)]
+        } else {
+            &reply.content.text
+        };
+        match send_rich_message(client, bot_token, &reply.channel.id, &reply.channel.thread_id, rich_text).await {
             Ok(_) => return,
             Err(e) => warn!("sendRichMessage failed ({e}), falling back to sendMessage"),
         }

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -222,18 +222,32 @@ fn is_markdown_parse_error(description: &str) -> bool {
 
 /// Returns true if the content is complex enough to benefit from sendRichMessage.
 fn is_complex_markdown(text: &str) -> bool {
-    if text.contains("|---|") || text.contains("```") || text.len() > 4096 {
+    if text.contains("```") || text.len() > 4096 {
         return true;
     }
-    // Check for ATX headings (# through ######) at line start
     text.lines().any(|line| {
         let trimmed = line.trim_start();
-        trimmed.starts_with("# ")
+        // ATX headings
+        if trimmed.starts_with("# ")
             || trimmed.starts_with("## ")
             || trimmed.starts_with("### ")
             || trimmed.starts_with("#### ")
             || trimmed.starts_with("##### ")
             || trimmed.starts_with("###### ")
+        {
+            return true;
+        }
+        // Table separator row: |---|, |:---|, |---:|, | :---: |, etc.
+        if trimmed.starts_with('|') && trimmed.ends_with('|') {
+            let inner = &trimmed[1..trimmed.len() - 1];
+            if inner.split('|').all(|cell| {
+                let c = cell.trim().trim_matches(':');
+                !c.is_empty() && c.chars().all(|ch| ch == '-')
+            }) {
+                return true;
+            }
+        }
+        false
     })
 }
 
@@ -626,17 +640,25 @@ mod tests {
 
     #[test]
     fn test_is_complex_markdown() {
+        // Tables
         assert!(is_complex_markdown("| Col1 | Col2 |\n|---|---|\n| a | b |"));
+        assert!(is_complex_markdown("| Col1 | Col2 |\n| :--- | ---: |\n| a | b |"));
+        assert!(is_complex_markdown("| A | B |\n| :---: | :---: |\n| x | y |"));
+        // Code blocks
         assert!(is_complex_markdown("```rust\nfn main() {}\n```"));
+        // Headings
         assert!(is_complex_markdown("# Heading\n\nSome text"));
         assert!(is_complex_markdown("## Heading 2 at start"));
         assert!(is_complex_markdown("### Heading 3 at start"));
         assert!(is_complex_markdown("#### Heading 4"));
         assert!(is_complex_markdown("text\n##### Heading 5"));
         assert!(is_complex_markdown("  ## Indented heading"));
+        // Size
         assert!(is_complex_markdown(&"x".repeat(4097)));
+        // Negatives
         assert!(!is_complex_markdown("Hello world"));
         assert!(!is_complex_markdown("*bold* and _italic_"));
         assert!(!is_complex_markdown("#hashtag no space"));
+        assert!(!is_complex_markdown("| just | pipes |"));
     }
 }

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -222,13 +222,19 @@ fn is_markdown_parse_error(description: &str) -> bool {
 
 /// Returns true if the content is complex enough to benefit from sendRichMessage.
 fn is_complex_markdown(text: &str) -> bool {
-    text.contains("|---|")
-        || text.contains("```")
-        || text.starts_with("# ")
-        || text.contains("\n# ")
-        || text.contains("\n## ")
-        || text.contains("\n### ")
-        || text.len() > 4096
+    if text.contains("|---|") || text.contains("```") || text.len() > 4096 {
+        return true;
+    }
+    // Check for ATX headings (# through ######) at line start
+    text.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with("# ")
+            || trimmed.starts_with("## ")
+            || trimmed.starts_with("### ")
+            || trimmed.starts_with("#### ")
+            || trimmed.starts_with("##### ")
+            || trimmed.starts_with("###### ")
+    })
 }
 
 /// Send a rich message via Bot API 10.1 sendRichMessage.
@@ -617,8 +623,14 @@ mod tests {
         assert!(is_complex_markdown("| Col1 | Col2 |\n|---|---|\n| a | b |"));
         assert!(is_complex_markdown("```rust\nfn main() {}\n```"));
         assert!(is_complex_markdown("# Heading\n\nSome text"));
+        assert!(is_complex_markdown("## Heading 2 at start"));
+        assert!(is_complex_markdown("### Heading 3 at start"));
+        assert!(is_complex_markdown("#### Heading 4"));
+        assert!(is_complex_markdown("text\n##### Heading 5"));
+        assert!(is_complex_markdown("  ## Indented heading"));
         assert!(is_complex_markdown(&"x".repeat(4097)));
         assert!(!is_complex_markdown("Hello world"));
         assert!(!is_complex_markdown("*bold* and _italic_"));
+        assert!(!is_complex_markdown("#hashtag no space"));
     }
 }

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -392,6 +392,19 @@ pub async fn handle_reply(
         return;
     }
 
+    // Handle edit_message → stream via sendRichMessageDraft
+    if reply.command.as_deref() == Some("edit_message") && rich_messages {
+        let text = if reply.content.text.len() > 32768 {
+            &reply.content.text[..reply.content.text.floor_char_boundary(32768)]
+        } else {
+            &reply.content.text
+        };
+        // Use chat_id hash as stable draft_id for animated transitions
+        let draft_id: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs() % 1_000_000 + 1;
+        let _ = send_rich_message_draft(client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id, text).await;
+        return;
+    }
+
     // Handle add_reaction / remove_reaction
     if reply.command.as_deref() == Some("add_reaction")
         || reply.command.as_deref() == Some("remove_reaction")

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -474,6 +474,16 @@ pub async fn handle_reply(
     }
 
     // Normal send_message
+    // Suppress streaming placeholder "…" — the thinking draft handles this
+    if rich_messages && (reply.content.text.trim() == "…" || reply.content.text.trim() == "...") {
+        let draft_id: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs() % 1_000_000 + 1;
+        let _ = send_rich_message_draft(
+            client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id,
+            "<tg-thinking>Thinking...</tg-thinking>",
+        ).await;
+        return;
+    }
+
     info!(
         chat_id = %reply.channel.id,
         thread_id = ?reply.channel.thread_id,

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -220,6 +220,66 @@ fn is_markdown_parse_error(description: &str) -> bool {
         || desc_lower.contains("parse entities")
 }
 
+/// Returns true if the content is complex enough to benefit from sendRichMessage.
+fn is_complex_markdown(text: &str) -> bool {
+    text.contains("|---|")
+        || text.contains("```")
+        || text.starts_with("# ")
+        || text.contains("\n# ")
+        || text.contains("\n## ")
+        || text.contains("\n### ")
+        || text.len() > 4096
+}
+
+/// Send a rich message via Bot API 10.1 sendRichMessage.
+async fn send_rich_message(
+    client: &reqwest::Client,
+    bot_token: &str,
+    chat_id: &str,
+    thread_id: &Option<String>,
+    text: &str,
+) -> Result<serde_json::Value, String> {
+    let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/sendRichMessage");
+    let body = serde_json::json!({
+        "chat_id": chat_id,
+        "message_thread_id": thread_id,
+        "rich_message": { "markdown": text },
+    });
+    let resp = client.post(&url).json(&body).send().await.map_err(|e| e.to_string())?;
+    let json: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
+    if json["ok"].as_bool() == Some(true) {
+        Ok(json)
+    } else {
+        Err(json["description"].as_str().unwrap_or("unknown error").to_string())
+    }
+}
+
+/// Stream a partial rich message via sendRichMessageDraft.
+#[allow(dead_code)]
+async fn send_rich_message_draft(
+    client: &reqwest::Client,
+    bot_token: &str,
+    chat_id: &str,
+    thread_id: &Option<String>,
+    draft_id: i64,
+    text: &str,
+) -> Result<(), String> {
+    let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/sendRichMessageDraft");
+    let body = serde_json::json!({
+        "chat_id": chat_id,
+        "message_thread_id": thread_id,
+        "draft_id": draft_id,
+        "rich_message": { "markdown": text },
+    });
+    let resp = client.post(&url).json(&body).send().await.map_err(|e| e.to_string())?;
+    let json: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
+    if json["ok"].as_bool() == Some(true) {
+        Ok(())
+    } else {
+        Err(json["description"].as_str().unwrap_or("unknown error").to_string())
+    }
+}
+
 // --- Reply handler ---
 
 pub async fn handle_reply(
@@ -228,6 +288,7 @@ pub async fn handle_reply(
     client: &reqwest::Client,
     event_tx: &tokio::sync::broadcast::Sender<String>,
     reaction_state: &Arc<Mutex<HashMap<String, Vec<String>>>>,
+    rich_messages: bool,
 ) {
     // Handle create_topic command
     if reply.command.as_deref() == Some("create_topic") {
@@ -338,6 +399,15 @@ pub async fn handle_reply(
         thread_id = ?reply.channel.thread_id,
         "gateway → telegram"
     );
+
+    // Try sendRichMessage for complex content when enabled
+    if rich_messages && is_complex_markdown(&reply.content.text) {
+        match send_rich_message(client, bot_token, &reply.channel.id, &reply.channel.thread_id, &reply.content.text).await {
+            Ok(_) => return,
+            Err(e) => warn!("sendRichMessage failed ({e}), falling back to sendMessage"),
+        }
+    }
+
     let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage");
     let resp = client
         .post(&url)
@@ -540,5 +610,15 @@ mod tests {
         assert!(is_markdown_parse_error("can't parse entities in message text"));
         assert!(!is_markdown_parse_error("Unauthorized"));
         assert!(!is_markdown_parse_error("Bad Request: chat not found"));
+    }
+
+    #[test]
+    fn test_is_complex_markdown() {
+        assert!(is_complex_markdown("| Col1 | Col2 |\n|---|---|\n| a | b |"));
+        assert!(is_complex_markdown("```rust\nfn main() {}\n```"));
+        assert!(is_complex_markdown("# Heading\n\nSome text"));
+        assert!(is_complex_markdown(&"x".repeat(4097)));
+        assert!(!is_complex_markdown("Hello world"));
+        assert!(!is_complex_markdown("*bold* and _italic_"));
     }
 }

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -315,7 +315,7 @@ async fn send_rich_message_draft(
         "chat_id": chat_id,
         "message_thread_id": thread_id,
         "draft_id": draft_id,
-        "rich_message": { "markdown": text },
+        "rich_message": if text.contains("<tg-") { serde_json::json!({ "html": text }) } else { serde_json::json!({ "markdown": text }) },
     });
     let resp = client.post(&url).json(&body).send().await.map_err(|e| e.to_string())?;
     let json: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -221,13 +221,28 @@ fn is_markdown_parse_error(description: &str) -> bool {
 }
 
 /// Returns true if the content is complex enough to benefit from sendRichMessage.
+///
+/// Design decisions:
+/// - We classify at the adapter layer (not agent) so agents don't need prompt changes.
+/// - Conservative: only route to rich when legacy sendMessage would visibly break.
+/// - False positives are acceptable (rich renders simple text fine too), but we avoid
+///   unnecessary API switches for plain prose to reduce risk surface.
+/// - LaTeX and blockquotes are intentionally omitted for now (Phase 2).
 fn is_complex_markdown(text: &str) -> bool {
-    if text.contains("```") || text.contains("~~~") || text.len() > 4096 {
+    // Fenced code blocks (backtick or tilde) — sendMessage can't syntax-highlight.
+    // We check both ``` and ~~~ since LLM outputs vary.
+    if text.contains("```") || text.contains("~~~") {
+        return true;
+    }
+    // sendMessage hard limit is 4096 chars. Rich messages support 32768.
+    // Rather than chunking (which breaks tables/code mid-block), prefer rich.
+    if text.len() > 4096 {
         return true;
     }
     text.lines().any(|line| {
         let trimmed = line.trim_start();
-        // ATX headings
+        // ATX headings (h1-h6): sendMessage has zero heading support.
+        // We require "# " (with space) to avoid matching "#hashtag".
         if trimmed.starts_with("# ")
             || trimmed.starts_with("## ")
             || trimmed.starts_with("### ")
@@ -237,7 +252,10 @@ fn is_complex_markdown(text: &str) -> bool {
         {
             return true;
         }
-        // Table separator row: |---|, |:---|, |---:|, | :---: |, etc.
+        // GFM table separator row detection.
+        // Must start and end with |, and every cell between pipes must be
+        // only dashes (optionally wrapped in colons for alignment).
+        // This avoids false positives on lines like "| just | pipes |".
         if trimmed.starts_with('|') && trimmed.ends_with('|') {
             let inner = &trimmed[1..trimmed.len() - 1];
             if inner.split('|').all(|cell| {
@@ -252,6 +270,10 @@ fn is_complex_markdown(text: &str) -> bool {
 }
 
 /// Send a rich message via Bot API 10.1 sendRichMessage.
+///
+/// Design: we pass agent markdown directly via InputRichMessage.markdown.
+/// Rich Markdown is GFM-compatible, so no conversion layer is needed.
+/// The API handles rendering (tables, syntax highlighting, headings, etc.)
 async fn send_rich_message(
     client: &reqwest::Client,
     bot_token: &str,
@@ -275,6 +297,10 @@ async fn send_rich_message(
 }
 
 /// Stream a partial rich message via sendRichMessageDraft.
+///
+/// Design: ephemeral 30-second preview. Caller must follow up with
+/// sendRichMessage to persist. Same draft_id = animated transition.
+/// Wired but unused until gateway streaming infrastructure integrates.
 #[allow(dead_code)]
 async fn send_rich_message_draft(
     client: &reqwest::Client,
@@ -420,9 +446,14 @@ pub async fn handle_reply(
         "gateway → telegram"
     );
 
-    // Try sendRichMessage for complex content when enabled
+    // --- Rich Message routing ---
+    // Design: try sendRichMessage first for complex content. On ANY failure
+    // (unsupported client, API version mismatch, network error), fall back to
+    // legacy sendMessage. This ensures zero-downtime rollout — the worst case
+    // is one extra round-trip, not a failed delivery.
     if rich_messages && is_complex_markdown(&reply.content.text) {
-        // Bot API limit: 32768 UTF-8 chars for rich messages
+        // Bot API limit: 32768 UTF-8 chars for rich messages.
+        // Truncate here to avoid sending oversized payloads that will always fail.
         let rich_text = if reply.content.text.len() > 32768 {
             &reply.content.text[..reply.content.text.floor_char_boundary(32768)]
         } else {

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -409,21 +409,22 @@ pub async fn handle_reply(
     if reply.command.as_deref() == Some("add_reaction")
         || reply.command.as_deref() == Some("remove_reaction")
     {
-        // Send thinking draft on first reaction (👀 = processing started)
-        if rich_messages
-            && reply.command.as_deref() == Some("add_reaction")
-            && reply.content.text == "👀"
-        {
-            let draft_id: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs() % 1_000_000 + 1;
-            let _ = send_rich_message_draft(
-                client,
-                bot_token,
-                &reply.channel.id,
-                &reply.channel.thread_id,
-                draft_id,
-                "<tg-thinking>\u{200d}</tg-thinking>",
-            )
-            .await;
+        // Send thinking draft on reaction changes — reflects agent state
+        if rich_messages && reply.command.as_deref() == Some("add_reaction") {
+            let thinking_text = match reply.content.text.as_str() {
+                "👀" => Some("<tg-thinking><tg-emoji emoji-id=\"5535034915403333642\">\u{200d}</tg-emoji> Looking...</tg-thinking>"),
+                "🤔" => Some("<tg-thinking><tg-emoji emoji-id=\"5537353471893700616\">\u{200d}</tg-emoji> Thinking...</tg-thinking>"),
+                "👨\u{200d}💻" => Some("<tg-thinking><tg-emoji emoji-id=\"5537511986251694100\">\u{200d}</tg-emoji> Writing code...</tg-thinking>"),
+                "🔥" => Some("<tg-thinking><tg-emoji emoji-id=\"5537207975581581325\">\u{200d}</tg-emoji> Working...</tg-thinking>"),
+                "⚡" => Some("<tg-thinking><tg-emoji emoji-id=\"5537346136089559052\">\u{200d}</tg-emoji> Running tools...</tg-thinking>"),
+                _ => None,
+            };
+            if let Some(text) = thinking_text {
+                let draft_id: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs() % 1_000_000 + 1;
+                let _ = send_rich_message_draft(
+                    client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id, text,
+                ).await;
+            }
         }
 
         let msg_key = format!("{}:{}", reply.channel.id, reply.reply_to);

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -409,6 +409,23 @@ pub async fn handle_reply(
     if reply.command.as_deref() == Some("add_reaction")
         || reply.command.as_deref() == Some("remove_reaction")
     {
+        // Send thinking draft on first reaction (👀 = processing started)
+        if rich_messages
+            && reply.command.as_deref() == Some("add_reaction")
+            && reply.content.text == "👀"
+        {
+            let draft_id: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs() % 1_000_000 + 1;
+            let _ = send_rich_message_draft(
+                client,
+                bot_token,
+                &reply.channel.id,
+                &reply.channel.thread_id,
+                draft_id,
+                "<tg-thinking>\u{200d}</tg-thinking>",
+            )
+            .await;
+        }
+
         let msg_key = format!("{}:{}", reply.channel.id, reply.reply_to);
         let emoji = &reply.content.text;
         let tg_emoji = match emoji.as_str() {

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -418,7 +418,12 @@ pub async fn handle_reply(
     }
 
     // Handle edit_message → stream via sendRichMessageDraft
-    if reply.command.as_deref() == Some("edit_message") && rich_messages {
+    if reply.command.as_deref() == Some("edit_message") {
+        if !rich_messages {
+            // Without rich messages, "draft" placeholder has no real message_id to edit.
+            // Silently drop — the final reply will be sent as a new message via send_message.
+            return;
+        }
         // Skip short updates — let thinking animation show until meaningful content arrives
         if reply.content.text.len() < 30 {
             return;
@@ -428,7 +433,10 @@ pub async fn handle_reply(
         } else {
             &reply.content.text
         };
-        let draft_id: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs() % 1_000_000 + 1;
+        // Combine channel + thread to avoid draft_id collision in forum topics
+        let chan: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs();
+        let tid: i64 = reply.channel.thread_id.as_deref().and_then(|t| t.parse::<i64>().ok()).unwrap_or(0).abs();
+        let draft_id: i64 = (chan.wrapping_add(tid)) % 1_000_000 + 1;
         let _ = send_rich_message_draft(client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id, text).await;
         return;
     }
@@ -448,7 +456,9 @@ pub async fn handle_reply(
                 _ => None,
             };
             if let Some(text) = thinking_text {
-                let draft_id: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs() % 1_000_000 + 1;
+                let chan: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs();
+                let tid: i64 = reply.channel.thread_id.as_deref().and_then(|t| t.parse::<i64>().ok()).unwrap_or(0).abs();
+                let draft_id: i64 = (chan.wrapping_add(tid)) % 1_000_000 + 1;
                 let _ = send_rich_message_draft(
                     client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id, text,
                 ).await;

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -412,11 +412,11 @@ pub async fn handle_reply(
         // Send thinking draft on reaction changes — reflects agent state
         if rich_messages && reply.command.as_deref() == Some("add_reaction") {
             let thinking_text = match reply.content.text.as_str() {
-                "👀" => Some("<tg-thinking><tg-emoji emoji-id=\"5535034915403333642\">\u{200d}</tg-emoji> Looking...</tg-thinking>"),
-                "🤔" => Some("<tg-thinking><tg-emoji emoji-id=\"5537353471893700616\">\u{200d}</tg-emoji> Thinking...</tg-thinking>"),
-                "👨\u{200d}💻" => Some("<tg-thinking><tg-emoji emoji-id=\"5537511986251694100\">\u{200d}</tg-emoji> Writing code...</tg-thinking>"),
-                "🔥" => Some("<tg-thinking><tg-emoji emoji-id=\"5537207975581581325\">\u{200d}</tg-emoji> Working...</tg-thinking>"),
-                "⚡" => Some("<tg-thinking><tg-emoji emoji-id=\"5537346136089559052\">\u{200d}</tg-emoji> Running tools...</tg-thinking>"),
+                "👀" => Some("<tg-thinking>Looking...</tg-thinking>"),
+                "🤔" => Some("<tg-thinking>Thinking...</tg-thinking>"),
+                "👨\u{200d}💻" => Some("<tg-thinking>Writing code...</tg-thinking>"),
+                "🔥" => Some("<tg-thinking>Working...</tg-thinking>"),
+                "⚡" => Some("<tg-thinking>Running tools...</tg-thinking>"),
                 _ => None,
             };
             if let Some(text) = thinking_text {

--- a/gateway/src/adapters/telegram.rs
+++ b/gateway/src/adapters/telegram.rs
@@ -222,7 +222,7 @@ fn is_markdown_parse_error(description: &str) -> bool {
 
 /// Returns true if the content is complex enough to benefit from sendRichMessage.
 fn is_complex_markdown(text: &str) -> bool {
-    if text.contains("```") || text.len() > 4096 {
+    if text.contains("```") || text.contains("~~~") || text.len() > 4096 {
         return true;
     }
     text.lines().any(|line| {
@@ -646,6 +646,7 @@ mod tests {
         assert!(is_complex_markdown("| A | B |\n| :---: | :---: |\n| x | y |"));
         // Code blocks
         assert!(is_complex_markdown("```rust\nfn main() {}\n```"));
+        assert!(is_complex_markdown("~~~\ncode\n~~~"));
         // Headings
         assert!(is_complex_markdown("# Heading\n\nSome text"));
         assert!(is_complex_markdown("## Heading 2 at start"));

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -45,6 +45,8 @@ pub struct AppState {
     pub telegram_bot_token: Option<String>,
     /// Telegram webhook secret token for request validation
     pub telegram_secret_token: Option<String>,
+    /// Use sendRichMessage for complex content (Bot API 10.1+)
+    pub telegram_rich_messages: bool,
     /// LINE channel secret for signature validation
     pub line_channel_secret: Option<String>,
     /// LINE channel access token for reply API
@@ -138,6 +140,7 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                                         &client,
                                         &state_for_recv.event_tx,
                                         &reaction_state,
+                                        state_for_recv.telegram_rich_messages,
                                     )
                                     .await;
                                 } else {
@@ -241,6 +244,9 @@ async fn main() -> Result<()> {
     // Telegram adapter
     let telegram_bot_token = std::env::var("TELEGRAM_BOT_TOKEN").ok();
     let telegram_secret_token = std::env::var("TELEGRAM_SECRET_TOKEN").ok();
+    let telegram_rich_messages = std::env::var("TELEGRAM_RICH_MESSAGES")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
     if telegram_bot_token.is_some() {
         let webhook_path =
             std::env::var("TELEGRAM_WEBHOOK_PATH").unwrap_or_else(|_| "/webhook/telegram".into());
@@ -378,6 +384,7 @@ async fn main() -> Result<()> {
     let state = Arc::new(AppState {
         telegram_bot_token,
         telegram_secret_token,
+        telegram_rich_messages,
         line_channel_secret,
         line_access_token,
         teams,

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -245,8 +245,8 @@ async fn main() -> Result<()> {
     let telegram_bot_token = std::env::var("TELEGRAM_BOT_TOKEN").ok();
     let telegram_secret_token = std::env::var("TELEGRAM_SECRET_TOKEN").ok();
     let telegram_rich_messages = std::env::var("TELEGRAM_RICH_MESSAGES")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
+        .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+        .unwrap_or(true);
     if telegram_bot_token.is_some() {
         let webhook_path =
             std::env::var("TELEGRAM_WEBHOOK_PATH").unwrap_or_else(|_| "/webhook/telegram".into());

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -714,12 +714,20 @@ impl AdapterRouter {
                                 }
                             }
                         } else {
-                            // Normal streaming: edit first chunk into placeholder, send rest
-                            if let Some(first) = chunks.first() {
-                                let _ = adapter.edit_message(&msg, first).await;
-                            }
-                            for chunk in chunks.iter().skip(1) {
-                                let _ = adapter.send_message(&thread_channel, chunk).await;
+                            // Normal streaming: edit first chunk into placeholder, send rest.
+                            // If placeholder is a dummy "draft" ref (no real message), send as
+                            // new message instead — the gateway will persist via sendRichMessage.
+                            if msg.message_id == "draft" {
+                                for chunk in &chunks {
+                                    let _ = adapter.send_message(&thread_channel, chunk).await;
+                                }
+                            } else {
+                                if let Some(first) = chunks.first() {
+                                    let _ = adapter.edit_message(&msg, first).await;
+                                }
+                                for chunk in chunks.iter().skip(1) {
+                                    let _ = adapter.send_message(&thread_channel, chunk).await;
+                                }
                             }
                         }
                     } else {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -260,6 +260,13 @@ pub trait ChatAdapter: Send + Sync + 'static {
     /// not be detected until the next message. This is acceptable: the first
     /// response may stream, but subsequent ones will correctly use send-once.
     fn use_streaming(&self, other_bot_present: bool) -> bool;
+
+    /// Whether to send the "…" placeholder message before streaming starts.
+    /// Default: true. Platforms using drafts (e.g. Telegram Rich Messages) can
+    /// return false to suppress the placeholder.
+    fn show_streaming_placeholder(&self) -> bool {
+        true
+    }
 }
 
 // --- AdapterRouter ---
@@ -489,7 +496,15 @@ impl AdapterRouter {
                         } else {
                             "…".to_string()
                         };
-                        let msg = adapter.send_message(&thread_channel, &initial).await?;
+                        let msg = if adapter.show_streaming_placeholder() {
+                            adapter.send_message(&thread_channel, &initial).await?
+                        } else {
+                            // Dummy ref for edit loop — gateway uses drafts, doesn't need real msg_id
+                            MessageRef {
+                                id: "draft".to_string(),
+                                channel: thread_channel.clone(),
+                            }
+                        };
                         let (tx, rx) = tokio::sync::watch::channel(initial);
                         let edit_adapter = adapter.clone();
                         let edit_msg = msg.clone();

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -501,7 +501,7 @@ impl AdapterRouter {
                         } else {
                             // Dummy ref for edit loop — gateway uses drafts, doesn't need real msg_id
                             MessageRef {
-                                id: "draft".to_string(),
+                                message_id: "draft".to_string(),
                                 channel: thread_channel.clone(),
                             }
                         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -339,6 +339,9 @@ pub struct GatewayConfig {
     /// Enable streaming (typewriter) mode — requires gateway platform to support message editing.
     #[serde(default)]
     pub streaming: bool,
+    /// Show "…" placeholder at streaming start. Default: true. Set false for platforms using drafts.
+    #[serde(default = "default_true")]
+    pub streaming_placeholder: bool,
     /// Message dispatch mode. Default: per-message.
     #[serde(default)]
     pub message_processing_mode: MessageProcessingMode,

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -135,6 +135,7 @@ pub struct GatewayAdapter {
     pending: PendingRequests,
     platform_name: &'static str,
     streaming: bool,
+    streaming_placeholder: bool,
 }
 
 impl GatewayAdapter {
@@ -143,12 +144,14 @@ impl GatewayAdapter {
         pending: PendingRequests,
         platform_name: &'static str,
         streaming: bool,
+        streaming_placeholder: bool,
     ) -> Self {
         Self {
             ws_tx,
             pending,
             platform_name,
             streaming,
+            streaming_placeholder,
         }
     }
 
@@ -518,6 +521,10 @@ impl ChatAdapter for GatewayAdapter {
     fn use_streaming(&self, _other_bot_present: bool) -> bool {
         self.streaming
     }
+
+    fn show_streaming_placeholder(&self) -> bool {
+        self.streaming_placeholder
+    }
 }
 
 // --- Run the gateway adapter (connects to gateway WS, routes events to AdapterRouter) ---
@@ -533,6 +540,7 @@ pub struct GatewayParams {
     pub allow_all_users: bool,
     pub allowed_users: Vec<String>,
     pub streaming: bool,
+    pub streaming_placeholder: bool,
     pub stt: crate::config::SttConfig,
 }
 
@@ -552,6 +560,7 @@ pub async fn run_gateway_adapter(
     let allow_all_users = params.allow_all_users;
     let allowed_users = params.allowed_users;
     let streaming = params.streaming;
+    let streaming_placeholder = params.streaming_placeholder;
     let stt_config = params.stt;
 
     let connect_url = match &params.token {
@@ -601,6 +610,7 @@ pub async fn run_gateway_adapter(
             pending.clone(),
             platform,
             streaming,
+            streaming_placeholder,
         ));
         let slash_ws_tx = ws_tx.clone(); // for fire-and-forget slash command responses
         let mut tasks: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,6 +310,7 @@ async fn main() -> anyhow::Result<()> {
             ),
             allowed_users: gw_cfg.allowed_users,
             streaming: gw_cfg.streaming,
+            streaming_placeholder: gw_cfg.streaming_placeholder,
             stt: cfg.stt.clone(),
         };
         let gw_router = router.clone();


### PR DESCRIPTION
## Summary

[Telegram Bot API 10.1](https://core.telegram.org/bots/api#rich-message-formatting-options) introduced **Rich Messages** — allowing bots to send highly structured text with native tables, code blocks, headings, math formulas, and stream AI-generated replies.

This PR integrates Rich Messages into the OAB gateway TG adapter. **Default on** — users don't need any configuration. Set `TELEGRAM_RICH_MESSAGES=false` to opt out.

### Classification Logic

The adapter auto-classifies each reply and routes to `sendRichMessage` when **any** of these conditions are met:

| Condition | Why |
|-----------|-----|
| Table separator row detected (e.g. `\|---\|`, `\|:---:\|`) | Markdown table — sendMessage cannot render it |
| Contains triple backticks | Fenced code block — rich message adds syntax highlighting |
| Content > 4096 chars | Exceeds sendMessage limit; rich message supports up to 32768 |
| Line starts with `#` through `######` (followed by space) | ATX headings — sendMessage has no heading support |

If none match → uses traditional `sendMessage` with Markdown parse mode.

### Changes

- `sendRichMessage()` for structured content
- `sendRichMessageDraft()` wired for future AI streaming support
- `is_complex_markdown()` classifier with robust table separator + ATX heading detection
- 32768 char truncation guard before API call
- Default on (`TELEGRAM_RICH_MESSAGES=true`), opt-out with `=false`
- Graceful fallback to `sendMessage` on API failure

### Architecture

```
Agent markdown output → TG Adapter classifies:
  Simple text      → sendMessage (existing path)
  Tables/code/h1+  → sendRichMessage (new, default)
  Streaming        → sendRichMessageDraft → sendRichMessage (future)
```

No agent-side changes needed — existing markdown output is GFM-compatible with Rich Markdown.

### References

- [Bot API 10.1 Rich Messages](https://core.telegram.org/bots/api#rich-message-formatting-options)
- [sendRichMessage](https://core.telegram.org/bots/api#sendrichmessage)
- [sendRichMessageDraft](https://core.telegram.org/bots/api#sendrichmessagedraft)