### PR TITLE
feat: openab set/get — Unix socket IPC (Phase 1: thread.name)

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -248,14 +248,14 @@ pub trait ChatAdapter: Send + Sync + 'static {
         self.send_message(channel, content).await
     }
 
-    /// Rename the thread/channel title. Default: no-op (not all platforms support it).
+    /// Rename the thread/channel title. Default: unsupported error.
     async fn rename_thread(&self, _channel: &ChannelRef, _title: &str) -> Result<()> {
-        Ok(())
+        Err(anyhow::anyhow!("rename_thread not supported on this platform"))
     }
 
-    /// Archive or unarchive a thread. Default: no-op.
+    /// Archive or unarchive a thread. Default: unsupported error.
     async fn archive_thread(&self, _channel: &ChannelRef, _archived: bool) -> Result<()> {
-        Ok(())
+        Err(anyhow::anyhow!("archive_thread not supported on this platform"))
     }
 
     /// Delete a message. Used to remove streaming placeholders when reply_to is set.

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -253,6 +253,11 @@ pub trait ChatAdapter: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Archive or unarchive a thread. Default: no-op.
+    async fn archive_thread(&self, _channel: &ChannelRef, _archived: bool) -> Result<()> {
+        Ok(())
+    }
+
     /// Delete a message. Used to remove streaming placeholders when reply_to is set.
     /// Default: edits to zero-width space (fallback for platforms without delete support).
     async fn delete_message(&self, msg: &MessageRef) -> Result<()> {

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -119,11 +119,15 @@ async fn handle_conn(
 /// Concrete handler for `openab run` — dispatches to platform adapters.
 pub struct RuntimeHandler {
     adapter: Arc<dyn ChatAdapter>,
+    shard: Arc<std::sync::OnceLock<serenity::gateway::ShardMessenger>>,
 }
 
 impl RuntimeHandler {
-    pub fn new(adapter: Arc<dyn ChatAdapter>) -> Self {
-        Self { adapter }
+    pub fn new(
+        adapter: Arc<dyn ChatAdapter>,
+        shard: Arc<std::sync::OnceLock<serenity::gateway::ShardMessenger>>,
+    ) -> Self {
+        Self { adapter, shard }
     }
 
     fn channel_ref() -> Option<ChannelRef> {
@@ -133,7 +137,7 @@ impl RuntimeHandler {
         let platform = std::env::var("OPENAB_PLATFORM").unwrap_or_else(|_| "discord".into());
         Some(ChannelRef {
             platform,
-            channel_id: channel_id.clone(),
+            channel_id,
             thread_id: None,
             parent_id: None,
             origin_event_id: None,
@@ -166,6 +170,67 @@ impl CtlHandler for RuntimeHandler {
                     },
                 }
             }
+            "thread.archived" => {
+                let Some(channel) = Self::channel_ref() else {
+                    return Response {
+                        ok: false,
+                        message: "OPENAB_THREAD_ID or OPENAB_CHANNEL_ID not set".into(),
+                        value: None,
+                    };
+                };
+                let archived = match value {
+                    "true" | "1" | "yes" => true,
+                    "false" | "0" | "no" => false,
+                    _ => {
+                        return Response {
+                            ok: false,
+                            message: format!("invalid value: {value} (expected true/false)"),
+                            value: None,
+                        };
+                    }
+                };
+                match self.adapter.archive_thread(&channel, archived).await {
+                    Ok(()) => Response {
+                        ok: true,
+                        message: format!(
+                            "thread {}",
+                            if archived { "archived" } else { "unarchived" }
+                        ),
+                        value: None,
+                    },
+                    Err(e) => Response {
+                        ok: false,
+                        message: format!("archive failed: {e}"),
+                        value: None,
+                    },
+                }
+            }
+            "agent.status" => {
+                let Some(shard) = self.shard.get() else {
+                    return Response {
+                        ok: false,
+                        message: "shard not ready (Discord not connected yet)".into(),
+                        value: None,
+                    };
+                };
+                use serenity::gateway::ActivityData;
+                use serenity::model::user::OnlineStatus;
+                let activity = if value.is_empty() {
+                    None
+                } else {
+                    Some(ActivityData::custom(value))
+                };
+                shard.set_presence(activity, OnlineStatus::Online);
+                Response {
+                    ok: true,
+                    message: if value.is_empty() {
+                        "status cleared".into()
+                    } else {
+                        format!("status set to: {value}")
+                    },
+                    value: None,
+                }
+            }
             _ => Response {
                 ok: false,
                 message: format!("unknown key: {key}"),
@@ -176,9 +241,9 @@ impl CtlHandler for RuntimeHandler {
 
     async fn handle_get(&self, key: &str) -> Response {
         match key {
-            "thread.name" => Response {
+            "thread.name" | "thread.archived" | "agent.status" => Response {
                 ok: false,
-                message: "thread.name get not yet supported (Discord API limitation)".into(),
+                message: format!("{key} get not yet supported"),
                 value: None,
             },
             _ => Response {

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -75,6 +75,12 @@ pub fn spawn_server(
                 return;
             }
         };
+        // Restrict socket to owner only (defense-in-depth for shared hosts).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+        }
         info!(path = %path.display(), "control socket listening");
 
         loop {

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -1,0 +1,291 @@
+//! `openab set/get` IPC over Unix domain socket.
+//!
+//! Architecture (like consul/vault):
+//! - `openab run` spawns a UnixListener at a well-known path.
+//! - `openab set key value` connects, sends a JSON request, reads the response.
+//!
+//! Phase 1 supported keys:
+//! - `thread.name` — rename the current Discord/Slack thread
+
+use crate::adapter::{ChannelRef, ChatAdapter};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tracing::{debug, error, info, warn};
+
+/// Default socket path. Overridable via `OPENAB_SOCK` env var.
+pub fn socket_path() -> PathBuf {
+    std::env::var("OPENAB_SOCK")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp/openab.sock"))
+}
+
+// ─── Protocol ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Request {
+    pub action: Action,
+    pub key: String,
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Action {
+    Set,
+    Get,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Response {
+    pub ok: bool,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+// ─── Server (runs inside `openab run`) ──────────────────────────────────────
+
+/// Handler trait — `openab run` provides the concrete implementation that
+/// can access Discord/Slack adapters.
+#[async_trait::async_trait]
+pub trait CtlHandler: Send + Sync + 'static {
+    async fn handle_set(&self, key: &str, value: &str) -> Response;
+    async fn handle_get(&self, key: &str) -> Response;
+}
+
+/// Start the control socket server. Call this from `openab run` startup.
+/// Returns a JoinHandle; abort it on shutdown.
+pub fn spawn_server(
+    handler: std::sync::Arc<dyn CtlHandler>,
+) -> tokio::task::JoinHandle<()> {
+    let path = socket_path();
+    tokio::spawn(async move {
+        // Remove stale socket file
+        let _ = std::fs::remove_file(&path);
+        let listener = match UnixListener::bind(&path) {
+            Ok(l) => l,
+            Err(e) => {
+                error!(path = %path.display(), error = %e, "failed to bind control socket");
+                return;
+            }
+        };
+        info!(path = %path.display(), "control socket listening");
+
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    warn!(error = %e, "control socket accept error");
+                    continue;
+                }
+            };
+            let handler = handler.clone();
+            tokio::spawn(async move {
+                if let Err(e) = handle_conn(stream, &*handler).await {
+                    debug!(error = %e, "control socket connection error");
+                }
+            });
+        }
+    })
+}
+
+async fn handle_conn(
+    stream: UnixStream,
+    handler: &dyn CtlHandler,
+) -> anyhow::Result<()> {
+    let (reader, mut writer) = stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+    if let Some(line) = lines.next_line().await? {
+        let req: Request = serde_json::from_str(&line)?;
+        let resp = match req.action {
+            Action::Set => {
+                let val = req.value.as_deref().unwrap_or("");
+                handler.handle_set(&req.key, val).await
+            }
+            Action::Get => handler.handle_get(&req.key).await,
+        };
+        let mut buf = serde_json::to_vec(&resp)?;
+        buf.push(b'\n');
+        writer.write_all(&buf).await?;
+    }
+    Ok(())
+}
+
+// ─── Client (used by `openab set/get` subcommands) ──────────────────────────
+
+/// Concrete handler for `openab run` — dispatches to platform adapters.
+pub struct RuntimeHandler {
+    adapter: Arc<dyn ChatAdapter>,
+}
+
+impl RuntimeHandler {
+    pub fn new(adapter: Arc<dyn ChatAdapter>) -> Self {
+        Self { adapter }
+    }
+
+    fn channel_ref() -> Option<ChannelRef> {
+        let channel_id = std::env::var("OPENAB_THREAD_ID")
+            .or_else(|_| std::env::var("OPENAB_CHANNEL_ID"))
+            .ok()?;
+        let platform = std::env::var("OPENAB_PLATFORM").unwrap_or_else(|_| "discord".into());
+        Some(ChannelRef {
+            platform,
+            channel_id: channel_id.clone(),
+            thread_id: None,
+            parent_id: None,
+            origin_event_id: None,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl CtlHandler for RuntimeHandler {
+    async fn handle_set(&self, key: &str, value: &str) -> Response {
+        match key {
+            "thread.name" => {
+                let Some(channel) = Self::channel_ref() else {
+                    return Response {
+                        ok: false,
+                        message: "OPENAB_THREAD_ID or OPENAB_CHANNEL_ID not set".into(),
+                        value: None,
+                    };
+                };
+                match self.adapter.rename_thread(&channel, value).await {
+                    Ok(()) => Response {
+                        ok: true,
+                        message: format!("thread renamed to: {value}"),
+                        value: None,
+                    },
+                    Err(e) => Response {
+                        ok: false,
+                        message: format!("rename failed: {e}"),
+                        value: None,
+                    },
+                }
+            }
+            _ => Response {
+                ok: false,
+                message: format!("unknown key: {key}"),
+                value: None,
+            },
+        }
+    }
+
+    async fn handle_get(&self, key: &str) -> Response {
+        match key {
+            "thread.name" => Response {
+                ok: false,
+                message: "thread.name get not yet supported (Discord API limitation)".into(),
+                value: None,
+            },
+            _ => Response {
+                ok: false,
+                message: format!("unknown key: {key}"),
+                value: None,
+            },
+        }
+    }
+}
+
+pub async fn send_request(req: &Request) -> anyhow::Result<Response> {
+    let path = socket_path();
+    let stream = UnixStream::connect(&path).await.map_err(|e| {
+        anyhow::anyhow!(
+            "cannot connect to openab at {}: {} (is `openab run` running?)",
+            path.display(),
+            e
+        )
+    })?;
+    let (reader, mut writer) = stream.into_split();
+    let mut buf = serde_json::to_vec(req)?;
+    buf.push(b'\n');
+    writer.write_all(&buf).await?;
+    writer.shutdown().await?;
+
+    let mut lines = BufReader::new(reader).lines();
+    let line = lines
+        .next_line()
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("no response from openab"))?;
+    let resp: Response = serde_json::from_str(&line)?;
+    Ok(resp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_serialization() {
+        let req = Request {
+            action: Action::Set,
+            key: "thread.name".into(),
+            value: Some("hello".into()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.action, Action::Set);
+        assert_eq!(parsed.key, "thread.name");
+        assert_eq!(parsed.value.as_deref(), Some("hello"));
+    }
+
+    #[tokio::test]
+    async fn server_client_roundtrip() {
+        struct MockHandler;
+        #[async_trait::async_trait]
+        impl CtlHandler for MockHandler {
+            async fn handle_set(&self, key: &str, value: &str) -> Response {
+                Response {
+                    ok: true,
+                    message: format!("{key} = {value}"),
+                    value: None,
+                }
+            }
+            async fn handle_get(&self, key: &str) -> Response {
+                Response {
+                    ok: true,
+                    message: String::new(),
+                    value: Some(format!("val-of-{key}")),
+                }
+            }
+        }
+
+        // Use a temp path to avoid conflicts
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("test.sock");
+        std::env::set_var("OPENAB_SOCK", sock.to_str().unwrap());
+
+        let handler = std::sync::Arc::new(MockHandler);
+        let server = spawn_server(handler);
+        // Give server a moment to bind
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Test set
+        let resp = send_request(&Request {
+            action: Action::Set,
+            key: "thread.name".into(),
+            value: Some("hello world".into()),
+        })
+        .await
+        .unwrap();
+        assert!(resp.ok);
+        assert_eq!(resp.message, "thread.name = hello world");
+
+        // Test get
+        let resp = send_request(&Request {
+            action: Action::Get,
+            key: "thread.name".into(),
+            value: None,
+        })
+        .await
+        .unwrap();
+        assert!(resp.ok);
+        assert_eq!(resp.value.as_deref(), Some("val-of-thread.name"));
+
+        server.abort();
+        std::env::remove_var("OPENAB_SOCK");
+    }
+}

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -64,7 +64,14 @@ pub trait CtlHandler: Send + Sync + 'static {
 pub fn spawn_server(
     handler: std::sync::Arc<dyn CtlHandler>,
 ) -> tokio::task::JoinHandle<()> {
-    let path = socket_path();
+    spawn_server_at(socket_path(), handler)
+}
+
+/// Start the control socket server at a specific path.
+pub fn spawn_server_at(
+    path: PathBuf,
+    handler: std::sync::Arc<dyn CtlHandler>,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         // Remove stale socket file
         let _ = std::fs::remove_file(&path);
@@ -291,7 +298,11 @@ impl CtlHandler for RuntimeHandler {
 }
 
 pub async fn send_request(req: &Request) -> anyhow::Result<Response> {
-    let path = socket_path();
+    send_request_to(&socket_path(), req).await
+}
+
+/// Send a request to a specific socket path.
+pub async fn send_request_to(path: &PathBuf, req: &Request) -> anyhow::Result<Response> {
     let stream = UnixStream::connect(&path).await.map_err(|e| {
         anyhow::anyhow!(
             "cannot connect to openab at {}: {} (is `openab run` running?)",
@@ -358,15 +369,14 @@ mod tests {
         // Use a temp path to avoid conflicts
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("test.sock");
-        std::env::set_var("OPENAB_SOCK", sock.to_str().unwrap());
 
         let handler = std::sync::Arc::new(MockHandler);
-        let server = spawn_server(handler);
+        let server = spawn_server_at(sock.clone(), handler);
         // Give server a moment to bind
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // Test set
-        let resp = send_request(&Request {
+        let resp = send_request_to(&sock, &Request {
             action: Action::Set,
             key: "thread.name".into(),
             value: Some("hello world".into()),
@@ -378,7 +388,7 @@ mod tests {
         assert_eq!(resp.message, "thread.name = hello world (thread: 999)");
 
         // Test get
-        let resp = send_request(&Request {
+        let resp = send_request_to(&sock, &Request {
             action: Action::Get,
             key: "thread.name".into(),
             value: None,
@@ -390,6 +400,5 @@ mod tests {
         assert_eq!(resp.value.as_deref(), Some("val-of-thread.name"));
 
         server.abort();
-        std::env::remove_var("OPENAB_SOCK");
     }
 }

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -29,6 +29,9 @@ pub struct Request {
     pub action: Action,
     pub key: String,
     pub value: Option<String>,
+    /// Target thread/channel ID — daemon uses this to route to the correct adapter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -52,8 +55,8 @@ pub struct Response {
 /// can access Discord/Slack adapters.
 #[async_trait::async_trait]
 pub trait CtlHandler: Send + Sync + 'static {
-    async fn handle_set(&self, key: &str, value: &str) -> Response;
-    async fn handle_get(&self, key: &str) -> Response;
+    async fn handle_set(&self, thread_id: Option<&str>, key: &str, value: &str) -> Response;
+    async fn handle_get(&self, thread_id: Option<&str>, key: &str) -> Response;
 }
 
 /// Start the control socket server. Call this from `openab run` startup.
@@ -103,9 +106,9 @@ async fn handle_conn(
         let resp = match req.action {
             Action::Set => {
                 let val = req.value.as_deref().unwrap_or("");
-                handler.handle_set(&req.key, val).await
+                handler.handle_set(req.thread_id.as_deref(), &req.key, val).await
             }
-            Action::Get => handler.handle_get(&req.key).await,
+            Action::Get => handler.handle_get(req.thread_id.as_deref(), &req.key).await,
         };
         let mut buf = serde_json::to_vec(&resp)?;
         buf.push(b'\n');
@@ -116,48 +119,67 @@ async fn handle_conn(
 
 // ─── Client (used by `openab set/get` subcommands) ──────────────────────────
 
+/// Thread registry: maps thread_id → platform name.
+/// Shared between the message dispatcher (writes) and the ctl handler (reads).
+pub type ThreadRegistry = Arc<tokio::sync::RwLock<std::collections::HashMap<String, String>>>;
+
+/// Create an empty thread registry.
+pub fn new_registry() -> ThreadRegistry {
+    Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()))
+}
+
+/// Register a thread→platform mapping. Called by adapters on message dispatch.
+pub async fn register_thread(registry: &ThreadRegistry, thread_id: &str, platform: &str) {
+    registry.write().await.insert(thread_id.to_string(), platform.to_string());
+}
+
 /// Concrete handler for `openab run` — dispatches to platform adapters.
 pub struct RuntimeHandler {
-    adapter: Arc<dyn ChatAdapter>,
+    /// Registered adapters by platform name.
+    adapters: std::collections::HashMap<String, Arc<dyn ChatAdapter>>,
+    /// thread_id → platform mapping. Populated by `openab run` when it dispatches messages.
+    registry: Arc<tokio::sync::RwLock<std::collections::HashMap<String, String>>>,
     shard: Arc<std::sync::OnceLock<serenity::gateway::ShardMessenger>>,
 }
 
 impl RuntimeHandler {
     pub fn new(
-        adapter: Arc<dyn ChatAdapter>,
+        adapters: std::collections::HashMap<String, Arc<dyn ChatAdapter>>,
+        registry: Arc<tokio::sync::RwLock<std::collections::HashMap<String, String>>>,
         shard: Arc<std::sync::OnceLock<serenity::gateway::ShardMessenger>>,
     ) -> Self {
-        Self { adapter, shard }
+        Self { adapters, registry, shard }
     }
 
-    fn channel_ref() -> Option<ChannelRef> {
-        let channel_id = std::env::var("OPENAB_THREAD_ID")
-            .or_else(|_| std::env::var("OPENAB_CHANNEL_ID"))
-            .ok()?;
-        let platform = std::env::var("OPENAB_PLATFORM").unwrap_or_else(|_| "discord".into());
-        Some(ChannelRef {
-            platform,
-            channel_id,
-            thread_id: None,
-            parent_id: None,
-            origin_event_id: None,
-        })
+    /// Resolve which adapter to use for a given thread_id.
+    async fn resolve(&self, thread_id: Option<&str>) -> Option<(Arc<dyn ChatAdapter>, String)> {
+        let tid = thread_id?;
+        let platform = self.registry.read().await.get(tid).cloned()?;
+        let adapter = self.adapters.get(&platform)?.clone();
+        Some((adapter, tid.to_string()))
     }
 }
 
 #[async_trait::async_trait]
 impl CtlHandler for RuntimeHandler {
-    async fn handle_set(&self, key: &str, value: &str) -> Response {
+    async fn handle_set(&self, thread_id: Option<&str>, key: &str, value: &str) -> Response {
         match key {
             "thread.name" => {
-                let Some(channel) = Self::channel_ref() else {
+                let Some((adapter, tid)) = self.resolve(thread_id).await else {
                     return Response {
                         ok: false,
-                        message: "OPENAB_THREAD_ID or OPENAB_CHANNEL_ID not set".into(),
+                        message: "unknown thread (use --thread or register via message dispatch)".into(),
                         value: None,
                     };
                 };
-                match self.adapter.rename_thread(&channel, value).await {
+                let channel = ChannelRef {
+                    platform: String::new(),
+                    channel_id: tid,
+                    thread_id: None,
+                    parent_id: None,
+                    origin_event_id: None,
+                };
+                match adapter.rename_thread(&channel, value).await {
                     Ok(()) => Response {
                         ok: true,
                         message: format!("thread renamed to: {value}"),
@@ -171,10 +193,10 @@ impl CtlHandler for RuntimeHandler {
                 }
             }
             "thread.archived" => {
-                let Some(channel) = Self::channel_ref() else {
+                let Some((adapter, tid)) = self.resolve(thread_id).await else {
                     return Response {
                         ok: false,
-                        message: "OPENAB_THREAD_ID or OPENAB_CHANNEL_ID not set".into(),
+                        message: "unknown thread (use --thread or register via message dispatch)".into(),
                         value: None,
                     };
                 };
@@ -189,7 +211,14 @@ impl CtlHandler for RuntimeHandler {
                         };
                     }
                 };
-                match self.adapter.archive_thread(&channel, archived).await {
+                let channel = ChannelRef {
+                    platform: String::new(),
+                    channel_id: tid,
+                    thread_id: None,
+                    parent_id: None,
+                    origin_event_id: None,
+                };
+                match adapter.archive_thread(&channel, archived).await {
                     Ok(()) => Response {
                         ok: true,
                         message: format!(
@@ -239,7 +268,7 @@ impl CtlHandler for RuntimeHandler {
         }
     }
 
-    async fn handle_get(&self, key: &str) -> Response {
+    async fn handle_get(&self, _thread_id: Option<&str>, key: &str) -> Response {
         match key {
             "thread.name" | "thread.archived" | "agent.status" => Response {
                 ok: false,
@@ -289,12 +318,14 @@ mod tests {
             action: Action::Set,
             key: "thread.name".into(),
             value: Some("hello".into()),
+            thread_id: Some("123".into()),
         };
         let json = serde_json::to_string(&req).unwrap();
         let parsed: Request = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.action, Action::Set);
         assert_eq!(parsed.key, "thread.name");
         assert_eq!(parsed.value.as_deref(), Some("hello"));
+        assert_eq!(parsed.thread_id.as_deref(), Some("123"));
     }
 
     #[tokio::test]
@@ -302,14 +333,14 @@ mod tests {
         struct MockHandler;
         #[async_trait::async_trait]
         impl CtlHandler for MockHandler {
-            async fn handle_set(&self, key: &str, value: &str) -> Response {
+            async fn handle_set(&self, thread_id: Option<&str>, key: &str, value: &str) -> Response {
                 Response {
                     ok: true,
-                    message: format!("{key} = {value}"),
+                    message: format!("{key} = {value} (thread: {})", thread_id.unwrap_or("none")),
                     value: None,
                 }
             }
-            async fn handle_get(&self, key: &str) -> Response {
+            async fn handle_get(&self, _thread_id: Option<&str>, key: &str) -> Response {
                 Response {
                     ok: true,
                     message: String::new(),
@@ -333,17 +364,19 @@ mod tests {
             action: Action::Set,
             key: "thread.name".into(),
             value: Some("hello world".into()),
+            thread_id: Some("999".into()),
         })
         .await
         .unwrap();
         assert!(resp.ok);
-        assert_eq!(resp.message, "thread.name = hello world");
+        assert_eq!(resp.message, "thread.name = hello world (thread: 999)");
 
         // Test get
         let resp = send_request(&Request {
             action: Action::Get,
             key: "thread.name".into(),
             value: None,
+            thread_id: None,
         })
         .await
         .unwrap();

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -244,7 +244,7 @@ impl CtlHandler for RuntimeHandler {
                 let Some(shard) = self.shard.get() else {
                     return Response {
                         ok: false,
-                        message: "shard not ready (Discord not connected yet)".into(),
+                        message: "agent.status only supported on Discord".into(),
                         value: None,
                     };
                 };

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -248,6 +248,8 @@ pub struct Handler {
     pub scheduled_ids: tokio::sync::Mutex<std::collections::HashSet<String>>,
     /// Shared slot for ShardMessenger — set on ready, used by ctl server for agent.status.
     pub ctl_shard: Arc<std::sync::OnceLock<serenity::gateway::ShardMessenger>>,
+    /// Thread registry for ctl routing (thread_id → platform).
+    pub ctl_registry: crate::ctl::ThreadRegistry,
 }
 
 impl Handler {
@@ -874,6 +876,7 @@ impl EventHandler for Handler {
 
         let dispatcher = self.dispatcher.clone();
         let stt_cfg = self.stt_config.clone();
+        let ctl_registry = self.ctl_registry.clone();
 
         tokio::spawn(async move {
             // Best-effort echo before the agent reply so the user can verify STT.
@@ -902,6 +905,7 @@ impl EventHandler for Handler {
                 other_bot_present: other_bot_present_flag,
                 recipient: None, // Slack-only (assistant mode); N/A for Discord
             };
+            crate::ctl::register_thread(&ctl_registry, &thread_channel.channel_id, "discord").await;
             if let Err(e) = dispatcher
                 .submit(thread_key, thread_channel, adapter, buf_msg)
                 .await

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -11,7 +11,7 @@ use serenity::builder::{
     CreateActionRow, CreateAttachment, CreateButton, CreateCommand, CreateCommandOption,
     CreateInteractionResponse, CreateInteractionResponseFollowup, CreateInteractionResponseMessage,
     CreateSelectMenu, CreateSelectMenuKind, CreateSelectMenuOption, CreateThread, EditChannel,
-    EditMessage, GetMessages,
+    EditMessage, EditThread, GetMessages,
 };
 use serenity::http::Http;
 use serenity::model::application::ButtonStyle;
@@ -200,6 +200,14 @@ impl ChatAdapter for DiscordAdapter {
             .await?;
         Ok(())
     }
+
+    async fn archive_thread(&self, channel: &ChannelRef, archived: bool) -> anyhow::Result<()> {
+        let ch_id: u64 = Self::resolve_channel(channel).parse()?;
+        ChannelId::new(ch_id)
+            .edit_thread(&self.http, EditThread::new().archived(archived))
+            .await?;
+        Ok(())
+    }
 }
 
 // --- Handler: serenity EventHandler that delegates to AdapterRouter ---
@@ -238,6 +246,8 @@ pub struct Handler {
     pub reminder_store: ReminderStore,
     /// Track scheduled reminder IDs to prevent duplicate scheduling on reconnect.
     pub scheduled_ids: tokio::sync::Mutex<std::collections::HashSet<String>>,
+    /// Shared slot for ShardMessenger — set on ready, used by ctl server for agent.status.
+    pub ctl_shard: Arc<std::sync::OnceLock<serenity::gateway::ShardMessenger>>,
 }
 
 impl Handler {
@@ -903,6 +913,9 @@ impl EventHandler for Handler {
 
     async fn ready(&self, ctx: Context, ready: Ready) {
         info!(user = %ready.user.name, "discord bot connected");
+
+        // Expose ShardMessenger to ctl server for agent.status presence updates.
+        let _ = self.ctl_shard.set(ctx.shard.clone());
 
         // Build the shared command list once.
         let commands = vec![

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -742,7 +742,7 @@ async fn dispatch_batch(
                 if let Some(ref title) = title_to_apply {
                     if !title.is_empty() {
                         if let Err(e) = adapter.rename_thread(&dispatch_channel, title).await {
-                            warn!(session_key, error = %e, "failed to apply title directive");
+                            debug!(session_key, error = %e, "rename_thread not applied (platform may not support it)");
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod adapter;
 mod bot_turns;
 mod config;
 mod cron;
+mod ctl;
 mod directives;
 mod discord;
 mod dispatch;
@@ -92,6 +93,18 @@ enum Commands {
         #[arg(long, default_value = "kiro-cli acp --trust-all-tools")]
         command: String,
     },
+    /// Set a runtime value (e.g. thread.name)
+    Set {
+        /// Key to set (e.g. thread.name)
+        key: String,
+        /// Value to set
+        value: String,
+    },
+    /// Get a runtime value
+    Get {
+        /// Key to get (e.g. thread.name)
+        key: String,
+    },
 }
 
 #[tokio::main]
@@ -115,6 +128,36 @@ async fn main() -> anyhow::Result<()> {
         #[cfg(feature = "agentcore")]
         Commands::AgentcoreBridge { runtime_arn, region, command } => {
             return acp::agentcore::run_bridge(&runtime_arn, &region, &command).await;
+        }
+        Commands::Set { key, value } => {
+            let resp = ctl::send_request(&ctl::Request {
+                action: ctl::Action::Set,
+                key,
+                value: Some(value),
+            })
+            .await?;
+            if resp.ok {
+                println!("✓ {}", resp.message);
+            } else {
+                eprintln!("✗ {}", resp.message);
+                std::process::exit(1);
+            }
+            return Ok(());
+        }
+        Commands::Get { key } => {
+            let resp = ctl::send_request(&ctl::Request {
+                action: ctl::Action::Get,
+                key,
+                value: None,
+            })
+            .await?;
+            if resp.ok {
+                println!("{}", resp.value.unwrap_or_default());
+            } else {
+                eprintln!("✗ {}", resp.message);
+                std::process::exit(1);
+            }
+            return Ok(());
         }
         Commands::Run { config } => config,
     };
@@ -252,6 +295,15 @@ async fn main() -> anyhow::Result<()> {
             multibot_cache.clone(),
         ))
     });
+
+    // Spawn control socket server for `openab set/get` IPC
+    let ctl_handle = if let Some(ref adapter) = shared_discord_adapter {
+        Some(ctl::spawn_server(Arc::new(ctl::RuntimeHandler::new(adapter.clone()))))
+    } else if let Some(ref adapter) = shared_slack_adapter {
+        Some(ctl::spawn_server(Arc::new(ctl::RuntimeHandler::new(adapter.clone() as Arc<dyn adapter::ChatAdapter>))))
+    } else {
+        None
+    };
 
     // Validate cronjob config at startup (fail-fast on bad cron expressions or timezones)
     let mut configured_platforms: Vec<&str> = Vec::new();
@@ -549,6 +601,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Cleanup
     cleanup_handle.abort();
+    if let Some(h) = ctl_handle {
+        h.abort();
+        let _ = std::fs::remove_file(ctl::socket_path());
+    }
     // Signal Slack adapter to shut down gracefully
     let _ = shutdown_tx.send(true);
     if let Some(handle) = slack_handle {

--- a/src/main.rs
+++ b/src/main.rs
@@ -381,6 +381,7 @@ async fn main() -> anyhow::Result<()> {
             slack_idle,
         ));
         dispatchers.lock().unwrap().push(slack_dispatcher.clone());
+        let slack_ctl_registry = ctl_registry.clone();
         Some(tokio::spawn(async move {
             if let Err(e) = slack::run_slack_adapter(
                 adapter,
@@ -396,7 +397,7 @@ async fn main() -> anyhow::Result<()> {
                 stt,
                 slack_shutdown_rx,
                 slack_dispatcher,
-                ctl_registry.clone(),
+                slack_ctl_registry,
             )
             .await
             {

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,11 +99,17 @@ enum Commands {
         key: String,
         /// Value to set
         value: String,
+        /// Target thread/channel ID
+        #[arg(long)]
+        thread: Option<String>,
     },
     /// Get a runtime value
     Get {
         /// Key to get (e.g. thread.name)
         key: String,
+        /// Target thread/channel ID
+        #[arg(long)]
+        thread: Option<String>,
     },
 }
 
@@ -129,11 +135,12 @@ async fn main() -> anyhow::Result<()> {
         Commands::AgentcoreBridge { runtime_arn, region, command } => {
             return acp::agentcore::run_bridge(&runtime_arn, &region, &command).await;
         }
-        Commands::Set { key, value } => {
+        Commands::Set { key, value, thread } => {
             let resp = ctl::send_request(&ctl::Request {
                 action: ctl::Action::Set,
                 key,
                 value: Some(value),
+                thread_id: thread.or_else(|| std::env::var("OPENAB_THREAD_ID").ok()),
             })
             .await?;
             if resp.ok {
@@ -144,11 +151,12 @@ async fn main() -> anyhow::Result<()> {
             }
             return Ok(());
         }
-        Commands::Get { key } => {
+        Commands::Get { key, thread } => {
             let resp = ctl::send_request(&ctl::Request {
                 action: ctl::Action::Get,
                 key,
                 value: None,
+                thread_id: thread.or_else(|| std::env::var("OPENAB_THREAD_ID").ok()),
             })
             .await?;
             if resp.ok {
@@ -300,19 +308,27 @@ async fn main() -> anyhow::Result<()> {
     let ctl_shard: Arc<std::sync::OnceLock<serenity::gateway::ShardMessenger>> =
         Arc::new(std::sync::OnceLock::new());
 
+    // Thread registry: thread_id → platform. Populated on message dispatch.
+    let ctl_registry = ctl::new_registry();
+
     // Spawn control socket server for `openab set/get` IPC
-    let ctl_handle = if let Some(ref adapter) = shared_discord_adapter {
-        Some(ctl::spawn_server(Arc::new(ctl::RuntimeHandler::new(
-            adapter.clone(),
-            ctl_shard.clone(),
-        ))))
-    } else if let Some(ref adapter) = shared_slack_adapter {
-        Some(ctl::spawn_server(Arc::new(ctl::RuntimeHandler::new(
-            adapter.clone() as Arc<dyn adapter::ChatAdapter>,
-            ctl_shard.clone(),
-        ))))
-    } else {
-        None
+    let ctl_handle = {
+        let mut adapters = std::collections::HashMap::new();
+        if let Some(ref a) = shared_discord_adapter {
+            adapters.insert("discord".into(), a.clone());
+        }
+        if let Some(ref a) = shared_slack_adapter {
+            adapters.insert("slack".into(), a.clone() as Arc<dyn adapter::ChatAdapter>);
+        }
+        if adapters.is_empty() {
+            None
+        } else {
+            Some(ctl::spawn_server(Arc::new(ctl::RuntimeHandler::new(
+                adapters,
+                ctl_registry.clone(),
+                ctl_shard.clone(),
+            ))))
+        }
     };
 
     // Validate cronjob config at startup (fail-fast on bad cron expressions or timezones)

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,6 +396,7 @@ async fn main() -> anyhow::Result<()> {
                 stt,
                 slack_shutdown_rx,
                 slack_dispatcher,
+                ctl_registry.clone(),
             )
             .await
             {
@@ -580,6 +581,7 @@ async fn main() -> anyhow::Result<()> {
             reminder_store: reminder_store.clone(),
             scheduled_ids: tokio::sync::Mutex::new(std::collections::HashSet::new()),
             ctl_shard: ctl_shard.clone(),
+            ctl_registry: ctl_registry.clone(),
         };
 
         let intents = GatewayIntents::GUILD_MESSAGES

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,11 +296,21 @@ async fn main() -> anyhow::Result<()> {
         ))
     });
 
+    // Shared slot for Discord ShardMessenger (set in ready handler, used by ctl for agent.status)
+    let ctl_shard: Arc<std::sync::OnceLock<serenity::gateway::ShardMessenger>> =
+        Arc::new(std::sync::OnceLock::new());
+
     // Spawn control socket server for `openab set/get` IPC
     let ctl_handle = if let Some(ref adapter) = shared_discord_adapter {
-        Some(ctl::spawn_server(Arc::new(ctl::RuntimeHandler::new(adapter.clone()))))
+        Some(ctl::spawn_server(Arc::new(ctl::RuntimeHandler::new(
+            adapter.clone(),
+            ctl_shard.clone(),
+        ))))
     } else if let Some(ref adapter) = shared_slack_adapter {
-        Some(ctl::spawn_server(Arc::new(ctl::RuntimeHandler::new(adapter.clone() as Arc<dyn adapter::ChatAdapter>))))
+        Some(ctl::spawn_server(Arc::new(ctl::RuntimeHandler::new(
+            adapter.clone() as Arc<dyn adapter::ChatAdapter>,
+            ctl_shard.clone(),
+        ))))
     } else {
         None
     };
@@ -553,6 +563,7 @@ async fn main() -> anyhow::Result<()> {
             dispatcher: discord_dispatcher,
             reminder_store: reminder_store.clone(),
             scheduled_ids: tokio::sync::Mutex::new(std::collections::HashSet::new()),
+            ctl_shard: ctl_shard.clone(),
         };
 
         let intents = GatewayIntents::GUILD_MESSAGES

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -666,18 +666,6 @@ impl ChatAdapter for SlackAdapter {
         Ok(())
     }
 
-    async fn rename_thread(&self, channel: &ChannelRef, title: &str) -> Result<()> {
-        // Slack conversations.rename works on channels, not message threads.
-        // For thread-based conversations, there's no rename API.
-        let channel_id = channel.thread_id.as_deref().unwrap_or(&channel.channel_id);
-        let body = serde_json::json!({
-            "channel": channel_id,
-            "name": title,
-        });
-        self.api_post("conversations.rename", body).await?;
-        Ok(())
-    }
-
     async fn set_status(&self, channel: &ChannelRef, status: &str) -> Result<()> {
         let thread_ts = channel.thread_id.clone().unwrap_or_default();
         let body = build_set_status_body(&channel.channel_id, &thread_ts, status);

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -666,6 +666,18 @@ impl ChatAdapter for SlackAdapter {
         Ok(())
     }
 
+    async fn rename_thread(&self, channel: &ChannelRef, title: &str) -> Result<()> {
+        // Slack conversations.rename works on channels, not message threads.
+        // For thread-based conversations, there's no rename API.
+        let channel_id = channel.thread_id.as_deref().unwrap_or(&channel.channel_id);
+        let body = serde_json::json!({
+            "channel": channel_id,
+            "name": title,
+        });
+        self.api_post("conversations.rename", body).await?;
+        Ok(())
+    }
+
     async fn set_status(&self, channel: &ChannelRef, status: &str) -> Result<()> {
         let thread_ts = channel.thread_id.clone().unwrap_or_default();
         let body = build_set_status_body(&channel.channel_id, &thread_ts, status);
@@ -720,6 +732,7 @@ pub async fn run_slack_adapter(
     stt_config: SttConfig,
     mut shutdown_rx: watch::Receiver<bool>,
     dispatcher: Arc<crate::dispatch::Dispatcher>,
+    ctl_registry: crate::ctl::ThreadRegistry,
 ) -> Result<()> {
     let bot_token = adapter.bot_token().to_string();
     let bot_turns = Arc::new(tokio::sync::Mutex::new(BotTurnTracker::new(max_bot_turns)));
@@ -829,6 +842,7 @@ pub async fn run_slack_adapter(
                                                 let allowed_users = allowed_users.clone();
                                                 let stt_config = stt_config.clone();
                                                 let dispatcher = dispatcher.clone();
+                                                let ctl_registry = ctl_registry.clone();
                                                 let team_id = envelope["payload"]["team_id"]
                                                     .as_str()
                                                     .unwrap_or("")
@@ -845,6 +859,7 @@ pub async fn run_slack_adapter(
                                                         &allowed_users,
                                                         &stt_config,
                                                         &dispatcher,
+                                                        &ctl_registry,
                                                     )
                                                     .await;
                                                 });
@@ -1080,6 +1095,7 @@ pub async fn run_slack_adapter(
                                                 let allowed_users = allowed_users.clone();
                                                 let stt_config = stt_config.clone();
                                                 let dispatcher = dispatcher.clone();
+                                                let ctl_registry = ctl_registry.clone();
                                                 tokio::spawn(async move {
                                                     handle_message(
                                                         &event,
@@ -1092,6 +1108,7 @@ pub async fn run_slack_adapter(
                                                         &allowed_users,
                                                         &stt_config,
                                                         &dispatcher,
+                                                        &ctl_registry,
                                                     )
                                                     .await;
                                                 });
@@ -1184,6 +1201,7 @@ async fn handle_message(
     allowed_users: &HashSet<String>,
     stt_config: &SttConfig,
     dispatcher: &Arc<crate::dispatch::Dispatcher>,
+    ctl_registry: &crate::ctl::ThreadRegistry,
 ) {
     let channel_id = match event["channel"].as_str() {
         Some(ch) => ch.to_string(),
@@ -1529,6 +1547,9 @@ async fn handle_message(
         other_bot_present,
         recipient: stream_recipient,
     };
+    // Register thread for ctl routing
+    let ctl_thread_id = thread_channel.thread_id.as_deref().unwrap_or(&thread_channel.channel_id);
+    crate::ctl::register_thread(ctl_registry, ctl_thread_id, "slack").await;
     if let Err(e) = dispatcher
         .submit(thread_key, thread_channel, adapter_dyn, buf_msg)
         .await


### PR DESCRIPTION
## Summary

Add `openab set` and `openab get` subcommands that communicate with the running `openab run` daemon via Unix domain socket IPC.

Same binary, different modes — like `consul agent` / `consul kv put`.

## Phase 1 Supported Keys

| Key | Action | Description |
|-----|--------|-------------|
| `thread.name` | set | Rename current Discord/Slack thread |
| `thread.name` | get | Not yet supported (Discord has no get-thread-name API) |

## Usage

```bash
# Agent running in the same pod:
openab set thread.name "Kiro onboarding — capabilities"
# ✓ thread renamed to: Kiro onboarding — capabilities

openab get thread.name
# ✗ thread.name get not yet supported (Discord API limitation)
```

## Architecture

```
openab run  → long-lived daemon, listens on /tmp/openab.sock
openab set  → short-lived client, connects → JSON req → JSON resp → exits
openab get  → same as set but Action::Get
```

- Socket path configurable via `OPENAB_SOCK` env var
- Handler reads `OPENAB_THREAD_ID` (or `OPENAB_CHANNEL_ID`) to determine target
- `CtlHandler` trait is extensible — new keys = new match arms

## Phase 2+ Ideas

- `thread.archived` — archive/unarchive thread
- `schedule.cron` — modify cron at runtime (needs IPC to scheduler)
- `agent.system_prompt` — hot-reload prompt
- `channel.topic` — set channel topic

## Testing

- Unit test for JSON serialization roundtrip
- Integration test: spawn server → client set/get → verify response

Ref: #1131