### PR TITLE
fix(ci): fail PR check when Discord Discussion URL is missing

### DIFF
--- a/.github/workflows/pr-discussion-check.yml
+++ b/.github/workflows/pr-discussion-check.yml
@@ -79,16 +79,16 @@ jobs:
 
               const msg = [
                 marker,
-                '⚠️ This PR is missing a **Discord Discussion URL** in the body.',
+                '> [!CAUTION]',
+                '> This PR is missing a **Discord Discussion URL** in the body.',
+                '> This PR will be **automatically closed in 24 hours** if the link is not added.',
                 '',
                 'All PRs must reference a prior Discord discussion to ensure community alignment before implementation.',
                 '',
                 'Please edit the PR description to include a link like:',
                 '```',
                 'Discord Discussion URL: https://discord.com/channels/...',
-                '```',
-                '',
-                `This PR will be **automatically closed in 24 hours** if the link is not added.`
+                '```'
               ].join('\n');
 
               if (!old) {
@@ -98,6 +98,8 @@ jobs:
                   body: msg
                 });
               }
+
+              core.setFailed('PR body is missing a Discord Discussion URL');
             } else {
               // URL found — remove label and comment if present
               if (labels.includes(label)) {


### PR DESCRIPTION
## Problem

The `pr-discussion-check` workflow posts a warning comment when a PR is missing a Discord Discussion URL, but the CI check itself always passes (green ✅). This means PRs without the required link don't show a failed status check.

Discord Discussion URL: https://discord.com/channels/1490282656913559673/1517256307340611726

## Changes

1. **Add `core.setFailed()`** — the check now shows ❌ when the Discord URL is absent
2. **Use `> [!CAUTION]` alert syntax** — the comment is more visible with GitHub's native alert rendering

## Before / After

**Before:** Check always ✅, comment uses plain ⚠️ emoji  
**After:** Check shows ❌ when URL missing, comment renders as a GitHub CAUTION alert block