### PR TITLE
docs: add Issue Guidelines section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,54 @@
 # Contributing to OpenAB
 
-Thanks for your interest in contributing! This guide covers what we expect in pull requests.
+Thanks for your interest in contributing! This guide covers what we expect in issues and pull requests.
 
-For the full rationale behind these guidelines, see the [PR Contribution Guidelines ADR](/docs/adr/pr-contribution-guidelines.md).
+For the full rationale behind the PR guidelines, see the [PR Contribution Guidelines ADR](/docs/adr/pr-contribution-guidelines.md).
+
+## Issue Guidelines
+
+The fastest way to file an issue is to use the [issue templates](https://github.com/openabdev/openab/issues/new/choose) — they auto-apply the correct labels and pass automated validation.
+
+### Issue Types
+
+| Type | Template | Required Sections |
+|------|----------|-------------------|
+| Bug | [bug.yml](/.github/ISSUE_TEMPLATE/bug.yml) | Description, Steps to Reproduce, Expected Behavior |
+| Feature | [feature.yml](/.github/ISSUE_TEMPLATE/feature.yml) | Description, Use Case |
+| Documentation | [documentation.yml](/.github/ISSUE_TEMPLATE/documentation.yml) | Description |
+| Guidance | [guidance.yml](/.github/ISSUE_TEMPLATE/guidance.yml) | Question |
+| RFC | [rfc.yml](/.github/ISSUE_TEMPLATE/rfc.yml) | Proposal (free-form, no heading validation) |
+
+### Filing Without a Template
+
+If you file an issue via CLI or API (bypassing the template UI), keep these rules in mind:
+
+1. **Title prefix helps auto-detection.** The following prefixes are recognized:
+   - `fix(...)` or `bug(...)` → Bug
+   - `feat(...)` or `feature(...)` → Feature
+   - `docs(...)` or `documentation(...)` → Documentation
+   - `RFC:` → RFC
+
+2. **Use the required headings** (as `##` or `###`). Common synonyms are accepted:
+
+   | Required Field | Accepted Synonyms |
+   |----------------|-------------------|
+   | Description | Problem, Summary, Overview, Background, What happened, Bug description |
+   | Steps to Reproduce | Reproduction, How to reproduce, Repro steps, Steps to replicate, Repro |
+   | Expected Behavior | Expected result, What should happen, Expected behaviour, Expected outcome |
+   | Use Case | Motivation, Why, Rationale, Use cases, Why it matters, Benefits, Proposal |
+   | Question | (no synonyms) |
+
+3. **Headings must have content.** An empty heading or `_No response_` does not count.
+
+### Automated Validation
+
+A GitHub Action ([issue-check.yml](/.github/workflows/issue-check.yml)) runs on every issue open, edit, and label event:
+
+- **Missing type label + unrecognizable format** → `incomplete` label is added, a bot comment asks you to wait for a maintainer to apply a type label.
+- **Type is known but required sections are missing** → `incomplete` label is added, a bot comment lists exactly what's missing.
+- **All required sections present** → `incomplete` label is automatically removed.
+
+To fix an `incomplete` issue, simply edit the issue body to add the missing sections — no need to close and re-open.
 
 ## Pull Request Guidelines
 


### PR DESCRIPTION
## What problem does this solve?

`CONTRIBUTING.md` only documented PR guidelines. Contributors filing issues via CLI/API had no way to know the format requirements enforced by `issue-check.yml`, leading to well-written issues being incorrectly flagged as `incomplete` (e.g. #1101, #1109, #1114).

## At a Glance

N/A (docs-only change)

## Prior Art & Industry Research

Not applicable — documentation improvement with no architectural impact.

## Proposed Solution

Add an `## Issue Guidelines` section before the existing PR Guidelines, covering:

- All 5 issue types with their required sections (matching the templates)
- Title prefix auto-detection rules (`fix(`, `feat(`, `docs(`, `RFC:`)
- Accepted heading synonyms table
- How automated validation works (the `incomplete` label lifecycle)

## Why This Approach

Mirrors the structure and tone of the existing PR Guidelines section. Placed before PR Guidelines since the normal contribution flow is: file issue → discuss → open PR.

## Alternatives Considered

- Separate `docs/filing-issues.md` — rejected because GitHub auto-prompts users to read `CONTRIBUTING.md`, not arbitrary docs files.
- Adding notes to the issue templates themselves — insufficient for CLI/API users who bypass templates.

## Validation

- Links are valid, renders correctly in GitHub preview
- Content matches the actual `issue-check.yml` rules and template definitions

## Discord Discussion URL

https://discord.com/channels/1491295327620169908/1516364427429937222