### PR TITLE
fix(ci): revert to GITHUB_TOKEN for PR review

### DIFF
--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -29,17 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Generate App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Circuit breaker — max 30 review cycles
         id: breaker
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
           SHAS=$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
@@ -70,7 +63,7 @@ jobs:
       - name: Set pending status
         id: pending
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
           gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
@@ -102,7 +95,7 @@ jobs:
       - name: Mark error on Discord failure
         if: failure() && steps.breaker.outcome == 'success' && steps.webhook.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
             -f state="error" \


### PR DESCRIPTION
With `pull_request_target`, `GITHUB_TOKEN` already has full write permissions (including `statuses: write`) even for fork PRs. The app token is unnecessary and was failing due to missing app permissions.

Reverts the app-token step and uses `secrets.GITHUB_TOKEN` directly.