### PR TITLE
fix: persist multibot thread detection to disk

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -222,6 +222,8 @@ pub struct Handler {
     /// Positive-only cache: thread channel_id → cached_at for threads where other bots have posted.
     /// Like participation, a thread becoming multi-bot is irreversible (bot messages don't disappear).
     pub multibot_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
+    /// Persistent disk cache for multibot thread detection (survives restarts).
+    pub multibot_cache: crate::multibot_cache::MultibotCache,
     /// TTL for participation cache entries (from pool.session_ttl_hours).
     pub session_ttl: std::time::Duration,
     /// Configurable soft limit on bot turns per thread (reset by human message).
@@ -264,7 +266,7 @@ impl Handler {
             cache
                 .get(&key)
                 .is_some_and(|ts| ts.elapsed() < self.session_ttl)
-        };
+        } || self.multibot_cache.is_multibot(&key).await;
 
         // Both cached → skip fetch entirely
         // With early detection from msg.author, multibot_threads is populated
@@ -314,20 +316,25 @@ impl Handler {
         }
 
         if other_bot_present && !cached_multibot {
-            let mut cache = self.multibot_threads.lock().await;
-            cache.insert(key, tokio::time::Instant::now());
+            {
+                let mut cache = self.multibot_threads.lock().await;
+                cache.insert(key.clone(), tokio::time::Instant::now());
 
-            if cache.len() > PARTICIPATION_CACHE_MAX {
-                cache.retain(|_, ts| ts.elapsed() < self.session_ttl);
                 if cache.len() > PARTICIPATION_CACHE_MAX {
-                    let mut entries: Vec<_> = cache.iter().map(|(k, v)| (k.clone(), *v)).collect();
-                    entries.sort_by_key(|(_, ts)| *ts);
-                    let evict_count = entries.len() / 2;
-                    for (k, _) in entries.into_iter().take(evict_count) {
-                        cache.remove(&k);
+                    cache.retain(|_, ts| ts.elapsed() < self.session_ttl);
+                    if cache.len() > PARTICIPATION_CACHE_MAX {
+                        let mut entries: Vec<_> =
+                            cache.iter().map(|(k, v)| (k.clone(), *v)).collect();
+                        entries.sort_by_key(|(_, ts)| *ts);
+                        let evict_count = entries.len() / 2;
+                        for (k, _) in entries.into_iter().take(evict_count) {
+                            cache.remove(&k);
+                        }
                     }
                 }
             }
+            // Persist to disk — multibot is irreversible
+            self.multibot_cache.mark_multibot(&key).await;
         }
 
         (involved, other_bot_present)
@@ -343,8 +350,12 @@ impl EventHandler for Handler {
         // Runs before self-check and bot gating so we always detect other bots. (#481)
         if msg.author.bot && msg.author.id != bot_id {
             let key = msg.channel_id.to_string();
-            let mut cache = self.multibot_threads.lock().await;
-            cache.entry(key).or_insert_with(tokio::time::Instant::now);
+            {
+                let mut cache = self.multibot_threads.lock().await;
+                cache.entry(key.clone()).or_insert_with(tokio::time::Instant::now);
+            }
+            // Persist to disk — multibot is irreversible
+            self.multibot_cache.mark_multibot(&key).await;
         }
 
         // Bot turn counting: runs before self-check so ALL bot messages

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -292,10 +292,9 @@ impl Handler {
         };
 
         let involved = cached_involved || messages.iter().any(|m| m.author.id == bot_id);
-        let other_bot_present = cached_multibot
-            || messages
-                .iter()
-                .any(|m| m.author.bot && m.author.id != bot_id);
+        // other_bot_present relies solely on early detection + disk cache;
+        // no longer scanned from fetched messages (200-msg window was unreliable).
+        let other_bot_present = cached_multibot;
 
         if involved && !cached_involved {
             let mut cache = self.participated_threads.lock().await;
@@ -313,28 +312,6 @@ impl Handler {
                     }
                 }
             }
-        }
-
-        if other_bot_present && !cached_multibot {
-            {
-                let mut cache = self.multibot_threads.lock().await;
-                cache.insert(key.clone(), tokio::time::Instant::now());
-
-                if cache.len() > PARTICIPATION_CACHE_MAX {
-                    cache.retain(|_, ts| ts.elapsed() < self.session_ttl);
-                    if cache.len() > PARTICIPATION_CACHE_MAX {
-                        let mut entries: Vec<_> =
-                            cache.iter().map(|(k, v)| (k.clone(), *v)).collect();
-                        entries.sort_by_key(|(_, ts)| *ts);
-                        let evict_count = entries.len() / 2;
-                        for (k, _) in entries.into_iter().take(evict_count) {
-                            cache.remove(&k);
-                        }
-                    }
-                }
-            }
-            // Persist to disk — multibot is irreversible
-            self.multibot_cache.mark_multibot(&key).await;
         }
 
         (involved, other_bot_present)

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -852,7 +852,7 @@ impl EventHandler for Handler {
         let other_bot_present_flag = {
             let cache = self.multibot_threads.lock().await;
             cache.contains_key(&msg.channel_id.to_string())
-        };
+        } || self.multibot_cache.is_multibot(&msg.channel_id.to_string());
 
         // Backfill thread_id: when OAB just created a new thread, the sender
         // was built before the thread existed. Patch it so the agent sees

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -266,7 +266,7 @@ impl Handler {
             cache
                 .get(&key)
                 .is_some_and(|ts| ts.elapsed() < self.session_ttl)
-        } || self.multibot_cache.is_multibot(&key).await;
+        } || self.multibot_cache.is_multibot(&key);
 
         // Both cached → skip fetch entirely
         // With early detection from msg.author, multibot_threads is populated

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod gateway;
 mod hooks;
 mod markdown;
 mod media;
