### PR TITLE
fix(agy-acp): preserve configOptions on session/load

### DIFF
--- a/agy-acp/src/adapter.rs
+++ b/agy-acp/src/adapter.rs
@@ -281,8 +281,10 @@ impl Adapter {
                 error: Some(json!({"code":-32602,"message":"missing sessionId"})) };
         }
         if self.restore_session_state(session_id) {
+            let model_id = self.sessions.get(session_id).and_then(|s| s.model_id.clone());
+            let config_options = self.config_options_json(model_id.as_deref());
             return JsonRpcResponse { jsonrpc: "2.0", id,
-                result: Some(json!({ "sessionId": session_id })), error: None };
+                result: Some(json!({ "sessionId": session_id, "configOptions": config_options })), error: None };
         }
         JsonRpcResponse { jsonrpc: "2.0", id, result: None,
             error: Some(json!({"code":-32000,"message":format!("unknown sessionId: {session_id}")})) }

--- a/agy-acp/src/main.rs
+++ b/agy-acp/src/main.rs
@@ -480,6 +480,41 @@ mod tests {
 
     #[test]
     #[ignore]
+    fn test_session_load_returns_config_options_for_models() {
+        let root = std::env::temp_dir().join(format!("agy-acp-load-models-{}", Uuid::new_v4()));
+        let _ = fs::create_dir_all(&root);
+        let selected_model = "Gemini 3.1 Pro (High)";
+        let mut adapter = Adapter {
+            sessions: HashMap::new(), working_dir: root.to_string_lossy().to_string(),
+            conversations_dir: root.join("conversations"), state_file: root.join("sessions.json"),
+            available_models: Some(vec![
+                "Gemini 3.5 Flash (Low)".to_string(),
+                selected_model.to_string(),
+            ]),
+        };
+        adapter.persist_session("sess-1", Some("conv-abc"), 5, Some(selected_model));
+        let response = adapter.handle_session_load(json!(7), &json!({"sessionId": "sess-1"}));
+        assert!(response.error.is_none());
+
+        let result = response.result.expect("session/load should return a result");
+        assert_eq!(result["sessionId"], json!("sess-1"));
+        let config_options = result["configOptions"]
+            .as_array()
+            .expect("session/load should include configOptions");
+        assert_eq!(config_options.len(), 1);
+        assert_eq!(config_options[0]["id"], json!("model"));
+        assert_eq!(config_options[0]["currentValue"], json!(selected_model));
+
+        let options = config_options[0]["options"]
+            .as_array()
+            .expect("model config option should include options");
+        assert_eq!(options.len(), 2);
+        assert!(options.iter().any(|option| option["value"] == json!(selected_model)));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[ignore]
     fn test_persist_and_restore_session() {
         let root = std::env::temp_dir().join(format!("agy-acp-state-{}", Uuid::new_v4()));
         let _ = fs::create_dir_all(&root);


### PR DESCRIPTION
## What problem does this solve?

When OpenAB resumes an agy session via `session/load`, the adapter returns only `sessionId` and omits `configOptions`. OpenAB then drops the cached model options for that thread, so `/models` no longer shows available models and model switching stops working after resume.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1516836512594002020

## At a Glance

```text
session/new
  -> agy-acp returns sessionId + configOptions
  -> OpenAB caches model options
  -> /models works

session/load (before)
  -> agy-acp returns sessionId only
  -> OpenAB loses cached model options
  -> /models breaks on resumed sessions

session/load (after)
  -> agy-acp returns sessionId + configOptions
  -> OpenAB keeps model options
  -> /models still works after resume
```

## Prior Art & Industry Research

Not applicable — this is a narrow adapter bug fix that restores expected ACP response data for resumed sessions. It does not introduce a new architecture, runtime design, or persistence model.

## Proposed Solution

Update `agy-acp` so `session/load` returns `configOptions` in the same shape as `session/new`.

When restoring a persisted session, the adapter now:
- looks up the restored `model_id`
- rebuilds the `configOptions` payload
- returns both `sessionId` and `configOptions`

Also add a regression test that verifies `session/load` returns model options with the restored model selected.

## Why this approach?

This is the smallest fix that restores the expected behavior without changing OpenAB's ACP connection model or session persistence format.

Tradeoffs / limitations:
- keeps the fix scoped to `agy-acp`
- does not change how OpenAB handles other adapters that omit `configOptions`
- follows the existing `agy-acp` test-file convention by marking the filesystem-touching regression test as `#[ignore]`

## Alternatives Considered

- Preserve old cached options in OpenAB when `session/load` omits `configOptions`
  - Rejected because it papers over an adapter contract bug and can hide stale adapter state.
- Re-fetch model options in OpenAB after every `session/load`
  - Rejected as unnecessary complexity for a bug that can be fixed at the source.

## Validation

- [x] `cargo check`
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --manifest-path agy-acp/Cargo.toml`
- [x] `cargo test --manifest-path agy-acp/Cargo.toml test_session_load_returns_config_options_for_models -- --ignored`

Manual testing:
- Confirmed the new regression test writes only to a unique temp directory and cleans it up.
- Confirmed default `agy-acp` test runs still pass with the new filesystem-touching test marked `#[ignore]`.
