### PR TITLE
fix(slack): detect half-open Socket Mode via ping + idle-timeout reconnect

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -674,6 +674,28 @@ impl ChatAdapter for SlackAdapter {
 /// Hard cap on consecutive bot messages in a thread. Prevents runaway loops.
 const MAX_CONSECUTIVE_BOT_TURNS: usize = 1000;
 
+/// Socket Mode keepalive. Slack's inbound WebSocket can go half-open (e.g. a NAT
+/// idle-timeout silently drops inbound frames with no Close/FIN), which leaves
+/// `read.next()` blocked forever, so the reconnect loop never fires and the bot
+/// goes deaf while still showing as connected. We proactively ping and force a
+/// reconnect when no inbound frame (including Slack's own pings) has arrived
+/// within the idle window. Reconnect backoff mirrors the gateway adapter.
+const PING_INTERVAL_SECS: u64 = 30;
+const IDLE_TIMEOUT_SECS: u64 = 75;
+const MAX_BACKOFF_SECS: u64 = 30;
+
+/// Next reconnect delay: double, capped. Reset to 1 on a successful connect.
+fn next_backoff(cur: u64) -> u64 {
+    (cur * 2).min(MAX_BACKOFF_SECS)
+}
+
+/// The socket is considered dead (half-open) when no inbound frame has arrived
+/// within `timeout`; Slack sends periodic pings, so silence past the window
+/// means the inbound path is gone.
+fn socket_idle(since_last_inbound: std::time::Duration, timeout: std::time::Duration) -> bool {
+    since_last_inbound >= timeout
+}
+
 /// Run the Slack adapter using Socket Mode (persistent WebSocket, no public URL needed).
 /// Reconnects automatically on disconnect.
 #[allow(clippy::too_many_arguments)]
@@ -694,6 +716,7 @@ pub async fn run_slack_adapter(
 ) -> Result<()> {
     let bot_token = adapter.bot_token().to_string();
     let bot_turns = Arc::new(tokio::sync::Mutex::new(BotTurnTracker::new(max_bot_turns)));
+    let mut backoff_secs = 1u64;
 
     loop {
         // Check for shutdown before (re)connecting
@@ -705,8 +728,12 @@ pub async fn run_slack_adapter(
         let ws_url = match get_socket_mode_url(&app_token).await {
             Ok(url) => url,
             Err(e) => {
-                error!("failed to get Socket Mode URL: {e}");
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                error!(err = %e, backoff = backoff_secs, "failed to get Socket Mode URL, retrying");
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
+                    _ = shutdown_rx.changed() => { return Ok(()); }
+                }
+                backoff_secs = next_backoff(backoff_secs);
                 continue;
             }
         };
@@ -715,11 +742,17 @@ pub async fn run_slack_adapter(
         match tokio_tungstenite::connect_async(&ws_url).await {
             Ok((ws_stream, _)) => {
                 info!("Slack Socket Mode connected");
+                backoff_secs = 1; // reset on success
                 let (mut write, mut read) = ws_stream.split();
+                let mut ping_interval =
+                    tokio::time::interval(std::time::Duration::from_secs(PING_INTERVAL_SECS));
+                ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                let mut last_inbound = std::time::Instant::now();
 
                 loop {
                     tokio::select! {
                         msg_result = read.next() => {
+                            last_inbound = std::time::Instant::now();
                             let Some(msg_result) = msg_result else { break };
                             match msg_result {
                                 Ok(tungstenite::Message::Text(text)) => {
@@ -1058,6 +1091,22 @@ pub async fn run_slack_adapter(
                                 _ => {}
                             }
                         }
+                        _ = ping_interval.tick() => {
+                            if socket_idle(
+                                last_inbound.elapsed(),
+                                std::time::Duration::from_secs(IDLE_TIMEOUT_SECS),
+                            ) {
+                                warn!(
+                                    idle_secs = last_inbound.elapsed().as_secs(),
+                                    "Slack Socket Mode idle past timeout (likely half-open), forcing reconnect"
+                                );
+                                break;
+                            }
+                            if let Err(e) = write.send(tungstenite::Message::Ping(Vec::new())).await {
+                                warn!(error = %e, "Slack Socket Mode ping failed, reconnecting");
+                                break;
+                            }
+                        }
                         _ = shutdown_rx.changed() => {
                             info!("Slack adapter received shutdown signal");
                             let _ = write.send(tungstenite::Message::Close(None)).await;
@@ -1067,12 +1116,16 @@ pub async fn run_slack_adapter(
                 }
             }
             Err(e) => {
-                error!("failed to connect to Slack Socket Mode: {e}");
+                error!(err = %e, backoff = backoff_secs, "failed to connect to Slack Socket Mode, retrying");
             }
         }
 
-        warn!("reconnecting to Slack Socket Mode in 5s...");
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        warn!(backoff = backoff_secs, "reconnecting to Slack Socket Mode");
+        tokio::select! {
+            _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
+            _ = shutdown_rx.changed() => { return Ok(()); }
+        }
+        backoff_secs = next_backoff(backoff_secs);
     }
 }
 
@@ -2214,5 +2267,37 @@ mod tests {
         let ttl = std::time::Duration::from_secs(300);
         let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, true);
         assert!(adapter.renders_native_tables());
+    }
+}
+
+#[cfg(test)]
+mod socket_keepalive_tests {
+    use super::{next_backoff, socket_idle, IDLE_TIMEOUT_SECS, MAX_BACKOFF_SECS};
+    use std::time::Duration;
+
+    /// Backoff doubles and caps, matching the gateway adapter (1,2,4,8,16,30,30…).
+    #[test]
+    fn backoff_doubles_then_caps() {
+        let mut b = 1u64;
+        let seq: Vec<u64> = (0..8)
+            .map(|_| {
+                let cur = b;
+                b = next_backoff(b);
+                cur
+            })
+            .collect();
+        assert_eq!(seq, vec![1, 2, 4, 8, 16, MAX_BACKOFF_SECS, MAX_BACKOFF_SECS, MAX_BACKOFF_SECS]);
+        assert_eq!(next_backoff(MAX_BACKOFF_SECS), MAX_BACKOFF_SECS);
+    }
+
+    /// A half-open socket (no inbound past the window) is detected; an active one
+    /// (recent inbound, e.g. a Slack ping) is not. This is the deaf-socket guard.
+    #[test]
+    fn idle_detects_half_open_at_boundary() {
+        let timeout = Duration::from_secs(IDLE_TIMEOUT_SECS);
+        assert!(!socket_idle(Duration::from_secs(0), timeout));
+        assert!(!socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS - 1), timeout));
+        assert!(socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS), timeout));
+        assert!(socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS + 10), timeout));
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -93,7 +93,12 @@ impl SlackAdapter {
         assistant_mode: bool,
     ) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            // Bound every Slack Web API call; an unbounded inline gating call in the
+            // read loop could otherwise stall the Socket Mode idle-timeout watchdog.
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
             bot_token,
             bot_user_id: tokio::sync::OnceCell::new(),
             user_cache: tokio::sync::Mutex::new(HashMap::new()),
@@ -716,6 +721,9 @@ pub async fn run_slack_adapter(
 ) -> Result<()> {
     let bot_token = adapter.bot_token().to_string();
     let bot_turns = Arc::new(tokio::sync::Mutex::new(BotTurnTracker::new(max_bot_turns)));
+    // Warm the bot-user-id cache once so the per-message path never does the
+    // cold-cache `auth.test` inline in the read loop.
+    let _ = adapter.get_bot_user_id().await;
     let mut backoff_secs = 1u64;
 
     loop {
@@ -897,34 +905,47 @@ pub async fn run_slack_adapter(
                                                 } else {
                                                     format!("{}:{}", channel_id, event["ts"].as_str().unwrap_or(""))
                                                 };
-                                                {
+                                                // Classify under the lock (order-sensitive, kept in the read
+                                                // loop), but run any warning send AFTER releasing it; holding
+                                                // the tracker mutex across `chat.postMessage` would stall turn
+                                                // tracking for every thread, not just this one.
+                                                let turn_action = {
                                                     let mut tracker = bot_turns.lock().await;
                                                     if is_bot {
-                                                        match tracker.classify_bot_message(&turn_key) {
-                                                            TurnAction::Continue => {}
-                                                            TurnAction::SilentStop => continue,
-                                                            TurnAction::WarnAndStop { severity, turns, user_message } => {
-                                                                match severity {
-                                                                    TurnSeverity::Hard => warn!(channel_id, turns, "hard bot turn limit reached"),
-                                                                    TurnSeverity::Soft => info!(channel_id, turns, max = max_bot_turns, "soft bot turn limit reached"),
-                                                                }
-                                                                let channel_allowed = allow_all_channels
-                                                                    || allowed_channels.contains(channel_id);
-                                                                if !is_own_bot_msg && channel_allowed {
-                                                                    let warn_channel = ChannelRef {
-                                                                        platform: "slack".into(),
-                                                                        channel_id: channel_id.to_string(),
-                                                                        thread_id: event["thread_ts"].as_str().map(|s| s.to_string()),
-                                                                        parent_id: None,
-                                                                        origin_event_id: None,
-                                                                    };
-                                                                    let _ = adapter.send_message(&warn_channel, &user_message).await;
-                                                                }
-                                                                continue;
-                                                            }
+                                                        tracker.classify_bot_message(&turn_key)
+                                                    } else {
+                                                        if is_plain_user_message(subtype, msg_text) {
+                                                            tracker.on_human_message(&turn_key);
                                                         }
-                                                    } else if is_plain_user_message(subtype, msg_text) {
-                                                        tracker.on_human_message(&turn_key);
+                                                        TurnAction::Continue
+                                                    }
+                                                };
+                                                match turn_action {
+                                                    TurnAction::Continue => {}
+                                                    TurnAction::SilentStop => continue,
+                                                    TurnAction::WarnAndStop { severity, turns, user_message } => {
+                                                        match severity {
+                                                            TurnSeverity::Hard => warn!(channel_id, turns, "hard bot turn limit reached"),
+                                                            TurnSeverity::Soft => info!(channel_id, turns, max = max_bot_turns, "soft bot turn limit reached"),
+                                                        }
+                                                        let channel_allowed = allow_all_channels
+                                                            || allowed_channels.contains(channel_id);
+                                                        if !is_own_bot_msg && channel_allowed {
+                                                            let warn_channel = ChannelRef {
+                                                                platform: "slack".into(),
+                                                                channel_id: channel_id.to_string(),
+                                                                thread_id: event["thread_ts"].as_str().map(|s| s.to_string()),
+                                                                parent_id: None,
+                                                                origin_event_id: None,
+                                                            };
+                                                            let adapter = adapter.clone();
+                                                            tokio::spawn(async move {
+                                                                if let Err(e) = adapter.send_message(&warn_channel, &user_message).await {
+                                                                    warn!(error = %e, "failed to send bot turn limit warning");
+                                                                }
+                                                            });
+                                                        }
+                                                        continue;
                                                     }
                                                 }
 


### PR DESCRIPTION
## 0. Discord Discussion URL

https://discord.com/channels/1491295327620169908/1491969620754567270/1516296200893239297

## 1. What problem does this solve?

Closes #1050, #1101.

The Slack adapter's Socket Mode connection can go **half-open**: the TCP socket stays
"ESTABLISHED" but inbound frames silently stop arriving, with no Close/FIN. After this
happens the bot is **deaf to every `app_mention` / message for hours**, yet keeps logging
`Slack Socket Mode connected` and looks healthy. Bots that also run cron jobs appear alive
(their outbound posts still go out); bots without cron go completely silent.

Root cause: in `run_slack_adapter` the inner event loop is

```rust
tokio::select! {
    msg_result = read.next() => { ... }      // only wakes on an inbound frame
    _ = shutdown_rx.changed() => { ... }      // or shutdown
}
```

When the inbound path dies without a TCP FIN/RST (a NAT/proxy idle-timeout dropping the
connection is the common cause), `read.next()` never returns: not `Close`, not `Err`, not
`None`, so the loop blocks forever. The reconnect path at the bottom of the outer loop is
only reached via `break` (on `Close`/`Err`/`None`) or a connect failure, none of which fire.
The adapter also only sends `Pong` in response to a server `Ping`; it never pings on its
own, so a dead inbound path is never probed. Slack rotates Socket Mode sockets every few
hours, but that rotation signal also arrives inbound, so it is lost too.

This is the same "deaf while showing connected" class documented upstream in the Slack
ecosystem (see the Prior Art section).

## 2. At a Glance

```
BEFORE (half-open = permanent deafness)
  Slack ──X (NAT drops inbound, no FIN) ──▶  read.next() blocks forever
  select! { read.next(), shutdown }   (no timeout arm)  ──▶  never breaks ──▶ never reconnects
  result: 0 inbound events for hours; log still says "connected"

AFTER (proactive ping + idle watchdog)
  select! {
    read.next()        ─▶ on ANY inbound frame: last_inbound = now
    ping_interval(30s) ─▶ if now - last_inbound >= 75s  ─▶ warn + break ─▶ reconnect
                          else send Ping  (Slack replies Pong = inbound = liveness)
    shutdown
  }
  on break ─▶ reconnect with capped exponential backoff (1→2→4→…→30s, reset on success)
```

## 3. Prior Art & Industry Research

This touches runtime/delivery, so prior art applies. The chosen pattern (proactive ping +
"no inbound frame within N seconds means reconnect" idle watchdog + capped backoff) is the
industry default, and is what both of openab's named reference projects do.

| Project / SDK | Keepalive mechanism | How it detects a dead socket | Reconnect strategy |
|---|---|---|---|
| **Slack Socket Mode** (server) | Server sends WS pings; sends `type:"disconnect"` (`reason:"refresh_requested"`, optional `"warning"` ~10s prior) before rotating every few hours | Protocol expects clients to reconnect on disconnect frames and dropped sockets | Client reconnects (URL re-fetched via `apps.connections.open`) |
| **@slack/socket-mode** (official Node/Bolt SDK) | Client ping + watches server pings: `clientPingTimeout` (5s pong-wait), `serverPingTimeout` (30s no-inbound-frame idle watchdog) | Either timeout means dead | `autoReconnectEnabled` (default true) |
| **python-slack-sdk** `SocketModeClient` | `ping_interval` (5s) + `current_session_monitor` thread | monitor's `check_state()` reconnects when session closed | `auto_reconnect_enabled` (default true) |
| **OpenClaw** | Delegates ping/pong to Bolt; `clientPingTimeout: 15000ms`; "App events are useful status activity, but not transport proof" | SDK pong-timeout close; refuses to treat app events as liveness | Capped exp backoff + jitter (`2s→30s, factor 1.8, jitter 0.25, 12 attempts`); fail-fast on auth |
| **Hermes Agent** | Bolt ping/pong + external `_socket_watchdog_loop` (15s poll) | watchdog reconnects when socket task done or transport probe disconnected ("self-heal when Slack silently drops the websocket") | lock-guarded restart; siblings + repo convention: exp backoff + jitter |
| **RFC 6455 / WebSocket.org** | App-layer ping/pong every 20-45s (opcodes 0x9/0xA) | missed pong / no inbound within timeout means zombie | reconnect, capped exp backoff + jitter |

Key findings (citations):
- Slack's server sends pings and `type:"disconnect"` before socket rotation, so a healthy
  socket receives inbound frames regularly; an absence of any inbound for ~75s is a sound
  dead-socket signal. https://docs.slack.dev/apis/events-api/using-socket-mode/
- Slack's official Node SDK already ships exactly this: `serverPingTimeout` is the canonical
  "no inbound frame within N ms means reconnect" watchdog; this PR is a conservative tuning of it.
  https://docs.slack.dev/tools/node-slack-sdk/reference/socket-mode/interfaces/SocketModeOptions/
- python-slack-sdk pairs a ping with a `current_session_monitor` watchdog + auto-reconnect.
  https://docs.slack.dev/tools/python-slack-sdk/reference/socket_mode/builtin/client.html
- **OpenClaw** (primary reference) implements the same pattern and names the insight directly
  ("App messages and events remain application state, not transport liveness signals"),
  reconnecting on the SDK pong-timeout with bounded backoff.
  https://github.com/openclaw/openclaw/blob/main/extensions/slack/src/monitor/reconnect-policy.ts
- The half-open mode is a filed defect in that ecosystem: OpenClaw #61072 (stale-socket
  restart) and #58519 ("silent message loss… gateway logs successful delivery, but Slack
  never receives it"), the same symptom. https://github.com/openclaw/openclaw/issues/58519
- **Hermes Agent** (other reference) self-heals via a watchdog precisely because "Slack
  silently drops the websocket". https://github.com/NousResearch/hermes-agent/blob/main/gateway/platforms/slack.py
- General best practice: TCP keepalive cannot catch a half-open socket; app-layer ping + idle
  timeout (~75% of the shortest proxy timeout; proxies kill idle conns in 60-100s) is the
  standard remedy. https://websocket.org/guides/heartbeat/ , https://datatracker.ietf.org/doc/html/rfc6455

Divergence note: neither OpenClaw nor Hermes hand-rolls Slack ping frames; both delegate to
the Bolt SDK and add a watchdog/reconnect layer. openab speaks the WebSocket directly via
`tokio-tungstenite` (no Bolt equivalent), so the ping + idle watchdog is implemented in the
adapter loop itself, same principle applied at the layer openab actually owns.

## 4. Proposed Solution

In `run_slack_adapter` (`src/slack.rs`):

1. **Idle watchdog + proactive ping.** Per connection, create a `tokio::time::interval`
   (30s, `MissedTickBehavior::Delay`, mirroring `cron.rs`) and track `last_inbound: Instant`.
   The `read.next()` arm updates `last_inbound` on any inbound frame. A new `select!` arm on
   `ping_interval.tick()`:
   - if `now - last_inbound >= 75s` then `warn!` and `break` to reconnect (half-open detected);
   - else send a `Ping` (Slack's `Pong` reply arrives inbound and refreshes `last_inbound`);
   - if the `Ping` send itself errors, `break` to reconnect.
2. **Align reconnect backoff with `gateway.rs`.** Replace the fixed `sleep(5s)` (and the
   bare URL-fetch retry `sleep`) with capped exponential backoff: `backoff_secs` starts at 1,
   resets to 1 on a successful connect, grows `(x*2).min(30)`, and every sleep is wrapped in a
   `select!` so shutdown interrupts it (the old fixed sleep was not shutdown-interruptible).
3. **Testable decisions.** The two decisions are extracted as pure functions,
   `socket_idle(elapsed, timeout)` and `next_backoff(cur)`, and unit-tested.
4. **Keep the read loop responsive without moving gating off it (review follow-up).**
   The first review noted that inline Slack Web API awaits in the `read.next()` arm
   (`conversations.replies`, `bot_participated_in_thread`, trusted-bot lookup) could starve
   the `select!` so the watchdog tick was delayed. Rather than relocate gating into the
   spawned task (which would break the dispatcher's arrival-order guarantee and let the
   consecutive-bot-turn cap race on cold start), gating stays serial in the read loop, the
   batching ADR's canonical adapter pattern, and the I/O is bounded instead:
   - the Slack Web API client gets a **30s request timeout** (it was an unbounded
     `reqwest::Client::new()`), so no inline gating call can block the loop indefinitely; the
     bot path makes at most two sequential gating calls, so the worst case stays under the 75s
     idle window, and in practice these calls are sub-second;
   - `bot_user_id` is resolved once before the loop, so the per-message path never does the
     cold-cache `auth.test` inline;
   - the turn-limit warning is classified under the `bot_turns` lock but sent from a detached
     task after the lock is released, and its result is checked and logged instead of dropped.

The 75s window sits in the recommended band (>Slack's 30s default, <typical 60-120s proxy
idle-kill, well under Slack's multi-hour refresh): long enough not to churn a quiet-but-healthy
socket, short enough to recover a dead one in ~1 minute instead of never.

## 5. Why This Approach

- **Minimal + consistent.** It reuses patterns already in the tree (the `interval` +
  `MissedTickBehavior::Delay` from `cron.rs`, the capped-backoff `select!` from `gateway.rs`),
  so the Slack adapter stops being the odd one out (it was the only WS loop with a fixed,
  non-interruptible 5s reconnect and no liveness check).
- **Stays on the canonical adapter pattern.** Gating remains serial in the read loop as the
  batching ADR prescribes, so there is no reordering of dispatcher submits and no concurrent
  bot-turn cap check. The staleness concern is solved by bounding the I/O (a request timeout
  the client was missing anyway), not by adding a per-thread async queue the ADR discourages.
- **No new dependencies, no config surface.** Constants are hardcoded like `gateway.rs`'s
  `MAX_BACKOFF`; this keeps the PR to one concern. They can be promoted to `[slack]` config in
  a follow-up if tuning is ever needed.
- **Self-validating liveness.** Counting any inbound frame (Slack's own pings, our ping's
  pong, real events) as liveness means a quiet-but-healthy socket is never falsely reconnected.

Limitations: a 30s ping interval means worst-case detection is ~75-105s, not instant (a
deliberate tradeoff against churn). The constants aren't yet configurable.

## 6. Alternatives Considered

- **TCP keepalive (`SO_KEEPALIVE`).** Rejected: default ~2h, and OS/proxy behavior is
  inconsistent; RFC/industry guidance says it doesn't reliably catch half-open client sockets.
- **Periodic forced reconnect (every N hours).** Rejected: blunt; drops a healthy socket and
  still leaves a multi-hour deaf window before the timer fires.
- **External k8s liveness probe that restarts the pod on silence.** Rejected: kills the whole
  process for one dead adapter, loses other adapters' state, and is ops config rather than a
  fix in the code that owns the socket. (It remains a fine defense-in-depth, but not the fix.)
- **Only add backoff, no heartbeat.** Rejected: backoff helps repeated connect failures but
  does nothing for a half-open socket that never errors; the heartbeat is the actual fix.
- **Move the gating + dispatch off the read loop into per-thread workers (to fix staleness).**
  Considered and implemented in an earlier revision, then reverted. It addressed staleness but
  introduced two regressions: `dispatcher.submit` ran in gating-completion order rather than
  arrival order (against the dispatcher's no-reorder invariant), and the `conversations.replies`
  bot-turn cap ran concurrently per thread, so two near-simultaneous bot messages could both
  pass the cap (notably right after a restart, when the in-memory turn tracker is empty and that
  scan is the only true-history defense). It also reintroduced a keyed async queue, which the
  batching ADR's canonical adapter pattern explicitly says not to add. Bounding the inline I/O
  keeps the canonical serial pattern and avoids both regressions, so it is preferred here.

## 7. Validation

Rust (package `openab`):
- `cargo clippy -p openab -- -D warnings` is clean.
- `cargo test -p openab` is green except one pre-existing, unrelated failure
  (`secrets::tests::resolve_exec_nonzero_exit`), which reproduces on the base branch with this
  PR's changes stashed (an environment-specific `/bin/false` error-string check in a file this
  PR does not touch). The half-open detection is covered by `socket_keepalive_tests`
  (`backoff_doubles_then_caps`, `idle_detects_half_open_at_boundary`).
- Diff is confined to `src/slack.rs`.
- Live deployment: the exact PR image was deployed to a live Slack bot on a single-node k8s
  cluster (`imagePullPolicy: Never`); the pod is healthy (`1/1 Running`) and the adapter logs
  `Slack Socket Mode connected` on startup, so the gating-in-loop path runs on the shipped
  binary. The half-open recovery is a network-timing condition (NAT/proxy idle-drop), so it is
  being observed on that long-lived connection for the `forcing reconnect` log over a
  multi-hour window.

Test level matches this crate's convention for adapter/reconnect code: the idle and backoff
decisions are pure functions with unit tests, like the rest of `src/slack.rs`. The half-open
detection + reconnect path itself is not unit-tested, consistent with `src/gateway.rs`, whose
reconnect loop has no test either; the trigger is a network-timing condition (NAT/proxy
idle-drop) best verified by deployment observation (watch for the `forcing reconnect` log on a
long-lived connection). There is no new unit test for the gating order / cap path because the
fix is a revert to the canonical serial pattern (correct by construction) and the main crate's
`src/` has no Socket Mode mock-server harness today; happy to add one if maintainers want that
bar raised for the WS adapters.

Notes:
- I did not run crate-wide `cargo fmt`: on the current toolchain `main` is not rustfmt-clean
  (unrelated files like `src/acp/agentcore.rs` reflow), and reformatting them would add noise
  unrelated to this fix (one concern per PR). The added lines are rustfmt-clean.
