### PR TITLE
fix(streaming): recover from Feishu 20-edit cap (errcode 230072)

### DIFF
--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -1112,7 +1112,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openab-gateway"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "aes",
  "anyhow",

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -713,9 +713,12 @@ pub struct FeishuAdapter {
     /// Per-message edit count tracker for Feishu's 20-edits-per-message hard cap
     /// (errcode 230072 — "The message has reached the number of times it can be edited").
     /// Insertion-order FIFO eviction: when over `EDIT_COUNTS_CACHE_MAX`, the
-    /// oldest *insertions* are dropped, never the lowest-count entries — so
-    /// active streaming messages (just-started, low count) are never the
-    /// eviction target.
+    /// oldest *insertions* are dropped, not the lowest-count entries — so a
+    /// just-started active stream is far less likely to be evicted than under a
+    /// count-ascending policy. (A very long-lived stream can still age out once
+    /// 4096 newer messages have been inserted behind it; that resets its count
+    /// to 1, which is acceptable — it only loses the local preemptive margin and
+    /// the on-wire 230072 sentinel still backstops.)
     pub edit_counts: Arc<std::sync::Mutex<EditCountsCache>>,
     pub client: reqwest::Client,
 }
@@ -723,10 +726,11 @@ pub struct FeishuAdapter {
 /// Insertion-order edit-count cache for Feishu's per-message edit cap.
 ///
 /// `counts` holds the current edit count (or `u32::MAX` cap-reached sentinel)
-/// for each message_id. `order` records the insertion order so eviction is
-/// FIFO rather than count-ascending; this matters because count-ascending
-/// would target *active* streams (low count = just started) while leaving
-/// stale cap-reached entries in place.
+/// for each message_id. `order` records insertion order so eviction is FIFO
+/// rather than count-ascending; this matters because count-ascending would
+/// preferentially target *active* streams (low count = just started) while
+/// leaving stale cap-reached entries in place. FIFO instead ages out the
+/// oldest insertions, which strongly favours keeping active streams.
 #[derive(Default)]
 pub struct EditCountsCache {
     pub counts: HashMap<String, u32>,
@@ -1193,7 +1197,7 @@ fn is_feishu_cap_reached_body(body: &str) -> bool {
     match serde_json::from_str::<serde_json::Value>(body) {
         Ok(v) => v
             .get("code")
-            .and_then(|c| c.as_u64())
+            .and_then(|c| c.as_i64())
             .is_some_and(|code| code == 230072),
         Err(_) => {
             body.contains("230072")
@@ -1313,19 +1317,23 @@ async fn edit_feishu_message(
         .header("Content-Type", "application/json; charset=utf-8")
         .json(&body).send().await
     {
-        Ok(resp) if resp.status().is_success() => {
-            increment_edit_count(&adapter.edit_counts, message_id);
-            tracing::trace!(message_id = %message_id, "feishu message edited");
-            EditOutcome::Edited
-        }
         Ok(resp) => {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            // Detect errcode 230072 ("The message has reached the number of times
-            // it can be edited") — server-side confirmation of edit cap. Trust
-            // JSON `code` field; fall back to substring only for non-JSON bodies
-            // (HTML proxy errors, truncated responses) to avoid false positives
-            // on JSON responses where "230072" appears in an unrelated string.
+            // Feishu OpenAPI convention: the business result lives in the body
+            // `code` field, and an edit-cap rejection (errcode 230072) can arrive
+            // with HTTP 200. So we decide on the body — consistent with token
+            // refresh and the WS endpoint elsewhere in this file — rather than
+            // trusting HTTP status alone, which would miscount a 200 + non-zero
+            // `code` response as a successful edit and never reach cap detection.
+            //
+            // This relies on Feishu returning `code` as a JSON integer (which it
+            // always does). A non-integer or absent code falls through to the
+            // HTTP-status fallback below, so a malformed 2xx body is treated as
+            // success — acceptable, since Feishu never emits such a body.
+            //
+            // 1. Cap reached? `is_feishu_cap_reached_body` is the sole authority
+            //    (JSON code == 230072, or substring fallback for non-JSON bodies).
             if is_feishu_cap_reached_body(&body) {
                 mark_edit_cap(&adapter.edit_counts, message_id);
                 tracing::warn!(
@@ -1333,15 +1341,45 @@ async fn edit_feishu_message(
                     status = %status,
                     "feishu edit cap reached (errcode 230072); signaling core for cap-reached recovery"
                 );
-                EditOutcome::CapReached
-            } else {
-                tracing::error!(
-                    message_id = %message_id,
-                    status = %status,
-                    body = %body,
-                    "feishu edit message failed"
-                );
-                EditOutcome::Failed(format!("HTTP {status}: {body}"))
+                return EditOutcome::CapReached;
+            }
+            // 2. Otherwise classify by body `code` (0 = success), falling back to
+            //    HTTP status only for non-JSON bodies (proxy HTML, truncated).
+            match serde_json::from_str::<serde_json::Value>(&body)
+                .ok()
+                .and_then(|v| v.get("code").and_then(|c| c.as_i64()))
+            {
+                Some(0) => {
+                    increment_edit_count(&adapter.edit_counts, message_id);
+                    tracing::trace!(message_id = %message_id, "feishu message edited");
+                    EditOutcome::Edited
+                }
+                Some(code) => {
+                    tracing::error!(
+                        message_id = %message_id,
+                        status = %status,
+                        code,
+                        body = %body,
+                        "feishu edit message failed"
+                    );
+                    EditOutcome::Failed(format!("code {code}: {body}"))
+                }
+                None => {
+                    // Body wasn't JSON-with-code; trust HTTP status as last resort.
+                    if status.is_success() {
+                        increment_edit_count(&adapter.edit_counts, message_id);
+                        tracing::trace!(message_id = %message_id, "feishu message edited (non-JSON 2xx body)");
+                        EditOutcome::Edited
+                    } else {
+                        tracing::error!(
+                            message_id = %message_id,
+                            status = %status,
+                            body = %body,
+                            "feishu edit message failed"
+                        );
+                        EditOutcome::Failed(format!("HTTP {status}: {body}"))
+                    }
+                }
             }
         }
         Err(e) => {
@@ -1356,22 +1394,14 @@ async fn edit_feishu_message(
 /// so this works even on messages that have already exhausted their edit quota.
 /// Used by the streaming finalize path to remove the half-edited placeholder
 /// before sending the full content as fresh messages, avoiding visual overlap.
+///
+/// `message_id` shape is validated by the caller (`handle_reply` dispatch seam,
+/// via `is_valid_feishu_message_id`) before this is reached, so it is safe to
+/// interpolate into the URL path here.
 async fn delete_feishu_message(
     adapter: &FeishuAdapter,
     message_id: &str,
 ) -> Result<(), String> {
-    // Defence-in-depth: validate message_id shape before interpolating into the
-    // REST URL path. The trust boundary is the core↔gateway WebSocket (not
-    // external input), but a crafted ID with `/`, `?`, or `#` could otherwise
-    // alter URL semantics.
-    if !is_valid_feishu_message_id(message_id) {
-        tracing::warn!(
-            message_id = %message_id,
-            "feishu delete refused: message_id failed shape validation"
-        );
-        return Err("invalid message_id format".to_string());
-    }
-
     let token = adapter
         .token_cache
         .get_token(&adapter.client)
@@ -2175,6 +2205,38 @@ pub async fn handle_reply(
 ) {
     // Handle reactions — add/remove emoji on the original message
     if let Some(ref cmd) = reply.command {
+        // Defence-in-depth: every command below interpolates `reply.reply_to`
+        // into a REST URL path (edit/delete → /im/v1/messages/{id}; reactions →
+        // /im/v1/messages/{id}/reactions). Validate the id shape once here, at
+        // the dispatch seam, so a crafted id with URL metacharacters can't alter
+        // request semantics. Trust boundary is the core↔gateway WebSocket, so
+        // this is belt-and-suspenders — but it closes the guard over every
+        // url-path-bearing command instead of just delete.
+        let interpolates_message_id = matches!(
+            cmd.as_str(),
+            "edit_message" | "delete_message" | "add_reaction" | "remove_reaction"
+        );
+        if interpolates_message_id && !is_valid_feishu_message_id(&reply.reply_to) {
+            tracing::warn!(
+                command = %cmd,
+                message_id = %reply.reply_to,
+                "feishu: refusing command — message_id failed shape validation"
+            );
+            if let Some(ref req_id) = reply.request_id {
+                let resp = crate::schema::GatewayResponse {
+                    schema: "openab.gateway.response.v1".into(),
+                    request_id: req_id.clone(),
+                    success: false,
+                    thread_id: None,
+                    message_id: None,
+                    error: Some("invalid message_id format".to_string()),
+                };
+                if let Ok(json) = serde_json::to_string(&resp) {
+                    let _ = event_tx.send(json);
+                }
+            }
+            return;
+        }
         match cmd.as_str() {
             "add_reaction" => {
                 add_reaction(adapter, &reply.reply_to, &reply.content.text).await;
@@ -2190,10 +2252,10 @@ pub async fn handle_reply(
                     &reply.reply_to,
                     &reply.content.text,
                 ).await;
-                // Translate outcome → (success, message_id, error). For CapReached
-                // we attempt an append-new fallback: post the latest content as a
-                // fresh in-thread message so the user gets the rest of the reply
-                // even though the original message can no longer be edited.
+                // Translate outcome → (success, message_id, error). For
+                // CapReached we deliberately do NOT append-new at the gateway
+                // layer (see the rationale on the CapReached arm below); we
+                // signal failure so core's finalize path owns recovery.
                 let (success, message_id, error) = match outcome {
                     EditOutcome::Edited => {
                         (true, Some(reply.reply_to.clone()), None)
@@ -2249,6 +2311,11 @@ pub async fn handle_reply(
                     Ok(()) => (true, None),
                     Err(e) => (false, Some(e)),
                 };
+                // Dormant by design: core's delete_message is fire-and-forget
+                // (request_id = None), so this response branch is currently
+                // never taken. Kept for symmetry with the other handlers and so
+                // delete becomes observable for free if a future caller (or
+                // another gateway client) sets request_id.
                 if let Some(ref req_id) = reply.request_id {
                     let resp = crate::schema::GatewayResponse {
                         schema: "openab.gateway.response.v1".into(),
@@ -3672,5 +3739,174 @@ mod tests {
         // Length cap (defense against pathological inputs).
         let too_long = format!("om_{}", "a".repeat(200));
         assert!(!is_valid_feishu_message_id(&too_long));
+    }
+
+    // --- edit_feishu_message integration (wiremock): proves the cap is detected
+    //     through the HTTP-status gate, including the HTTP-200 + body-code case ---
+
+    async fn mount_token(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/open-apis/auth/v3/tenant_access_token/internal"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 0,
+                "msg": "ok",
+                "tenant_access_token": "t-edit-test",
+                "expire": 7200
+            })))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn edit_cap_detected_on_http_200_body_code() {
+        // Feishu returns the edit-cap rejection as HTTP 200 + {"code":230072}.
+        // Regression guard for the body-code-first fix: a status-only success
+        // gate would miscount this as Edited and never trip cap detection.
+        let server = MockServer::start().await;
+        mount_token(&server).await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/im/v1/messages/om_capped"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 230072,
+                "msg": "The message has reached the number of times it can be edited."
+            })))
+            .mount(&server)
+            .await;
+
+        let mut config = test_config();
+        config.api_base_override = Some(server.uri());
+        let adapter = FeishuAdapter::new(config);
+
+        let outcome = edit_feishu_message(&adapter, "om_capped", "hello").await;
+        assert!(
+            matches!(outcome, EditOutcome::CapReached),
+            "HTTP 200 + code 230072 must yield CapReached, got non-cap outcome"
+        );
+        // Sentinel marked → subsequent pre-check short-circuits.
+        assert!(is_edit_cap_reached(&adapter.edit_counts, "om_capped"));
+    }
+
+    #[tokio::test]
+    async fn edit_success_on_http_200_code_zero() {
+        // HTTP 200 + {"code":0} is a real success → Edited + count incremented.
+        let server = MockServer::start().await;
+        mount_token(&server).await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/im/v1/messages/om_ok"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 0,
+                "msg": "success",
+                "data": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let mut config = test_config();
+        config.api_base_override = Some(server.uri());
+        let adapter = FeishuAdapter::new(config);
+
+        let outcome = edit_feishu_message(&adapter, "om_ok", "hello").await;
+        assert!(
+            matches!(outcome, EditOutcome::Edited),
+            "HTTP 200 + code 0 must yield Edited"
+        );
+        let map = adapter.edit_counts.lock().unwrap();
+        assert_eq!(map.counts.get("om_ok").copied(), Some(1));
+    }
+
+    #[tokio::test]
+    async fn edit_failure_on_http_200_other_code() {
+        // HTTP 200 + non-zero, non-cap code is a genuine failure, not a success.
+        let server = MockServer::start().await;
+        mount_token(&server).await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/im/v1/messages/om_err"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 99991,
+                "msg": "rate limited"
+            })))
+            .mount(&server)
+            .await;
+
+        let mut config = test_config();
+        config.api_base_override = Some(server.uri());
+        let adapter = FeishuAdapter::new(config);
+
+        let outcome = edit_feishu_message(&adapter, "om_err", "hello").await;
+        assert!(
+            matches!(outcome, EditOutcome::Failed(_)),
+            "HTTP 200 + code 99991 must yield Failed, not Edited"
+        );
+        // Failure must NOT increment the edit count.
+        let map = adapter.edit_counts.lock().unwrap();
+        assert_eq!(map.counts.get("om_err").copied(), None);
+    }
+
+    // --- handle_reply dispatch-seam message_id validation (R3) ---
+    // These exercise the seam reject path directly (the edit_* tests above call
+    // edit_feishu_message and bypass the seam). The guard runs before any
+    // network call, so no mock server is needed.
+
+    #[tokio::test]
+    async fn handle_reply_seam_rejects_invalid_id_with_response() {
+        let adapter = FeishuAdapter::new(test_config());
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+
+        let reply = crate::schema::GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: "draft".into(), // sentinel, not an om_ id → rejected
+            platform: "feishu".into(),
+            channel: crate::schema::ReplyChannel {
+                id: "oc_chat1".into(),
+                thread_id: None,
+            },
+            content: crate::schema::Content {
+                content_type: "text".into(),
+                text: "hello".into(),
+                attachments: vec![],
+            },
+            command: Some("edit_message".into()),
+            request_id: Some("req_seam_1".into()),
+            quote_message_id: None,
+        };
+
+        handle_reply(&reply, &adapter, &event_tx).await;
+
+        let raw = event_rx.try_recv().expect("expected a GatewayResponse");
+        let resp: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(resp["request_id"], "req_seam_1");
+        assert_eq!(resp["success"], false);
+        assert_eq!(resp["error"], "invalid message_id format");
+    }
+
+    #[tokio::test]
+    async fn handle_reply_seam_rejects_invalid_id_silently_without_request_id() {
+        let adapter = FeishuAdapter::new(test_config());
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+
+        let reply = crate::schema::GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: "om_bad/segment".into(), // URL metachar → rejected
+            platform: "feishu".into(),
+            channel: crate::schema::ReplyChannel {
+                id: "oc_chat1".into(),
+                thread_id: None,
+            },
+            content: crate::schema::Content {
+                content_type: "text".into(),
+                text: "hello".into(),
+                attachments: vec![],
+            },
+            command: Some("delete_message".into()),
+            request_id: None,
+            quote_message_id: None,
+        };
+
+        handle_reply(&reply, &adapter, &event_tx).await;
+
+        assert!(
+            event_rx.try_recv().is_err(),
+            "no response expected when request_id is absent"
+        );
     }
 }

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -1287,6 +1287,12 @@ fn is_edit_cap_reached(
         .is_some_and(|&n| n >= FEISHU_EDIT_CAP)
 }
 
+/// Edit (update) an existing Feishu message in-place for streaming.
+///
+/// Returns [`EditOutcome`] so the caller can distinguish success, cap-reached,
+/// and generic failure. Performs a preemptive local cap check (`FEISHU_EDIT_CAP`)
+/// before hitting the network, and detects the server-side errcode 230072 via
+/// body-code-first parsing if the local count drifts from reality.
 async fn edit_feishu_message(
     adapter: &FeishuAdapter,
     message_id: &str,
@@ -2217,11 +2223,21 @@ pub async fn handle_reply(
             "edit_message" | "delete_message" | "add_reaction" | "remove_reaction"
         );
         if interpolates_message_id && !is_valid_feishu_message_id(&reply.reply_to) {
-            tracing::warn!(
-                command = %cmd,
-                message_id = %reply.reply_to,
-                "feishu: refusing command — message_id failed shape validation"
-            );
+            // "draft" is a known sentinel from core when streaming_placeholder=false;
+            // not a security concern, just a no-op — log at debug to avoid noise.
+            if reply.reply_to == "draft" {
+                tracing::debug!(
+                    command = %cmd,
+                    message_id = %reply.reply_to,
+                    "feishu: skipping command — draft placeholder has no real message_id"
+                );
+            } else {
+                tracing::warn!(
+                    command = %cmd,
+                    message_id = %reply.reply_to,
+                    "feishu: refusing command — message_id failed shape validation"
+                );
+            }
             if let Some(ref req_id) = reply.request_id {
                 let resp = crate::schema::GatewayResponse {
                     schema: "openab.gateway.response.v1".into(),

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -2,7 +2,7 @@ use crate::schema::*;
 use axum::extract::State;
 use prost::Message as ProstMessage;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::RwLock;
@@ -712,11 +712,25 @@ pub struct FeishuAdapter {
     pub multibot_threads: Arc<std::sync::Mutex<HashMap<String, Instant>>>,
     /// Per-message edit count tracker for Feishu's 20-edits-per-message hard cap
     /// (errcode 230072 — "The message has reached the number of times it can be edited").
-    /// Key: message_id, Value: count of successful edits, or u32::MAX as sentinel
-    /// for "cap reached, do not attempt further edits". Lazily evicted at insert
-    /// when over EDIT_COUNTS_CACHE_MAX.
-    pub edit_counts: Arc<std::sync::Mutex<HashMap<String, u32>>>,
+    /// Insertion-order FIFO eviction: when over `EDIT_COUNTS_CACHE_MAX`, the
+    /// oldest *insertions* are dropped, never the lowest-count entries — so
+    /// active streaming messages (just-started, low count) are never the
+    /// eviction target.
+    pub edit_counts: Arc<std::sync::Mutex<EditCountsCache>>,
     pub client: reqwest::Client,
+}
+
+/// Insertion-order edit-count cache for Feishu's per-message edit cap.
+///
+/// `counts` holds the current edit count (or `u32::MAX` cap-reached sentinel)
+/// for each message_id. `order` records the insertion order so eviction is
+/// FIFO rather than count-ascending; this matters because count-ascending
+/// would target *active* streams (low count = just started) while leaving
+/// stale cap-reached entries in place.
+#[derive(Default)]
+pub struct EditCountsCache {
+    pub counts: HashMap<String, u32>,
+    pub order: VecDeque<String>,
 }
 
 impl FeishuAdapter {
@@ -734,7 +748,7 @@ impl FeishuAdapter {
             bot_turns: Arc::new(std::sync::Mutex::new(HashMap::new())),
             participated_threads: Arc::new(std::sync::Mutex::new(HashMap::new())),
             multibot_threads: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            edit_counts: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            edit_counts: Arc::new(std::sync::Mutex::new(EditCountsCache::default())),
             client: reqwest::Client::new(),
         }
     }
@@ -1154,58 +1168,119 @@ const FEISHU_EDIT_CAP: u32 = 18;
 /// Maximum entries in the per-adapter edit_counts cache before lazy eviction kicks in.
 const EDIT_COUNTS_CACHE_MAX: usize = 4096;
 
+/// Validates that a Feishu message_id matches the expected `om_<base62>` shape
+/// before it is interpolated into a REST URL path. Feishu's documented
+/// message_id format is the `om_` prefix followed by base62-style characters
+/// (`[A-Za-z0-9_]`). Rejecting anything else stops crafted IDs containing `/`,
+/// `?`, or `#` from altering URL semantics — defence in depth, since the trust
+/// boundary is the core↔gateway WebSocket and not external input.
+fn is_valid_feishu_message_id(id: &str) -> bool {
+    let bytes = id.as_bytes();
+    if !id.starts_with("om_") || id.len() < 4 || id.len() > 128 {
+        return false;
+    }
+    bytes
+        .iter()
+        .all(|b| b.is_ascii_alphanumeric() || *b == b'_')
+}
+
+/// Detect whether a Feishu API response body indicates the per-message edit
+/// cap (errcode 230072). Trusts JSON `code` field when the body parses as
+/// JSON; falls back to substring match only on non-JSON bodies (proxy HTML,
+/// truncated responses, …) so a JSON body with an unrelated `code` cannot be
+/// false-positively flagged just because some inner string contains "230072".
+fn is_feishu_cap_reached_body(body: &str) -> bool {
+    match serde_json::from_str::<serde_json::Value>(body) {
+        Ok(v) => v
+            .get("code")
+            .and_then(|c| c.as_u64())
+            .is_some_and(|code| code == 230072),
+        Err(_) => {
+            body.contains("230072")
+                || body.contains("number of times it can be edited")
+        }
+    }
+}
+
 /// Outcome of an edit_feishu_message attempt. Distinguishes the cap-reached case
-/// from generic failure so the caller can switch to append-new fallback.
+/// from generic failure so the caller can stop attempting edits and let the
+/// core finalize path handle recovery.
 pub enum EditOutcome {
     /// Edit succeeded; the on-screen message now reflects the new content.
     Edited,
     /// The 20-edits-per-message cap is exhausted (either tracked locally or
-    /// signaled by errcode 230072). Caller should switch to append-new.
+    /// signaled by errcode 230072). Caller should stop attempting edits;
+    /// recovery (delete placeholder + send fresh) is handled at the core
+    /// finalize layer in `src/adapter.rs`, not here — appending new messages
+    /// per cosmetic flush would spam the user with continuation messages.
     CapReached,
     /// Generic failure (network, token, other API errors).
     Failed(String),
 }
 
-/// Increment the edit count for a message_id, evicting half the cache (oldest first)
-/// when over capacity. u32::MAX is a sentinel for "cap reached" — never increment
-/// past that value.
+/// Increment the edit count for a message_id. New keys are appended to the
+/// FIFO order queue; existing keys keep their position. When the cache is
+/// over `EDIT_COUNTS_CACHE_MAX`, the oldest *insertions* are evicted (not the
+/// lowest-count entries) so active streams are not bumped out from under
+/// themselves.
 fn increment_edit_count(
-    cache: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
+    cache: &Arc<std::sync::Mutex<EditCountsCache>>,
     message_id: &str,
 ) {
-    let mut map = cache.lock().unwrap_or_else(|e| e.into_inner());
-    if map.len() > EDIT_COUNTS_CACHE_MAX {
-        let mut entries: Vec<_> = map.iter().map(|(k, v)| (k.clone(), *v)).collect();
-        entries.sort_by_key(|(_, n)| *n);
-        let evict = entries.len() / 2;
-        for (k, _) in entries.into_iter().take(evict) {
-            map.remove(&k);
-        }
-    }
-    let entry = map.entry(message_id.to_string()).or_insert(0);
+    let mut c = cache.lock().unwrap_or_else(|e| e.into_inner());
+    let was_new = !c.counts.contains_key(message_id);
+    let entry = c.counts.entry(message_id.to_string()).or_insert(0);
     if *entry != u32::MAX {
         *entry = entry.saturating_add(1);
     }
+    if was_new {
+        c.order.push_back(message_id.to_string());
+        evict_if_overcap(&mut c);
+    }
 }
 
-/// Mark a message_id as cap-reached; subsequent edit attempts skip the API call
-/// and go straight to append-new fallback.
+/// Mark a message_id as cap-reached; subsequent edit attempts skip the API
+/// call and signal `EditOutcome::CapReached` directly so the core finalize
+/// path can take over.
 fn mark_edit_cap(
-    cache: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
+    cache: &Arc<std::sync::Mutex<EditCountsCache>>,
     message_id: &str,
 ) {
-    let mut map = cache.lock().unwrap_or_else(|e| e.into_inner());
-    map.insert(message_id.to_string(), u32::MAX);
+    let mut c = cache.lock().unwrap_or_else(|e| e.into_inner());
+    let was_new = !c.counts.contains_key(message_id);
+    c.counts.insert(message_id.to_string(), u32::MAX);
+    if was_new {
+        c.order.push_back(message_id.to_string());
+        evict_if_overcap(&mut c);
+    }
 }
 
-/// Return true if this message_id has already reached the edit cap (either tracked
-/// locally or marked via 230072 sentinel).
+/// FIFO eviction helper: when over `EDIT_COUNTS_CACHE_MAX`, drop the oldest
+/// half by insertion order. Tolerant of `order`/`counts` drift — entries that
+/// only exist in `order` are silently skipped.
+fn evict_if_overcap(c: &mut EditCountsCache) {
+    if c.counts.len() > EDIT_COUNTS_CACHE_MAX {
+        let evict = c.counts.len() / 2;
+        for _ in 0..evict {
+            if let Some(oldest) = c.order.pop_front() {
+                c.counts.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+/// Return true if this message_id has already reached the edit cap (either
+/// tracked locally or marked via 230072 sentinel).
 fn is_edit_cap_reached(
-    cache: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
+    cache: &Arc<std::sync::Mutex<EditCountsCache>>,
     message_id: &str,
 ) -> bool {
-    let map = cache.lock().unwrap_or_else(|e| e.into_inner());
-    map.get(message_id).is_some_and(|&n| n >= FEISHU_EDIT_CAP)
+    let c = cache.lock().unwrap_or_else(|e| e.into_inner());
+    c.counts
+        .get(message_id)
+        .is_some_and(|&n| n >= FEISHU_EDIT_CAP)
 }
 
 async fn edit_feishu_message(
@@ -1215,7 +1290,7 @@ async fn edit_feishu_message(
 ) -> EditOutcome {
     // Pre-check: if we've already tracked >= FEISHU_EDIT_CAP edits (or the sentinel
     // u32::MAX from a 230072 response), skip the API call and signal CapReached so
-    // the caller switches to append-new.
+    // the caller can stop attempting edits and let the core finalize path recover.
     if is_edit_cap_reached(&adapter.edit_counts, message_id) {
         return EditOutcome::CapReached;
     }
@@ -1247,25 +1322,30 @@ async fn edit_feishu_message(
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
             // Detect errcode 230072 ("The message has reached the number of times
-            // it can be edited") — server-side confirmation of edit cap. Mark sentinel
-            // so future attempts on this message_id skip the API call entirely.
-            let cap_reached = body.contains("230072")
-                || body.contains("number of times it can be edited");
-            if cap_reached {
+            // it can be edited") — server-side confirmation of edit cap. Trust
+            // JSON `code` field; fall back to substring only for non-JSON bodies
+            // (HTML proxy errors, truncated responses) to avoid false positives
+            // on JSON responses where "230072" appears in an unrelated string.
+            if is_feishu_cap_reached_body(&body) {
                 mark_edit_cap(&adapter.edit_counts, message_id);
                 tracing::warn!(
                     message_id = %message_id,
                     status = %status,
-                    "feishu edit cap reached (errcode 230072); switching to append-new fallback"
+                    "feishu edit cap reached (errcode 230072); signaling core for cap-reached recovery"
                 );
                 EditOutcome::CapReached
             } else {
-                tracing::error!(status = %status, body = %body, "feishu edit message failed");
+                tracing::error!(
+                    message_id = %message_id,
+                    status = %status,
+                    body = %body,
+                    "feishu edit message failed"
+                );
                 EditOutcome::Failed(format!("HTTP {status}: {body}"))
             }
         }
         Err(e) => {
-            tracing::error!(err = %e, "feishu edit message request failed");
+            tracing::error!(message_id = %message_id, err = %e, "feishu edit message request failed");
             EditOutcome::Failed(format!("request error: {e}"))
         }
     }
@@ -1280,6 +1360,18 @@ async fn delete_feishu_message(
     adapter: &FeishuAdapter,
     message_id: &str,
 ) -> Result<(), String> {
+    // Defence-in-depth: validate message_id shape before interpolating into the
+    // REST URL path. The trust boundary is the core↔gateway WebSocket (not
+    // external input), but a crafted ID with `/`, `?`, or `#` could otherwise
+    // alter URL semantics.
+    if !is_valid_feishu_message_id(message_id) {
+        tracing::warn!(
+            message_id = %message_id,
+            "feishu delete refused: message_id failed shape validation"
+        );
+        return Err("invalid message_id format".to_string());
+    }
+
     let token = adapter
         .token_cache
         .get_token(&adapter.client)
@@ -3439,5 +3531,146 @@ mod tests {
         // wiremock expect(1) on both mocks verifies:
         // 1. Reply API was called (and failed)
         // 2. Plain send was called (fallback triggered by quote_message_id.is_some() guard)
+    }
+
+    // --- Edit-cap helpers (F3/F4/F8/F10): no network required ---
+
+    fn fresh_cache() -> Arc<std::sync::Mutex<EditCountsCache>> {
+        Arc::new(std::sync::Mutex::new(EditCountsCache::default()))
+    }
+
+    #[test]
+    fn cap_detect_json_code_match() {
+        // Real-shape Feishu error body: trusted JSON code field == 230072.
+        let body = r#"{"code":230072,"msg":"The message has reached the number of times it can be edited","data":{}}"#;
+        assert!(is_feishu_cap_reached_body(body));
+    }
+
+    #[test]
+    fn cap_detect_json_other_code_no_false_positive() {
+        // JSON parses but code is unrelated; any inner string containing
+        // "230072" must NOT trigger cap detection.
+        let body = r#"{"code":99999,"msg":"some other error 230072 in description"}"#;
+        assert!(!is_feishu_cap_reached_body(body));
+    }
+
+    #[test]
+    fn cap_detect_substring_fallback_for_non_json() {
+        // Proxy-style HTML / non-JSON body — substring fallback kicks in.
+        let html = "<html><body>Error 230072 — number of times it can be edited</body></html>";
+        assert!(is_feishu_cap_reached_body(html));
+
+        let plain = "upstream error: 230072";
+        assert!(is_feishu_cap_reached_body(plain));
+    }
+
+    #[test]
+    fn cap_detect_unrelated_body_returns_false() {
+        let body = r#"{"code":99991,"msg":"rate limited","data":{}}"#;
+        assert!(!is_feishu_cap_reached_body(body));
+        assert!(!is_feishu_cap_reached_body("plain text without the code"));
+        assert!(!is_feishu_cap_reached_body(""));
+    }
+
+    #[test]
+    fn cap_pre_check_below_threshold_does_not_trip() {
+        let cache = fresh_cache();
+        // Cap is FEISHU_EDIT_CAP (18). 17 increments must stay below.
+        for _ in 0..17 {
+            increment_edit_count(&cache, "om_msg1");
+        }
+        assert!(!is_edit_cap_reached(&cache, "om_msg1"));
+    }
+
+    #[test]
+    fn cap_pre_check_at_threshold_trips() {
+        let cache = fresh_cache();
+        for _ in 0..(FEISHU_EDIT_CAP as usize) {
+            increment_edit_count(&cache, "om_msg1");
+        }
+        assert!(is_edit_cap_reached(&cache, "om_msg1"));
+    }
+
+    #[test]
+    fn mark_edit_cap_short_circuits_pre_check() {
+        let cache = fresh_cache();
+        mark_edit_cap(&cache, "om_msg1");
+        // Sentinel u32::MAX >= FEISHU_EDIT_CAP, so pre-check trips immediately.
+        assert!(is_edit_cap_reached(&cache, "om_msg1"));
+    }
+
+    #[test]
+    fn mark_edit_cap_does_not_double_increment() {
+        let cache = fresh_cache();
+        mark_edit_cap(&cache, "om_msg1");
+        increment_edit_count(&cache, "om_msg1");
+        // Increment must not push past u32::MAX sentinel.
+        let map = cache.lock().unwrap();
+        assert_eq!(map.counts.get("om_msg1").copied(), Some(u32::MAX));
+    }
+
+    #[test]
+    fn eviction_drops_oldest_inserts_not_lowest_count() {
+        // Pre-fill cache to over capacity, simulating a long-running adapter.
+        let cache = fresh_cache();
+        // First insert message_id "old_*" with high counts so they would
+        // *survive* a count-ascending eviction (the buggy strategy). They
+        // must instead be the *first* evicted under FIFO.
+        let overcap = EDIT_COUNTS_CACHE_MAX + 100;
+        for i in 0..overcap {
+            let id = format!("om_msg_{i:05}");
+            increment_edit_count(&cache, &id);
+        }
+        // Insert a fresh "active stream" id last — its low count would have
+        // marked it for eviction under count-ascending. With FIFO it must
+        // survive.
+        increment_edit_count(&cache, "om_active_recent");
+
+        let map = cache.lock().unwrap();
+        // FIFO eviction: the newest insert must still be present.
+        assert!(
+            map.counts.contains_key("om_active_recent"),
+            "active recent insert was evicted under FIFO — bug regressed"
+        );
+        // FIFO eviction: at least one of the very first inserts must be gone.
+        let some_oldest_evicted = (0..50).any(|i| {
+            let id = format!("om_msg_{i:05}");
+            !map.counts.contains_key(&id)
+        });
+        assert!(
+            some_oldest_evicted,
+            "no early-insert key was evicted — FIFO not working"
+        );
+        // Cache size bounded.
+        assert!(
+            map.counts.len() <= EDIT_COUNTS_CACHE_MAX,
+            "cache size {} > max {}",
+            map.counts.len(),
+            EDIT_COUNTS_CACHE_MAX
+        );
+    }
+
+    #[test]
+    fn message_id_validation_accepts_valid_shapes() {
+        assert!(is_valid_feishu_message_id("om_dc13264520392907fcq2e6kpngacls"));
+        assert!(is_valid_feishu_message_id("om_abc123"));
+        assert!(is_valid_feishu_message_id("om_A_B_c_1_2_3"));
+    }
+
+    #[test]
+    fn message_id_validation_rejects_path_traversal_and_query() {
+        // The shape guard is the F8 defence: stop crafted IDs containing URL
+        // metachars from altering /im/v1/messages/{id} semantics.
+        assert!(!is_valid_feishu_message_id("../etc/passwd"));
+        assert!(!is_valid_feishu_message_id("om_abc/extra"));
+        assert!(!is_valid_feishu_message_id("om_abc?q=1"));
+        assert!(!is_valid_feishu_message_id("om_abc#frag"));
+        assert!(!is_valid_feishu_message_id("om_abc%2Fextra"));
+        assert!(!is_valid_feishu_message_id(""));
+        assert!(!is_valid_feishu_message_id("om_"));
+        assert!(!is_valid_feishu_message_id("not_om_prefix"));
+        // Length cap (defense against pathological inputs).
+        let too_long = format!("om_{}", "a".repeat(200));
+        assert!(!is_valid_feishu_message_id(&too_long));
     }
 }

--- a/gateway/src/adapters/feishu.rs
+++ b/gateway/src/adapters/feishu.rs
@@ -710,6 +710,12 @@ pub struct FeishuAdapter {
     /// Positive-only cache: thread_id → first_seen for threads where other bots
     /// have posted. Used by multibot-mentions mode to require @mention.
     pub multibot_threads: Arc<std::sync::Mutex<HashMap<String, Instant>>>,
+    /// Per-message edit count tracker for Feishu's 20-edits-per-message hard cap
+    /// (errcode 230072 — "The message has reached the number of times it can be edited").
+    /// Key: message_id, Value: count of successful edits, or u32::MAX as sentinel
+    /// for "cap reached, do not attempt further edits". Lazily evicted at insert
+    /// when over EDIT_COUNTS_CACHE_MAX.
+    pub edit_counts: Arc<std::sync::Mutex<HashMap<String, u32>>>,
     pub client: reqwest::Client,
 }
 
@@ -728,6 +734,7 @@ impl FeishuAdapter {
             bot_turns: Arc::new(std::sync::Mutex::new(HashMap::new())),
             participated_threads: Arc::new(std::sync::Mutex::new(HashMap::new())),
             multibot_threads: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            edit_counts: Arc::new(std::sync::Mutex::new(HashMap::new())),
             client: reqwest::Client::new(),
         }
     }
@@ -1138,12 +1145,86 @@ async fn resolve_user_name(
 // ---------------------------------------------------------------------------
 // Send message
 /// Edit (update) an existing feishu message in-place for streaming.
-async fn edit_feishu_message(adapter: &FeishuAdapter, message_id: &str, text: &str) {
+/// Feishu message edit cap: API returns errcode 230072 after 20 edits per message.
+/// We stop preemptively at 18 to leave a 2-edit safety margin (handles races where
+/// multiple in-flight edits could each push count to the wall) and also catch 230072
+/// defensively in case the local count drifts from server reality.
+const FEISHU_EDIT_CAP: u32 = 18;
+
+/// Maximum entries in the per-adapter edit_counts cache before lazy eviction kicks in.
+const EDIT_COUNTS_CACHE_MAX: usize = 4096;
+
+/// Outcome of an edit_feishu_message attempt. Distinguishes the cap-reached case
+/// from generic failure so the caller can switch to append-new fallback.
+pub enum EditOutcome {
+    /// Edit succeeded; the on-screen message now reflects the new content.
+    Edited,
+    /// The 20-edits-per-message cap is exhausted (either tracked locally or
+    /// signaled by errcode 230072). Caller should switch to append-new.
+    CapReached,
+    /// Generic failure (network, token, other API errors).
+    Failed(String),
+}
+
+/// Increment the edit count for a message_id, evicting half the cache (oldest first)
+/// when over capacity. u32::MAX is a sentinel for "cap reached" — never increment
+/// past that value.
+fn increment_edit_count(
+    cache: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
+    message_id: &str,
+) {
+    let mut map = cache.lock().unwrap_or_else(|e| e.into_inner());
+    if map.len() > EDIT_COUNTS_CACHE_MAX {
+        let mut entries: Vec<_> = map.iter().map(|(k, v)| (k.clone(), *v)).collect();
+        entries.sort_by_key(|(_, n)| *n);
+        let evict = entries.len() / 2;
+        for (k, _) in entries.into_iter().take(evict) {
+            map.remove(&k);
+        }
+    }
+    let entry = map.entry(message_id.to_string()).or_insert(0);
+    if *entry != u32::MAX {
+        *entry = entry.saturating_add(1);
+    }
+}
+
+/// Mark a message_id as cap-reached; subsequent edit attempts skip the API call
+/// and go straight to append-new fallback.
+fn mark_edit_cap(
+    cache: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
+    message_id: &str,
+) {
+    let mut map = cache.lock().unwrap_or_else(|e| e.into_inner());
+    map.insert(message_id.to_string(), u32::MAX);
+}
+
+/// Return true if this message_id has already reached the edit cap (either tracked
+/// locally or marked via 230072 sentinel).
+fn is_edit_cap_reached(
+    cache: &Arc<std::sync::Mutex<HashMap<String, u32>>>,
+    message_id: &str,
+) -> bool {
+    let map = cache.lock().unwrap_or_else(|e| e.into_inner());
+    map.get(message_id).is_some_and(|&n| n >= FEISHU_EDIT_CAP)
+}
+
+async fn edit_feishu_message(
+    adapter: &FeishuAdapter,
+    message_id: &str,
+    text: &str,
+) -> EditOutcome {
+    // Pre-check: if we've already tracked >= FEISHU_EDIT_CAP edits (or the sentinel
+    // u32::MAX from a 230072 response), skip the API call and signal CapReached so
+    // the caller switches to append-new.
+    if is_edit_cap_reached(&adapter.edit_counts, message_id) {
+        return EditOutcome::CapReached;
+    }
+
     let token = match adapter.token_cache.get_token(&adapter.client).await {
         Ok(t) => t,
         Err(e) => {
             tracing::error!(err = %e, "feishu: cannot get token for edit");
-            return;
+            return EditOutcome::Failed(format!("token error: {e}"));
         }
     };
     let api_base = adapter.config.api_base();
@@ -1158,15 +1239,74 @@ async fn edit_feishu_message(adapter: &FeishuAdapter, message_id: &str, text: &s
         .json(&body).send().await
     {
         Ok(resp) if resp.status().is_success() => {
+            increment_edit_count(&adapter.edit_counts, message_id);
             tracing::trace!(message_id = %message_id, "feishu message edited");
+            EditOutcome::Edited
         }
         Ok(resp) => {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            tracing::error!(status = %status, body = %body, "feishu edit message failed");
+            // Detect errcode 230072 ("The message has reached the number of times
+            // it can be edited") — server-side confirmation of edit cap. Mark sentinel
+            // so future attempts on this message_id skip the API call entirely.
+            let cap_reached = body.contains("230072")
+                || body.contains("number of times it can be edited");
+            if cap_reached {
+                mark_edit_cap(&adapter.edit_counts, message_id);
+                tracing::warn!(
+                    message_id = %message_id,
+                    status = %status,
+                    "feishu edit cap reached (errcode 230072); switching to append-new fallback"
+                );
+                EditOutcome::CapReached
+            } else {
+                tracing::error!(status = %status, body = %body, "feishu edit message failed");
+                EditOutcome::Failed(format!("HTTP {status}: {body}"))
+            }
         }
         Err(e) => {
             tracing::error!(err = %e, "feishu edit message request failed");
+            EditOutcome::Failed(format!("request error: {e}"))
+        }
+    }
+}
+
+/// Delete a Feishu message via DELETE /open-apis/im/v1/messages/{id}.
+/// Unlike PATCH (edit), DELETE is not subject to the 20-edits-per-message cap,
+/// so this works even on messages that have already exhausted their edit quota.
+/// Used by the streaming finalize path to remove the half-edited placeholder
+/// before sending the full content as fresh messages, avoiding visual overlap.
+async fn delete_feishu_message(
+    adapter: &FeishuAdapter,
+    message_id: &str,
+) -> Result<(), String> {
+    let token = adapter
+        .token_cache
+        .get_token(&adapter.client)
+        .await
+        .map_err(|e| format!("token error: {e}"))?;
+    let api_base = adapter.config.api_base();
+    let url = format!("{}/open-apis/im/v1/messages/{}", api_base, message_id);
+    match adapter
+        .client
+        .delete(&url)
+        .bearer_auth(&token)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::info!(message_id = %message_id, "feishu message deleted");
+            Ok(())
+        }
+        Ok(resp) => {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            tracing::warn!(status = %status, body = %body, message_id = %message_id, "feishu delete message failed");
+            Err(format!("HTTP {status}: {body}"))
+        }
+        Err(e) => {
+            tracing::warn!(err = %e, message_id = %message_id, "feishu delete message request failed");
+            Err(format!("request error: {e}"))
         }
     }
 }
@@ -1953,11 +2093,83 @@ pub async fn handle_reply(
                 return;
             }
             "edit_message" => {
-                edit_feishu_message(adapter, &reply.reply_to, &reply.content.text).await;
+                let outcome = edit_feishu_message(
+                    adapter,
+                    &reply.reply_to,
+                    &reply.content.text,
+                ).await;
+                // Translate outcome → (success, message_id, error). For CapReached
+                // we attempt an append-new fallback: post the latest content as a
+                // fresh in-thread message so the user gets the rest of the reply
+                // even though the original message can no longer be edited.
+                let (success, message_id, error) = match outcome {
+                    EditOutcome::Edited => {
+                        (true, Some(reply.reply_to.clone()), None)
+                    }
+                    EditOutcome::CapReached => {
+                        // Do NOT append-new fallback at the gateway layer. Core's
+                        // cosmetic streaming loop flushes every ~1500ms — if every
+                        // post-cap edit spawned a new message, the user would be
+                        // spammed with 20+ duplicate continuation messages over the
+                        // remainder of a long reply.
+                        //
+                        // Instead, signal failure so:
+                        //   1. core's mid-stream cosmetic edit loop hits its
+                        //      consecutive-failures break (3 strikes) and stops
+                        //      attempting edits, freezing the placeholder mid-content
+                        //   2. the final delivery path in src/adapter.rs sees the
+                        //      placeholder edit fail and falls back to send_message
+                        //      so the user gets the full reply as a fresh message
+                        //
+                        // Net UX: half-edited placeholder + one complete continuation
+                        // message + ✅ done reaction (vs. today's mid-truncation + 🆗
+                        // false success, or naive append-fallback's 25-message spam).
+                        (
+                            false,
+                            None,
+                            Some("edit_cap_reached".to_string()),
+                        )
+                    }
+                    EditOutcome::Failed(err) => (false, None, Some(err)),
+                };
+                if let Some(ref req_id) = reply.request_id {
+                    let resp = crate::schema::GatewayResponse {
+                        schema: "openab.gateway.response.v1".into(),
+                        request_id: req_id.clone(),
+                        success,
+                        thread_id: None,
+                        message_id,
+                        error,
+                    };
+                    if let Ok(json) = serde_json::to_string(&resp) {
+                        let _ = event_tx.send(json);
+                    }
+                }
                 return;
             }
             "create_topic" | "set_reaction" => {
                 tracing::debug!(command = %cmd, "feishu: skipping unsupported command");
+                return;
+            }
+            "delete_message" => {
+                let result = delete_feishu_message(adapter, &reply.reply_to).await;
+                let (success, error) = match result {
+                    Ok(()) => (true, None),
+                    Err(e) => (false, Some(e)),
+                };
+                if let Some(ref req_id) = reply.request_id {
+                    let resp = crate::schema::GatewayResponse {
+                        schema: "openab.gateway.response.v1".into(),
+                        request_id: req_id.clone(),
+                        success,
+                        thread_id: None,
+                        message_id: None,
+                        error,
+                    };
+                    if let Ok(json) = serde_json::to_string(&resp) {
+                        let _ = event_tx.send(json);
+                    }
+                }
                 return;
             }
             _ => {}
@@ -2046,26 +2258,59 @@ pub async fn handle_reply(
             }
         }
     } else {
-        let mut sent_any = false;
-        for chunk in split_text(text, limit) {
+        // Track per-chunk success so we can report partial-failure back to core.
+        // Previously this branch returned no GatewayResponse at all and used
+        // "any chunk succeeded" as the success criterion — letting core fall
+        // through to a 5s timeout and silently mark the turn delivered. With
+        // request/response now wired through, we propagate exact health.
+        let chunks: Vec<&str> = split_text(text, limit);
+        let total_chunks = chunks.len();
+        let mut succeeded = 0usize;
+        let mut last_msg_id: Option<String> = None;
+        for chunk in &chunks {
             if let Some(msg_id) = send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, reply_target, chunk).await {
                 adapter.dedupe.is_duplicate(&msg_id);
-                sent_any = true;
+                succeeded += 1;
+                last_msg_id = Some(msg_id);
             }
         }
         // Fallback: if quote_message_id caused all chunks to fail, retry without it
-        if !sent_any && reply.quote_message_id.is_some() {
+        if succeeded == 0 && reply.quote_message_id.is_some() {
             tracing::warn!(quote_message_id = ?reply.quote_message_id, channel_id = %reply.channel.id, "chunked reply-to failed, falling back to plain send");
-            for chunk in split_text(text, limit) {
+            for chunk in &chunks {
                 if let Some(msg_id) = send_post_message(&adapter.client, &api_base, &token, &reply.channel.id, thread_id, chunk).await {
                     adapter.dedupe.is_duplicate(&msg_id);
-                    sent_any = true;
+                    succeeded += 1;
+                    last_msg_id = Some(msg_id);
                 }
             }
         }
-        if sent_any {
+        if succeeded > 0 {
             if let Some(tid) = thread_id {
                 record_participation(&adapter.participated_threads, tid, adapter.config.session_ttl_secs);
+            }
+        }
+        // Report back to core. Success requires every chunk delivered — partial
+        // success becomes failure so dispatch surfaces ❌ rather than 🆗.
+        if let Some(ref req_id) = reply.request_id {
+            let success = succeeded == total_chunks && total_chunks > 0;
+            let error = if success {
+                None
+            } else {
+                Some(format!(
+                    "chunked send delivered {succeeded}/{total_chunks} chunks"
+                ))
+            };
+            let resp = crate::schema::GatewayResponse {
+                schema: "openab.gateway.response.v1".into(),
+                request_id: req_id.clone(),
+                success,
+                thread_id: None,
+                message_id: last_msg_id,
+                error,
+            };
+            if let Ok(json) = serde_json::to_string(&resp) {
+                let _ = event_tx.send(json);
             }
         }
     }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -934,7 +934,7 @@ impl AdapterRouter {
                                 if let Err(e) =
                                     adapter.stream_append(msg, &native_pending).await
                                 {
-                                    tracing::warn!(error = ?e, "native finalize stream_append failed");
+                                    tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "native finalize stream_append failed");
                                     delivery_failed = true;
                                 }
                             }
@@ -946,14 +946,14 @@ impl AdapterRouter {
                             match chunks.first() {
                                 Some(first) => {
                                     if let Err(e) = adapter.stream_finish(msg, first).await {
-                                        tracing::warn!(error = ?e, "native stream_finish failed");
+                                        tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "native stream_finish failed");
                                         delivery_failed = true;
                                     }
                                     for chunk in chunks.iter().skip(1) {
                                         if let Err(e) =
                                             adapter.send_message(&thread_channel, chunk).await
                                         {
-                                            tracing::warn!(error = ?e, "native overflow chunk send failed");
+                                            tracing::warn!(error = ?e, platform = %thread_channel.platform, "native overflow chunk send failed");
                                             delivery_failed = true;
                                         }
                                     }
@@ -962,7 +962,7 @@ impl AdapterRouter {
                                     if let Err(e) =
                                         adapter.stream_finish(msg, &final_content).await
                                     {
-                                        tracing::warn!(error = ?e, "native stream_finish (no chunks) failed");
+                                        tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "native stream_finish (no chunks) failed");
                                         delivery_failed = true;
                                     }
                                 }
@@ -980,7 +980,7 @@ impl AdapterRouter {
                                 if let Err(e) =
                                     adapter.send_message(&thread_channel, chunk).await
                                 {
-                                    tracing::warn!(error = ?e, "native fallback chunk send failed");
+                                    tracing::warn!(error = ?e, platform = %thread_channel.platform, "native fallback chunk send failed");
                                     delivery_failed = true;
                                 }
                             }
@@ -1000,21 +1000,21 @@ impl AdapterRouter {
                                     ).await {
                                         Ok(_) => { send_ok = true; }
                                         Err(e) => {
-                                            tracing::warn!(error = ?e, "reply_to send failed; preserving placeholder");
+                                            tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "reply_to send failed; preserving placeholder");
                                             delivery_failed = true;
                                         }
                                     }
                                 } else if let Err(e) =
                                     adapter.send_message(&thread_channel, chunk).await
                                 {
-                                    tracing::warn!(error = ?e, "reply_to overflow chunk send failed");
+                                    tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "reply_to overflow chunk send failed");
                                     delivery_failed = true;
                                 }
                                 first = false;
                             }
                             if send_ok {
                                 if let Err(e) = adapter.delete_message(&msg).await {
-                                    tracing::warn!(error = ?e, "delete placeholder failed; placeholder will remain visible");
+                                    tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "delete placeholder failed; placeholder will remain visible");
                                 }
                             }
                         } else if adapter.platform() == "discord"
@@ -1031,14 +1031,14 @@ impl AdapterRouter {
                                         send_ok = true;
                                     }
                                     Err(e) => {
-                                        tracing::warn!(error = ?e, "discord bot-mention first chunk send failed");
+                                        tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "discord bot-mention first chunk send failed");
                                         delivery_failed = true;
                                     }
                                 }
                             }
                             for chunk in chunks.iter().skip(1) {
                                 if let Err(e) = adapter.send_message(&thread_channel, chunk).await {
-                                    tracing::warn!(error = ?e, "streaming overflow chunk send failed");
+                                    tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "streaming overflow chunk send failed");
                                     delivery_failed = true;
                                 }
                             }
@@ -1054,7 +1054,7 @@ impl AdapterRouter {
                                     if let Err(e) =
                                         adapter.send_message(&thread_channel, chunk).await
                                     {
-                                        tracing::warn!(error = ?e, "draft placeholder fallback chunk send failed");
+                                        tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "draft placeholder fallback chunk send failed");
                                         delivery_failed = true;
                                     }
                                 }
@@ -1069,14 +1069,14 @@ impl AdapterRouter {
                                 // fails the placeholder simply remains — same
                                 // UX as pre-recovery, not a hard failure.
                                 if let Err(e) = adapter.edit_message(&msg, first).await {
-                                    tracing::warn!(error = ?e, "final streaming edit failed; deleting placeholder and sending fresh");
+                                    tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "final streaming edit failed; deleting placeholder and sending fresh");
                                     if let Err(de) = adapter.delete_message(&msg).await {
-                                        tracing::warn!(error = ?de, "delete placeholder failed; user will see overlap");
+                                        tracing::warn!(error = ?de, platform = %thread_channel.platform, message_id = %msg.message_id, "delete placeholder failed; user will see overlap");
                                     }
                                     if let Err(e2) =
                                         adapter.send_message(&thread_channel, first).await
                                     {
-                                        tracing::error!(error = ?e2, "fallback send_message also failed");
+                                        tracing::error!(error = ?e2, platform = %thread_channel.platform, message_id = %msg.message_id, "fallback send_message also failed");
                                         delivery_failed = true;
                                     }
                                 }
@@ -1084,7 +1084,7 @@ impl AdapterRouter {
                                     if let Err(e) =
                                         adapter.send_message(&thread_channel, chunk).await
                                     {
-                                        tracing::warn!(error = ?e, "streaming overflow chunk send failed");
+                                        tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "streaming overflow chunk send failed");
                                         delivery_failed = true;
                                     }
                                 }
@@ -1102,19 +1102,19 @@ impl AdapterRouter {
                                         chunk,
                                         reply_id,
                                     ).await {
-                                        tracing::warn!(error = ?e, "send-once reply_to first chunk failed");
+                                        tracing::warn!(error = ?e, platform = %thread_channel.platform, "send-once reply_to first chunk failed");
                                         delivery_failed = true;
                                     }
                                 } else if let Err(e) =
                                     adapter.send_message(&thread_channel, chunk).await
                                 {
-                                    tracing::warn!(error = ?e, "send-once first chunk failed");
+                                    tracing::warn!(error = ?e, platform = %thread_channel.platform, "send-once first chunk failed");
                                     delivery_failed = true;
                                 }
                             } else if let Err(e) =
                                 adapter.send_message(&thread_channel, chunk).await
                             {
-                                tracing::warn!(error = ?e, "send-once subsequent chunk failed");
+                                tracing::warn!(error = ?e, platform = %thread_channel.platform, "send-once subsequent chunk failed");
                                 delivery_failed = true;
                             }
                             first = false;

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -632,6 +632,13 @@ impl AdapterRouter {
                         let mut buf_rx = rx;
                         tokio::spawn(async move {
                             let mut last = String::new();
+                            // Track consecutive edit failures so we can abort cosmetic
+                            // streaming when the platform stops accepting edits (e.g.
+                            // Feishu's 20-edits-per-message hard cap, errcode 230072).
+                            // Once aborted, the final delivery path still runs and the
+                            // user sees the complete content at turn end.
+                            let mut consecutive_failures: u32 = 0;
+                            const MAX_CONSECUTIVE_FAILURES: u32 = 3;
                             loop {
                                 tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
                                 if buf_rx.has_changed().unwrap_or(false) {
@@ -645,9 +652,33 @@ impl AdapterRouter {
                                         } else {
                                             content.clone()
                                         };
-                                        let _ =
-                                            edit_adapter.edit_message(&edit_msg, &display).await;
-                                        last = content;
+                                        match edit_adapter
+                                            .edit_message(&edit_msg, &display)
+                                            .await
+                                        {
+                                            Ok(_) => {
+                                                consecutive_failures = 0;
+                                                last = content;
+                                            }
+                                            Err(e) => {
+                                                consecutive_failures += 1;
+                                                tracing::debug!(
+                                                    error = ?e,
+                                                    consecutive_failures,
+                                                    "mid-stream cosmetic edit failed"
+                                                );
+                                                if consecutive_failures
+                                                    >= MAX_CONSECUTIVE_FAILURES
+                                                {
+                                                    tracing::warn!(
+                                                        consecutive_failures,
+                                                        "mid-stream cosmetic edit aborted; \
+                                                         final content will be delivered at turn end"
+                                                    );
+                                                    break;
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                                 if buf_rx.has_changed().is_err() {
@@ -864,6 +895,11 @@ impl AdapterRouter {
 
                     let final_content = markdown::convert_tables(&final_content, table_mode);
                     let chunks = format::split_message(&final_content, message_limit);
+                    // Track delivery health across all final write paths. Any failure
+                    // here means the user's view is incomplete; we propagate Err at the
+                    // end of the closure so dispatch surfaces set_error (❌) instead of
+                    // silently calling set_done (🆗) over a half-delivered turn.
+                    let mut delivery_failed = false;
                     // Clear the assistant status line before delivering the final message.
                     if assistant_status {
                         let _ = adapter.set_status(&thread_channel, "").await;
@@ -871,7 +907,12 @@ impl AdapterRouter {
                     if native {
                         if let Some(msg) = &native_msg {
                             if !native_pending.is_empty() {
-                                let _ = adapter.stream_append(msg, &native_pending).await;
+                                if let Err(e) =
+                                    adapter.stream_append(msg, &native_pending).await
+                                {
+                                    tracing::warn!(error = ?e, "native finalize stream_append failed");
+                                    delivery_failed = true;
+                                }
                             }
                             // Finalize the streamed message with the first chunk (full-replace),
                             // then post any overflow chunks as new in-thread messages — mirrors
@@ -880,13 +921,26 @@ impl AdapterRouter {
                             // streaming mode — the streamed message is the in-thread reply.
                             match chunks.first() {
                                 Some(first) => {
-                                    let _ = adapter.stream_finish(msg, first).await;
+                                    if let Err(e) = adapter.stream_finish(msg, first).await {
+                                        tracing::warn!(error = ?e, "native stream_finish failed");
+                                        delivery_failed = true;
+                                    }
                                     for chunk in chunks.iter().skip(1) {
-                                        let _ = adapter.send_message(&thread_channel, chunk).await;
+                                        if let Err(e) =
+                                            adapter.send_message(&thread_channel, chunk).await
+                                        {
+                                            tracing::warn!(error = ?e, "native overflow chunk send failed");
+                                            delivery_failed = true;
+                                        }
                                     }
                                 }
                                 None => {
-                                    let _ = adapter.stream_finish(msg, &final_content).await;
+                                    if let Err(e) =
+                                        adapter.stream_finish(msg, &final_content).await
+                                    {
+                                        tracing::warn!(error = ?e, "native stream_finish (no chunks) failed");
+                                        delivery_failed = true;
+                                    }
                                 }
                             }
                         } else {
@@ -899,7 +953,12 @@ impl AdapterRouter {
                             // accumulated text_buf) as plain in-thread messages so
                             // the turn is never silently dropped.
                             for chunk in &chunks {
-                                let _ = adapter.send_message(&thread_channel, chunk).await;
+                                if let Err(e) =
+                                    adapter.send_message(&thread_channel, chunk).await
+                                {
+                                    tracing::warn!(error = ?e, "native fallback chunk send failed");
+                                    delivery_failed = true;
+                                }
                             }
                         }
                     } else if let Some(msg) = placeholder_msg {
@@ -918,10 +977,14 @@ impl AdapterRouter {
                                         Ok(_) => { send_ok = true; }
                                         Err(e) => {
                                             tracing::warn!(error = ?e, "reply_to send failed; preserving placeholder");
+                                            delivery_failed = true;
                                         }
                                     }
-                                } else {
-                                    let _ = adapter.send_message(&thread_channel, chunk).await;
+                                } else if let Err(e) =
+                                    adapter.send_message(&thread_channel, chunk).await
+                                {
+                                    tracing::warn!(error = ?e, "reply_to overflow chunk send failed");
+                                    delivery_failed = true;
                                 }
                                 first = false;
                             }
@@ -944,7 +1007,10 @@ impl AdapterRouter {
                                 }
                             }
                             for chunk in chunks.iter().skip(1) {
-                                let _ = adapter.send_message(&thread_channel, chunk).await;
+                                if let Err(e) = adapter.send_message(&thread_channel, chunk).await {
+                                    tracing::warn!(error = ?e, "streaming overflow chunk send failed");
+                                    delivery_failed = true;
+                                }
                             }
                             if send_ok {
                                 let _ = adapter.delete_message(&msg).await;
@@ -957,12 +1023,35 @@ impl AdapterRouter {
                                 for chunk in &chunks {
                                     let _ = adapter.send_message(&thread_channel, chunk).await;
                                 }
-                            } else {
-                                if let Some(first) = chunks.first() {
-                                    let _ = adapter.edit_message(&msg, first).await;
+                            } else if let Some(first) = chunks.first() {
+                                // If the placeholder edit fails (e.g. Feishu's
+                                // 20-edits-per-message cap was hit during
+                                // cosmetic streaming and the gateway reports
+                                // edit_cap_reached), fall back to deleting the
+                                // half-edited placeholder and sending the first
+                                // chunk as a fresh message so the user sees the
+                                // complete reply without overlap. If delete
+                                // fails the placeholder simply remains — same
+                                // UX as pre-recovery, not a hard failure.
+                                if let Err(e) = adapter.edit_message(&msg, first).await {
+                                    tracing::warn!(error = ?e, "final streaming edit failed; deleting placeholder and sending fresh");
+                                    if let Err(de) = adapter.delete_message(&msg).await {
+                                        tracing::warn!(error = ?de, "delete placeholder failed; user will see overlap");
+                                    }
+                                    if let Err(e2) =
+                                        adapter.send_message(&thread_channel, first).await
+                                    {
+                                        tracing::error!(error = ?e2, "fallback send_message also failed");
+                                        delivery_failed = true;
+                                    }
                                 }
                                 for chunk in chunks.iter().skip(1) {
-                                    let _ = adapter.send_message(&thread_channel, chunk).await;
+                                    if let Err(e) =
+                                        adapter.send_message(&thread_channel, chunk).await
+                                    {
+                                        tracing::warn!(error = ?e, "streaming overflow chunk send failed");
+                                        delivery_failed = true;
+                                    }
                                 }
                             }
                         }
@@ -973,22 +1062,37 @@ impl AdapterRouter {
                         for chunk in &chunks {
                             if first {
                                 if let Some(ref reply_id) = directives.reply_to {
-                                    let _ = adapter.send_message_with_reply(
+                                    if let Err(e) = adapter.send_message_with_reply(
                                         &thread_channel,
                                         chunk,
                                         reply_id,
-                                    ).await;
-                                } else {
-                                    let _ = adapter.send_message(&thread_channel, chunk).await;
+                                    ).await {
+                                        tracing::warn!(error = ?e, "send-once reply_to first chunk failed");
+                                        delivery_failed = true;
+                                    }
+                                } else if let Err(e) =
+                                    adapter.send_message(&thread_channel, chunk).await
+                                {
+                                    tracing::warn!(error = ?e, "send-once first chunk failed");
+                                    delivery_failed = true;
                                 }
-                            } else {
-                                let _ = adapter.send_message(&thread_channel, chunk).await;
+                            } else if let Err(e) =
+                                adapter.send_message(&thread_channel, chunk).await
+                            {
+                                tracing::warn!(error = ?e, "send-once subsequent chunk failed");
+                                delivery_failed = true;
                             }
                             first = false;
                         }
                     }
 
-                    Ok(())
+                    if delivery_failed {
+                        Err(anyhow::anyhow!(
+                            "streaming finalization had delivery failures; user view is incomplete"
+                        ))
+                    } else {
+                        Ok(())
+                    }
                 })
             })
             .await

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -953,7 +953,7 @@ impl AdapterRouter {
                                         if let Err(e) =
                                             adapter.send_message(&thread_channel, chunk).await
                                         {
-                                            tracing::warn!(error = ?e, platform = %thread_channel.platform, "native overflow chunk send failed");
+                                            tracing::warn!(error = ?e, platform = %thread_channel.platform, message_id = %msg.message_id, "native overflow chunk send failed");
                                             delivery_failed = true;
                                         }
                                     }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -610,7 +610,7 @@ impl AdapterRouter {
                     const NATIVE_FLUSH_MS: u128 = 400;
 
                     // Streaming edit: send placeholder, spawn edit loop
-                    let (buf_tx, placeholder_msg) = if streaming && !native {
+                    let (buf_tx, placeholder_msg, edit_handle) = if streaming && !native {
                         let initial = if reset {
                             "⚠️ _Session expired, starting fresh..._\n\n…".to_string()
                         } else {
@@ -630,7 +630,7 @@ impl AdapterRouter {
                         let edit_msg = msg.clone();
                         let limit = message_limit;
                         let mut buf_rx = rx;
-                        tokio::spawn(async move {
+                        let edit_handle = tokio::spawn(async move {
                             let mut last = String::new();
                             // Track consecutive edit failures so we can abort cosmetic
                             // streaming when the platform stops accepting edits (e.g.
@@ -690,9 +690,9 @@ impl AdapterRouter {
                                 }
                             }
                         });
-                        (Some(tx), Some(msg))
+                        (Some(tx), Some(msg), Some(edit_handle))
                     } else {
-                        (None, None)
+                        (None, None, None)
                     };
 
                     // (#732) Liveness-aware recv loop. Filters stale id-bearing
@@ -873,8 +873,28 @@ impl AdapterRouter {
                     }
 
                     conn.prompt_done().await;
-                    // Stop the edit loop
+                    // Stop the cosmetic edit loop before the finalize write path
+                    // issues its authoritative edit. Dropping buf_tx closes the watch
+                    // channel so the loop breaks on its next check, but it may be
+                    // mid-edit (a single edit can now block up to the gateway response
+                    // timeout). Without an explicit abort+join, a cosmetic edit issued
+                    // just before close could land *after* the finalize edit and
+                    // overwrite it with stale, mid-stream content (#1122 review NEW-1).
+                    //
+                    // abort() cancels any cosmetic edit that has not yet been put on
+                    // the wire and interrupts the inter-flush sleep immediately; the
+                    // await confirms the task is gone before we proceed. This narrows
+                    // the race to near zero — it does NOT fully eliminate it: a PUT
+                    // already flushed microseconds before abort cannot be recalled,
+                    // and if finalize's PUT travels a different pooled connection the
+                    // server-side arrival order is not strictly guaranteed. That
+                    // residual window is display-only (stale tail briefly shown) and
+                    // far narrower than before this join existed.
                     drop(buf_tx);
+                    if let Some(handle) = edit_handle {
+                        handle.abort();
+                        let _ = handle.await;
+                    }
 
                     // Parse output directives from raw text_buf BEFORE compose_display.
                     // Directives are agent meta-layer, not content — must be stripped

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -663,6 +663,8 @@ impl AdapterRouter {
                                             Err(e) => {
                                                 consecutive_failures += 1;
                                                 tracing::debug!(
+                                                    message_id = %edit_msg.message_id,
+                                                    platform = %edit_msg.channel.platform,
                                                     error = ?e,
                                                     consecutive_failures,
                                                     "mid-stream cosmetic edit failed"
@@ -671,6 +673,8 @@ impl AdapterRouter {
                                                     >= MAX_CONSECUTIVE_FAILURES
                                                 {
                                                     tracing::warn!(
+                                                        message_id = %edit_msg.message_id,
+                                                        platform = %edit_msg.channel.platform,
                                                         consecutive_failures,
                                                         "mid-stream cosmetic edit aborted; \
                                                          final content will be delivered at turn end"
@@ -1002,8 +1006,14 @@ impl AdapterRouter {
                             // event since MESSAGE_UPDATE skips notifications (#1110).
                             let mut send_ok = false;
                             if let Some(first) = chunks.first() {
-                                if adapter.send_message(&thread_channel, first).await.is_ok() {
-                                    send_ok = true;
+                                match adapter.send_message(&thread_channel, first).await {
+                                    Ok(_) => {
+                                        send_ok = true;
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(error = ?e, "discord bot-mention first chunk send failed");
+                                        delivery_failed = true;
+                                    }
                                 }
                             }
                             for chunk in chunks.iter().skip(1) {
@@ -1021,7 +1031,12 @@ impl AdapterRouter {
                             // new message instead — the gateway will persist via sendRichMessage.
                             if msg.message_id == "draft" {
                                 for chunk in &chunks {
-                                    let _ = adapter.send_message(&thread_channel, chunk).await;
+                                    if let Err(e) =
+                                        adapter.send_message(&thread_channel, chunk).await
+                                    {
+                                        tracing::warn!(error = ?e, "draft placeholder fallback chunk send failed");
+                                        delivery_failed = true;
+                                    }
                                 }
                             } else if let Some(first) = chunks.first() {
                                 // If the placeholder edit fails (e.g. Feishu's

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -517,13 +517,18 @@ impl ChatAdapter for GatewayAdapter {
         // signals — cosmetic streaming would keep flushing forever and the final
         // edit fallback to send_message could not trigger.
         //
-        // Timeout is intentionally short (800ms) because we run inside cosmetic
-        // flush loops at ~1.5s cadence. Platforms that don't echo GatewayResponse
-        // for edits (LINE, Teams) hit timeout → treated as success (legacy fire-
-        // and-forget semantics, no behavior change for them).
+        // Scope intentionally limited to Feishu: it is the only adapter that
+        // currently emits `GatewayResponse` for `edit_message` and the only
+        // platform with a known per-message edit cap (errcode 230072). Other
+        // adapters (LINE, Teams, Slack, Discord, …) keep the original
+        // fire-and-forget path so cosmetic streaming on those platforms does
+        // not pay an 800 ms penalty per flush waiting for a response that
+        // never arrives. When more adapters wire request/response feedback,
+        // this allowlist is where to extend.
         const EDIT_RESPONSE_TIMEOUT_MS: u64 = 800;
+        let needs_response = self.streaming && msg.channel.platform == "feishu";
 
-        let req_id = if self.streaming {
+        let req_id = if needs_response {
             Some(format!("req_{}", uuid::Uuid::new_v4()))
         } else {
             None
@@ -575,14 +580,16 @@ impl ChatAdapter for GatewayAdapter {
                     Ok(())
                 }
                 Err(_) => {
-                    // Timeout — most adapters (LINE, Teams) don't emit
-                    // GatewayResponse for edits. Treat as success to preserve
-                    // legacy fire-and-forget behavior.
+                    // Timeout — feishu didn't respond within the window
+                    // (probably a slow API). Treat as success to avoid
+                    // false-positive ❌; the cap-reached path already short-
+                    // circuits much faster (gateway returns immediately).
                     self.pending.lock().await.remove(id);
                     Ok(())
                 }
             }
         } else {
+            // Non-feishu (or non-streaming): fire-and-forget, no added latency.
             Ok(())
         }
     }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -13,6 +13,33 @@ use tracing::{error, info, warn};
 /// Timeout for waiting on gateway reply acknowledgement.
 const GATEWAY_REPLY_TIMEOUT_SECS: u64 = 5;
 
+/// Platforms whose gateway adapter emits a `GatewayResponse` for `edit_message`
+/// so core can observe edit success or failure (used to gate the per-edit
+/// response-wait below).
+///
+/// Today only Feishu does, because it is the only adapter with a known
+/// per-message edit cap (errcode 230072) that requires core-side recovery, and
+/// the only one wired to ack edits.
+///
+/// NOTE: this gates the `edit_message` response-wait only. `delete_message` is
+/// unconditionally fire-and-forget (the recovery path sends fresh content
+/// regardless of the delete outcome), so it does not consult this list.
+///
+/// TECH DEBT: this is platform-identity standing in for a *capability*. The
+/// right model is a capability handshake at gateway-connect time ("does this
+/// adapter acknowledge edits?") rather than a hardcoded platform name. We
+/// accept the hardcode now because there is no handshake protocol yet; when one
+/// lands, replace this allowlist with a negotiated capability flag. Any new
+/// adapter that wires request/response for edits MUST be added here, or its
+/// edit failures stay invisible to core (silent failure mode).
+const EDIT_RESPONSE_PLATFORMS: &[&str] = &["feishu"];
+
+/// Whether `platform` acknowledges `edit_message` with a `GatewayResponse`.
+/// See `EDIT_RESPONSE_PLATFORMS`.
+fn platform_acks_writes(platform: &str) -> bool {
+    EDIT_RESPONSE_PLATFORMS.contains(&platform)
+}
+
 // --- Gateway event/reply schemas (mirrors gateway service) ---
 
 #[derive(Clone, Debug, Deserialize)]
@@ -517,16 +544,12 @@ impl ChatAdapter for GatewayAdapter {
         // signals — cosmetic streaming would keep flushing forever and the final
         // edit fallback to send_message could not trigger.
         //
-        // Scope intentionally limited to Feishu: it is the only adapter that
-        // currently emits `GatewayResponse` for `edit_message` and the only
-        // platform with a known per-message edit cap (errcode 230072). Other
-        // adapters (LINE, Teams, Slack, Discord, …) keep the original
-        // fire-and-forget path so cosmetic streaming on those platforms does
-        // not pay an 800 ms penalty per flush waiting for a response that
-        // never arrives. When more adapters wire request/response feedback,
-        // this allowlist is where to extend.
+        // Scope intentionally limited to platforms that ack writes (see
+        // EDIT_RESPONSE_PLATFORMS). Other adapters (LINE, Teams, Slack, Discord,
+        // …) keep the original fire-and-forget path so cosmetic streaming on
+        // those platforms does not pay a response-wait penalty per flush.
         const EDIT_RESPONSE_TIMEOUT_MS: u64 = 800;
-        let needs_response = self.streaming && msg.channel.platform == "feishu";
+        let needs_response = self.streaming && platform_acks_writes(&msg.channel.platform);
 
         let req_id = if needs_response {
             Some(format!("req_{}", uuid::Uuid::new_v4()))
@@ -604,7 +627,10 @@ impl ChatAdapter for GatewayAdapter {
     ///
     /// Fire-and-forget: gateway adapters that don't implement delete will simply
     /// ignore the command. Failure is non-fatal — if delete fails, the user sees
-    /// the placeholder remain (same behavior as before this override).
+    /// the placeholder remain (same behavior as before this override). We do not
+    /// wait on a response here: the recovery path sends fresh content regardless
+    /// of whether the delete landed, so a response would only buy an extra log
+    /// line at the cost of a per-finalize wait.
     async fn delete_message(&self, msg: &MessageRef) -> Result<()> {
         let reply = GatewayReply {
             schema: "openab.gateway.reply.v1".into(),

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -200,15 +200,29 @@ impl GatewayAdapter {
         let msg_id = if let (Some(rx), Some(ref id)) = (pending_rx, &req_id) {
             match tokio::time::timeout(std::time::Duration::from_secs(GATEWAY_REPLY_TIMEOUT_SECS), rx).await {
                 Ok(Ok(resp)) if resp.success => resp.message_id.unwrap_or_else(|| "gw_sent".into()),
-                Ok(Ok(_resp)) => {
-                    tracing::warn!(request_id = %id, "gateway replied with failure");
-                    "gw_sent".into()
+                Ok(Ok(resp)) => {
+                    // Gateway explicitly reported failure (success=false). Surface
+                    // as Err so dispatch sets ❌ instead of 🆗 over an incomplete
+                    // delivery. Examples: Feishu edit cap reached after append-new
+                    // fallback also failed; chunked send delivered N/M chunks.
+                    let err_msg = resp.error.clone()
+                        .unwrap_or_else(|| "gateway reported failure".to_string());
+                    tracing::warn!(request_id = %id, error = %err_msg, "gateway replied with failure");
+                    return Err(anyhow::anyhow!("gateway reported failure: {err_msg}"));
                 }
                 Ok(Err(_)) => {
+                    // Channel closed (gateway shutting down or pending dropped).
+                    // Maintain legacy behavior — adapters that don't implement
+                    // GatewayResponse for all reply types (LINE, Teams) rely on
+                    // this for non-failure outcomes.
                     tracing::warn!(request_id = %id, "gateway response channel closed");
                     "gw_sent".into()
                 }
                 Err(_) => {
+                    // Timeout. Many adapters (LINE, Teams) intentionally do not
+                    // emit GatewayResponse for replies, so timeout is the expected
+                    // path for them. Maintain legacy behavior to avoid breaking
+                    // platforms that have not yet wired request/response feedback.
                     tracing::warn!(request_id = %id, "gateway reply timed out");
                     self.pending.lock().await.remove(id);
                     "gw_sent".into()
@@ -497,6 +511,30 @@ impl ChatAdapter for GatewayAdapter {
     }
 
     async fn edit_message(&self, msg: &MessageRef, content: &str) -> Result<()> {
+        // Use a short request/response cycle so we can react to platform-level
+        // edit failures (e.g. Feishu's 20-edits-per-message cap, errcode 230072).
+        // Without this, edit_message was fire-and-forget and core never saw cap
+        // signals — cosmetic streaming would keep flushing forever and the final
+        // edit fallback to send_message could not trigger.
+        //
+        // Timeout is intentionally short (800ms) because we run inside cosmetic
+        // flush loops at ~1.5s cadence. Platforms that don't echo GatewayResponse
+        // for edits (LINE, Teams) hit timeout → treated as success (legacy fire-
+        // and-forget semantics, no behavior change for them).
+        const EDIT_RESPONSE_TIMEOUT_MS: u64 = 800;
+
+        let req_id = if self.streaming {
+            Some(format!("req_{}", uuid::Uuid::new_v4()))
+        } else {
+            None
+        };
+        let pending_rx = if let Some(ref id) = req_id {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            self.pending.lock().await.insert(id.clone(), tx);
+            Some(rx)
+        } else {
+            None
+        };
         let reply = GatewayReply {
             schema: "openab.gateway.reply.v1".into(),
             reply_to: msg.message_id.clone(),
@@ -510,6 +548,70 @@ impl ChatAdapter for GatewayAdapter {
                 text: content.into(),
             },
             command: Some("edit_message".into()),
+            quote_message_id: None,
+            request_id: req_id.clone(),
+        };
+        let json = serde_json::to_string(&reply)?;
+        if let Err(e) = self.ws_tx.lock().await.send(Message::Text(json)).await {
+            if let Some(ref id) = req_id {
+                self.pending.lock().await.remove(id);
+            }
+            return Err(e.into());
+        }
+        if let (Some(rx), Some(ref id)) = (pending_rx, &req_id) {
+            match tokio::time::timeout(
+                std::time::Duration::from_millis(EDIT_RESPONSE_TIMEOUT_MS),
+                rx,
+            ).await {
+                Ok(Ok(resp)) if resp.success => Ok(()),
+                Ok(Ok(resp)) => {
+                    let err_msg = resp.error.clone()
+                        .unwrap_or_else(|| "gateway reported edit failure".to_string());
+                    tracing::warn!(request_id = %id, error = %err_msg, "edit_message gateway replied failure");
+                    Err(anyhow::anyhow!("edit failure: {err_msg}"))
+                }
+                Ok(Err(_)) => {
+                    tracing::debug!(request_id = %id, "edit_message gateway response channel closed");
+                    Ok(())
+                }
+                Err(_) => {
+                    // Timeout — most adapters (LINE, Teams) don't emit
+                    // GatewayResponse for edits. Treat as success to preserve
+                    // legacy fire-and-forget behavior.
+                    self.pending.lock().await.remove(id);
+                    Ok(())
+                }
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Override default delete_message (which falls back to edit-to-zero-width)
+    /// so platforms with native delete APIs (e.g. Feishu DELETE /im/v1/messages/{id})
+    /// can perform real deletions. Critical for the streaming-edit-cap recovery
+    /// path: when Feishu's 20-edits-per-message cap is hit and we send full
+    /// content as a fresh message, we need to remove the half-edited placeholder
+    /// to avoid duplicated content. The default zero-width-edit fallback would
+    /// itself fail on a cap-reached message, leaving the placeholder visible.
+    ///
+    /// Fire-and-forget: gateway adapters that don't implement delete will simply
+    /// ignore the command. Failure is non-fatal — if delete fails, the user sees
+    /// the placeholder remain (same behavior as before this override).
+    async fn delete_message(&self, msg: &MessageRef) -> Result<()> {
+        let reply = GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: msg.message_id.clone(),
+            platform: msg.channel.platform.clone(),
+            channel: ReplyChannel {
+                id: msg.channel.channel_id.clone(),
+                thread_id: msg.channel.thread_id.clone(),
+            },
+            content: ReplyContent {
+                content_type: "text".into(),
+                text: String::new(),
+            },
+            command: Some("delete_message".into()),
             quote_message_id: None,
             request_id: None,
         };


### PR DESCRIPTION
## Summary

Long Feishu replies that triggered streaming edits beyond 20 cycles got truncated mid-content while the bot still showed 🆗 — users saw a half-baked reply and a "success" reaction at the same time. This PR makes streaming edit-cap aware: detect Feishu's `230072` cap, abort cosmetic edits cleanly, and recover by deleting the half-edited placeholder and posting the full content as fresh messages.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1500160821567684660

## Root cause

Feishu's `PATCH /open-apis/im/v1/messages/{id}` enforces a hard cap of **20 edits per message**, returning `{"code":230072, "msg":"The message has reached the number of times it can be edited."}` ([official help center](https://www.feishu.cn/hc/en-US/articles/219464343884)). OAB's streaming layer flushes cosmetic edits every ~1.5s, so any LLM reply that runs longer than ~30s exhausts the quota and every subsequent edit is rejected.

Four overlapping defects let this fail silently:

1. **`src/adapter.rs` streaming finalize swallowed every error** — every delivery-path `let _ = adapter.edit_message(...)` / `let _ = adapter.send_message(...)` site in the streaming closure returned `Ok(())` regardless of outcome, so `dispatch.rs` always saw `result.is_ok()` and triggered `set_done()` (🆗) even when delivery never completed.
2. **`gateway/src/adapters/feishu.rs::edit_feishu_message` returned `()`** — failures only landed in `tracing::error!`, never propagated to the core.
3. **`src/gateway.rs::edit_message` was fire-and-forget** (`request_id: None`) — even if the gateway emitted a `GatewayResponse{success:false}`, the core dropped it on the floor.
4. **No edit-cap detection or recovery path** — once Feishu started rejecting, OAB just kept hammering on every cosmetic flush.

In production this surfaced as: placeholder visible with the cosmetic-truncated tail of the reply, then 🆗 attached to the trigger message, with the rest of the LLM output silently lost. One observed trigger logged **88 `edit_message` commands → 68 rejections with `230072` → exactly 20 successful edits before the cap kicked in**, matching the documented limit precisely.

For context: OpenClaw and the official `larksuite/openclaw-lark` plugin sidestep this entirely by using Feishu's interactive card streaming API (`im/v1/cards/*`), which has no edit-count cap. Hermes-Agent's Feishu adapter shares the same `PATCH /im/v1/messages/{id}` path as OAB pre-fix, with no cap handling — likely one long reply away from the same failure mode. A migration to interactive card streaming is the right long-term direction (see Known Limitations); this PR keeps the current architecture and makes it cap-aware so the bug stops biting today.

## What this PR does

### `src/adapter.rs` — surface delivery failures, abort cosmetic loop, recover at finalize

- All delivery-path `let _ =` sites in the streaming closure (native finalize, native fallback, reply_to, Discord bot-mention, draft-placeholder fallback, send-once) now match on `Result` and feed a single `delivery_failed: bool` flag. The closure ends with `if delivery_failed { Err(...) } else { Ok(()) }` so dispatch calls `set_error()` (❌) instead of `set_done()` (🆗) when delivery is incomplete. The three remaining `let _ =` are non-delivery cosmetic side effects (`set_status("Thinking…")`, `set_status("")`, post-success placeholder cleanup after Discord bot-mention).
- Mid-stream cosmetic edit loop tracks `consecutive_failures` and breaks after `MAX_CONSECUTIVE_FAILURES = 3`. Loop tracing carries `message_id` + `platform` so concurrent streams can be correlated.
- The cosmetic loop's task handle is now **aborted and joined at finalize**, right after the watch channel closes, so an in-flight cosmetic edit cannot land after — and overwrite — the authoritative finalize edit.
- Final placeholder edit failure path: `delete_message(&placeholder)` to remove the half-edited message, then `send_message(chunks[0])` so the user gets the complete content as a fresh message without overlap. If `delete_message` fails the placeholder simply remains — same UX as before, not a regression.

### `gateway/src/adapters/feishu.rs` — track edit count, detect 230072, expose delete

- `FeishuAdapter` gains `edit_counts: Arc<Mutex<EditCountsCache>>`, where `EditCountsCache` holds a `HashMap<String, u32>` of counts plus a `VecDeque<String>` of insertion order. Eviction at `EDIT_COUNTS_CACHE_MAX = 4096` is **FIFO by insertion order** — never count-ascending — so just-started active streams are not the eviction target. `u32::MAX` is a cap-reached sentinel.
- `FEISHU_EDIT_CAP = 18` — preemptive ceiling with a 2-edit safety margin against in-flight races.
- `edit_feishu_message` returns `EditOutcome { Edited, CapReached, Failed(String) }` and **decides on the response body `code`**, not HTTP status alone — matching Feishu's HTTP-200 + business-code convention used by token refresh and the WS endpoint in this file. Order: (1) `is_feishu_cap_reached_body` is the sole cap authority (JSON `code == 230072`, substring fallback only for non-JSON bodies); (2) otherwise `code == 0` → Edited, non-zero → Failed, non-JSON → fall back to HTTP status. This stops a `230072` (or any error) returned with HTTP 200 from being miscounted as a successful edit.
- `handle_reply` reports `success=false / error=edit_cap_reached` on `CapReached`. The gateway deliberately does **not** append-new on cap (cosmetic flushes would spam 20+ duplicates); recovery is owned by core's finalize path.
- New `delete_feishu_message` + `handle_reply` `"delete_message"` branch: native `DELETE /open-apis/im/v1/messages/{id}`, **not** subject to the 20-edit cap — verified end-to-end against a cap-reached message.
- **message_id shape validation** (`^om_[A-Za-z0-9_]+$`, length ≤128) is enforced at the `handle_reply` dispatch seam for every command that interpolates `reply.reply_to` into a REST URL path (edit / delete / add_reaction / remove_reaction), as defence in depth.
- Chunked `send_post_message` path requires `succeeded == total_chunks` for `success=true` and emits a `GatewayResponse` for partial failures.

### `src/gateway.rs` — wire request/response for writes (acking platforms), add delete override

- `edit_message` is no longer fire-and-forget when streaming, for platforms in `EDIT_RESPONSE_PLATFORMS` (today: `["feishu"]`, behind a `platform_acks_writes()` helper with a tech-debt note that this should become a connect-time capability handshake). It carries a `request_id`, awaits the `GatewayResponse` with an 800ms timeout, returns `Err` on explicit `success=false` (cap-reached), and `Ok(())` on timeout/channel-closed. Other adapters keep the original zero-latency fire-and-forget path.
- New `delete_message` override emits `command="delete_message"` over the WS (fire-and-forget). Replaces the trait default of edit-to-zero-width, which itself fails on cap-reached messages and is exactly what we're recovering from.
- `send_gateway_reply` returns `Err` on explicit `success=false`; timeout/channel-closed remain legacy `Ok` to avoid breaking adapters mid-rollout.

## Verification

### Tests

- `cargo test --bins` (core) — **504 passed / 0 failed**
- `cargo test --bins` (gateway) — **198 passed / 0 failed**, including:
  - **9 unit tests** for cap detection (JSON-first + substring fallback + false-positive guard), cap pre-check thresholds, sentinel no-double-increment, FIFO eviction (active-stream survival regression guard), and message_id shape validation.
  - **3 integration tests** (wiremock) proving cap detection is reached *through* `edit_feishu_message`'s status handling: HTTP 200 + `{code:230072}` → `CapReached` + sentinel; HTTP 200 + `{code:0}` → `Edited` + count incremented; HTTP 200 + `{code:99991}` → `Failed`, no increment.
- `cargo clippy --release --bins --tests -- -D warnings` — both crates clean
- `cargo build --release` — both crates clean

### E2E (local Feishu instance, 5 rounds with progressively harder prompts)

| Round | Behaviour | Result |
|---|---|---|
| Baseline (pre-fix) | long reply | 🆗 over half-truncated content (the reported bug) |
| Fix r1 (naive append-new fallback) | long reply | 25-message spam — cosmetic loop triggered fallback every 1.5s |
| Fix r2 (cap returns success=false) | long reply | Half-truncated placeholder + chunks[1..]; chunks[0] lost (edit fire-and-forget) |
| Fix r3 (`edit_message` carries request_id) | long reply | Complete + 🆗, but placeholder/chunks[0] overlapped ~2000 chars |
| Fix r4 (final fallback delete→send) | long reply | Half placeholder removed, complete content, no overlap, 🆗 |

Key log signals: `edit_message gateway replied failure ... error=edit_cap_reached` (wire), `mid-stream cosmetic edit aborted message_id=om_x...` (abort), `final streaming edit failed; deleting placeholder and sending fresh` (finalize), `feishu message deleted message_id=om_x...` (DELETE recovers cap-reached messages).

**Round-2 re-validation (2026-06-18)** — re-ran against a live Feishu instance on the round-2 implementation. Full recovery chain confirmed end-to-end and visually (observed: brief pause → one message retracted → complete content, no overlap, 🆗):

```
CORE  edit_message gateway replied failure  error=edit_cap_reached
CORE  mid-stream cosmetic edit failed  consecutive_failures=1..3
CORE  mid-stream cosmetic edit aborted (R2)
CORE  final streaming edit failed; deleting placeholder and sending fresh
GW    feishu message deleted  message_id=om_x100b6...
```

In this run the cap was caught by the preemptive local count (`FEISHU_EDIT_CAP=18`, two below the server's 20) rather than an on-wire 230072 — the intended common path. A separate run with the preemptive cap temporarily raised above 20 drove edits to the server's real limit and exercised the on-wire `230072` detection (R1) directly: the gateway logged `feishu edit cap reached (errcode 230072) ... status=400 Bad Request`, then the identical recovery chain ran (cosmetic 3-strike abort → finalize delete → send fresh, 🆗). **Empirical finding: Feishu returns `230072` with HTTP 400 (not 200).** This means the pre-R1 status-only success gate did already fall through to the cap-detection branch; R1 is therefore consistency/robustness hardening (aligning with the token/WS body-code convention in the same file) rather than a fix for an active miscounting bug — see R1 in the table below.

### Backward compatibility

- **LINE / Teams / other gateway adapters** — not in `EDIT_RESPONSE_PLATFORMS`, so edit/delete take the fire-and-forget fast path with zero added latency. No regression.
- **Discord / Slack** — don't go through the gateway path — unaffected.
- **Telegram / Google Chat / WeCom** — fire-and-forget for writes today; add them to `EDIT_RESPONSE_PLATFORMS` when they wire `GatewayResponse` for writes.

## Review iterations

### Round 1 — chaodu-agent ([review](https://github.com/openabdev/openab/pull/1122#issuecomment-4736709136))

| # | Sev | Finding | Resolution |
|---|---|---|---|
| F1 | 🔴 | draft fallback `send_message` failure not propagated | `delivery_failed` now set |
| F2 | 🔴 | Discord bot-mention first chunk failure not propagated | `match Ok/Err`, Err sets `delivery_failed` |
| F3 | 🟡 | `230072` raw substring match | `is_feishu_cap_reached_body` JSON-first + non-JSON fallback |
| F4 | 🟡 | eviction by count-ascending evicts active messages | `EditCountsCache` FIFO insertion-order eviction |
| F5 | 🟡 | 800ms edit timeout latency for non-acking adapters | gated to acking platforms only |
| F6 | 🟡 | `message_id` absent from cosmetic loop traces | added `message_id` + `platform` |
| F7 | 🟡 | "append-new fallback" doc/log misleading | doc + warn rewritten |
| F8 | 🟡 | DELETE `message_id` unvalidated | `^om_[A-Za-z0-9_]+$` shape guard |
| F9 | 🟡 | PR body `let _ =` claim inaccurate | corrected |
| F10 | 🟡 | safety-critical paths untested | 9 unit tests |

### Round 2 — internal architecture/bug review

| # | Sev | Finding | Resolution |
|---|---|---|---|
| R1 | 🟡 | `edit_feishu_message` gated success on HTTP status only, inconsistent with the token-refresh/WS body-code convention in the same file | body-code-first decision + 3 integration tests through the status gate. **E2E later confirmed Feishu returns `230072` as HTTP 400**, so the original non-2xx branch did catch it — R1 is consistency/robustness hardening (and guards the hypothetical HTTP-200 case), not a fix for an active bug |
| R2 | 🟡 | cosmetic edit loop task not joined at finalize — an in-flight edit could overwrite the finalize edit (window widened by the per-edit response wait) | capture handle, `abort()` + `await` at finalize |
| R3 | 🟡 | F8 message_id guard covered delete only, not edit/reactions (same URL template, same source) | lifted validation to the `handle_reply` dispatch seam for all url-path commands |
| R4 | 🟡 | `platform == "feishu"` hardcode is platform-identity standing in for capability | `EDIT_RESPONSE_PLATFORMS` + `platform_acks_writes()` + tech-debt note |
| R5 | 🟢 | stale "append-new fallback" header comment on edit branch | rewritten |
| R6 | 🟢 | core `delete_message` fire-and-forget; delete success invisible to core | **Evaluated, not adopted** — recovery sends fresh content regardless of the delete outcome, so wiring a response would only add a log line at the cost of a per-finalize wait. Delete stays fire-and-forget. |
| — | 🟢 | nits: `as_u64`→`as_i64`; over-absolute eviction doc wording | fixed |

## Known limitations (out of scope for this PR)

- `markdown_to_post` doesn't recognise GFM tables, and its fence detection is slightly more permissive than `format::split_message`'s. When chunks split across a markdown table or oddly-fenced code block, the post-side renderer can box boundary content into a phantom code block. **Pre-existed**; only visible now that long replies aren't truncated. Follow-up: `gateway: align markdown_to_post fence detection with split_message; handle GFM tables`.
- **Long-term direction — Feishu interactive card streaming.** Feishu's CardKit (`im/v1/cards/*`) has no edit-count cap and is the path used by `larksuite/openclaw-lark` and OpenClaw upstream. Migration estimate ~7.5 person-days for an MVP; prerequisite is 24-72h of production observation on this PR. Tracked separately.

---
