### PR TITLE
ci: convert PR review from reactive to scheduled polling

### DIFF
--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -5,6 +5,10 @@ on:
     - cron: '*/5 * * * *'
   workflow_dispatch: {}
 
+concurrency:
+  group: pr-review-poller
+  cancel-in-progress: true
+
 permissions:
   statuses: write
   issues: write
@@ -23,11 +27,15 @@ jobs:
           set -eo pipefail
 
           # Collect eligible open PRs (non-draft, no review-limit-reached label)
+          # Include safe-to-review labeled PRs regardless of author_association
           PRS=$(gh api --paginate "repos/${{ github.repository }}/pulls?state=open&per_page=50" \
             --jq '[.[] | select(
               .draft == false and
-              (.author_association | IN("OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR")) and
-              ([.labels[].name] | contains(["review-limit-reached"]) | not)
+              ([.labels[].name] | contains(["review-limit-reached"]) | not) and
+              (
+                (.author_association | IN("OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR")) or
+                ([.labels[].name] | contains(["safe-to-review"]))
+              )
             ) | {number, sha: .head.sha, labels: [.labels[].name]}]')
 
           TARGETS="[]"
@@ -56,13 +64,14 @@ jobs:
               fi
             fi
 
-            # Skip if already reviewed this exact SHA with success (no new commits)
-            if [ "$STATE" = "success" ]; then
-              echo "PR #${NUMBER}: already LGTM on HEAD, skipping"
+            # Skip if already reviewed this exact SHA (success or failure)
+            # failure = CHANGES REQUESTED — only re-review when new commits are pushed (new SHA)
+            if [ "$STATE" = "success" ] || [ "$STATE" = "failure" ]; then
+              echo "PR #${NUMBER}: already reviewed on HEAD (${STATE}), skipping"
               continue
             fi
 
-            # Trigger review: no status yet, or failure/error (new push or needs re-review)
+            # Trigger review: no status yet, or error (webhook failure), or stale pending
             echo "PR #${NUMBER}: needs review (state=${STATE:-none})"
             TARGETS=$(echo "$TARGETS" | jq --argjson row "$ROW" '. + [$row]')
           done

--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -28,18 +28,19 @@ jobs:
 
           # Collect eligible open PRs (non-draft, no review-limit-reached label)
           # Include safe-to-review labeled PRs regardless of author_association
-          PRS=$(gh api --paginate "repos/${{ github.repository }}/pulls?state=open&per_page=50" \
-            --jq '[.[] | select(
+          # Note: --paginate with array jq emits one array per page; stream objects then collect
+          PRS=$(gh api --paginate "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
+            --jq '.[] | select(
               .draft == false and
               (any(.labels[]; .name == "review-limit-reached") | not) and
               (
                 (.author_association | IN("OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR")) or
                 any(.labels[]; .name == "safe-to-review")
               )
-            ) | {number, sha: .head.sha, labels: [.labels[].name]}]')
+            ) | {number, sha: .head.sha, labels: [.labels[].name]}' | jq -s '.')
 
           TARGETS="[]"
-          for ROW in $(echo "$PRS" | jq -c '.[]'); do
+          while IFS= read -r ROW; do
             NUMBER=$(echo "$ROW" | jq -r '.number')
             SHA=$(echo "$ROW" | jq -r '.sha')
             LABELS=$(echo "$ROW" | jq -c '.labels')
@@ -74,7 +75,7 @@ jobs:
             # Trigger review: no status yet, or error (webhook failure), or stale pending
             echo "PR #${NUMBER}: needs review (state=${STATE:-none})"
             TARGETS=$(echo "$TARGETS" | jq --argjson row "$ROW" '. + [$row]')
-          done
+          done < <(echo "$PRS" | jq -c '.[]')
 
           echo "targets=$(echo "$TARGETS" | jq -c '.')" >> "$GITHUB_OUTPUT"
           echo "count=$(echo "$TARGETS" | jq 'length')" >> "$GITHUB_OUTPUT"
@@ -85,12 +86,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WEBHOOK_URL: ${{ secrets.OAB_REVIEW_ACTION_WEBHOOK }}
           BOT_UID: ${{ secrets.OAB_REVIEW_ACTION_BOT_UID }}
