### PR TITLE
fix(acp/pool): preserve session ID on session/load timeout

### DIFF
--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -9,6 +9,11 @@ use tokio::sync::{Mutex, RwLock};
 use tokio::time::Instant;
 use tracing::{info, warn};
 
+/// Error substrings produced by `AcpConnection::send_request` that indicate a
+/// transient failure worth preserving the session ID for retry, as opposed to
+/// a permanent agent-side rejection.
+const TRANSIENT_LOAD_ERRORS: &[&str] = &["timeout waiting for", "channel closed"];
+
 /// Combined state protected by a single lock to prevent deadlocks.
 /// Lock ordering: never await a per-connection mutex while holding `state`.
 struct PoolState {
@@ -243,7 +248,7 @@ impl SessionPool {
         new_conn.initialize().await?;
 
         let mut resumed = false;
-        let mut load_failed = false;
+        let mut load_failed: Option<&str> = None;
         if let Some(ref sid) = saved_session_id {
             if new_conn.supports_load_session {
                 match new_conn.session_load(sid, &effective_workdir).await {
@@ -252,11 +257,16 @@ impl SessionPool {
                         resumed = true;
                     }
                     Err(e) => {
-                        let is_timeout = e.to_string().contains("timeout waiting for");
-                        if is_timeout {
+                        let err_str = e.to_string();
+                        let is_transient = TRANSIENT_LOAD_ERRORS.iter().any(|s| err_str.contains(s));
+                        if is_transient {
                             warn!(thread_id, session_id = %sid, error = %e,
-                                "session/load timed out, preserving session ID for retry");
-                            load_failed = true;
+                                "session/load failed transiently, preserving session ID for retry");
+                            load_failed = Some(if err_str.contains("timeout waiting for") {
+                                "timeout"
+                            } else {
+                                "connection lost"
+                            });
                         } else {
                             warn!(thread_id, session_id = %sid, error = %e,
                                 "session/load failed, creating new session");
@@ -266,12 +276,12 @@ impl SessionPool {
             }
         }
 
-        if load_failed {
-            // session/load timed out transiently. The original session ID is already
+        if let Some(reason) = load_failed {
+            // session/load failed transiently. The original session ID is already
             // in state.persisted (we haven't touched it), so the next message will
             // retry session/load automatically. Return an error so the current message
             // is not processed against a context-free session.
-            return Err(anyhow!("session load timeout: could not restore previous session"));
+            return Err(anyhow!("session load {reason}: could not restore previous session"));
         }
 
         if !resumed {

--- a/src/acp/pool.rs
+++ b/src/acp/pool.rs
@@ -243,6 +243,7 @@ impl SessionPool {
         new_conn.initialize().await?;
 
         let mut resumed = false;
+        let mut load_failed = false;
         if let Some(ref sid) = saved_session_id {
             if new_conn.supports_load_session {
                 match new_conn.session_load(sid, &effective_workdir).await {
@@ -251,19 +252,32 @@ impl SessionPool {
                         resumed = true;
                     }
                     Err(e) => {
-                        warn!(thread_id, session_id = %sid, error = %e, "session/load failed, creating new session");
+                        let is_timeout = e.to_string().contains("timeout waiting for");
+                        if is_timeout {
+                            warn!(thread_id, session_id = %sid, error = %e,
+                                "session/load timed out, preserving session ID for retry");
+                            load_failed = true;
+                        } else {
+                            warn!(thread_id, session_id = %sid, error = %e,
+                                "session/load failed, creating new session");
+                        }
                     }
                 }
             }
         }
 
+        if load_failed {
+            // session/load timed out transiently. The original session ID is already
+            // in state.persisted (we haven't touched it), so the next message will
+            // retry session/load automatically. Return an error so the current message
+            // is not processed against a context-free session.
+            return Err(anyhow!("session load timeout: could not restore previous session"));
+        }
+
         if !resumed {
             new_conn.session_new(&effective_workdir).await?;
-            // Surface the reset banner both for restored sessions and for stale
-            // live entries that died before we could recover a resumable
-            // session id. In both cases the caller is continuing after an
-            // unexpected session loss.
             if had_existing || saved_session_id.is_some() {
+                // Genuine session loss (agent died, session file gone, etc.).
                 new_conn.session_reset = true;
             }
         }

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -10,6 +10,9 @@ pub fn format_user_error(message: &str) -> String {
     let msg_lower = message.to_lowercase();
 
     // Startup / connection errors (code == 0 from anyhow)
+    if msg_lower.contains("session load timeout") {
+        return "**Session Load Timeout**\nCould not restore your previous session. Send any message to retry, or use /reset to start fresh.".to_string();
+    }
     if msg_lower.contains("timeout waiting for") {
         // Use msg_lower for extraction to stay case-insistent with the match above.
         // msg_lower and message are the same length, so byte offsets are valid.
@@ -96,6 +99,13 @@ mod tests {
     use super::*;
 
     // ─── format_user_error tests ─────────────────────────────────────────────
+
+    #[test]
+    fn format_user_error_session_load_timeout() {
+        let result = format_user_error("session load timeout: could not restore previous session");
+        assert!(result.contains("Session Load Timeout"));
+        assert!(result.contains("/reset"));
+    }
 
     #[test]
     fn format_user_error_timeout() {

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -11,7 +11,10 @@ pub fn format_user_error(message: &str) -> String {
 
     // Startup / connection errors (code == 0 from anyhow)
     if msg_lower.contains("session load timeout") {
-        return "**Session Load Timeout**\nCould not restore your previous session. Send any message to retry, or use /reset to start fresh.".to_string();
+        return "**Session Load Timeout**\nCould not restore your previous session. Your message was not sent — send any message to retry, or use /reset to start fresh.".to_string();
+    }
+    if msg_lower.contains("session load connection lost") {
+        return "**Session Load Failed**\nThe agent connection was lost while restoring your session. Your message was not sent — send any message to retry, or use /reset to start fresh.".to_string();
     }
     if msg_lower.contains("timeout waiting for") {
         // Use msg_lower for extraction to stay case-insistent with the match above.
@@ -104,6 +107,15 @@ mod tests {
     fn format_user_error_session_load_timeout() {
         let result = format_user_error("session load timeout: could not restore previous session");
         assert!(result.contains("Session Load Timeout"));
+        assert!(result.contains("not sent"));
+        assert!(result.contains("/reset"));
+    }
+
+    #[test]
+    fn format_user_error_session_load_connection_lost() {
+        let result = format_user_error("session load connection lost: could not restore previous session");
+        assert!(result.contains("Session Load Failed"));
+        assert!(result.contains("not sent"));
         assert!(result.contains("/reset"));
     }
 


### PR DESCRIPTION
## What problem does this solve?

When `session/load` times out (30-second limit), OpenAB falls through to `session/new` and **permanently overwrites** `thread_map.json` with the new session ID. The user's previous conversation history becomes inaccessible without manual SSH intervention — caused by a transient network condition, not a real session loss.

Discord Discussion: https://discord.com/channels/1491295327620169908/1517011191447158795

## At a Glance

```
Before (timeout path):
  session/load timeout
       │
       ▼
  session/new          ← user's message processed against empty context
       │
       ▼
  thread_map.json      ← old session ID OVERWRITTEN ← history lost


After (this PR):
  session/load timeout
       │
       ├── permanent rejection → fall through to session/new (unchanged)
       │
       └── timeout
             │
             ▼
         return Err        ← current message NOT processed
             │
             ▼
         thread_map.json   ← old session ID PRESERVED (never touched)
             │
             ▼
         user sees: "Session Load Timeout. Send any message to retry, or /reset"
```

## Prior Art & Industry Research

**OpenClaw** ([session-thread-info-loaded.ts](https://github.com/openclaw/openclaw/blob/main/src/channels/plugins/session-thread-info-loaded.ts)):
On session key resolution failure, OpenClaw explicitly preserves the original session key rather than generating a new one. Quote: _"if the channel hook has no thread id, preserve the original session key."_ Same conservative principle: on uncertainty, keep what you have.

**Hermes Agent** ([use-session-actions.ts](https://github.com/NousResearch/hermes-agent/blob/main/apps/desktop/src/app/session/hooks/use-session-actions.ts)):
Hermes tracks resume failures via `resumeFailedSessionId` state, arms a retry UI on RPC failure, and never automatically discards the session ID. The session ID is only cleared by explicit user action (`/reset` equivalent). This directly matches the approach in this PR: distinguish transient failure from permanent loss, preserve the ID, let the user decide.

## Proposed Solution

- In `pool.rs`, distinguish timeout errors from permanent rejections using the existing `"timeout waiting for"` string (produced by `send_request` in `connection.rs`)
- On timeout: return `Err` immediately — the original session ID is already in `state.persisted` (never modified on this code path), so the next message retries `session/load` automatically
- On permanent rejection (`session/load rejected`): fall through to `session/new` as before
- Add a `"session load timeout"` match in `format_user_error` with a clear user-facing message, plus a unit test

## Why this approach?

The core insight is that `state.persisted` already holds the old session ID — we never touch it before the timeout, so there is nothing to "preserve". The fix is purely about not overwriting it (by not reaching `session/new`) and not processing the current message against an empty context.

**Known limitations:**
- "Retry" does not guarantee success — if the agent's session file is gone, the next retry hits a permanent rejection and falls through to `session/new`. This is acceptable: the user ends up in a fresh session, same as before, but only after a deliberate retry rather than silently on a transient failure.
- If a session consistently exceeds the 30-second load timeout (e.g. very large history), the user will see repeated timeout errors. This is intentional: the user retains control and can use `/reset` to start fresh at any time. Automatic fallback would silently destroy history, which is the bug this PR fixes.

## Alternatives Considered

- **Raise timeout to 120s**: Mitigates the symptom but doesn't fix the destructive fallback. Rejected.
- **Add in-pool retry loop**: Adds complexity, delays error response, still doesn't guarantee success. Rejected.
- **Preserve ID + fall through to session/new anyway (v1 of this PR)**: Message processed against blank context, confusing response. Rejected.
- **Retry counter cap (fall through to session/new after N timeouts)**: Removes user control — the user is in the best position to decide when to give up and /reset. Rejected.

## Validation

- [x] `cargo check` ✅
- [x] `cargo test` ✅  507 passed; 0 failed (includes new `format_user_error_session_load_timeout` test)
- [x] `cargo clippy` ✅
