### PR TITLE
docs(codex): fix deprecated approval_policy = "auto-review"

### DIFF
--- a/docs/codex.md
+++ b/docs/codex.md
@@ -249,6 +249,19 @@ agents:
 > pod. If you also need codex to write back to it (e.g. `codex features enable`
 > persisting flags), pre-seed the config on the PVC instead.
 
+Alternatively, copy a local `config.toml` directly into the running pod's PVC
+(writable, persists across restarts):
+
+```bash
+kubectl cp config.toml <pod-name>:/home/node/.codex/config.toml
+```
+
+Then restart to pick up the changes:
+
+```bash
+kubectl rollout restart deployment/openab-codex
+```
+
 ### What Auto-review does
 
 - Approves ~99% of legitimate out-of-sandbox actions automatically.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -187,27 +187,32 @@ Use $discord-imagegen-deliver to generate a warm hand-painted sky with birds and
 
 ## Approval Policy & Auto-review
 
-Codex offers three approval modes that control what happens when the agent
-tries to act outside the sandbox (network calls, running scripts, etc.):
+Codex separates **when** to ask for approval (`approval_policy`) from **who**
+reviews the request (`approvals_reviewer`):
 
-| Mode | Behaviour | Best for |
-|------|-----------|----------|
-| **Manual** (`approval_policy = "on-request"`) | Every out-of-sandbox action waits for a human to approve | Interactive, attended sessions |
-| **Auto-review** (`approval_policy = "auto-review"`) | A separate reviewer agent (GPT-5.4 Thinking) approves or denies automatically | **OpenAB / unattended agents** |
-| **Full Access** (`approval_policy = "full-access"`) | No sandbox enforcement at all | Trusted, isolated environments only |
+| Key | Valid values | Purpose |
+|-----|-------------|---------|
+| `approval_policy` | `untrusted`, `on-failure` (deprecated), `on-request`, `granular`, `never` | When Codex must request approval before acting |
+| `approvals_reviewer` | `"user"` (default), `"auto_review"` | Who handles the approval — human or GPT-5.4 Thinking reviewer |
 
 For OpenAB deployments, **Auto-review is the recommended mode**. OpenAB agents
 run as long-lived background processes with no human watching the terminal, so
-manual approval is impractical and Full Access removes all guardrails.
+manual approval is impractical and `"never"` removes all guardrails.
 
 Enable Auto-review in `/home/node/.codex/config.toml`:
 
 ```toml
-approval_policy = "auto-review"
+sandbox_mode = "danger-full-access"
+approval_policy = "on-request"
+approvals_reviewer = "auto_review"
+
+[features]
+image_generation = true
 ```
 
-> `approval_policy` is a **top-level** key in `config.toml`, not under a
-> `[sandbox]` section. Codex silently ignores it if nested.
+> `sandbox_mode`, `approval_policy`, and `approvals_reviewer` are **top-level**
+> keys in `config.toml`, not under a `[sandbox]` section. Codex silently ignores
+> them if nested.
 
 Or mount a `ConfigMap` containing the codex `config.toml` into the agent via the
 chart's `extraVolumes` / `extraVolumeMounts` (the chart does not expose a
@@ -217,7 +222,14 @@ to come in as a mounted file or be pre-seeded into the PVC):
 ```bash
 # Create the codex config as a ConfigMap.
 kubectl create configmap codex-config \
-  --from-literal=config.toml='approval_policy = "auto-review"'
+  --from-literal=config.toml='
+sandbox_mode = "danger-full-access"
+approval_policy = "on-request"
+approvals_reviewer = "auto_review"
+
+[features]
+image_generation = true
+'
 
 # values.yaml — mount it over /home/node/.codex/config.toml
 agents:
@@ -285,23 +297,27 @@ runtime already provides isolation):
 ```toml
 # /home/node/.codex/config.toml
 sandbox_mode = "danger-full-access"
-approval_policy = "auto-review"
+approval_policy = "on-request"
+approvals_reviewer = "auto_review"
 ```
 
-> `sandbox_mode` and `approval_policy` are **top-level** keys in `config.toml`.
-> A `[sandbox]` section header is silently ignored by Codex 0.137+ — verified
-> empirically: with the nested form in place, `codex exec` still fails with
-> `bwrap: No permissions to create new namespace`; moving the same keys to the
-> top level makes `codex exec` report `sandbox: danger-full-access` and run.
+> `sandbox_mode`, `approval_policy`, and `approvals_reviewer` are **top-level**
+> keys in `config.toml`. A `[sandbox]` section header is silently ignored by
+> Codex 0.137+ — verified empirically: with the nested form in place, `codex
+> exec` still fails with `bwrap: No permissions to create new namespace`; moving
+> the same keys to the top level makes `codex exec` report
+> `sandbox: danger-full-access` and run.
 
-> **Do NOT pair `danger-full-access` with `approval_policy = "on-request"` on
-> an OpenAB deployment.** `on-request` pauses each tool call to wait for an
-> interactive human approval, and OpenAB agents have no terminal attached —
-> every tool call hangs in `in_progress` until openab's 1800 s hard timeout
-> fires. Use `"auto-review"` (recommended, see
-> [§Approval Policy](#approval-policy--auto-review)) or `"never"` for trusted
-> and already-isolated pods (`"never"` removes all per-call guardrails — the
-> outer pod isolation is the only remaining boundary).
+> **Do NOT pair `danger-full-access` with `approval_policy = "on-request"` and
+> `approvals_reviewer = "user"` on an OpenAB deployment.** Without auto-review,
+> `on-request` pauses each tool call to wait for an interactive human approval,
+> and OpenAB agents have no terminal attached — every tool call hangs in
+> `in_progress` until openab's 1800 s hard timeout fires. Use
+> `approvals_reviewer = "auto_review"` (recommended, see
+> [§Approval Policy](#approval-policy--auto-review)) or
+> `approval_policy = "never"` for trusted and already-isolated pods (`"never"`
+> removes all per-call guardrails — the outer pod isolation is the only
+> remaining boundary).
 
 Or launch with:
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -202,6 +202,7 @@ manual approval is impractical and `"never"` removes all guardrails.
 Enable Auto-review in `/home/node/.codex/config.toml`:
 
 ```toml
+# Full recommended config for OpenAB agents
 sandbox_mode = "danger-full-access"
 approval_policy = "on-request"
 approvals_reviewer = "auto_review"


### PR DESCRIPTION
## Summary

Codex CLI no longer accepts `"auto-review"` as a valid `approval_policy` value. Loading a config with this value now fails with:

```
Error loading config.toml: unknown variant `auto-review`, expected one of
`untrusted`, `on-failure`, `on-request`, `granular`, `never` in `approval_policy`
```

Auto-review is now enabled via a **separate key** `approvals_reviewer`:

```toml
sandbox_mode = "danger-full-access"
approval_policy = "on-request"
approvals_reviewer = "auto_review"

[features]
image_generation = true
```

## Changes

- Replace the old 3-mode approval table with a 2-key explanation (`approval_policy` + `approvals_reviewer`)
- Update all `approval_policy = "auto-review"` config examples to the correct form
- Update the ConfigMap example with the full recommended config
- Fix the troubleshooting section config block and warning text

## References

- [openai/codex#23875](https://github.com/openai/codex/issues/23875) — related context compaction bug
- [OpenAI Alignment Blog: Auto-review](https://alignment.openai.com/auto-review)
