### PR TITLE
docs: fix expired Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, Hermes, Grok Build, Antigravity, Pi, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](gateway/).
 
-🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://discord.gg/DmbhfDZjQS)** 🎉
+🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://discord.gg/dQMWnYscGC)** 🎉
 
 ```
 ┌──────────────┐  Gateway WS   ┌──────────────┐  ACP stdio    ┌──────────────────┐


### PR DESCRIPTION
## Summary

- Updates the README community Discord invite to the current invite URL.
- Keeps the change scoped to the top-level README link only.

## Prior Research

- Checked existing issues for `discord invite README`: none found.
- Checked existing PRs for `discord invite README`: found older merged PRs for previous invite updates, no open duplicate.

## Testing

- Not run (docs-only change).