### PR TITLE
feat: add MiMo-Code ACP support

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -20,6 +20,7 @@ jobs:
           - { dockerfile: Dockerfile.copilot, suffix: "-copilot", agent: "copilot", agent_args: "--acp" }
           - { dockerfile: Dockerfile.opencode, suffix: "-opencode", agent: "opencode", agent_args: "acp" }
           - { dockerfile: Dockerfile.cursor, suffix: "-cursor", agent: "cursor-agent", agent_args: "acp" }
+          - { dockerfile: Dockerfile.mimocode, suffix: "-mimocode", agent: "mimo", agent_args: "acp" }
           - { dockerfile: Dockerfile.hermes, suffix: "-hermes", agent: "hermes-acp", agent_args: "" }
           - { dockerfile: Dockerfile.grok, suffix: "-grok", agent: "grok", agent_args: "agent stdio" }
           - { dockerfile: Dockerfile.antigravity, suffix: "-antigravity", agent: "agy-acp", agent_args: "" }

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -22,6 +22,7 @@ on:
           - gemini
           - grok
           - hermes
+          - mimocode
           - native
           - opencode
           - pi

--- a/Dockerfile.mimocode
+++ b/Dockerfile.mimocode
@@ -39,9 +39,10 @@ RUN mkdir -p /home/node/.config/mimocode && chown -R node:node /home/node
 
 USER node
 
-# Disable Bedrock auto-detection — prevents mimo from silently using AWS models
-# when running on ECS/EC2 with IAM roles attached.
-RUN echo '{"disabled_providers":["amazon-bedrock"]}' > /home/node/.config/mimocode/config.json
+# Disable Bedrock auto-detection and set mimo-auto as default model.
+# Without this, ACP mode picks the "best" (paid) model from Provider.sort()
+# which fails silently when running on AWS without a paid Xiaomi account.
+RUN echo '{"disabled_providers":["amazon-bedrock"],"model":"mimo/mimo-auto"}' > /home/node/.config/mimocode/config.json
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1

--- a/Dockerfile.mimocode
+++ b/Dockerfile.mimocode
@@ -39,10 +39,9 @@ RUN mkdir -p /home/node/.config/mimocode && chown -R node:node /home/node
 
 USER node
 
-# Disable Bedrock auto-detection and set mimo-auto as default model.
-# Without this, ACP mode picks the "best" (paid) model from Provider.sort()
-# which fails silently when running on AWS without a paid Xiaomi account.
-RUN echo '{"disabled_providers":["amazon-bedrock"],"model":"mimo/mimo-auto"}' > /home/node/.config/mimocode/config.json
+# Disable Bedrock auto-detection — prevents mimo from silently using AWS models
+# when running on ECS/EC2 with IAM roles attached.
+RUN echo '{"disabled_providers":["amazon-bedrock"]}' > /home/node/.config/mimocode/config.json
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1

--- a/Dockerfile.mimocode
+++ b/Dockerfile.mimocode
@@ -39,10 +39,6 @@ RUN mkdir -p /home/node/.config/mimocode && chown -R node:node /home/node
 
 USER node
 
-# Disable Bedrock auto-detection — prevents mimo from silently using AWS models
-# when running on ECS/EC2 with IAM roles attached.
-RUN echo '{"disabled_providers":["amazon-bedrock"]}' > /home/node/.config/mimocode/config.json
-
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND="mimo acp"

--- a/Dockerfile.mimocode
+++ b/Dockerfile.mimocode
@@ -1,0 +1,47 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage ---
+# MiMo-Code (https://github.com/XiaomiMiMo/MiMo-Code) is a fork of OpenCode
+# with persistent memory, intelligent context management, subagent orchestration,
+# and MiMo Auto (free channel) built in.
+#
+# Installed via npm as @mimo-ai/cli. The binary is `mimo`.
+# ACP is supported via `mimo acp` (same JSON-RPC/stdio protocol as OpenCode).
+#
+# Version is pinned for reproducible builds.
+FROM node:22-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
+
+# Install MiMo-Code
+ARG MIMOCODE_VERSION=0.1.1
+RUN npm install -g @mimo-ai/cli@${MIMOCODE_VERSION} --retry 3
+
+# Install gh CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/node
+WORKDIR /home/node
+
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+
+RUN mkdir -p /home/node/.config/mimocode && chown -R node:node /home/node
+
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="mimo acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="mimo auth login"
+
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.mimocode
+++ b/Dockerfile.mimocode
@@ -38,10 +38,17 @@ COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bi
 RUN mkdir -p /home/node/.config/mimocode && chown -R node:node /home/node
 
 USER node