+mod multibot_cache;
 mod reactions;
 mod remind;
 mod secrets;
@@ -232,12 +233,23 @@ async fn main() -> anyhow::Result<()> {
             Arc::new(discord::DiscordAdapter::new(http)) as Arc<dyn adapter::ChatAdapter>
         });
     let session_ttl_dur = std::time::Duration::from_secs(ttl_secs);
+
+    // Initialize multibot cache (persists to $HOME/.openab/cache/threads.json)
+    let multibot_cache_path = std::env::var("HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_default()
+        .join(".openab")
+        .join("cache")
+        .join("threads.json");
+    let multibot_cache = multibot_cache::MultibotCache::load(multibot_cache_path);
+
     let shared_slack_adapter: Option<Arc<slack::SlackAdapter>> = cfg.slack.as_ref().map(|s| {
         Arc::new(slack::SlackAdapter::new(
             s.bot_token.clone(),
             session_ttl_dur,
             s.allow_bot_messages,
             s.assistant_mode,
+            multibot_cache.clone(),
         ))
     });
 
@@ -479,6 +491,7 @@ async fn main() -> anyhow::Result<()> {
             allowed_role_ids,
             participated_threads: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             multibot_threads: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            multibot_cache,
             session_ttl: std::time::Duration::from_secs(ttl_secs),
             max_bot_turns: discord_cfg.max_bot_turns,
             bot_turns: tokio::sync::Mutex::new(bot_turns::BotTurnTracker::new(

--- a/src/multibot_cache.rs
+++ b/src/multibot_cache.rs
@@ -1,0 +1,85 @@
+//! Persistent disk cache for multibot thread detection.
+//!
+//! Once a thread is identified as multi-bot (irreversible), it is stored in
+//! `~/.openab/cache/threads.json` so the detection survives restarts and
+//! in-memory TTL expiry.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+#[derive(Serialize, Deserialize, Clone)]
+struct Entry {
+    detected_at: DateTime<Utc>,
+}
+
+/// Shared multibot thread cache with file persistence.
+#[derive(Clone)]
+pub struct MultibotCache {
+    threads: Arc<Mutex<HashMap<String, Entry>>>,
+    path: PathBuf,
+}
+
+impl MultibotCache {
+    /// Load or create the cache from `~/.openab/cache/threads.json`.
+    pub fn load(path: PathBuf) -> Self {
+        let threads = match std::fs::read_to_string(&path) {
+            Ok(data) => serde_json::from_str(&data).unwrap_or_else(|e| {
+                warn!(error = %e, "failed to parse threads.json, starting empty");
+                HashMap::new()
+            }),
+            Err(_) => HashMap::new(),
+        };
+        info!(count = threads.len(), path = %path.display(), "loaded multibot cache");
+        Self {
+            threads: Arc::new(Mutex::new(threads)),
+            path,
+        }
+    }
+
+    /// Check if a thread is known to be multi-bot.
+    pub async fn is_multibot(&self, thread_id: &str) -> bool {
+        self.threads.lock().await.contains_key(thread_id)
+    }
+
+    /// Mark a thread as multi-bot and persist to disk.
+    pub async fn mark_multibot(&self, thread_id: &str) {
+        let snapshot = {
+            let mut threads = self.threads.lock().await;
+            if threads.contains_key(thread_id) {
+                return;
+            }
+            threads.insert(
+                thread_id.to_string(),
+                Entry {
+                    detected_at: Utc::now(),
+                },
+            );
+            threads.clone()
+        };
+        self.persist(&snapshot);
+    }
+
+    fn persist(&self, threads: &HashMap<String, Entry>) {
+        if let Some(parent) = self.path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                warn!(error = %e, "failed to create cache directory");
+                return;
+            }
+        }
+        match serde_json::to_string_pretty(threads) {
+            Ok(data) => {
+                if let Err(e) = std::fs::write(&self.path, data) {
+                    warn!(error = %e, "failed to persist threads.json");
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to serialize multibot cache");
+            }
+        }
+    }
+}

--- a/src/multibot_cache.rs
+++ b/src/multibot_cache.rs
@@ -8,8 +8,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tracing::{info, warn};
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -42,14 +41,14 @@ impl MultibotCache {
     }
 
     /// Check if a thread is known to be multi-bot.
-    pub async fn is_multibot(&self, thread_id: &str) -> bool {
-        self.threads.lock().await.contains_key(thread_id)
+    pub fn is_multibot(&self, thread_id: &str) -> bool {
+        self.threads.lock().unwrap().contains_key(thread_id)
     }
 
-    /// Mark a thread as multi-bot and persist to disk.
+    /// Mark a thread as multi-bot and persist to disk (non-blocking).
     pub async fn mark_multibot(&self, thread_id: &str) {
         let snapshot = {
-            let mut threads = self.threads.lock().await;
+            let mut threads = self.threads.lock().unwrap();
             if threads.contains_key(thread_id) {
                 return;
             }
@@ -61,25 +60,26 @@ impl MultibotCache {
             );
             threads.clone()
         };
-        self.persist(&snapshot);
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || persist(&path, &snapshot)).await.ok();
     }
+}
 
-    fn persist(&self, threads: &HashMap<String, Entry>) {
-        if let Some(parent) = self.path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                warn!(error = %e, "failed to create cache directory");
-                return;
+fn persist(path: &PathBuf, threads: &HashMap<String, Entry>) {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            warn!(error = %e, "failed to create cache directory");
+            return;
+        }
+    }
+    match serde_json::to_string_pretty(threads) {
+        Ok(data) => {
+            if let Err(e) = std::fs::write(path, data) {
+                warn!(error = %e, "failed to persist threads.json");
             }
         }
-        match serde_json::to_string_pretty(threads) {
-            Ok(data) => {
-                if let Err(e) = std::fs::write(&self.path, data) {
-                    warn!(error = %e, "failed to persist threads.json");
-                }
-            }
-            Err(e) => {
-                warn!(error = %e, "failed to serialize multibot cache");
-            }
+        Err(e) => {
+            warn!(error = %e, "failed to serialize multibot cache");
         }
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -119,11 +119,13 @@ impl SlackAdapter {
     /// event loop when a bot message arrives, so multibot detection doesn't
     /// depend on fetching thread history. Idempotent.
     async fn note_other_bot_in_thread(&self, thread_ts: &str) {
-        let mut cache = self.multibot_threads.lock().await;
-        cache
-            .entry(thread_ts.to_string())
-            .or_insert_with(tokio::time::Instant::now);
-        enforce_cache_bounds(&mut cache, self.session_ttl);
+        {
+            let mut cache = self.multibot_threads.lock().await;
+            cache
+                .entry(thread_ts.to_string())
+                .or_insert_with(tokio::time::Instant::now);
+            enforce_cache_bounds(&mut cache, self.session_ttl);
+        }
         // Persist to disk — multibot is irreversible
         self.multibot_cache.mark_multibot(thread_ts).await;
     }
@@ -323,7 +325,7 @@ impl SlackAdapter {
             cache
                 .get(thread_ts)
                 .is_some_and(|ts| ts.elapsed() < self.session_ttl)
-        } || self.multibot_cache.is_multibot(thread_ts).await;
+        } || self.multibot_cache.is_multibot(thread_ts);
 
         // Eager multibot detection from message events populates the cache
         // before this runs. When already involved and cached, skip the fetch.

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -75,6 +75,8 @@ pub struct SlackAdapter {
     /// Positive-only cache: thread_ts → cached_at for threads where other bots have posted.
     /// Like participation, a thread becoming multi-bot is irreversible (bot messages don't disappear).
     multibot_threads: tokio::sync::Mutex<HashMap<String, tokio::time::Instant>>,
+    /// Persistent disk cache for multibot thread detection (survives restarts).
+    multibot_cache: crate::multibot_cache::MultibotCache,
     /// TTL for participation cache entries (matches session_ttl_hours from config).
     session_ttl: std::time::Duration,
     /// Assistant mode: stream via chat.startStream + assistant.threads.setStatus.
@@ -91,6 +93,7 @@ impl SlackAdapter {
         session_ttl: std::time::Duration,
         _allow_bot_messages: AllowBots,
         assistant_mode: bool,
+        multibot_cache: crate::multibot_cache::MultibotCache,
     ) -> Self {
         Self {
             client: reqwest::Client::new(),
@@ -100,6 +103,7 @@ impl SlackAdapter {
             bot_id_cache: tokio::sync::Mutex::new(HashMap::new()),
             participated_threads: tokio::sync::Mutex::new(HashMap::new()),
             multibot_threads: tokio::sync::Mutex::new(HashMap::new()),
+            multibot_cache,
             session_ttl,
             assistant_mode,
             streams: tokio::sync::Mutex::new(HashMap::new()),
@@ -120,6 +124,8 @@ impl SlackAdapter {
             .entry(thread_ts.to_string())
             .or_insert_with(tokio::time::Instant::now);
         enforce_cache_bounds(&mut cache, self.session_ttl);
+        // Persist to disk — multibot is irreversible
+        self.multibot_cache.mark_multibot(thread_ts).await;
     }
 
 
@@ -317,7 +323,7 @@ impl SlackAdapter {
             cache
                 .get(thread_ts)
                 .is_some_and(|ts| ts.elapsed() < self.session_ttl)
-        };
+        } || self.multibot_cache.is_multibot(thread_ts).await;
 
         // Eager multibot detection from message events populates the cache
         // before this runs. When already involved and cached, skip the fetch.
@@ -1761,7 +1767,7 @@ mod tests {
 
     #[tokio::test]
     async fn degraded_stream_append_accumulates() {
-        let adapter = SlackAdapter::new("xoxb-test".into(), std::time::Duration::from_secs(60), AllowBots::Off, true);
+        let adapter = SlackAdapter::new("xoxb-test".into(), std::time::Duration::from_secs(60), AllowBots::Off, true, crate::multibot_cache::MultibotCache::load("/dev/null".into()));
         adapter.streams.lock().await.insert(
             "TS".into(),
             StreamEntry { active: false, degraded_buf: String::new() },
@@ -2070,7 +2076,7 @@ mod tests {
     #[test]
     fn streaming_per_thread() {
         let ttl = std::time::Duration::from_secs(300);
-        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, false);
+        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, false, crate::multibot_cache::MultibotCache::load("/dev/null".into()));
 
         assert!(
             adapter.use_streaming(false),
@@ -2087,13 +2093,13 @@ mod tests {
         let ttl = std::time::Duration::from_secs(60);
         // assistant_mode=true → status API on; native streaming on (no other bot),
         // off when another bot is present; post+edit streaming on regardless.
-        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Off, true);
+        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Off, true, crate::multibot_cache::MultibotCache::load("/dev/null".into()));
         assert!(adapter.uses_assistant_status(), "assistant_mode enables status API");
         assert!(adapter.use_streaming(false), "post+edit streaming on when no other bot");
         assert!(adapter.uses_native_streaming(false), "native streaming on when no other bot");
         assert!(!adapter.uses_native_streaming(true), "other bot present disables native");
         // assistant_mode=false → no status API, no native streaming; post+edit still streams.
-        let adapter2 = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Off, false);
+        let adapter2 = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Off, false, crate::multibot_cache::MultibotCache::load("/dev/null".into()));
         assert!(!adapter2.uses_assistant_status());
         assert!(adapter2.use_streaming(false), "post+edit streaming independent of assistant_mode");
         assert!(!adapter2.uses_native_streaming(false), "native streaming requires assistant_mode");
@@ -2150,7 +2156,7 @@ mod tests {
     #[test]
     fn typical_long_table_stays_in_one_chunk() {
         let ttl = std::time::Duration::from_secs(300);
-        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, true);
+        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, true, crate::multibot_cache::MultibotCache::load("/dev/null".into()));
         let limit = adapter.message_limit();
         assert_eq!(limit, MARKDOWN_BLOCK_LIMIT);
         let mut table = String::from("| col a | col b | col c |\n|---|---|---|\n");
@@ -2212,7 +2218,7 @@ mod tests {
     #[test]
     fn slack_renders_native_tables() {
         let ttl = std::time::Duration::from_secs(300);
-        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, true);
+        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, true, crate::multibot_cache::MultibotCache::load("/dev/null".into()));
         assert!(adapter.renders_native_tables());
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1423,7 +1423,10 @@ async fn handle_message(
                 .get(ts)
                 .is_some_and(|inst| inst.elapsed() < adapter.session_ttl)
         })
-    };
+    } || thread_channel
+        .thread_id
+        .as_deref()
+        .is_some_and(|ts| adapter.multibot_cache.is_multibot(ts));
 
     // Best-effort echo before the agent reply so the user can verify STT.
     crate::stt::post_echo(

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -372,18 +372,12 @@ impl SlackAdapter {
         let bot_posted = messages.iter().any(|m| m["user"].as_str() == Some(bot_id));
 
         let involved = parent_mentions_bot || bot_posted;
-        let other_bot_present = cached_multibot
-            || messages.iter().any(|m| {
-                let is_bot_msg =
-                    m["bot_id"].is_string() || m["subtype"].as_str() == Some("bot_message");
-                is_bot_msg && m["user"].as_str() != Some(bot_id)
-            });
+        // other_bot_present relies solely on early detection + disk cache;
+        // no longer scanned from fetched messages (200-msg window was unreliable).
+        let other_bot_present = cached_multibot;
 
         if involved {
             self.cache_participation(thread_ts).await;
-        }
-        if other_bot_present && !cached_multibot {
-            self.note_other_bot_in_thread(thread_ts).await;
         }
 
         (involved, other_bot_present)


### PR DESCRIPTION
## Summary

Multi-bot thread detection was stored only in-memory with TTL expiry. When a bot restarts or TTL expires in a thread with >200 messages, the multibot state is lost — all bots revert to responding without `@mention`.

## Design Decision

**`other_bot_present` no longer relies on fetching message history.** Detection is now purely event-driven:

| Source | Purpose |
|--------|---------|
| Early detection (real-time) | When any bot message arrives → immediately mark as multibot |
| Disk cache (`~/.openab/cache/threads.json`) | Persist across restarts, never expires |
| In-memory cache | Fast-path for current session |

The 200-message fetch is **retained only for `involved` check** (has the bot previously posted in this thread?).

## Why This Works

- If another bot is active → early detection fires → multibot marked instantly
- If another bot is inactive → no pile-on problem exists anyway
- Bot restart → disk cache provides continuity
- No dependency on message window depth

## Changes

- New `multibot_cache` module: `~/.openab/cache/threads.json` (auto-created)
- Discord + Slack: check disk cache for multibot state
- Discord + Slack: persist on early detection
- Discord + Slack: **removed** fetch-based `other_bot_present` scanning
- `MultibotCache`: `std::sync::Mutex` + `spawn_blocking` for I/O
- Both adapters share a single `MultibotCache` instance

## Cache Format

```json
{
  "1516512900397928548": { "detected_at": "2026-06-16T20:46:12Z" }
}
```

## Testing

- CI: cargo check + 15 Docker smoke tests passing
- All existing test instances updated
- Lock ordering verified (no locks held across await points)