### PR TITLE
fix(native): add --no-browser to OPENAB_AGENT_AUTH_COMMAND

### DIFF
--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -33,7 +33,7 @@ USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND="openab-agent"
-ENV OPENAB_AGENT_AUTH_COMMAND="openab-agent auth codex-oauth"
+ENV OPENAB_AGENT_AUTH_COMMAND="openab-agent auth codex-oauth --no-browser"
 
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]


### PR DESCRIPTION
## Summary

Adds `--no-browser` flag to `OPENAB_AGENT_AUTH_COMMAND` in `Dockerfile.native`.

Without this flag, the auth command attempts to open a browser which doesn't exist in the container environment.

## Changes

- `Dockerfile.native`: `openab-agent auth codex-oauth` → `openab-agent auth codex-oauth --no-browser`

Fixes #1110