+
+# Disable Bedrock auto-detection — prevents mimo from silently using AWS models
+# when running on ECS/EC2 with IAM roles attached.
+RUN echo '{"disabled_providers":["amazon-bedrock"]}' > /home/node/.config/mimocode/config.json
+
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
 ENV OPENAB_AGENT_COMMAND="mimo acp"
-ENV OPENAB_AGENT_AUTH_COMMAND="mimo auth login"
+ENV OPENAB_AGENT_AUTH_COMMAND="mimo auth login --provider mimo --method \"MiMo Auto (free)\""
 
 ENTRYPOINT ["tini", "--"]
-CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+# Auth with MiMo Auto (free) at container start — token is ephemeral (~1h)
+# so it must be provisioned fresh each boot, not baked at build time.
+CMD ["sh", "-c", "mimo auth login --provider mimo --method 'MiMo Auto (free)' 2>/dev/null; exec openab run -c /etc/openab/config.toml"]

--- a/Dockerfile.mimocode
+++ b/Dockerfile.mimocode
@@ -45,6 +45,4 @@ ENV OPENAB_AGENT_COMMAND="mimo acp"
 ENV OPENAB_AGENT_AUTH_COMMAND="mimo auth login --provider mimo --method \"MiMo Auto (free)\""
 
 ENTRYPOINT ["tini", "--"]
-# Auth with MiMo Auto (free) at container start — token is ephemeral (~1h)
-# so it must be provisioned fresh each boot, not baked at build time.
-CMD ["sh", "-c", "mimo auth login --provider mimo --method 'MiMo Auto (free)' 2>/dev/null; exec openab run -c /etc/openab/config.toml"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![OpenAB banner](images/banner.jpg)
 
-A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, Hermes, Grok Build, Antigravity, Pi, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](gateway/).
+A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Copilot CLI, Hermes, Grok Build, Antigravity, Pi, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](gateway/).
 
 🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://openab.dev/discord)** 🎉
 
@@ -20,7 +20,8 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 │   User       │            │         │                       │ copilot --acp    │
 ├──────────────┤            ▼         ▼                       │ hermes-acp       │
 │   LINE       │◄──webhook──┌──────────────────┐              │ opencode acp     │
-│   User       │            │  Custom Gateway  │              │ grok agent stdio │
+│   User       │            │  Custom Gateway  │              │ mimo acp         │
+├──────────────┤            │  (standalone)    │              │ grok agent stdio │
 ├──────────────┤            │  (standalone)    │              │ agy-acp          │
 │  Feishu/Lark │◄───WS──────│                  │              │ pi-acp           │
 │   User       │            │                  │              └──────────────────┘
@@ -38,7 +39,7 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 
 - **Multi-platform** — supports Discord and Slack, run one or both simultaneously
 - **Custom Gateway** — extend to Telegram, LINE, Feishu/Lark, Google Chat, MS Teams via standalone [gateway](gateway/)
-- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, Copilot CLI, Hermes, Grok Build, Antigravity, Pi via config
+- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Copilot CLI, Hermes, Grok Build, Antigravity, Pi via config
 - **@mention trigger** — mention the bot in an allowed channel to start a conversation
 - **Thread-based multi-turn** — auto-creates threads; no @mention needed for follow-ups
 - **Multi-agent collaboration** — bot-to-bot messaging for coordinated workflows ([docs/multi-agent.md](docs/multi-agent.md))