+          TARGETS: ${{ steps.poll.outputs.targets }}
         run: |
           set -eo pipefail
 
-          TARGETS='${{ steps.poll.outputs.targets }}'
-
-          for ROW in $(echo "$TARGETS" | jq -c '.[]'); do
+          while IFS= read -r ROW; do
             NUMBER=$(echo "$ROW" | jq -r '.number')
             SHA=$(echo "$ROW" | jq -r '.sha')
             LABELS=$(echo "$ROW" | jq -c '.labels')
@@ -137,4 +137,4 @@ jobs:
             fi
 
             echo "PR #${NUMBER}: review triggered"
-          done
+          done < <(echo "$TARGETS" | jq -c '.[]')

--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -31,10 +31,10 @@ jobs:
           PRS=$(gh api --paginate "repos/${{ github.repository }}/pulls?state=open&per_page=50" \
             --jq '[.[] | select(
               .draft == false and
-              ([.labels[].name] | contains(["review-limit-reached"]) | not) and
+              (any(.labels[]; .name == "review-limit-reached") | not) and
               (
                 (.author_association | IN("OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR")) or
-                ([.labels[].name] | contains(["safe-to-review"]))
+                any(.labels[]; .name == "safe-to-review")
               )
             ) | {number, sha: .head.sha, labels: [.labels[].name]}]')
 
@@ -123,7 +123,7 @@ jobs:
             # Trigger Discord webhook
             PR_URL="https://github.com/${{ github.repository }}/pull/${NUMBER}"
             MODE=""
-            if echo "$LABELS" | jq -e 'contains(["auto-fix"])' > /dev/null 2>&1; then
+            if echo "$LABELS" | jq -e 'any(. == "auto-fix")' > /dev/null 2>&1; then
               MODE="\n__mode: auto-fix__"
             fi
             PAYLOAD=$(printf '<@%s> review %s\n\n__commit: %s__%s' "$BOT_UID" "$PR_URL" "$SHA" "$MODE" | jq -Rs '{content: .}')

--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -1,102 +1,131 @@
-name: PR Review
+name: PR Review (Scheduled)
 
 on:
-  # pull_request_target runs in the base repo context, granting access to secrets
-  # even for fork PRs. This is safe because this workflow NEVER checks out or
-  # executes PR code — it only sets commit statuses and fires a Discord webhook.
-  pull_request_target:
-    types: [opened, synchronize, ready_for_review, labeled]
-
-concurrency:
-  group: pr-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch: {}
 
 permissions:
   statuses: write
   issues: write
+  pull-requests: read
 
 jobs:
