### PR TITLE
build(claude): bump claude-agent-acp 0.45.0 + claude-code 2.1.177

### DIFF
--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # Install claude-agent-acp adapter and Claude Code CLI.
 # Without CLAUDE_CODE_EXECUTABLE the adapter uses its own bundled SDK cli.js,
 # ignoring the globally installed claude-code binary (see #418).
-ARG CLAUDE_AGENT_ACP_VERSION=0.29.2
-ARG CLAUDE_CODE_VERSION=2.1.146
+ARG CLAUDE_AGENT_ACP_VERSION=0.45.0
+ARG CLAUDE_CODE_VERSION=2.1.177
 RUN npm install -g @agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION} @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} --retry 3
 ENV CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude
 


### PR DESCRIPTION
## What

Bump the Claude image's pinned versions in `Dockerfile.claude`:

- `claude-agent-acp`: 0.29.2 → **0.45.0**
- `claude-code`: 2.1.146 → **2.1.177**

## Why

Both versions have been running in production on a local-binary canary deployment with no issues. They are bumped together as a **matched pair** — bumping the adapter alone (new ACP 0.45 against the old 2.1.146 CLI) would be an untested combination, and the `CLAUDE_CODE_EXECUTABLE` wiring (see #418) means the adapter drives the globally-installed `claude` binary directly, so the two should stay in sync.

## Scope

Only `Dockerfile.claude` — the `CLAUDE_AGENT_ACP_VERSION` / `CLAUDE_CODE_VERSION` ARGs are specific to this Dockerfile and do not affect the other 10 Dockerfiles, which pin their own agent versions.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404/1516312573124018277