### PR TITLE
fix(ci): use pull_request_target for fork PR secret access

### DIFF
--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -1,7 +1,10 @@
 name: PR Review
 
 on:
-  pull_request:
+  # pull_request_target runs in the base repo context, granting access to secrets
+  # even for fork PRs. This is safe because this workflow NEVER checks out or
+  # executes PR code — it only sets commit statuses and fires a Discord webhook.
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, labeled]
 
 concurrency:


### PR DESCRIPTION
The app token fix (#1136) still fails for fork PRs because `pull_request` events don't expose secrets to fork workflows.

Switch to `pull_request_target` which runs in the base repo context with full secret access. This is safe because the workflow never checks out or executes PR code — it only sets commit statuses and triggers a Discord webhook.