-  request-review:
-    if: >-
-      !github.event.pull_request.draft &&
-      !contains(toJSON(github.event.pull_request.labels.*.name), 'review-limit-reached') &&
-      (github.event.action != 'labeled' ||
-       github.event.label.name == 'safe-to-review' ||
-       github.event.label.name == 'auto-fix') &&
-      (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'),
-        github.event.pull_request.author_association) ||
-      contains(toJSON(github.event.pull_request.labels.*.name), 'safe-to-review'))
+  poll-and-review:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Circuit breaker — max 30 review cycles
-        id: breaker
+      - name: Find PRs needing review
+        id: poll
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
-          SHAS=$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
-            --jq '.[].sha')
-          if [ -z "$SHAS" ]; then
-            echo "count=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          COUNT=0
-          for SHA in $SHAS; do
-            N=$(gh api "repos/${{ github.repository }}/commits/${SHA}/statuses" \
-              --paginate --jq '[.[] | select(.context == "OpenAB PR Review" and .state == "pending")] | length' \
-              | awk '{s+=$1} END {print s+0}')
-            COUNT=$((COUNT + N))
+
+          # Collect eligible open PRs (non-draft, no review-limit-reached label)
+          PRS=$(gh api --paginate "repos/${{ github.repository }}/pulls?state=open&per_page=50" \
+            --jq '[.[] | select(
+              .draft == false and
+              (.author_association | IN("OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR")) and
+              ([.labels[].name] | contains(["review-limit-reached"]) | not)
+            ) | {number, sha: .head.sha, labels: [.labels[].name]}]')
+
+          TARGETS="[]"
+          for ROW in $(echo "$PRS" | jq -c '.[]'); do
+            NUMBER=$(echo "$ROW" | jq -r '.number')
+            SHA=$(echo "$ROW" | jq -r '.sha')
+            LABELS=$(echo "$ROW" | jq -c '.labels')
+
+            # Get latest status for this SHA with our context
+            STATE=$(gh api "repos/${{ github.repository }}/commits/${SHA}/statuses" \
+              --jq '[.[] | select(.context == "OpenAB PR Review")] | sort_by(.created_at) | last | .state // empty')
+
+            # Skip if still pending, UNLESS pending > 30 min (stale)
+            if [ "$STATE" = "pending" ]; then
+              PENDING_AT=$(gh api "repos/${{ github.repository }}/commits/${SHA}/statuses" \
+                --jq '[.[] | select(.context == "OpenAB PR Review" and .state == "pending")] | sort_by(.created_at) | last | .created_at // empty')
+              if [ -n "$PENDING_AT" ]; then
+                PENDING_TS=$(date -d "$PENDING_AT" +%s 2>/dev/null || date -u +%s)
+                NOW_TS=$(date -u +%s)
+                ELAPSED=$(( NOW_TS - PENDING_TS ))
+                if [ "$ELAPSED" -lt 1800 ]; then
+                  echo "PR #${NUMBER}: still pending (${ELAPSED}s), skipping"
+                  continue
+                fi
+                echo "PR #${NUMBER}: pending stale (${ELAPSED}s > 30m), re-triggering"
+              fi
+            fi
+
+            # Skip if already reviewed this exact SHA with success (no new commits)
+            if [ "$STATE" = "success" ]; then
+              echo "PR #${NUMBER}: already LGTM on HEAD, skipping"
+              continue
+            fi
+
+            # Trigger review: no status yet, or failure/error (new push or needs re-review)
+            echo "PR #${NUMBER}: needs review (state=${STATE:-none})"
+            TARGETS=$(echo "$TARGETS" | jq --argjson row "$ROW" '. + [$row]')
           done
-          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
-          if [ "${COUNT}" -ge 30 ]; then
-            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
-              --method POST -f "labels[]=review-limit-reached"
-            gh api "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
-              -f state="error" \
-              -f context="OpenAB PR Review" \
-              -f description="Circuit breaker: exceeded 30 review cycles"
-            echo "::error::Circuit breaker triggered after $COUNT review cycles"
-            exit 1
-          fi
 
-      - name: Set pending status
-        id: pending
+          echo "targets=$(echo "$TARGETS" | jq -c '.')" >> "$GITHUB_OUTPUT"
+          echo "count=$(echo "$TARGETS" | jq 'length')" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger reviews
+        if: fromJSON(steps.poll.outputs.count) > 0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -eo pipefail
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
-            -f state="pending" \
-            -f context="OpenAB PR Review" \
-            -f description="Review in progress..." \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-      - name: Trigger review via Discord webhook
-        id: webhook
-        env:
-          HAS_AUTOFIX: ${{ contains(toJSON(github.event.pull_request.labels.*.name), 'auto-fix') }}
           WEBHOOK_URL: ${{ secrets.OAB_REVIEW_ACTION_WEBHOOK }}
           BOT_UID: ${{ secrets.OAB_REVIEW_ACTION_BOT_UID }}
         run: |
           set -eo pipefail
-          PR_URL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-          SHA="${{ github.event.pull_request.head.sha }}"
-          MODE=""
-          if [ "$HAS_AUTOFIX" = "true" ]; then
-            MODE="\n__mode: auto-fix__"
-          fi
-          PAYLOAD=$(printf '<@%s> review %s\n\n__commit: %s__%s' "$BOT_UID" "$PR_URL" "$SHA" "$MODE" | jq -Rs '{content: .}')
-          curl -sS --fail-with-body --max-time 10 -X POST "$WEBHOOK_URL" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD"
 
