### PR TITLE
fix(discord): send_message for streaming replies with bot mentions

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -915,10 +915,13 @@ impl AdapterRouter {
                                     tracing::warn!(error = ?e, "delete placeholder failed; placeholder will remain visible");
                                 }
                             }
-                        } else if contains_bot_mention(&final_content) {
-                            // Bot mention detected: delete placeholder and send as
-                            // new message so Discord emits MESSAGE_CREATE — otherwise
-                            // the mentioned bot won't receive the gateway event (#1110).
+                        } else if adapter.platform() == "discord"
+                            && contains_bot_mention(&final_content)
+                        {
+                            // Discord-specific: bot mention detected. Delete placeholder
+                            // and send as new message so Discord emits MESSAGE_CREATE —
+                            // otherwise the mentioned bot won't receive the gateway
+                            // event since MESSAGE_UPDATE skips notifications (#1110).
                             let mut send_ok = false;
                             if let Some(first) = chunks.first() {
                                 if adapter.send_message(&thread_channel, first).await.is_ok() {
@@ -969,7 +972,7 @@ impl AdapterRouter {
     }
 }
 
-/// Returns true if `content` contains a Discord user/bot mention (`<@123>`).
+/// Returns true if `content` contains a Discord user/bot mention (`<@123>` or `<@!123>`).
 /// Used to detect cross-bot mentions so the streaming path can switch from
 /// edit (MESSAGE_UPDATE, no mention notification) to delete+send (MESSAGE_CREATE).
 fn contains_bot_mention(content: &str) -> bool {
@@ -977,8 +980,12 @@ fn contains_bot_mention(content: &str) -> bool {
     let bytes = content.as_bytes();
     while i + 2 < bytes.len() {
         if bytes[i] == b'<' && bytes[i + 1] == b'@' {
-            // skip optional '!' for role mentions — we only care about user mentions
-            let start = i + 2;
+            // Skip optional '!' for nickname-style mentions (<@!UID>)
+            let start = if i + 2 < bytes.len() && bytes[i + 2] == b'!' {
+                i + 3
+            } else {
+                i + 2
+            };
             if start < bytes.len() && bytes[start].is_ascii_digit() {
                 if let Some(end) = content[start..].find('>') {
                     if content[start..start + end].chars().all(|c| c.is_ascii_digit()) {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -915,6 +915,22 @@ impl AdapterRouter {
                                     tracing::warn!(error = ?e, "delete placeholder failed; placeholder will remain visible");
                                 }
                             }
+                        } else if contains_bot_mention(&final_content) {
+                            // Bot mention detected: delete placeholder and send as
+                            // new message so Discord emits MESSAGE_CREATE — otherwise
+                            // the mentioned bot won't receive the gateway event (#1110).
+                            let mut send_ok = false;
+                            if let Some(first) = chunks.first() {
+                                if adapter.send_message(&thread_channel, first).await.is_ok() {
+                                    send_ok = true;
+                                }
+                            }
+                            for chunk in chunks.iter().skip(1) {
+                                let _ = adapter.send_message(&thread_channel, chunk).await;
+                            }
+                            if send_ok {
+                                let _ = adapter.delete_message(&msg).await;
+                            }
                         } else {
                             // Normal streaming: edit first chunk into placeholder, send rest
                             if let Some(first) = chunks.first() {
@@ -951,6 +967,31 @@ impl AdapterRouter {
             })
             .await
     }
+}
+
+/// Returns true if `content` contains a Discord user/bot mention (`<@123>`).
+/// Used to detect cross-bot mentions so the streaming path can switch from
+/// edit (MESSAGE_UPDATE, no mention notification) to delete+send (MESSAGE_CREATE).
+fn contains_bot_mention(content: &str) -> bool {
+    let mut i = 0;
+    let bytes = content.as_bytes();
+    while i + 2 < bytes.len() {
+        if bytes[i] == b'<' && bytes[i + 1] == b'@' {
+            // skip optional '!' for role mentions — we only care about user mentions
+            let start = i + 2;
+            if start < bytes.len() && bytes[start].is_ascii_digit() {
+                if let Some(end) = content[start..].find('>') {
+                    if content[start..start + end].chars().all(|c| c.is_ascii_digit()) {
+                        return true;
+                    }
+                }
+            }
+            i = start;
+        } else {
+            i += 1;
+        }
+    }
+    false
 }
 
 /// Flatten a tool-call title into a single line safe for inline-code spans.

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -972,7 +972,8 @@ impl AdapterRouter {
     }
 }
 
-/// Returns true if `content` contains a Discord user/bot mention (`<@123>` or `<@!123>`).
+/// Returns true if `content` contains a Discord user/bot mention (`<@123>`, `<@!123>`)
+/// or a role mention (`<@&123>`).
 /// Used to detect cross-bot mentions so the streaming path can switch from
 /// edit (MESSAGE_UPDATE, no mention notification) to delete+send (MESSAGE_CREATE).
 fn contains_bot_mention(content: &str) -> bool {
@@ -980,8 +981,10 @@ fn contains_bot_mention(content: &str) -> bool {
     let bytes = content.as_bytes();
     while i + 2 < bytes.len() {
         if bytes[i] == b'<' && bytes[i + 1] == b'@' {
-            // Skip optional '!' for nickname-style mentions (<@!UID>)
-            let start = if i + 2 < bytes.len() && bytes[i + 2] == b'!' {
+            // Skip optional '!' (nickname mention) or '&' (role mention)
+            let start = if i + 2 < bytes.len()
+                && (bytes[i + 2] == b'!' || bytes[i + 2] == b'&')
+            {
                 i + 3
             } else {
                 i + 2

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1310,6 +1310,34 @@ mod tests {
         let out = compose_display(&tools, "response text", false, ToolDisplay::None);
         assert_eq!(out, "response text");
     }
+
+    #[test]
+    fn contains_bot_mention_user() {
+        assert!(contains_bot_mention("hello <@1234567890> world"));
+    }
+
+    #[test]
+    fn contains_bot_mention_nickname() {
+        assert!(contains_bot_mention("hey <@!9876543210>"));
+    }
+
+    #[test]
+    fn contains_bot_mention_role() {
+        assert!(contains_bot_mention("calling <@&1496247626675257384>"));
+    }
+
+    #[test]
+    fn contains_bot_mention_no_match() {
+        assert!(!contains_bot_mention("hello world"));
+        assert!(!contains_bot_mention("email user@example.com"));
+        assert!(!contains_bot_mention("<@not_a_number>"));
+        assert!(!contains_bot_mention("<#123456>")); // channel mention
+    }
+
+    #[test]
+    fn contains_bot_mention_embedded() {
+        assert!(contains_bot_mention("請問 <@1501788608439386172> 1+1=?"));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

When a streaming response contains `<@UID>` bot mentions, the current code edits the placeholder message (`MESSAGE_UPDATE`). Discord does **not** send mention notifications for edited messages, so the mentioned bot never receives the gateway event.

## Root Cause

```
┌─────────────────────────────────────────────────────────────────────┐
│                    BEFORE (Bug)                                      │
├─────────────────────────────────────────────────────────────────────┤
│                                                                     │
│  Bot A (streaming)         Discord                    Bot B         │
│  ─────────────────         ───────                    ─────         │
│        │                      │                         │           │
│        ├─── send_message ────►│  (placeholder "…")      │           │
│        │    MESSAGE_CREATE    │                         │           │
│        │                      │                         │           │
│        │   ... streaming ...  │                         │           │
│        │                      │                         │           │
│        ├─── edit_message ────►│  (final: "<@BotB> hi") │           │
│        │    MESSAGE_UPDATE    │                         │           │
│        │                      │──── ❌ NO event ────────┤           │
│        │                      │  (edits dont notify)    │           │
│        │                      │                         │           │
│        ▼                      ▼                         ▼           │
│                    Bot B never responds                              │
└─────────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────┐
│                    AFTER (Fix)                                       │
├─────────────────────────────────────────────────────────────────────┤
│                                                                     │
│  Bot A (streaming)         Discord                    Bot B         │
│  ─────────────────         ───────                    ─────         │
│        │                      │                         │           │
│        ├─── send_message ────►│  (placeholder "…")      │           │
│        │    MESSAGE_CREATE    │                         │           │
│        │                      │                         │           │
│        │   ... streaming ...  │                         │           │
│        │                      │                         │           │
│        ├─── send_message ────►│  (final: "<@BotB> hi") │           │
│        │    MESSAGE_CREATE    │                         │           │
│        │                      │──── ✅ EVENT ──────────►│           │
│        │                      │  (mention triggered!)   │           │
│        ├─── delete_message ──►│  (remove placeholder)   │           │
│        │                      │                         │           │
│        ▼                      ▼                         ▼           │
│                    Bot B receives & responds                         │
└─────────────────────────────────────────────────────────────────────┘
```

## Fix

In the streaming finalization path, detect if the final content contains Discord mentions (`<@UID>`, `<@!UID>`, or `<@&ROLE_ID>`). If so:
1. Send the response as a **new message** (`MESSAGE_CREATE`)
2. Delete the streaming placeholder

This ensures Discord triggers the mention notification and the mentioned bot receives the gateway event.

## Scope

- **Discord only** — gated by `adapter.platform() == "discord"`; Slack and other adapters are unaffected
- **Streaming mode only** — non-streaming (send-once) path already uses `send_message` and works correctly
- Covers user mentions (`<@123>`), nickname mentions (`<@!123>`), and role mentions (`<@&123>`)

## What Was Tested

- Confirmed via curl that `POST /channels/{thread_id}/messages` with `<@bot_id>` triggers the mentioned bot ✅
- Confirmed that `edit_message` with the same mention does **not** trigger the mentioned bot ❌
- Unit tests cover all mention formats and negative cases
- CI `check` passed ✅

Fixes #1110