### PR TITLE
fix(ci): use app token for PR review status

### DIFF
--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -26,10 +26,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Circuit breaker — max 30 review cycles
         id: breaker
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -eo pipefail
           SHAS=$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
@@ -60,7 +67,7 @@ jobs:
       - name: Set pending status
         id: pending
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -eo pipefail
           gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
@@ -92,7 +99,7 @@ jobs:
       - name: Mark error on Discord failure
         if: failure() && steps.breaker.outcome == 'success' && steps.webhook.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
             -f state="error" \


### PR DESCRIPTION
Fork PRs don't get `statuses: write` with `GITHUB_TOKEN`. Switch to app token so the PR Review workflow can set commit status on fork PRs.

Fixes #1122 CI failure.