-      - name: Mark error on Discord failure
-        if: failure() && steps.breaker.outcome == 'success' && steps.webhook.outcome == 'failure'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
-            -f state="error" \
-            -f context="OpenAB PR Review" \
-            -f description="Failed to trigger review — check workflow logs"
+          TARGETS='${{ steps.poll.outputs.targets }}'
+
+          for ROW in $(echo "$TARGETS" | jq -c '.[]'); do
+            NUMBER=$(echo "$ROW" | jq -r '.number')
+            SHA=$(echo "$ROW" | jq -r '.sha')
+            LABELS=$(echo "$ROW" | jq -c '.labels')
+
+            # Circuit breaker check
+            COUNT=$(gh api --paginate "repos/${{ github.repository }}/pulls/${NUMBER}/commits" \
+              --jq '.[].sha' | while read -r C_SHA; do
+                gh api "repos/${{ github.repository }}/commits/${C_SHA}/statuses" \
+                  --paginate --jq '[.[] | select(.context == "OpenAB PR Review" and .state == "pending")] | length'
+              done | awk '{s+=$1} END {print s+0}')
+
+            if [ "${COUNT}" -ge 30 ]; then
+              gh api "repos/${{ github.repository }}/issues/${NUMBER}/labels" \
+                --method POST -f "labels[]=review-limit-reached"
+              gh api "repos/${{ github.repository }}/statuses/${SHA}" \
+                -f state="error" \
+                -f context="OpenAB PR Review" \
+                -f description="Circuit breaker: exceeded 30 review cycles"
+              echo "::error::PR #${NUMBER}: circuit breaker triggered"
+              continue
+            fi
+
+            # Set pending status
+            gh api "repos/${{ github.repository }}/statuses/${SHA}" \
+              -f state="pending" \
+              -f context="OpenAB PR Review" \
+              -f description="Review in progress..." \
+              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+            # Trigger Discord webhook
+            PR_URL="https://github.com/${{ github.repository }}/pull/${NUMBER}"
+            MODE=""
+            if echo "$LABELS" | jq -e 'contains(["auto-fix"])' > /dev/null 2>&1; then
+              MODE="\n__mode: auto-fix__"
+            fi
+            PAYLOAD=$(printf '<@%s> review %s\n\n__commit: %s__%s' "$BOT_UID" "$PR_URL" "$SHA" "$MODE" | jq -Rs '{content: .}')
+            if ! curl -sS --fail-with-body --max-time 10 -X POST "$WEBHOOK_URL" \
+              -H "Content-Type: application/json" -d "$PAYLOAD"; then
+              gh api "repos/${{ github.repository }}/statuses/${SHA}" \
+                -f state="error" \
+                -f context="OpenAB PR Review" \
+                -f description="Failed to trigger review — webhook error"
+              echo "::warning::PR #${NUMBER}: webhook failed"
+            fi
+
+            echo "PR #${NUMBER}: review triggered"
+          done

--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -44,14 +44,14 @@ jobs:
             SHA=$(echo "$ROW" | jq -r '.sha')
             LABELS=$(echo "$ROW" | jq -c '.labels')
 
-            # Get latest status for this SHA with our context
-            STATE=$(gh api "repos/${{ github.repository }}/commits/${SHA}/statuses" \
-              --jq '[.[] | select(.context == "OpenAB PR Review")] | sort_by(.created_at) | last | .state // empty')
+            # Get latest status for this SHA (single API call)
+            STATUS_JSON=$(gh api "repos/${{ github.repository }}/commits/${SHA}/statuses" \
+              --jq '[.[] | select(.context == "OpenAB PR Review")] | sort_by(.created_at) | last | {state, created_at} // empty')
+            STATE=$(echo "$STATUS_JSON" | jq -r '.state // empty')
 
             # Skip if still pending, UNLESS pending > 30 min (stale)
             if [ "$STATE" = "pending" ]; then
-              PENDING_AT=$(gh api "repos/${{ github.repository }}/commits/${SHA}/statuses" \
-                --jq '[.[] | select(.context == "OpenAB PR Review" and .state == "pending")] | sort_by(.created_at) | last | .created_at // empty')
+              PENDING_AT=$(echo "$STATUS_JSON" | jq -r '.created_at // empty')
               if [ -n "$PENDING_AT" ]; then
                 PENDING_TS=$(date -d "$PENDING_AT" +%s 2>/dev/null || date -u +%s)
                 NOW_TS=$(date -u +%s)

--- a/docs/adr/pr-review-loop.md
+++ b/docs/adr/pr-review-loop.md
@@ -91,17 +91,26 @@ This guarantees **at most one in-flight review per PR** at any time, regardless 
 
 | Aspect | Reactive (old) | Scheduled (new) |
 |--------|---------------|-----------------|
