### PR TITLE
fix(openab-agent): implement session/load handler

### DIFF
--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -402,14 +402,21 @@ impl AcpServer {
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
-        if session_id.is_empty() || !self.sessions.contains_key(session_id) {
-            return self.error_response(id, -32000, "session not found");
+        if session_id.is_empty() {
+            return self.error_response(id, -32602, "missing sessionId");
+        }
+
+        if !self.sessions.contains_key(session_id) {
+            return self.error_response(id, -32000, &format!("unknown sessionId: {session_id}"));
         }
 
         // Update working directory if caller provides cwd
         if let Some(cwd) = params.get("cwd").and_then(|v| v.as_str()) {
             if !cwd.is_empty() {
                 self.working_dir = cwd.to_string();
+                if let Some(agent) = self.sessions.get_mut(session_id) {
+                    agent.set_working_dir(cwd.to_string());
+                }
             }
         }
 
@@ -980,12 +987,18 @@ mod tests {
     #[tokio::test]
     async fn test_session_load_unknown_session_returns_error() {
         let mut server = AcpServer::new();
+
+        // Unknown session → -32000
         let resp_str = server
             .handle_session_load(12, &json!({"sessionId": "nonexistent"}))
             .await;
         let resp: Value = serde_json::from_str(&resp_str).unwrap();
-
         assert!(resp["error"].is_object());
         assert_eq!(resp["error"]["code"], -32000);
+
+        // Missing sessionId → -32602
+        let resp_str = server.handle_session_load(13, &json!({})).await;
+        let resp: Value = serde_json::from_str(&resp_str).unwrap();
+        assert_eq!(resp["error"]["code"], -32602);
     }
 }

--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -373,6 +373,8 @@ impl AcpServer {
                     "gpt-5.4-mini".to_string()
                 }
             });
+        self.active_model = Some(model_name.clone());
+        self.active_provider = Some(active_provider.to_string());
         self.model_options = Self::available_models().await;
 
         let resp = JsonRpcResponse {
@@ -416,10 +418,13 @@ impl AcpServer {
             self.model_options = Self::available_models().await;
         }
 
-        let model_name = self
-            .active_model
-            .clone()
-            .unwrap_or_else(|| "claude-sonnet-4-20250514".to_string());
+        let model_name = self.active_model.clone().unwrap_or_else(|| {
+            if self.active_provider.as_deref() == Some("openai") {
+                "gpt-5.4-mini".to_string()
+            } else {
+                "claude-sonnet-4-20250514".to_string()
+            }
+        });
 
         self.ok_response(
             id,
@@ -937,5 +942,50 @@ mod tests {
             server.active_provider, None,
             "active_provider must not change on failure"
         );
+    }
+
+    #[tokio::test]
+    async fn test_session_load_returns_config_options() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("ANTHROPIC_API_KEY", "test-key") };
+        let mut server = AcpServer::new();
+
+        // Create a session first
+        let new_resp_str = server.handle_session_new(10).await;
+        let new_resp: Value = serde_json::from_str(&new_resp_str).unwrap();
+        let session_id = new_resp["result"]["sessionId"].as_str().unwrap();
+
+        // Load the session
+        let load_resp_str = server
+            .handle_session_load(11, &json!({"sessionId": session_id, "cwd": "/tmp"}))
+            .await;
+        let load_resp: Value = serde_json::from_str(&load_resp_str).unwrap();
+
+        assert_eq!(load_resp["id"], 11);
+        assert!(load_resp["error"].is_null());
+        assert_eq!(load_resp["result"]["sessionId"], session_id);
+
+        // configOptions must be present with model info
+        let opts = load_resp["result"]["configOptions"].as_array().unwrap();
+        assert!(!opts.is_empty());
+        assert_eq!(opts[0]["id"], "model");
+        assert_eq!(opts[0]["category"], "model");
+        assert!(!opts[0]["currentValue"].as_str().unwrap().is_empty());
+        assert!(!opts[0]["options"].as_array().unwrap().is_empty());
+
+        // working_dir should be updated
+        assert_eq!(server.working_dir, "/tmp");
+    }
+
+    #[tokio::test]
+    async fn test_session_load_unknown_session_returns_error() {
+        let mut server = AcpServer::new();
+        let resp_str = server
+            .handle_session_load(12, &json!({"sessionId": "nonexistent"}))
+            .await;
+        let resp: Value = serde_json::from_str(&resp_str).unwrap();
+
+        assert!(resp["error"].is_object());
+        assert_eq!(resp["error"]["code"], -32000);
     }
 }

