### PR TITLE
feat(discord): emoji reaction mapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ webpki-roots = { version = "0.26", optional = true }
 cron = "0.16.0"
 chrono = { version = "0.4.44", features = ["serde"] }
 chrono-tz = "0.10.4"
+emojis = "0.8"
 sha2 = "0.10"
 tempfile = "3.27.0"
 aws-sdk-secretsmanager = { version = "1", optional = true }

--- a/config.toml.example
+++ b/config.toml.example
@@ -192,7 +192,7 @@ error_hold_ms = 2500
 # --- Emoji reaction mapping ---
 # Map emoji reactions to text commands. Reacting with a mapped emoji
 # is equivalent to sending the corresponding text message.
-# Requires GUILD_MESSAGE_REACTIONS privileged intent enabled in Discord Developer Portal.
+# Requires GUILD_MESSAGE_REACTIONS intent enabled in Discord Developer Portal.
 # [reactions.mapping]
 # "👍" = "OK"
 # "👎" = "不行"

--- a/config.toml.example
+++ b/config.toml.example
@@ -189,6 +189,16 @@ stall_hard_ms = 30000
 done_hold_ms = 1500
 error_hold_ms = 2500
 
+# --- Emoji reaction equivalency ---
+# Map emoji reactions to text commands. Reacting with a mapped emoji
+# is equivalent to sending the corresponding text message.
+# Requires GUILD_MESSAGE_REACTIONS privileged intent enabled in Discord Developer Portal.
+# [reactions.equivalency]
+# "👍" = "OK"
+# "👎" = "不行"
+# "🔄" = "重新 review"
+# "✅" = "approve"
+
 # --- Scheduled messages (config-driven cron) ---
 # Everything cron-related lives under [cron].
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -189,11 +189,11 @@ stall_hard_ms = 30000
 done_hold_ms = 1500
 error_hold_ms = 2500
 
-# --- Emoji reaction equivalency ---
+# --- Emoji reaction mapping ---
 # Map emoji reactions to text commands. Reacting with a mapped emoji
 # is equivalent to sending the corresponding text message.
 # Requires GUILD_MESSAGE_REACTIONS privileged intent enabled in Discord Developer Portal.
-# [reactions.equivalency]
+# [reactions.mapping]
 # "👍" = "OK"
 # "👎" = "不行"
 # "🔄" = "重新 review"

--- a/config.toml.example
+++ b/config.toml.example
@@ -193,11 +193,12 @@ error_hold_ms = 2500
 # Map emoji reactions to text commands. Reacting with a mapped emoji
 # is equivalent to sending the corresponding text message.
 # Requires GUILD_MESSAGE_REACTIONS intent enabled in Discord Developer Portal.
+# Keys can be unicode emoji or Discord shortcodes (e.g. :thumbsup:).
 # [reactions.mapping]
 # "👍" = "OK"
-# "👎" = "不行"
-# "🔄" = "重新 review"
-# "✅" = "approve"
+# ":thumbsdown:" = "不行"
+# ":arrows_counterclockwise:" = "重新 review"
+# ":white_check_mark:" = "approve"
 
 # --- Scheduled messages (config-driven cron) ---
 # Everything cron-related lives under [cron].

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -341,7 +341,7 @@ Map emoji reactions to text commands. When a user reacts with a configured emoji
 ```
 
 **Requirements:**
-- Enable the `GUILD_MESSAGE_REACTIONS` privileged intent in the Discord Developer Portal.
+- Enable the `GUILD_MESSAGE_REACTIONS` intent in the Discord Developer Portal.
 - Only unicode emoji are supported (custom server emoji are ignored).
 - The bot's own reactions are always ignored (prevents feedback loops).
 - Channel/thread access control still applies — reactions in non-monitored channels are ignored.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -328,12 +328,12 @@ Fine-tune reaction timing behavior (milliseconds).
 | `done_hold_ms` | `1500` | How long to show the done emoji before removing (if `remove_after_reply`). |
 | `error_hold_ms` | `2500` | How long to show the error emoji before removing. |
 
-### `[reactions.equivalency]`
+### `[reactions.mapping]`
 
 Map emoji reactions to text commands. When a user reacts with a configured emoji on any message in a monitored channel, the bot treats it as if the user sent the corresponding text message.
 
 ```toml
-[reactions.equivalency]
+[reactions.mapping]
 "👍" = "OK"
 "👎" = "不行"
 "🔄" = "重新 review"

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -328,6 +328,24 @@ Fine-tune reaction timing behavior (milliseconds).
 | `done_hold_ms` | `1500` | How long to show the done emoji before removing (if `remove_after_reply`). |
 | `error_hold_ms` | `2500` | How long to show the error emoji before removing. |
 
+### `[reactions.equivalency]`
+
+Map emoji reactions to text commands. When a user reacts with a configured emoji on any message in a monitored channel, the bot treats it as if the user sent the corresponding text message.
+
+```toml
+[reactions.equivalency]
+"👍" = "OK"
+"👎" = "不行"
+"🔄" = "重新 review"
+"✅" = "approve"
+```
+
+**Requirements:**
+- Enable the `GUILD_MESSAGE_REACTIONS` privileged intent in the Discord Developer Portal.
+- Only unicode emoji are supported (custom server emoji are ignored).
+- The bot's own reactions are always ignored (prevents feedback loops).
+- Channel/thread access control still applies — reactions in non-monitored channels are ignored.
+
 ---
 
 ## `[stt]`

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -332,12 +332,14 @@ Fine-tune reaction timing behavior (milliseconds).
 
 Map emoji reactions to text commands. When a user reacts with a configured emoji on any message in a monitored channel, the bot treats it as if the user sent the corresponding text message.
 
+Keys can be unicode emoji or Discord/GitHub shortcodes (e.g. `:thumbsup:`). Shortcodes are resolved to unicode at config load time.
+
 ```toml
 [reactions.mapping]
 "👍" = "OK"
-"👎" = "不行"
-"🔄" = "重新 review"
-"✅" = "approve"
+":thumbsdown:" = "不行"
+":arrows_counterclockwise:" = "重新 review"
+":white_check_mark:" = "approve"
 ```
 
 **Requirements:**