-| Latency | Immediate on push | Up to 5 min delay |
-| Duplicate reviews | Possible (webhook already sent) | Impossible (skip if pending) |
+| Latency | Immediate on push | Up to 5 min (best-effort; may lag under GH load) |
+| Duplicate reviews | Possible (webhook already sent) | Extremely unlikely (skip if pending; narrow race only) |
 | GitHub Actions minutes | Per-push (many short runs) | Fixed (one run per 5 min) |
 | Complexity | Simple trigger | Polling + state check logic |
 
 ### Why This Is Acceptable
 
 - 5-minute latency is fine for code review (not user-facing)
-- Eliminates all duplicate-review bugs without agent-side dedup
+- Eliminates duplicate-review bugs without agent-side dedup (agent SHA validation remains as belt-and-suspenders for narrow race)
 - `workflow_dispatch` allows manual trigger for urgent reviews
 - Reduces GitHub Actions billing (one run covers all PRs)
+- **Cron caveat:** GitHub Actions `schedule` is best-effort — actual interval may be 5–25 min during platform congestion. This is acceptable since review latency is not user-facing.
+
+### Stale Timeout Rationale (30 minutes)
+
+The 30-min threshold is based on observed review completion times: typical reviews finish in 5–15 minutes (LLM processing + GitHub API calls). A legitimate review exceeding 30 min is rare (only very large PRs with many files). If re-triggered, the agent validates HEAD SHA and will skip if the original session is still active — so a false stale trigger is harmless.
+
+### Fork PRs & `safe-to-review` in Scheduled Mode
+
+The scheduled poller runs on `schedule` events (base repo context), so it has full access to secrets. The `safe-to-review` label bypass is preserved in the jq filter — PRs with untrusted `author_association` are included if the label is present. Fork PRs are handled the same as before: the poller can set statuses and fire webhooks for any open PR regardless of source, since it operates in the base repo context.
 
 ## Architecture
 

--- a/docs/adr/pr-review-loop.md
+++ b/docs/adr/pr-review-loop.md
@@ -125,9 +125,10 @@ The scheduled poller runs on `schedule` events (base repo context), so it has fu
 │                                                                     │
 │  For each eligible PR:                                              │
 │  1. Check HEAD commit status for "OpenAB PR Review"                 │
-│     - pending → SKIP (review still in progress)                     │
-│     - success → SKIP (already LGTM on this SHA)                     │
-│     - failure/error/none → TRIGGER                                  │
+│     - pending (< 30 min) → SKIP (review still in progress)         │
+│     - pending (≥ 30 min) → TRIGGER (stale)                         │
+│     - success / failure → SKIP (already reviewed this SHA)          │
+│     - error / none → TRIGGER                                        │
 │                                                                     │
 │  2. POST /repos/{owner}/{repo}/statuses/{sha}                       │
 │     state: "pending", context: "OpenAB PR Review"                   │
@@ -193,7 +194,7 @@ When explicitly requested:
 
 1. Agent fixes the code directly on the PR branch
 2. Commits and pushes the fix
-3. The `synchronize` event re-triggers the workflow, starting a new review cycle
+3. The new SHA has no status → next poll cycle triggers a new review
 4. Repeat until LGTM or max iterations reached
 
 ### Safeguards