--- a/openab-agent/src/acp.rs
+++ b/openab-agent/src/acp.rs
@@ -242,6 +242,10 @@ impl AcpServer {
             let output = match req.method.as_deref() {
                 Some("initialize") => vec![self.handle_initialize(id)],
                 Some("session/new") => vec![self.handle_session_new(id).await],
+                Some("session/load") => {
+                    let params = req.params.unwrap_or(json!({}));
+                    vec![self.handle_session_load(id, &params).await]
+                }
                 Some("session/prompt") => {
                     let params = req.params.unwrap_or(json!({}));
                     self.handle_session_prompt(id, &params).await
@@ -278,7 +282,7 @@ impl AcpServer {
                 },
                 "agentCapabilities": {
                     "streaming": false,
-                    "loadSession": false
+                    "loadSession": true
                 }
             })),
             error: None,
@@ -388,6 +392,49 @@ impl AcpServer {
             error: None,
         };
         serde_json::to_string(&resp).unwrap()
+    }
+
+    async fn handle_session_load(&mut self, id: u64, params: &Value) -> String {
+        let session_id = params
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        if session_id.is_empty() || !self.sessions.contains_key(session_id) {
+            return self.error_response(id, -32000, "session not found");
+        }
+
+        // Update working directory if caller provides cwd
+        if let Some(cwd) = params.get("cwd").and_then(|v| v.as_str()) {
+            if !cwd.is_empty() {
+                self.working_dir = cwd.to_string();
+            }
+        }
+
+        // Ensure model list is populated
+        if self.model_options.is_empty() {
+            self.model_options = Self::available_models().await;
+        }
+
+        let model_name = self
+            .active_model
+            .clone()
+            .unwrap_or_else(|| "claude-sonnet-4-20250514".to_string());
+
+        self.ok_response(
+            id,
+            json!({
+                "sessionId": session_id,
+                "configOptions": [{
+                    "id": "model",
+                    "name": "Model",
+                    "category": "model",
+                    "type": "enum",
+                    "currentValue": model_name,
+                    "options": self.model_options
+                }]
+            }),
+        )
     }
 
     /// List available models based on configured credentials.

--- a/openab-agent/src/agent.rs
+++ b/openab-agent/src/agent.rs
@@ -107,6 +107,12 @@ impl Agent {
         self.provider = provider;
     }
 
+    /// Update working directory and rebuild system prompt.
+    pub fn set_working_dir(&mut self, cwd: String) {
+        self.system_prompt = Self::build_system_prompt(&cwd, self.mcp_manager.as_ref());
+        self.working_dir = PathBuf::from(cwd);
+    }
+
     /// Number of messages in the conversation (test helper).
     #[cfg(test)]
     pub fn message_count(&self) -> usize {


### PR DESCRIPTION
## What problem does this solve?

When OpenAB resumes a thread that uses the `openab-agent` (agentcore) backend via `session/load`, the agent returns a "method not found" error because `session/load` was never implemented. OpenAB then falls back to `session/new`, which creates a fresh session and loses conversation history.

Additionally, `agentCapabilities.loadSession` was `false`, so OpenAB may skip attempting `session/load` entirely.

Discord Discussion URL: https://discord.com/channels/1491295927620169908/1516890561343262921

## Prior Art & Industry Research

**PR #1132 (agy-acp):** Fixed the same class of bug in the `agy-acp` adapter — `session/load` was missing `configOptions`. This PR applies the equivalent fix to `openab-agent`.

## Proposed Solution

1. Add `handle_session_load` that:
   - Validates `sessionId` exists in the in-memory sessions map
   - Updates `working_dir` if `cwd` param is provided
   - Returns `sessionId` + `configOptions` (same shape as `session/new`)
2. Set `loadSession: true` in `agentCapabilities`
3. Wire `"session/load"` into the method dispatch

## Why this approach?

Mirrors the exact pattern used by `agy-acp` (PR #1132). Minimal change, keeps the same response contract that `connection.rs` expects from `parse_config_options(result)`.

## Alternatives Considered

- Do nothing (OpenAB falls back to `session/new`) — rejected because it loses conversation history on resume.

## Test Plan

- [x] `rustfmt --edition 2021 --check` passes (syntax + formatting verified)
- [ ] `cargo check` — CI will verify (no C linker in dev environment)
- [ ] `cargo test` — CI will verify
- [ ] `cargo clippy -- -D warnings` — CI will verify