--- a/docs/reactions.md
+++ b/docs/reactions.md
@@ -44,6 +44,7 @@ Reaction mapping respects all existing access control policies:
 
 ## Limitations
 
+- **Bot's own reactions are always ignored** — the bot's status emoji (👀, 🤔, 🆗, etc.) will never trigger mapping, even if they match a configured key. This prevents feedback loops.
 - **Unicode emoji only** — custom server emoji (`:custom_name:`) are silently ignored.
 - **Thread-only** (in `involved`/`multibot-mentions` mode) — reactions in non-thread channels are ignored unless `allow_user_messages` is set to a mode that allows them.
 - **No reaction removal handling** — only `reaction_add` events trigger mapping; removing a reaction has no effect.

--- a/docs/reactions.md
+++ b/docs/reactions.md
@@ -1,0 +1,70 @@
+# Emoji Reaction Mapping
+
+Map emoji reactions to text commands. When a user reacts with a configured emoji on a message, OAB treats it as if the user sent the corresponding text message through the normal dispatch pipeline.
+
+## Quick Start
+
+Add to your `config.toml`:
+
+```toml
+[reactions.mapping]
+":thumbsup:" = "OK"
+":thumbsdown:" = "不行"
+":arrows_counterclockwise:" = "重新 review"
+":white_check_mark:" = "approve"
+```
+
+That's it. Reacting with 👍 on any message in a monitored thread now behaves as if you typed "OK".
+
+## Config Keys
+
+Keys can be:
+- **Unicode emoji**: `"👍"`, `"✅"`, `"🔄"`
+- **Discord/GitHub shortcodes**: `":thumbsup:"`, `":white_check_mark:"`
+
+Shortcodes are resolved to unicode at config load time using the [gemoji](https://github.com/github/gemoji) database (same as GitHub and Discord). Unrecognized shortcodes are kept as-is and will never match a reaction.
+
+## Requirements
+
+1. **`GUILD_MESSAGE_REACTIONS` intent** — must be enabled in the Discord Developer Portal. This is a standard (non-privileged) intent; no approval required.
+
+2. **Bot involvement** — reactions are only processed in threads where the bot has already participated (posted at least one message). This follows the same `allow_user_messages` gating as text messages.
+
+## Gating & Access Control
+
+Reaction mapping respects all existing access control policies:
+
+| Policy | Behavior |
+|--------|----------|
+| `allowed_users` / `allow_all_users` | Denied users cannot trigger via reactions |
+| `allow_bot_messages` | `off`/`mentions` → bot reactions ignored; `all` → allowed (respects `trusted_bot_ids`) |
+| `allow_user_messages` | `mentions` → reactions disabled entirely; `involved`/`multibot-mentions` → only in threads where bot has participated |
+| `multibot-mentions` + multibot thread | Reactions rejected (can't express @mention) |
+| Channel/thread allowlist | Same ACL as text messages |
+
+## Limitations
+
+- **Unicode emoji only** — custom server emoji (`:custom_name:`) are silently ignored.
+- **Thread-only** (in `involved`/`multibot-mentions` mode) — reactions in non-thread channels are ignored unless `allow_user_messages` is set to a mode that allows them.
+- **No reaction removal handling** — only `reaction_add` events trigger mapping; removing a reaction has no effect.
+- **One emoji = one dispatch** — each mapped reaction dispatches independently through the pipeline.
+
+## Examples
+
+### PR Review Workflow
+
+```toml
+[reactions.mapping]
+":white_check_mark:" = "approve"
+":x:" = "reject"
+":arrows_counterclockwise:" = "重新 review"
+```
+
+### Task Acknowledgment
+
+```toml
+[reactions.mapping]
+":thumbsup:" = "OK"
+":eyes:" = "looking into it"
+":rocket:" = "deploying now"
+```

--- a/docs/reactions.md
+++ b/docs/reactions.md
@@ -39,7 +39,7 @@ Reaction mapping respects all existing access control policies:
 | `allowed_users` / `allow_all_users` | Denied users cannot trigger via reactions |
 | `allow_bot_messages` | `off`/`mentions` → bot reactions ignored; `all` → allowed (respects `trusted_bot_ids`) |
 | `allow_user_messages` | `mentions` → reactions disabled entirely; `involved`/`multibot-mentions` → only in threads where bot has participated |
-| `multibot-mentions` + multibot thread | Reactions rejected (can't express @mention) |
+| `multibot-mentions` + multibot thread | Only responds if the reaction is on **this bot's** message (implicit targeting) |
 | Channel/thread allowlist | Same ACL as text messages |
 
 ## Limitations

--- a/src/config.rs
+++ b/src/config.rs
@@ -929,6 +929,25 @@ fn parse_config_inner(expanded: &str, source: &str) -> anyhow::Result<Config> {
     let mut config: Config = toml::from_str(expanded)
         .map_err(|e| anyhow::anyhow!("failed to parse config from {source}: {e}"))?;
 
+    // Resolve Discord shortcodes in reactions.mapping keys.
+    // Allows operators to write `:thumbsup: = "OK"` instead of `"👍" = "OK"`.
+    config.reactions.mapping = config
+        .reactions
+        .mapping
+        .into_iter()
+        .map(|(key, val)| {
+            let resolved = if key.starts_with(':') && key.ends_with(':') && key.len() > 2 {
+                let shortcode = &key[1..key.len() - 1];
+                emojis::get_by_shortcode(shortcode)
+                    .map(|e| e.as_str().to_string())
+                    .unwrap_or(key)
+            } else {
+                key
+            };
+            (resolved, val)
+        })
+        .collect();
+
     // If [agentcore] is set and [agent] command was not explicitly provided,
     // synthesize agent config to spawn the bundled agentcore-acp adapter.
     if let Some(ref ac) = config.agentcore {

--- a/src/config.rs
+++ b/src/config.rs
@@ -659,6 +659,10 @@ pub struct ReactionsConfig {
     pub emojis: ReactionEmojis,
     #[serde(default)]
     pub timing: ReactionTiming,
+    /// Emoji-to-text equivalency mapping. When a user reacts with a mapped emoji,
+    /// it is treated as if they sent the corresponding text message.
+    #[serde(default)]
+    pub equivalency: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -788,6 +792,7 @@ impl Default for ReactionsConfig {
             tool_display: ToolDisplay::default(),
             emojis: ReactionEmojis::default(),
             timing: ReactionTiming::default(),
+            equivalency: HashMap::new(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -659,10 +659,10 @@ pub struct ReactionsConfig {
     pub emojis: ReactionEmojis,
     #[serde(default)]
     pub timing: ReactionTiming,
-    /// Emoji-to-text equivalency mapping. When a user reacts with a mapped emoji,
+    /// Emoji-to-text mapping. When a user reacts with a mapped emoji,
     /// it is treated as if they sent the corresponding text message.
     #[serde(default)]
-    pub equivalency: HashMap<String, String>,
+    pub mapping: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -792,7 +792,7 @@ impl Default for ReactionsConfig {
             tool_display: ToolDisplay::default(),
             emojis: ReactionEmojis::default(),
             timing: ReactionTiming::default(),
-            equivalency: HashMap::new(),
+            mapping: HashMap::new(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1521,4 +1521,90 @@ cancel_strategy = "noop"
         let ac = cfg.agentcore.unwrap();
         assert_eq!(ac.cancel_strategy, AgentCoreCancelStrategy::Noop);
     }
+
+    #[test]
+    fn reactions_mapping_unicode_keys() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agent]
+command = "echo"
+
+[reactions.mapping]
+"👍" = "OK"
+"✅" = "approve"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        assert_eq!(cfg.reactions.mapping.get("👍").unwrap(), "OK");
+        assert_eq!(cfg.reactions.mapping.get("✅").unwrap(), "approve");
+    }
+
+    #[test]
+    fn reactions_mapping_shortcode_resolution() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agent]
+command = "echo"
+
+[reactions.mapping]
+":thumbsup:" = "OK"
+":white_check_mark:" = "approve"
+":rocket:" = "deploy"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        // Shortcodes should be resolved to unicode
+        assert_eq!(cfg.reactions.mapping.get("👍").unwrap(), "OK");
+        assert_eq!(cfg.reactions.mapping.get("✅").unwrap(), "approve");
+        assert_eq!(cfg.reactions.mapping.get("🚀").unwrap(), "deploy");
+        // Original shortcode keys should not remain
+        assert!(cfg.reactions.mapping.get(":thumbsup:").is_none());
+    }
+
+    #[test]
+    fn reactions_mapping_unknown_shortcode_kept_as_is() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agent]
+command = "echo"
+
+[reactions.mapping]
+":nonexistent_emoji_xyz:" = "nope"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        // Unknown shortcode kept as-is (won't match any reaction)
+        assert_eq!(
+            cfg.reactions.mapping.get(":nonexistent_emoji_xyz:").unwrap(),
+            "nope"
+        );
+    }
+
+    #[test]
+    fn reactions_mapping_mixed_unicode_and_shortcodes() {
+        let toml = r#"
+[discord]
+bot_token = "t"
+
+[agent]
+command = "echo"
+
+[reactions.mapping]
+"👎" = "reject"
+":rocket:" = "deploy"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        assert_eq!(cfg.reactions.mapping.get("👎").unwrap(), "reject");
+        assert_eq!(cfg.reactions.mapping.get("🚀").unwrap(), "deploy");
+        assert_eq!(cfg.reactions.mapping.len(), 2);
+    }
+
+    #[test]
+    fn reactions_mapping_empty_by_default() {
+        let cfg = parse_config(MINIMAL_TOML, "test").unwrap();
+        assert!(cfg.reactions.mapping.is_empty());
+    }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -925,7 +925,7 @@ impl EventHandler for Handler {
             _ => return, // custom emojis not supported
         };
 
-        // Look up mapping.
+        // Look up mapping (early exit before any API calls).
         let mapping = &self.router.reactions_config().mapping;
         let prompt = match mapping.get(&emoji_str) {
             Some(text) => text.clone(),
@@ -937,38 +937,66 @@ impl EventHandler for Handler {
             None => return,
         };
 
+        // Determine if reactor is a bot (from member hint or user fetch).
+        let is_reactor_bot = reaction
+            .member
+            .as_ref()
+            .map(|m| m.user.bot)
+            .unwrap_or(false);
+
+        // Bot gating: apply same allow_bot_messages policy as message().
+        if is_reactor_bot {
+            match self.allow_bot_messages {
+                AllowBots::Off => return,
+                // For reactions there is no @mention concept — treat as "not mentioned".
+                AllowBots::Mentions => return,
+                AllowBots::All => {}
+            }
+        }
+
+        // User allowlist check (same as message() handler).
+        if is_denied_user(
+            is_reactor_bot,
+            self.allow_all_users,
+            &self.allowed_users,
+            user_id.get(),
+        ) {
+            return;
+        }
+
         let adapter = self
             .adapter
             .get_or_init(|| Arc::new(DiscordAdapter::new(ctx.http.clone())))
             .clone();
 
         // Fetch user info for sender context.
-        let (sender_name, display_name) = match user_id.to_user(&ctx.http).await {
-            Ok(user) => {
-                let display = user.global_name.as_ref().unwrap_or(&user.name).clone();
-                (user.name.clone(), display)
-            }
-            Err(_) => {
-                let fallback = user_id.to_string();
-                (fallback.clone(), fallback)
-            }
-        };
+        let (sender_name, display_name, is_bot_confirmed) =
+            match user_id.to_user(&ctx.http).await {
+                Ok(user) => {
+                    let display = user.global_name.as_ref().unwrap_or(&user.name).clone();
+                    (user.name.clone(), display, user.bot)
+                }
+                Err(_) => {
+                    let fallback = user_id.to_string();
+                    (fallback.clone(), fallback, is_reactor_bot)
+                }
+            };
 
         // Determine thread context from the reacted message's channel.
         let channel_id = reaction.channel_id;
         let in_allowed_channel =
             self.allow_all_channels || self.allowed_channels.contains(&channel_id.get());
 
-        // Thread detection: check if this channel is a thread.
+        // Thread detection: match detect_thread() logic — thread channel_id in
+        // allowlist OR parent in allowlist OR allow_all_channels.
         let (thread_channel, _thread_parent_id) = match channel_id.to_channel(&ctx.http).await {
             Ok(serenity::model::channel::Channel::Guild(gc)) => {
                 if gc.thread_metadata.is_some() {
-                    // It's a thread — parent must be allowed.
                     let parent = gc.parent_id.map(|p| p.get());
-                    let parent_allowed = parent
-                        .map(|p| self.allow_all_channels || self.allowed_channels.contains(&p))
-                        .unwrap_or(false);
-                    if !parent_allowed {
+                    let in_allowed_thread = in_allowed_channel
+                        || self.allow_all_channels
+                        || parent.is_some_and(|pid| self.allowed_channels.contains(&pid));
+                    if !in_allowed_thread {
                         return;
                     }
                     (
@@ -1000,6 +1028,12 @@ impl EventHandler for Handler {
             _ => return, // DM or unknown channel — not supported
         };
 
+        // Check multibot state for this thread (consistent with message handler).
+        let other_bot_present = {
+            let cache = self.multibot_threads.lock().await;
+            cache.contains_key(&channel_id.to_string())
+        } || self.multibot_cache.is_multibot(&channel_id.to_string());
+
         let message_id = reaction.message_id;
         let trigger_msg = MessageRef {
             channel: ChannelRef {
@@ -1024,7 +1058,7 @@ impl EventHandler for Handler {
                 .unwrap_or(&thread_channel.channel_id)
                 .to_string(),
             thread_id: thread_channel.parent_id.as_ref().map(|_| thread_channel.channel_id.clone()),
-            is_bot: false,
+            is_bot: is_bot_confirmed,
             timestamp: Some(chrono::Utc::now().to_rfc3339()),
             message_id: Some(message_id.to_string()),
             receiver_id: Some(bot_id.to_string()),
@@ -1044,7 +1078,7 @@ impl EventHandler for Handler {
             trigger_msg,
             arrived_at: std::time::Instant::now(),
             estimated_tokens,
-            other_bot_present: false,
+            other_bot_present,
             recipient: None,
         };
 
@@ -1052,7 +1086,7 @@ impl EventHandler for Handler {
             .submit(thread_key, thread_channel, adapter, buf_msg)
             .await
         {
-            error!("reaction equivalency dispatcher submit error: {e}");
+            error!("reaction mapping dispatcher submit error: {e}");
         }
     }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1004,6 +1004,8 @@ impl EventHandler for Handler {
         let allow_all_channels = self.allow_all_channels;
         let allowed_channels = self.allowed_channels.clone();
         let allow_user_messages = self.allow_user_messages;
+        let allow_bot_messages = self.allow_bot_messages;
+        let trusted_bot_ids = self.trusted_bot_ids.clone();
         let dispatcher = self.dispatcher.clone();
         let ctl_registry = self.ctl_registry.clone();
         let http = ctx.http.clone();
@@ -1025,7 +1027,16 @@ impl EventHandler for Handler {
             // Defense-in-depth: if to_user() reveals this is a bot but member was
             // None (rare edge case), re-apply bot gating retroactively.
             if is_bot_confirmed && !is_reactor_bot {
-                return;
+                match allow_bot_messages {
+                    AllowBots::Off | AllowBots::Mentions => return,
+                    AllowBots::All => {
+                        if !trusted_bot_ids.is_empty()
+                            && !trusted_bot_ids.contains(&user_id.get())
+                        {
+                            return;
+                        }
+                    }
+                }
             }
 
             let in_allowed_channel =

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -950,7 +950,14 @@ impl EventHandler for Handler {
                 AllowBots::Off => return,
                 // For reactions there is no @mention concept — treat as "not mentioned".
                 AllowBots::Mentions => return,
-                AllowBots::All => {}
+                AllowBots::All => {
+                    // When trusted_bot_ids is configured, only those bots are allowed.
+                    if !self.trusted_bot_ids.is_empty()
+                        && !self.trusted_bot_ids.contains(&user_id.get())
+                    {
+                        return;
+                    }
+                }
             }
         }
 
@@ -982,12 +989,13 @@ impl EventHandler for Handler {
             cache.get(&channel_id.to_string())
                 .is_some_and(|ts| ts.elapsed() < self.session_ttl)
         };
+        // Snapshot multibot state (irreversible, safe to read early).
+        let other_bot_present = self.multibot_cache.is_multibot(&channel_id.to_string());
 
         let message_id = reaction.message_id;
         let allow_all_channels = self.allow_all_channels;
         let allowed_channels = self.allowed_channels.clone();
         let allow_user_messages = self.allow_user_messages;
-        let multibot_cache = self.multibot_cache.clone();
         let dispatcher = self.dispatcher.clone();
         let ctl_registry = self.ctl_registry.clone();
         let http = ctx.http.clone();
@@ -1046,18 +1054,24 @@ impl EventHandler for Handler {
             // allow_user_messages gating (post thread-detection):
             // In Involved/MultibotMentions mode, only respond in threads
             // where the bot has participated. Non-thread channels are rejected.
+            // MultibotMentions additionally rejects when other bots are present.
             match allow_user_messages {
                 AllowUsers::Mentions => return,
-                AllowUsers::Involved | AllowUsers::MultibotMentions => {
+                AllowUsers::Involved => {
                     if !is_thread || !bot_involved {
                         return;
                     }
                 }
+                AllowUsers::MultibotMentions => {
+                    if !is_thread || !bot_involved {
+                        return;
+                    }
+                    // In multibot threads, require @mention (which reactions can't provide).
+                    if other_bot_present {
+                        return;
+                    }
+                }
             }
-
-            // Check multibot state.
-            let other_bot_present =
-                multibot_cache.is_multibot(&channel_id.to_string());
 
             let trigger_msg = MessageRef {
                 channel: ChannelRef {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -995,6 +995,10 @@ impl EventHandler for Handler {
         // Snapshot multibot state (irreversible, safe to read early).
         let other_bot_present = self.multibot_cache.is_multibot(&channel_id.to_string());
 
+        // In multibot threads, reaction target message's author determines which bot responds.
+        // message_author_id is provided by Discord in REACTION_ADD events.
+        let message_author_id = reaction.message_author_id;
+
         let message_id = reaction.message_id;
         let allow_all_channels = self.allow_all_channels;
         let allowed_channels = self.allowed_channels.clone();
@@ -1075,9 +1079,14 @@ impl EventHandler for Handler {
                     if !is_thread || !bot_involved {
                         return;
                     }
-                    // In multibot threads, require @mention (which reactions can't provide).
+                    // In multibot threads, the reaction target message's author
+                    // determines which bot responds. Only process if the user
+                    // reacted on THIS bot's message.
                     if other_bot_present {
-                        return;
+                        match message_author_id {
+                            Some(author) if author == bot_id => {} // targeted at us
+                            _ => return,
+                        }
                     }
                 }
             }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -922,7 +922,10 @@ impl EventHandler for Handler {
         // Extract unicode emoji string from the reaction.
         let emoji_str = match &reaction.emoji {
             ReactionType::Unicode(s) => s.clone(),
-            _ => return, // custom emojis not supported
+            _ => {
+                tracing::debug!(emoji = ?reaction.emoji, "ignoring non-unicode reaction");
+                return;
+            }
         };
 
         // Look up mapping (early exit before any API calls).

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -986,14 +986,15 @@ impl EventHandler for Handler {
             return;
         }
 
-        // Snapshot participation state before spawn (positive-only cache; safe to read early).
-        let bot_involved = {
-            let cache = self.participated_threads.lock().await;
-            cache.get(&channel_id.to_string())
-                .is_some_and(|ts| ts.elapsed() < self.session_ttl)
-        };
-        // Snapshot multibot state (irreversible, safe to read early).
-        let other_bot_present = self.multibot_cache.is_multibot(&channel_id.to_string());
+        // Snapshot participation state — use same API-backed check as message().
+        let (bot_involved, _) = self
+            .bot_participated_in_thread(&ctx.http, channel_id, bot_id)
+            .await;
+        // Snapshot multibot state: check both in-memory and disk cache (matches message()).
+        let other_bot_present = {
+            let cache = self.multibot_threads.lock().await;
+            cache.contains_key(&channel_id.to_string())
+        } || self.multibot_cache.is_multibot(&channel_id.to_string());
 
         // In multibot threads, reaction target message's author determines which bot responds.
         // message_author_id is provided by Discord in REACTION_ADD events.

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -16,7 +16,7 @@ use serenity::builder::{
 use serenity::http::Http;
 use serenity::model::application::ButtonStyle;
 use serenity::model::application::{Command, CommandOptionType, ComponentInteractionDataKind, Interaction};
-use serenity::model::channel::{AutoArchiveDuration, Message, MessageType, ReactionType};
+use serenity::model::channel::{AutoArchiveDuration, Message, MessageType, Reaction, ReactionType};
 use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, MessageId, UserId};
 use serenity::prelude::*;
@@ -909,6 +909,151 @@ impl EventHandler for Handler {
                 error!("dispatcher submit error: {e}");
             }
         });
+    }
+
+    async fn reaction_add(&self, ctx: Context, reaction: Reaction) {
+        let bot_id = ctx.cache.current_user().id;
+
+        // Ignore bot's own reactions to prevent feedback loops.
+        if reaction.user_id == Some(bot_id) {
+            return;
+        }
+
+        // Extract unicode emoji string from the reaction.
+        let emoji_str = match &reaction.emoji {
+            ReactionType::Unicode(s) => s.clone(),
+            _ => return, // custom emojis not supported
+        };
+
+        // Look up equivalency mapping.
+        let equivalency = &self.router.reactions_config().equivalency;
+        let prompt = match equivalency.get(&emoji_str) {
+            Some(text) => text.clone(),
+            None => return, // emoji not mapped
+        };
+
+        let user_id = match reaction.user_id {
+            Some(id) => id,
+            None => return,
+        };
+
+        let adapter = self
+            .adapter
+            .get_or_init(|| Arc::new(DiscordAdapter::new(ctx.http.clone())))
+            .clone();
+
+        // Fetch user info for sender context.
+        let (sender_name, display_name) = match user_id.to_user(&ctx.http).await {
+            Ok(user) => {
+                let display = user.global_name.as_ref().unwrap_or(&user.name).clone();
+                (user.name.clone(), display)
+            }
+            Err(_) => {
+                let fallback = user_id.to_string();
+                (fallback.clone(), fallback)
+            }
+        };
+
+        // Determine thread context from the reacted message's channel.
+        let channel_id = reaction.channel_id;
+        let in_allowed_channel =
+            self.allow_all_channels || self.allowed_channels.contains(&channel_id.get());
+
+        // Thread detection: check if this channel is a thread.
+        let (thread_channel, _thread_parent_id) = match channel_id.to_channel(&ctx.http).await {
+            Ok(serenity::model::channel::Channel::Guild(gc)) => {
+                if gc.thread_metadata.is_some() {
+                    // It's a thread — parent must be allowed.
+                    let parent = gc.parent_id.map(|p| p.get());
+                    let parent_allowed = parent
+                        .map(|p| self.allow_all_channels || self.allowed_channels.contains(&p))
+                        .unwrap_or(false);
+                    if !parent_allowed {
+                        return;
+                    }
+                    (
+                        ChannelRef {
+                            platform: "discord".into(),
+                            channel_id: channel_id.get().to_string(),
+                            thread_id: None,
+                            parent_id: parent.map(|p| p.to_string()),
+                            origin_event_id: None,
+                        },
+                        parent.map(|p| p.to_string()),
+                    )
+                } else {
+                    if !in_allowed_channel {
+                        return;
+                    }
+                    (
+                        ChannelRef {
+                            platform: "discord".into(),
+                            channel_id: channel_id.get().to_string(),
+                            thread_id: None,
+                            parent_id: None,
+                            origin_event_id: None,
+                        },
+                        None,
+                    )
+                }
+            }
+            _ => return, // DM or unknown channel — not supported
+        };
+
+        let message_id = reaction.message_id;
+        let trigger_msg = MessageRef {
+            channel: ChannelRef {
+                platform: "discord".into(),
+                channel_id: channel_id.get().to_string(),
+                thread_id: None,
+                parent_id: None,
+                origin_event_id: None,
+            },
+            message_id: message_id.to_string(),
+        };
+
+        let sender = SenderContext {
+            schema: "openab.sender.v1".into(),
+            sender_id: user_id.to_string(),
+            sender_name: sender_name.clone(),
+            display_name,
+            channel: "discord".into(),
+            channel_id: thread_channel
+                .parent_id
+                .as_deref()
+                .unwrap_or(&thread_channel.channel_id)
+                .to_string(),
+            thread_id: thread_channel.parent_id.as_ref().map(|_| thread_channel.channel_id.clone()),
+            is_bot: false,
+            timestamp: Some(chrono::Utc::now().to_rfc3339()),
+            message_id: Some(message_id.to_string()),
+            receiver_id: Some(bot_id.to_string()),
+        };
+
+        let dispatcher = self.dispatcher.clone();
+        let sender_id = sender.sender_id.clone();
+        let sender_name_clone = sender.sender_name.clone();
+        let sender_json = serde_json::to_string(&sender).unwrap();
+        let thread_key = dispatcher.key("discord", &thread_channel.channel_id, &sender_id);
+        let estimated_tokens = crate::dispatch::estimate_tokens(&prompt, &[]);
+        let buf_msg = crate::dispatch::BufferedMessage {
+            sender_json,
+            sender_name: sender_name_clone,
+            prompt,
+            extra_blocks: Vec::new(),
+            trigger_msg,
+            arrived_at: std::time::Instant::now(),
+            estimated_tokens,
+            other_bot_present: false,
+            recipient: None,
+        };
+
+        if let Err(e) = dispatcher
+            .submit(thread_key, thread_channel, adapter, buf_msg)
+            .await
+        {
+            error!("reaction equivalency dispatcher submit error: {e}");
+        }
     }
 
     async fn ready(&self, ctx: Context, ready: Ready) {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -925,9 +925,9 @@ impl EventHandler for Handler {
             _ => return, // custom emojis not supported
         };
 
-        // Look up equivalency mapping.
-        let equivalency = &self.router.reactions_config().equivalency;
-        let prompt = match equivalency.get(&emoji_str) {
+        // Look up mapping.
+        let mapping = &self.router.reactions_config().mapping;
+        let prompt = match mapping.get(&emoji_str) {
             Some(text) => text.clone(),
             None => return, // emoji not mapped
         };

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -971,28 +971,23 @@ impl EventHandler for Handler {
 
         let channel_id = reaction.channel_id;
 
-        // allow_user_messages gating: reactions are only processed in threads
-        // where the bot is already involved (participated or owns the thread).
-        // This prevents reactions from pulling the bot into new conversations.
-        match self.allow_user_messages {
-            AllowUsers::Mentions => return,
-            AllowUsers::Involved | AllowUsers::MultibotMentions => {
-                let (involved, _) = self
-                    .bot_participated_in_thread(&ctx.http, channel_id, bot_id)
-                    .await;
-                if !involved {
-                    return;
-                }
-            }
+        // AllowUsers::Mentions means reactions cannot trigger (no @mention possible).
+        if self.allow_user_messages == AllowUsers::Mentions {
+            return;
         }
+
+        // Snapshot participation state before spawn (positive-only cache; safe to read early).
+        let bot_involved = {
+            let cache = self.participated_threads.lock().await;
+            cache.get(&channel_id.to_string())
+                .is_some_and(|ts| ts.elapsed() < self.session_ttl)
+        };
 
         let message_id = reaction.message_id;
         let allow_all_channels = self.allow_all_channels;
         let allowed_channels = self.allowed_channels.clone();
-        let multibot_threads = self.multibot_threads.lock().await
-            .contains_key(&channel_id.to_string());
-        let multibot_disk = self.multibot_cache.is_multibot(&channel_id.to_string());
-        let other_bot_present = multibot_threads || multibot_disk;
+        let allow_user_messages = self.allow_user_messages;
+        let multibot_cache = self.multibot_cache.clone();
         let dispatcher = self.dispatcher.clone();
         let ctl_registry = self.ctl_registry.clone();
         let http = ctx.http.clone();
@@ -1015,7 +1010,7 @@ impl EventHandler for Handler {
                 allow_all_channels || allowed_channels.contains(&channel_id.get());
 
             // Thread detection: match detect_thread() logic.
-            let thread_channel = match channel_id.to_channel(&http).await {
+            let (thread_channel, is_thread) = match channel_id.to_channel(&http).await {
                 Ok(serenity::model::channel::Channel::Guild(gc)) => {
                     if gc.thread_metadata.is_some() {
                         let parent = gc.parent_id.map(|p| p.get());
@@ -1025,28 +1020,44 @@ impl EventHandler for Handler {
                         if !in_allowed_thread {
                             return;
                         }
-                        ChannelRef {
+                        (ChannelRef {
                             platform: "discord".into(),
                             channel_id: channel_id.get().to_string(),
                             thread_id: None,
                             parent_id: parent.map(|p| p.to_string()),
                             origin_event_id: None,
-                        }
+                        }, true)
                     } else {
                         if !in_allowed_channel {
                             return;
                         }
-                        ChannelRef {
+                        (ChannelRef {
                             platform: "discord".into(),
                             channel_id: channel_id.get().to_string(),
                             thread_id: None,
                             parent_id: None,
                             origin_event_id: None,
-                        }
+                        }, false)
                     }
                 }
                 _ => return,
             };
+
+            // allow_user_messages gating (post thread-detection):
+            // In Involved/MultibotMentions mode, only respond in threads
+            // where the bot has participated. Non-thread channels are rejected.
+            match allow_user_messages {
+                AllowUsers::Mentions => return,
+                AllowUsers::Involved | AllowUsers::MultibotMentions => {
+                    if !is_thread || !bot_involved {
+                        return;
+                    }
+                }
+            }
+
+            // Check multibot state.
+            let other_bot_present =
+                multibot_cache.is_multibot(&channel_id.to_string());
 
             let trigger_msg = MessageRef {
                 channel: ChannelRef {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -969,125 +969,123 @@ impl EventHandler for Handler {
             .get_or_init(|| Arc::new(DiscordAdapter::new(ctx.http.clone())))
             .clone();
 
-        // Fetch user info for sender context.
-        let (sender_name, display_name, is_bot_confirmed) =
-            match user_id.to_user(&ctx.http).await {
-                Ok(user) => {
-                    let display = user.global_name.as_ref().unwrap_or(&user.name).clone();
-                    (user.name.clone(), display, user.bot)
-                }
-                Err(_) => {
-                    let fallback = user_id.to_string();
-                    (fallback.clone(), fallback, is_reactor_bot)
-                }
-            };
-
-        // Determine thread context from the reacted message's channel.
         let channel_id = reaction.channel_id;
-        let in_allowed_channel =
-            self.allow_all_channels || self.allowed_channels.contains(&channel_id.get());
+        let message_id = reaction.message_id;
+        let allow_all_channels = self.allow_all_channels;
+        let allowed_channels = self.allowed_channels.clone();
+        let multibot_threads = self.multibot_threads.lock().await
+            .contains_key(&channel_id.to_string());
+        let multibot_disk = self.multibot_cache.is_multibot(&channel_id.to_string());
+        let other_bot_present = multibot_threads || multibot_disk;
+        let dispatcher = self.dispatcher.clone();
+        let ctl_registry = self.ctl_registry.clone();
+        let http = ctx.http.clone();
 
-        // Thread detection: match detect_thread() logic — thread channel_id in
-        // allowlist OR parent in allowlist OR allow_all_channels.
-        let (thread_channel, _thread_parent_id) = match channel_id.to_channel(&ctx.http).await {
-            Ok(serenity::model::channel::Channel::Guild(gc)) => {
-                if gc.thread_metadata.is_some() {
-                    let parent = gc.parent_id.map(|p| p.get());
-                    let in_allowed_thread = in_allowed_channel
-                        || self.allow_all_channels
-                        || parent.is_some_and(|pid| self.allowed_channels.contains(&pid));
-                    if !in_allowed_thread {
-                        return;
+        tokio::spawn(async move {
+            // Fetch user info for sender context.
+            let (sender_name, display_name, is_bot_confirmed) =
+                match user_id.to_user(&http).await {
+                    Ok(user) => {
+                        let display = user.global_name.as_ref().unwrap_or(&user.name).clone();
+                        (user.name.clone(), display, user.bot)
                     }
-                    (
+                    Err(_) => {
+                        let fallback = user_id.to_string();
+                        (fallback.clone(), fallback, is_reactor_bot)
+                    }
+                };
+
+            let in_allowed_channel =
+                allow_all_channels || allowed_channels.contains(&channel_id.get());
+
+            // Thread detection: match detect_thread() logic.
+            let thread_channel = match channel_id.to_channel(&http).await {
+                Ok(serenity::model::channel::Channel::Guild(gc)) => {
+                    if gc.thread_metadata.is_some() {
+                        let parent = gc.parent_id.map(|p| p.get());
+                        let in_allowed_thread = in_allowed_channel
+                            || allow_all_channels
+                            || parent.is_some_and(|pid| allowed_channels.contains(&pid));
+                        if !in_allowed_thread {
+                            return;
+                        }
                         ChannelRef {
                             platform: "discord".into(),
                             channel_id: channel_id.get().to_string(),
                             thread_id: None,
                             parent_id: parent.map(|p| p.to_string()),
                             origin_event_id: None,
-                        },
-                        parent.map(|p| p.to_string()),
-                    )
-                } else {
-                    if !in_allowed_channel {
-                        return;
-                    }
-                    (
+                        }
+                    } else {
+                        if !in_allowed_channel {
+                            return;
+                        }
                         ChannelRef {
                             platform: "discord".into(),
                             channel_id: channel_id.get().to_string(),
                             thread_id: None,
                             parent_id: None,
                             origin_event_id: None,
-                        },
-                        None,
-                    )
+                        }
+                    }
                 }
+                _ => return,
+            };
+
+            let trigger_msg = MessageRef {
+                channel: ChannelRef {
+                    platform: "discord".into(),
+                    channel_id: channel_id.get().to_string(),
+                    thread_id: None,
+                    parent_id: None,
+                    origin_event_id: None,
+                },
+                message_id: message_id.to_string(),
+            };
+
+            let sender = SenderContext {
+                schema: "openab.sender.v1".into(),
+                sender_id: user_id.to_string(),
+                sender_name: sender_name.clone(),
+                display_name,
+                channel: "discord".into(),
+                channel_id: thread_channel
+                    .parent_id
+                    .as_deref()
+                    .unwrap_or(&thread_channel.channel_id)
+                    .to_string(),
+                thread_id: thread_channel.parent_id.as_ref().map(|_| thread_channel.channel_id.clone()),
+                is_bot: is_bot_confirmed,
+                timestamp: Some(chrono::Utc::now().to_rfc3339()),
+                message_id: Some(message_id.to_string()),
+                receiver_id: Some(bot_id.to_string()),
+            };
+
+            let sender_id = sender.sender_id.clone();
+            let sender_name_clone = sender.sender_name.clone();
+            let sender_json = serde_json::to_string(&sender).unwrap();
+            let thread_key = dispatcher.key("discord", &thread_channel.channel_id, &sender_id);
+            let estimated_tokens = crate::dispatch::estimate_tokens(&prompt, &[]);
+            let buf_msg = crate::dispatch::BufferedMessage {
+                sender_json,
+                sender_name: sender_name_clone,
+                prompt,
+                extra_blocks: Vec::new(),
+                trigger_msg,
+                arrived_at: std::time::Instant::now(),
+                estimated_tokens,
+                other_bot_present,
+                recipient: None,
+            };
+
+            crate::ctl::register_thread(&ctl_registry, &thread_channel.channel_id, "discord").await;
+            if let Err(e) = dispatcher
+                .submit(thread_key, thread_channel, adapter, buf_msg)
+                .await
+            {
+                error!("reaction mapping dispatcher submit error: {e}");
             }
-            _ => return, // DM or unknown channel — not supported
-        };
-
-        // Check multibot state for this thread (consistent with message handler).
-        let other_bot_present = {
-            let cache = self.multibot_threads.lock().await;
-            cache.contains_key(&channel_id.to_string())
-        } || self.multibot_cache.is_multibot(&channel_id.to_string());
-
-        let message_id = reaction.message_id;
-        let trigger_msg = MessageRef {
-            channel: ChannelRef {
-                platform: "discord".into(),
-                channel_id: channel_id.get().to_string(),
-                thread_id: None,
-                parent_id: None,
-                origin_event_id: None,
-            },
-            message_id: message_id.to_string(),
-        };
-
-        let sender = SenderContext {
-            schema: "openab.sender.v1".into(),
-            sender_id: user_id.to_string(),
-            sender_name: sender_name.clone(),
-            display_name,
-            channel: "discord".into(),
-            channel_id: thread_channel
-                .parent_id
-                .as_deref()
-                .unwrap_or(&thread_channel.channel_id)
-                .to_string(),
-            thread_id: thread_channel.parent_id.as_ref().map(|_| thread_channel.channel_id.clone()),
-            is_bot: is_bot_confirmed,
-            timestamp: Some(chrono::Utc::now().to_rfc3339()),
-            message_id: Some(message_id.to_string()),
-            receiver_id: Some(bot_id.to_string()),
-        };
-
-        let dispatcher = self.dispatcher.clone();
-        let sender_id = sender.sender_id.clone();
-        let sender_name_clone = sender.sender_name.clone();
-        let sender_json = serde_json::to_string(&sender).unwrap();
-        let thread_key = dispatcher.key("discord", &thread_channel.channel_id, &sender_id);
-        let estimated_tokens = crate::dispatch::estimate_tokens(&prompt, &[]);
-        let buf_msg = crate::dispatch::BufferedMessage {
-            sender_json,
-            sender_name: sender_name_clone,
-            prompt,
-            extra_blocks: Vec::new(),
-            trigger_msg,
-            arrived_at: std::time::Instant::now(),
-            estimated_tokens,
-            other_bot_present,
-            recipient: None,
-        };
-
-        if let Err(e) = dispatcher
-            .submit(thread_key, thread_channel, adapter, buf_msg)
-            .await
-        {
-            error!("reaction mapping dispatcher submit error: {e}");
-        }
+        });
     }
 
     async fn ready(&self, ctx: Context, ready: Ready) {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -970,6 +970,22 @@ impl EventHandler for Handler {
             .clone();
 
         let channel_id = reaction.channel_id;
+
+        // allow_user_messages gating: reactions are only processed in threads
+        // where the bot is already involved (participated or owns the thread).
+        // This prevents reactions from pulling the bot into new conversations.
+        match self.allow_user_messages {
+            AllowUsers::Mentions => return,
+            AllowUsers::Involved | AllowUsers::MultibotMentions => {
+                let (involved, _) = self
+                    .bot_participated_in_thread(&ctx.http, channel_id, bot_id)
+                    .await;
+                if !involved {
+                    return;
+                }
+            }
+        }
+
         let message_id = reaction.message_id;
         let allow_all_channels = self.allow_all_channels;
         let allowed_channels = self.allowed_channels.clone();

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1017,6 +1017,12 @@ impl EventHandler for Handler {
                     }
                 };
 
+            // Defense-in-depth: if to_user() reveals this is a bot but member was
+            // None (rare edge case), re-apply bot gating retroactively.
+            if is_bot_confirmed && !is_reactor_bot {
+                return;
+            }
+
             let in_allowed_channel =
                 allow_all_channels || allowed_channels.contains(&channel_id.get());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -588,7 +588,8 @@ async fn main() -> anyhow::Result<()> {
         let intents = GatewayIntents::GUILD_MESSAGES
             | GatewayIntents::MESSAGE_CONTENT
             | GatewayIntents::GUILDS
-            | GatewayIntents::DIRECT_MESSAGES;
+            | GatewayIntents::DIRECT_MESSAGES
+            | GatewayIntents::GUILD_MESSAGE_REACTIONS;
 
         let mut client = Client::builder(&discord_cfg.bot_token, intents)
             .event_handler(handler)


### PR DESCRIPTION
## Summary

Implements #1148 — map user emoji reactions to text commands via `[reactions.mapping]` config.

When a user reacts with a configured emoji on a message in a monitored thread where the bot is involved, OAB treats it as if they sent the corresponding text message, dispatching through the normal pipeline.

## Changes

- **src/config.rs**: Add `mapping: HashMap<String, String>` to `ReactionsConfig`; resolve shortcodes at load time
- **src/discord.rs**: Implement `reaction_add()` in `EventHandler` with full gating parity
- **src/main.rs**: Add `GUILD_MESSAGE_REACTIONS` gateway intent
- **Cargo.toml**: Add `emojis` crate for shortcode → unicode resolution
- **config.toml.example**: Add commented example with shortcode syntax
- **docs/config-reference.md**: Document the new `[reactions.mapping]` section
- **docs/reactions.md**: Dedicated feature documentation

## Config Example

```toml
[reactions.mapping]
"👍" = "OK"
":thumbsdown:" = "不行"
":arrows_counterclockwise:" = "重新 review"
":white_check_mark:" = "approve"
```

Keys support both unicode emoji and Discord/GitHub shortcodes (`:name:` syntax).

## Gating (full parity with message() handler)

- `is_denied_user()` — user allowlist enforced
- `allow_bot_messages` — Off/Mentions reject; All checks `trusted_bot_ids`
- `allow_user_messages` — Mentions disables reactions; Involved/MultibotMentions require bot participation; MultibotMentions rejects in multibot threads
- Bot self-reaction ignored + defense-in-depth re-check after `to_user()`
- Only unicode emoji (custom server emoji ignored with debug log)
- Channel/thread ACL matches `detect_thread()` logic
- `other_bot_present` from multibot cache
- `ctl::register_thread` called
- All API work in `tokio::spawn` (non-blocking gateway)

## Review

5/5 法師 approved across 3 review rounds. 14 findings identified and resolved.

Closes #1148