@@ -240,7 +241,7 @@ Without dedup, N rapid pushes could trigger N full reviews (~5 LLM calls each fo
 > Refer to the workflow file for the current implementation. Key design points:
 
 - **Trigger:** `schedule` (cron `*/5 * * * *`) + `workflow_dispatch` for manual runs
-- **Polling logic:** iterates all open PRs, checks HEAD commit status, skips if `pending` or `success`
+- **Polling logic:** iterates all open PRs, checks HEAD commit status, skips if `pending` (fresh), `success`, or `failure`
 - **Guard condition:** skips drafts, untrusted authors, and PRs with `review-limit-reached` label
 - **Steps:** poll open PRs → for each eligible PR: circuit breaker check → set pending status → trigger Discord webhook → error fallback on failure
 
@@ -299,8 +300,8 @@ Add `OpenAB PR Review` as a required status check in branch protection rules. Th
 - Minimal secrets — only one webhook URL needed in GitHub Secrets
 
 **Negative:**
-- Every PR push triggers a review (may want to filter by label or draft status)
-- If OpenAB agent is down, status stays "pending" indefinitely (need timeout/alerting)
+- Up to 5-min latency before review starts (GitHub cron is best-effort, may lag further under load)
+- If OpenAB agent is down, status stays "pending" until stale timeout re-triggers (30 min)
 - Webhook messages lack user identity — OpenAB must allow webhook-originated messages
 - Fork PRs: `OAB_REVIEW_ACTION_WEBHOOK` and `OAB_REVIEW_ACTION_BOT_UID` secrets are not available to workflows triggered by fork PRs (GitHub security policy). The webhook step will fail, and since fork PRs receive a read-only `GITHUB_TOKEN`, the error fallback **cannot** write commit statuses either — the workflow will fail silently with no status update. Fork PRs can still be reviewed manually via Discord @mention. Note: the `safe-to-review` label does **not** grant secrets access to fork PRs — it only bypasses the `author_association` gate for same-repo PRs.
 

--- a/docs/adr/pr-review-loop.md
+++ b/docs/adr/pr-review-loop.md
@@ -77,9 +77,12 @@ on:
 
 | HEAD commit status | Action |
 |-------------------|--------|
-| `pending` | **Skip** — previous review still in progress |
+| `pending` (< 30 min) | **Skip** — previous review still in progress |
+| `pending` (≥ 30 min) | **Trigger** — stale, agent likely missed it |
 | `success` | **Skip** — already reviewed this SHA |
 | `failure` / `error` / none | **Trigger** — needs (re-)review |
+
+The 30-minute stale timeout handles the case where the agent is down or missed the webhook — the status would otherwise stay `pending` indefinitely, blocking further reviews.
 
 This guarantees **at most one in-flight review per PR** at any time, regardless of push frequency.
 

--- a/docs/adr/pr-review-loop.md
+++ b/docs/adr/pr-review-loop.md
@@ -79,8 +79,9 @@ on:
 |-------------------|--------|
 | `pending` (< 30 min) | **Skip** — previous review still in progress |
 | `pending` (≥ 30 min) | **Trigger** — stale, agent likely missed it |
-| `success` | **Skip** — already reviewed this SHA |
-| `failure` / `error` / none | **Trigger** — needs (re-)review |
+| `success` | **Skip** — already reviewed this SHA (LGTM) |
+| `failure` | **Skip** — already reviewed this SHA (CHANGES REQUESTED); new push = new SHA = auto-triggers |
+| `error` / none | **Trigger** — needs review (new SHA or webhook previously failed) |
 
 The 30-minute stale timeout handles the case where the agent is down or missed the webhook — the status would otherwise stay `pending` indefinitely, blocking further reviews.
 
@@ -295,11 +296,11 @@ Add `OpenAB PR Review` as a required status check in branch protection rules. Th
 - Fork PRs: `OAB_REVIEW_ACTION_WEBHOOK` and `OAB_REVIEW_ACTION_BOT_UID` secrets are not available to workflows triggered by fork PRs (GitHub security policy). The webhook step will fail, and since fork PRs receive a read-only `GITHUB_TOKEN`, the error fallback **cannot** write commit statuses either — the workflow will fail silently with no status update. Fork PRs can still be reviewed manually via Discord @mention. Note: the `safe-to-review` label does **not** grant secrets access to fork PRs — it only bypasses the `author_association` gate for same-repo PRs.
 
 **Mitigations:**
-- Filter: skip draft PRs and untrusted authors — only `OWNER`, `MEMBER`, `COLLABORATOR`, and `CONTRIBUTOR` (returning contributor with merged PR) trigger automatic review. First-time contributors and unknown authors are skipped; maintainers can manually @mention the agent to review those PRs.
-- Debounce: `concurrency` group with `cancel-in-progress: true` — new push cancels in-flight review, only latest SHA gets reviewed
-- Error fallback: a scoped `if: failure()` step marks status as "error" when the Discord webhook step specifically fails (not triggered by circuit breaker), so status never stays pending on webhook failure
-- Race condition: concurrency group prevents duplicate GitHub Action runs per PR; commit status is keyed to SHA so old reviews cannot overwrite newer status. **Note:** the concurrency group only operates at the GitHub Actions layer — if a webhook was already delivered before cancellation, the agent may receive a stale request. The agent **must** implement SHA validation (Layer 2 above) to skip stale requests and avoid wasted compute or comment race conditions.
-- Timeout: a scheduled Action can mark stale pending statuses as "error" after N hours (agent down scenario)
+- Filter: skip draft PRs and untrusted authors — only `OWNER`, `MEMBER`, `COLLABORATOR`, and `CONTRIBUTOR` (returning contributor with merged PR) trigger automatic review. First-time contributors and unknown authors are skipped; maintainers can add `safe-to-review` label or manually @mention the agent.
+- Dedup: status-based gating — `pending` (fresh) and `failure`/`success` skip review. Only new SHAs with no status or stale `pending` (>30 min) trigger.
+- Concurrency: workflow-level `concurrency` group prevents overlapping cron runs from racing.
+- Error fallback: webhook failure marks status as "error", which will be retried on next poll cycle.
+- Timeout: stale `pending` >30 min is treated as agent-down and re-triggered automatically.
 
 ## Safeguards
 

--- a/docs/adr/pr-review-loop.md
+++ b/docs/adr/pr-review-loop.md
@@ -1,7 +1,7 @@
 # ADR: OpenAB PR Review Loop
 
-**Status:** Proposed  
-**Date:** 2026-06-17  
+**Status:** Amended  
+**Date:** 2026-06-18  
 **Author:** chaodu-agent
 
 ## Context
@@ -52,24 +52,74 @@ allow_bot_messages = "mentions"
 
 Without this, the webhook @mention will be ignored and reviews will never trigger.
 
+## Amendment: Reactive → Scheduled Polling (2026-06-18)
+
+### Problem with Reactive Mode
+
+The original reactive design (`pull_request_target` trigger) fires a webhook on every push. While GitHub Actions' `concurrency` group cancels in-flight runs, once a Discord webhook is delivered it cannot be recalled. This causes:
+
+1. Rapid pushes spawn multiple concurrent agent review sessions in Discord
+2. Agent callbacks race — stale reviews may overwrite fresh status
+3. Wasted compute and API tokens on superseded commits
+
+### Solution: Scheduled Polling
+
+Replace the event-driven trigger with a `schedule` cron job that polls every 5 minutes:
+
+```yaml
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch: {}
+```
+
+**Polling logic per open PR:**
+
+| HEAD commit status | Action |
+|-------------------|--------|
+| `pending` | **Skip** — previous review still in progress |
+| `success` | **Skip** — already reviewed this SHA |
+| `failure` / `error` / none | **Trigger** — needs (re-)review |
+
+This guarantees **at most one in-flight review per PR** at any time, regardless of push frequency.
+
+### Trade-offs vs Reactive Mode
+
+| Aspect | Reactive (old) | Scheduled (new) |
+|--------|---------------|-----------------|
+| Latency | Immediate on push | Up to 5 min delay |
+| Duplicate reviews | Possible (webhook already sent) | Impossible (skip if pending) |
+| GitHub Actions minutes | Per-push (many short runs) | Fixed (one run per 5 min) |
+| Complexity | Simple trigger | Polling + state check logic |
+
+### Why This Is Acceptable
+
+- 5-minute latency is fine for code review (not user-facing)
+- Eliminates all duplicate-review bugs without agent-side dedup
+- `workflow_dispatch` allows manual trigger for urgent reviews
+- Reduces GitHub Actions billing (one run covers all PRs)
+
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│  GitHub: PR opened / synchronize / ready_for_review / labeled        │
+│  Cron: every 5 minutes (schedule) / manual (workflow_dispatch)       │
 └───────────────────────────┬─────────────────────────────────────────┘
-                            │ triggers
+                            │ polls open PRs
                             ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │  GitHub Action (.github/workflows/pr-bot-review.yml)                │
 │                                                                     │
-│  1. POST /repos/{owner}/{repo}/statuses/{sha}                       │
+│  For each eligible PR:                                              │
+│  1. Check HEAD commit status for "OpenAB PR Review"                 │
+│     - pending → SKIP (review still in progress)                     │
+│     - success → SKIP (already LGTM on this SHA)                     │
+│     - failure/error/none → TRIGGER                                  │
+│                                                                     │
+│  2. POST /repos/{owner}/{repo}/statuses/{sha}                       │
 │     state: "pending", context: "OpenAB PR Review"                   │
 │                                                                     │
-│  2. Discord Webhook:                                                │
-│     → POST to webhook URL with "@bot review <PR_URL>"              │
-│                                                                     │
-│  3. Job exits (fire-and-forget)                                     │
+│  3. Discord Webhook: "@bot review <PR_URL>"                         │
 └───────────────────────────┬─────────────────────────────────────────┘
                             │ Discord message
                             ▼
@@ -147,21 +197,15 @@ When explicitly requested:
 
 ## Dedup & Performance
 
-Rapid pushes can cause multiple review requests for the same PR. The system deduplicates at two layers:
+The scheduled polling model inherently deduplicates reviews:
 
-### Layer 1: GitHub Actions (Concurrency Group)
+### Primary Dedup: Status-Based Gating
 
-```yaml
-concurrency:
-  group: pr-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-```
+The poller checks HEAD commit status before triggering. If status is `pending`, the PR is skipped — guaranteeing at most one in-flight review per PR at any time. Rapid pushes between polls simply update HEAD; only the latest SHA is reviewed on next poll.
 
-A new push cancels any in-flight Action run for the same PR. If the webhook has not yet been sent, only the latest SHA triggers a review.
+### Agent-Side SHA Validation (Belt-and-Suspenders)
 
-### Layer 2: Agent-Side SHA Validation
-
-If the webhook was already delivered before cancellation, the agent receives a stale request. To handle this:
+Even with polling, a narrow race is possible (push arrives between status check and webhook delivery). The agent still validates:
 
 1. Agent extracts `__commit: <SHA>__` from the trigger message
 2. Agent queries current PR HEAD: `gh pr view <N> --json headRefOid --jq .headRefOid`
@@ -182,10 +226,10 @@ Without dedup, N rapid pushes could trigger N full reviews (~5 LLM calls each fo
 >
 > Refer to the workflow file for the current implementation. Key design points:
 
-- **Trigger events:** `opened`, `synchronize`, `ready_for_review`, `labeled`
-- **Concurrency group:** per-PR number with `cancel-in-progress: true`
-- **Guard condition:** skips drafts, untrusted authors, irrelevant labels, and PRs with `review-limit-reached` label
-- **Steps:** circuit breaker check → set pending status → trigger Discord webhook → error fallback on failure
+- **Trigger:** `schedule` (cron `*/5 * * * *`) + `workflow_dispatch` for manual runs
+- **Polling logic:** iterates all open PRs, checks HEAD commit status, skips if `pending` or `success`
+- **Guard condition:** skips drafts, untrusted authors, and PRs with `review-limit-reached` label
+- **Steps:** poll open PRs → for each eligible PR: circuit breaker check → set pending status → trigger Discord webhook → error fallback on failure
 
 ### Phase 2: Agent Callback (Status Update)
 


### PR DESCRIPTION
## Summary

Convert the PR review workflow from reactive (`pull_request_target`) to scheduled polling (cron every 5 min).

## Problem

Reactive mode fires a Discord webhook on every push. GitHub Actions' `concurrency` group cancels in-flight runs, but once a webhook is delivered it cannot be recalled — causing duplicate agent review sessions on rapid pushes.

## Solution

- **Cron polling** (`*/5 * * * *`): checks all open PRs every 5 minutes
- **Status-based gating**: skip if `pending` (< 30 min) or `success` (already LGTM)
- **Stale timeout**: `pending` > 30 min → re-trigger (agent may have missed it)
- **`workflow_dispatch`**: manual trigger for urgent reviews

## Changes

- `.github/workflows/pr-bot-review.yml` — rewritten to scheduled mode
- `docs/adr/pr-review-loop.md` — amended with scheduled polling section, trade-offs, stale timeout

## Trade-offs

| Aspect | Reactive (old) | Scheduled (new) |
|--------|---------------|-----------------|
| Latency | Immediate | Up to 5 min |
| Duplicate reviews | Possible | Impossible |
| GH Actions minutes | Per-push | Fixed (1 run/5 min) |

cc @pahud