### PR TITLE
fix: address PR #1146 review findings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,6 @@ use openab_core::secrets;
 use openab_core::setup;
 #[cfg(feature = "slack")]
 use openab_core::slack;
-use openab_core::stt;
-
 use clap::Parser;
 #[cfg(feature = "discord")]
 use serenity::gateway::GatewayError;


### PR DESCRIPTION
## Summary

Address review feedback from PR #1146 (unified binary workspace):

- Remove unused `stt` import from `main.rs`
- Add `AppState` and related types to gateway `lib.rs`
- Apply layer cache optimization to agentcore and native Dockerfiles
- Optimize Dockerfile layer caching for workspace
- Add `COPY crates/` to all Dockerfiles for workspace build
- Update `Cargo.lock` + clean up CI gateway job
- Add unified mode hook in `main.rs`, update gateway CI workflows
- Address remaining review findings
- Wire workspace into `main.rs`, remove duplicated source
- Restructure as Cargo workspace with unified binary feature flags

## Testing

- CI checks pass on all affected Dockerfiles
- Workspace builds successfully with unified binary feature flags