@@ -167,6 +168,7 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 | Codex | `codex-acp` | [@zed-industries/codex-acp](https://github.com/zed-industries/codex-acp) | [docs/codex.md](docs/codex.md) |
 | Gemini | `gemini --acp` | Native | [docs/gemini.md](docs/gemini.md) |
 | OpenCode | `opencode acp` | Native | [docs/opencode.md](docs/opencode.md) |
+| MiMo-Code | `mimo acp` | Native | [docs/mimocode.md](docs/mimocode.md) |
 | Copilot CLI ⚠️ | `copilot --acp --stdio` | Native | [docs/copilot.md](docs/copilot.md) |
 | Cursor | `cursor-agent acp` | Native | [docs/cursor.md](docs/cursor.md) |
 | Hermes Agent | `hermes-acp` | Native | [docs/hermes.md](docs/hermes.md) |

--- a/config.toml.example
+++ b/config.toml.example
@@ -113,6 +113,15 @@ working_dir = "/home/agent"
 # # Run `opencode auth login` once before starting openab.
 
 # [agent]
+# command = "mimo"
+# args = ["acp"]
+# working_dir = "/home/node"
+# # MiMo-Code (Xiaomi fork of OpenCode) with persistent memory, subagents,
+# # and MiMo Auto (free channel). Same ACP protocol as OpenCode.
+# # Install: npm install -g @mimo-ai/cli
+# # Auth: kubectl exec -it <pod> -- mimo auth login
+
+# [agent]
 # command = "cursor-agent"
 # args = ["acp", "--model", "auto", "--workspace", "/home/agent"]
 # working_dir = "/home/agent"

--- a/docs/mimocode.md
+++ b/docs/mimocode.md
@@ -1,0 +1,126 @@
+# MiMo-Code
+
+[MiMo-Code](https://github.com/XiaomiMiMo/MiMo-Code) supports ACP natively via the `acp` subcommand — no adapter needed.
+
+MiMo-Code is a fork of [OpenCode](https://opencode.ai) by Xiaomi, adding persistent memory, intelligent context management, subagent orchestration, goal-driven autonomous loops, compose workflows, and dream/distill self-improvement. It includes **MiMo Auto** as a free-for-limited-time channel, so you can start with zero configuration.
+
+```
+┌──────────┐  Discord  ┌────────┐ ACP stdio ┌───────────┐   ┌───────────────────┐
+│ Discord  │◄────────► │ OpenAB │◄────────► │ MiMo-Code │──►│  LLM Providers    │
+│ Users    │ Gateway   │ (Rust) │ JSON-RPC  │   (ACP)   │   │                   │
+└──────────┘           └────────┘           └───────────┘   │ ┌───────────────┐ │
+                                                 │          │ │ MiMo Auto     │ │
+                                       mimocode.json        │ │ Xiaomi MiMo   │ │
+                                       sets model           │ │ OpenAI        │ │
+                                                            │ │ Anthropic     │ │
+                                                            │ │ AWS Bedrock   │ │
+                                                            │ │ OpenRouter    │ │
+                                                            │ │ Ollama (local)│ │
+                                                            │ │ + more...     │ │
+                                                            │ └───────────────┘ │
+                                                            └───────────────────┘
+```
+
+## Docker Image
+
+```bash
+docker build -f Dockerfile.mimocode -t openab-mimocode:latest .
+```
+
+The image installs `@mimo-ai/cli` globally via npm on `node:22-bookworm-slim`.
+
+## Helm Install
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.mimocode.enabled=true \
+  --set agents.mimocode.command=mimo \
+  --set 'agents.mimocode.args={acp}' \
+  --set agents.mimocode.image=ghcr.io/openabdev/openab-mimocode:latest \
+  --set agents.mimocode.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.mimocode.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.mimocode.workingDir=/home/node \
+  --set agents.mimocode.pool.maxSessions=3
+```
+
+> Set `agents.kiro.enabled=false` to disable the default Kiro agent.
+
+## Manual config.toml
+
+```toml
+[agent]
+command = "mimo"
+args = ["acp"]
+working_dir = "/home/node"
+```
+
+## Authentication
+
+MiMo-Code supports multiple auth methods:
+
+### MiMo Auto (zero config)
+
+MiMo Auto is built in as a free-for-limited-time channel. The first launch guides you through configuration automatically — select "MiMo Auto" for immediate use with no API keys.
+
+### Xiaomi MiMo Platform (OAuth)
+
+```bash
+kubectl exec -it deployment/openab-mimocode -- mimo auth login
+```
+
+Select "Xiaomi MiMo Platform" and follow the OAuth flow.
+
+### Import from Claude Code
+
+If you already have Claude Code credentials, MiMo-Code can import them:
+
+```bash
+kubectl exec -it deployment/openab-mimocode -- mimo auth login
+```
+
+Select "Import from Claude Code".
+
+### Custom Provider (OpenAI-compatible API)
+
+```bash
+kubectl exec -it deployment/openab-mimocode -- mimo auth login
+```
+
+Select "Custom Provider" and enter your API endpoint and key.
+
+## Configuration
+
+MiMo-Code is configured via `.mimocode/mimocode.json` in the working directory or `~/.config/mimocode/mimocode.json` globally. Example:
+
+```json
+{
+  "model": "mimo-auto"
+}
+```
+
+To set the model inside the pod:
+
+```bash
+kubectl exec deployment/openab-mimocode -- sh -c \
+  'mkdir -p /home/node/.mimocode && echo "{\"model\": \"mimo-auto\"}" > /home/node/.mimocode/mimocode.json'
+```
+
+## Key Differences from OpenCode
+
+| Feature | OpenCode | MiMo-Code |
+|---------|----------|-----------|
+| Persistent memory | ❌ | ✅ MEMORY.md + SQLite FTS5 |
+| Subagent system | ❌ | ✅ Parallel subagents |
+| Context management | Basic | ✅ Auto-checkpoint + reconstruction |
+| Goal / stop condition | ❌ | ✅ Independent judge |
+| Compose mode | ❌ | ✅ Specs-driven workflows |
+| Dream / Distill | ❌ | ✅ Self-improvement |
+| Free channel | ❌ | ✅ MiMo Auto |
+
+## Notes
+
+- **ACP compatibility**: MiMo-Code uses the same ACP protocol as OpenCode (`@agentclientprotocol/sdk`). All OAB ACP features (streaming, tool display, session management) work identically.
+- **Tool authorization**: Like OpenCode, MiMo-Code handles tool authorization internally — all tools run without user confirmation.
+- **Binary name**: The CLI binary is `mimo` (installed via `npm install -g @mimo-ai/cli`). Alternative install: `curl -fsSL https://mimo.xiaomi.com/install | bash`.
+- **Session persistence**: MiMo-Code's memory system (MEMORY.md, checkpoints) persists on the PVC and carries context across sessions automatically.

--- a/docs/mimocode.md
+++ b/docs/mimocode.md
@@ -1,113 +1,82 @@
-# MiMo-Code
+# MiMoCode (mimo)
 
-[MiMo-Code](https://github.com/XiaomiMiMo/MiMo-Code) supports ACP natively via the `acp` subcommand — no adapter needed.
+MiMoCode is a fork of OpenCode. It supports ACP over stdio and can be used as an OpenAB agent backend.
 
-MiMo-Code is a fork of [OpenCode](https://opencode.ai) by Xiaomi, adding persistent memory, intelligent context management, subagent orchestration, goal-driven autonomous loops, compose workflows, and dream/distill self-improvement. It includes **MiMo Auto** as a free-for-limited-time channel, so you can start with zero configuration.
+## Setup
 
-```
-┌──────────┐  Discord  ┌────────┐ ACP stdio ┌───────────┐   ┌───────────────────┐
-│ Discord  │◄────────► │ OpenAB │◄────────► │ MiMo-Code │──►│  LLM Providers    │
-│ Users    │ Gateway   │ (Rust) │ JSON-RPC  │   (ACP)   │   │                   │
-└──────────┘           └────────┘           └───────────┘   │ ┌───────────────┐ │
-                                                 │          │ │ MiMo Auto     │ │
-                                       mimocode.json        │ │ Xiaomi MiMo   │ │
-                                       sets model           │ │ OpenAI        │ │
-                                                            │ │ Anthropic     │ │
-                                                            │ │ AWS Bedrock   │ │
-                                                            │ │ OpenRouter    │ │
-                                                            │ │ Ollama (local)│ │
-                                                            │ │ + more...     │ │
-                                                            │ └───────────────┘ │
-                                                            └───────────────────┘
-```
-
-## Docker Image
-
-```bash
-docker build -f Dockerfile.mimocode -t openab-mimocode:latest .
-```
-
-The image installs `@mimo-ai/cli` globally via npm on `node:22-bookworm-slim`.
-
-## Helm Install
-
-```bash
-helm install openab openab/openab \
-  --set agents.kiro.enabled=false \
-  --set agents.mimocode.enabled=true \
-  --set agents.mimocode.image=ghcr.io/openabdev/openab-mimocode:latest \
-  --set-string 'agents.mimocode.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
-```
-
-> The Docker image already defines `command`, `args`, and `workingDir` via
-> `OPENAB_AGENT_COMMAND` and `WORKDIR` — no need to set them in Helm values.
+| Field | Value |
+|-------|-------|
+| Image | `openab-mimocode` (or any image with `mimo` installed) |
+| Command | `mimo` |
+| Args | `["acp"]` |
+| Working dir | `/home/node` |
 
 ## Authentication
 
-MiMo-Code supports multiple auth methods:
-
-### MiMo Auto (zero config)
-
-MiMo Auto is built in as a free-for-limited-time channel. The first launch guides you through configuration automatically — select "MiMo Auto" for immediate use with no API keys.
-
-### Xiaomi MiMo Platform (OAuth)
+MiMoCode offers a free tier (`MiMo Auto`) that requires no API key — just a one-time device auth:
 
 ```bash
-kubectl exec -it deployment/openab-mimocode -- mimo auth login
+mimo auth login --provider mimo --method "MiMo Auto (free)"
 ```
 
-Select "Xiaomi MiMo Platform" and follow the OAuth flow.
+This is **fully non-interactive** and can be used in Dockerfiles, pre-boot hooks, or CI scripts. It sets `mimo/mimo-auto` as the default model (1M context, free).
 
-### Import from Claude Code
+The token expires in ~1 hour but auto-refreshes on next ACP session start. For persistent deployments, run this in a `[hooks.pre_boot]` script to ensure fresh auth on every container start.
 
-If you already have Claude Code credentials, MiMo-Code can import them:
+## ⚠️ Important: SQLite DB Locking
+
+MiMoCode uses a SQLite database (`~/.local/share/mimocode/mimocode.db`) for state. **Only one process can access it at a time.**
+
+**Do NOT** run manual `mimo` commands (e.g. `mimo auth login`, `mimo debug config`, `mimo models`) while `mimo acp` is actively handling a request. This will corrupt or lock the database, causing all subsequent ACP requests to fail with empty responses or "Connection Lost".
+
+### Safe workflow:
+1. Start the bot (openab spawns `mimo acp` on first message)
+2. Auth **before** the first message, or while the session is idle
+3. If the DB gets corrupted:
+   ```bash
+   # As root:
+   rm -f ~/.local/share/mimocode/mimocode.db*
+   chown -R node:node ~/.local/share/mimocode/
+   # As node:
+   mimo auth login
+   ```
+
+## AWS/Bedrock Auto-Detection
+
+When running on AWS (ECS, EC2), MiMoCode auto-detects AWS credentials and registers `amazon-bedrock` as a provider. Combined with its `Provider.sort()` logic, ACP mode picks the "best" (paid) model — which fails silently with 0 tokens if you don't have a paid Xiaomi account.
+
+### Solution: pre_boot hook
+
+Add this to your `[hooks.pre_boot]` script:
 
 ```bash
-kubectl exec -it deployment/openab-mimocode -- mimo auth login
+# Write mimo config — disables Bedrock, sets free model as default
+mkdir -p ~/.config/mimocode
+echo '{"disabled_providers":["amazon-bedrock"],"model":"mimo/mimo-auto"}' > ~/.config/mimocode/config.json
+
+# Provision free-tier auth (non-interactive, token refreshes each boot)
+mimo auth login --provider mimo --method "MiMo Auto (free)" 2>/dev/null || true
 ```
 
-Select "Import from Claude Code".
+This ensures:
+1. Bedrock is never auto-detected
+2. `mimo/mimo-auto` is the default model (not `xiaomi/mimo-v2.5-pro-ultraspeed`)
+3. Fresh auth token every container start
 
-### Custom Provider (OpenAI-compatible API)
+For paid Xiaomi accounts, replace `mimo/mimo-auto` with your preferred model (e.g. `xiaomi/mimo-v2.5-pro`).
 
-```bash
-kubectl exec -it deployment/openab-mimocode -- mimo auth login
+## Config (gist)
+
+```toml
+[agent]
+command = "mimo"
+args = ["acp"]
+env = { GHPOOL_URL = "http://ghpool.openab.local:8080", PATH = "/home/node/bin:/usr/local/bin:/usr/bin:/bin" }
 ```
 
-Select "Custom Provider" and enter your API endpoint and key.
+## Known Limitations
 
-## Configuration
-
-MiMo-Code is configured via `.mimocode/mimocode.json` in the working directory or `~/.config/mimocode/mimocode.json` globally. Example:
-
-```json
-{
-  "model": "mimo-auto"
-}
-```
-
-To set the model inside the pod:
-
-```bash
-kubectl exec deployment/openab-mimocode -- sh -c \
-  'mkdir -p /home/node/.mimocode && echo "{\"model\": \"mimo-auto\"}" > /home/node/.mimocode/mimocode.json'
-```
-
-## Key Differences from OpenCode
-
-| Feature | OpenCode | MiMo-Code |
-|---------|----------|-----------|
-| Persistent memory | ❌ | ✅ MEMORY.md + SQLite FTS5 |
-| Subagent system | ❌ | ✅ Parallel subagents |
-| Context management | Basic | ✅ Auto-checkpoint + reconstruction |
-| Goal / stop condition | ❌ | ✅ Independent judge |
-| Compose mode | ❌ | ✅ Specs-driven workflows |
-| Dream / Distill | ❌ | ✅ Self-improvement |
-| Free channel | ❌ | ✅ MiMo Auto |
-
-## Notes
-
-- **ACP compatibility**: MiMo-Code uses the same ACP protocol as OpenCode (`@agentclientprotocol/sdk`). All OAB ACP features (streaming, tool display, session management) work identically.
-- **Tool authorization**: Like OpenCode, MiMo-Code handles tool authorization internally — all tools run without user confirmation.
-- **Binary name**: The CLI binary is `mimo` (installed via `npm install -g @mimo-ai/cli`). Alternative install: `curl -fsSL https://mimo.xiaomi.com/install | bash`.
-- **Session persistence**: MiMo-Code's memory system (MEMORY.md, checkpoints) persists on the PVC and carries context across sessions automatically.
+- `mimo acp` does not accept `--model` flag (unlike the TUI)
+- Default model is set during `mimo auth login` and stored in the DB
+- No `config set` CLI command — model selection is via auth flow only
+- The `-m/--model` flag only works for TUI/run modes, not ACP

--- a/docs/mimocode.md
+++ b/docs/mimocode.md
@@ -35,25 +35,12 @@ The image installs `@mimo-ai/cli` globally via npm on `node:22-bookworm-slim`.
 helm install openab openab/openab \
   --set agents.kiro.enabled=false \
   --set agents.mimocode.enabled=true \
-  --set agents.mimocode.command=mimo \
-  --set 'agents.mimocode.args={acp}' \
   --set agents.mimocode.image=ghcr.io/openabdev/openab-mimocode:latest \
-  --set agents.mimocode.discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set-string 'agents.mimocode.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
-  --set agents.mimocode.workingDir=/home/node \
-  --set agents.mimocode.pool.maxSessions=3
+  --set-string 'agents.mimocode.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
 ```
 
-> Set `agents.kiro.enabled=false` to disable the default Kiro agent.
-
-## Manual config.toml
-
-```toml
-[agent]
-command = "mimo"
-args = ["acp"]
-working_dir = "/home/node"
-```
+> The Docker image already defines `command`, `args`, and `workingDir` via
+> `OPENAB_AGENT_COMMAND` and `WORKDIR` — no need to set them in Helm values.
 
 ## Authentication
 


### PR DESCRIPTION
## MiMoCode Support

Adds `Dockerfile.mimocode` and `docs/mimocode.md` for running MiMoCode (Xiaomi's OpenCode fork) as an OpenAB agent backend.

### Key Findings

**Config file** (`~/.config/mimocode/config.json`):
- `disabled_providers`: array of provider IDs to block (e.g. `["amazon-bedrock"]`)
- `model`: default model in `provider/model` format (e.g. `"mimo/mimo-auto"`)

**AWS Bedrock auto-detection**: mimo auto-discovers Bedrock when AWS credentials are present (ECS/EC2). Its `Provider.sort()` picks the "best" paid model, causing silent 0-token responses on the free tier. Fix: `disabled_providers` in config.json.

**ACP model resolution**: `defaultModel()` reads `config.json` → `model` field, NOT the DB value set by `mimo auth login`. Without the config file, it falls through to `Provider.sort()`.

**First-request empty response**: The first `mimo acp` spawn runs a DB migration that blocks provider loading. Workaround: warmup `mimo acp` in pre_boot hook with a dummy initialize request.

### Pre-boot hook (required)

```bash
#!/bin/sh
mkdir -p ~/.config/mimocode
echo '{"disabled_providers":["amazon-bedrock"],"model":"mimo/mimo-auto"}' > ~/.config/mimocode/config.json
mimo auth login --provider mimo --method "MiMo Auto (free)" 2>/dev/null || true
printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"capabilities":{},"clientInfo":{"name":"warmup","version":"1.0"}}}' | timeout 10 mimo acp >/dev/null 2>&1 || true
```

### Non-interactive auth

```bash
mimo auth login --provider mimo --method "MiMo Auto (free)"
```

### Upstream Issues Filed

- XiaomiMiMo/MiMo-Code#865 — ACP mode ignores default model set by `mimo auth login`
- XiaomiMiMo/MiMo-Code#866 — First ACP request after cold start returns empty (DB migration race)