### PR TITLE
refactor(slack): extract allow-list source behind AllowListSource trait

### DIFF
--- a/src/allow_list.rs
+++ b/src/allow_list.rs
@@ -1,0 +1,106 @@
+//! Pluggable source for the per-platform "allow-list" of user IDs.
+//!
+//! The default in-tree implementation is [`StaticAllowList`], which wraps the
+//! static set produced from a platform's `allowed_users` config field.
+//! Downstream forks may provide alternative implementations (e.g. a
+//! file-watching impl that mirrors an IdP group) without modifying the
+//! gate-check call sites in the adapters.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// Provides the current set of user IDs allowed to interact with the bot.
+///
+/// Implementations must be cheap to call repeatedly: the dispatch path calls
+/// [`AllowListSource::allowed_users`] once per inbound message. Returning an
+/// `Arc<HashSet<String>>` lets implementations that hot-swap the underlying
+/// set (e.g. via `arc_swap`) hand out a consistent snapshot to each caller
+/// without taking a lock on the read path.
+pub trait AllowListSource: Send + Sync {
+    /// Returns a snapshot of the currently-allowed user IDs.
+    fn allowed_users(&self) -> Arc<HashSet<String>>;
+}
+
+/// In-tree default implementation: wraps a fixed set loaded once at startup
+/// from configuration. Snapshots share a single `Arc`-backed allocation, so
+/// the read path is allocation-free.
+pub struct StaticAllowList {
+    users: Arc<HashSet<String>>,
+}
+
+impl StaticAllowList {
+    pub fn new(users: HashSet<String>) -> Self {
+        Self {
+            users: Arc::new(users),
+        }
+    }
+}
+
+impl AllowListSource for StaticAllowList {
+    fn allowed_users(&self) -> Arc<HashSet<String>> {
+        Arc::clone(&self.users)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_round_trips_input() {
+        let input: HashSet<String> = ["U1", "U2"].iter().map(|s| s.to_string()).collect();
+        let source = StaticAllowList::new(input.clone());
+        assert_eq!(*source.allowed_users(), input);
+    }
+
+    #[test]
+    fn static_snapshots_share_allocation() {
+        let input: HashSet<String> = ["U1"].iter().map(|s| s.to_string()).collect();
+        let source = StaticAllowList::new(input);
+        let a = source.allowed_users();
+        let b = source.allowed_users();
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    /// Mock impl proving the seam supports downstream impls that swap the
+    /// underlying set at runtime. Mutex-guarded for test simplicity; a real
+    /// hot-reload impl would use `arc_swap::ArcSwap`.
+    struct SwappableSource {
+        inner: std::sync::Mutex<Arc<HashSet<String>>>,
+    }
+
+    impl SwappableSource {
+        fn new(initial: HashSet<String>) -> Self {
+            Self {
+                inner: std::sync::Mutex::new(Arc::new(initial)),
+            }
+        }
+
+        fn swap(&self, next: HashSet<String>) {
+            *self.inner.lock().unwrap() = Arc::new(next);
+        }
+    }
+
+    impl AllowListSource for SwappableSource {
+        fn allowed_users(&self) -> Arc<HashSet<String>> {
+            Arc::clone(&self.inner.lock().unwrap())
+        }
+    }
+
+    #[test]
+    fn custom_source_can_hot_swap_through_trait_object() {
+        let initial: HashSet<String> = ["U1"].iter().map(|s| s.to_string()).collect();
+        let typed = Arc::new(SwappableSource::new(initial));
+        let dyn_source: Arc<dyn AllowListSource> = typed.clone();
+
+        let before = dyn_source.allowed_users();
+        assert!(before.contains("U1"));
+
+        let next: HashSet<String> = ["U2"].iter().map(|s| s.to_string()).collect();
+        typed.swap(next);
+
+        let after = dyn_source.allowed_users();
+        assert!(after.contains("U2"));
+        assert!(!after.contains("U1"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod acp;
 mod adapter;
+mod allow_list;
 mod bot_turns;
 mod config;
 mod cron;
@@ -382,6 +383,10 @@ async fn main() -> anyhow::Result<()> {
         ));
         dispatchers.lock().unwrap().push(slack_dispatcher.clone());
         let slack_ctl_registry = ctl_registry.clone();
+        let slack_allow_list: Arc<dyn allow_list::AllowListSource> =
+            Arc::new(allow_list::StaticAllowList::new(
+                slack_cfg.allowed_users.into_iter().collect(),
+            ));
         Some(tokio::spawn(async move {
             if let Err(e) = slack::run_slack_adapter(
                 adapter,
@@ -389,7 +394,7 @@ async fn main() -> anyhow::Result<()> {
                 allow_all_channels,
                 allow_all_users,
                 slack_cfg.allowed_channels.into_iter().collect(),
-                slack_cfg.allowed_users.into_iter().collect(),
+                slack_allow_list,
                 slack_cfg.allow_bot_messages,
                 slack_cfg.trusted_bot_ids.into_iter().collect(),
                 slack_cfg.allow_user_messages,

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,5 +1,6 @@
 use crate::acp::ContentBlock;
 use crate::adapter::{ChannelRef, ChatAdapter, MessageRef, SenderContext};
+use crate::allow_list::AllowListSource;
 use crate::bot_turns::{BotTurnTracker, TurnAction, TurnSeverity};
 use crate::config::{AllowBots, AllowUsers, SttConfig};
 use crate::media;
@@ -712,7 +713,7 @@ pub async fn run_slack_adapter(
     allow_all_channels: bool,
     allow_all_users: bool,
     allowed_channels: HashSet<String>,
-    allowed_users: HashSet<String>,
+    allowed_users: Arc<dyn AllowListSource>,
     allow_bot_messages: AllowBots,
     trusted_bot_ids: HashSet<String>,
     allow_user_messages: AllowUsers,
@@ -827,7 +828,7 @@ pub async fn run_slack_adapter(
                                                 let adapter = adapter.clone();
                                                 let bot_token = bot_token.clone();
                                                 let allowed_channels = allowed_channels.clone();
-                                                let allowed_users = allowed_users.clone();
+                                                let allowed_users = allowed_users.allowed_users();
                                                 let stt_config = stt_config.clone();
                                                 let dispatcher = dispatcher.clone();
                                                 let ctl_registry = ctl_registry.clone();
@@ -1080,7 +1081,7 @@ pub async fn run_slack_adapter(
                                                 let adapter = adapter.clone();
                                                 let bot_token = bot_token.clone();
                                                 let allowed_channels = allowed_channels.clone();
-                                                let allowed_users = allowed_users.clone();
+                                                let allowed_users = allowed_users.allowed_users();
                                                 let stt_config = stt_config.clone();
                                                 let dispatcher = dispatcher.clone();
                                                 let ctl_registry = ctl_registry.clone();


### PR DESCRIPTION
## Summary

- Extracts the Slack allow-list source into a small `AllowListSource` trait (`src/allow_list.rs`)
- In-tree default `StaticAllowList` wraps `[slack].allowed_users` — **behaviour-preserving refactor**
- `src/slack.rs::run_slack_adapter` takes `Arc<dyn AllowListSource>` instead of bare `HashSet<String>`
- Each dispatch captures a snapshot via `.allowed_users()` → `Arc<HashSet<String>>`, lock-free on the read path
- Downstream forks can plug in alternative implementations (file-watching, IdP sync, etc.) without modifying gate-check call sites

## Context

This PR **supersedes #1109** (sync-feature for `[slack].allowed_users` in core). Per [Discord discussion on 2026-06-16](https://discord.com/channels/1491295327620169908/1491365157010542652/1516379532246908998), the consensus is to keep openab core IdP-agnostic and provide a clean extension point so downstream forks can add IdP-aware sources themselves.

@pahud-nodejs approved the trait-only refactor direction: 「完全合理，來吧！這很好！」

The actual IdP-sync implementation (e.g. Okta Groups → file → hot-reload) lives in downstream forks; openab core only commits to the trait shape.

## File changes

| File | Change |
|---|---|
| `src/allow_list.rs` (new) | Trait + `StaticAllowList` default + 3 unit tests (round-trip, snapshot Arc-sharing, hot-swap through `dyn` dispatch via a mock impl) |
| `src/main.rs` | `mod allow_list;`; wrap config-loaded HashSet in `StaticAllowList` before passing to `run_slack_adapter` |
| `src/slack.rs` | `run_slack_adapter` parameter type change; `use crate::allow_list::AllowListSource;`; two spawn-site preambles resolve `.allowed_users()` to a snapshot before dispatch |

Net: ~14 lines changed in existing files + ~110 lines of new module (mostly tests). No behaviour change.

## Scope

- **Slack only.** `discord` and `gateway` adapters continue to take bare `HashSet<String>` and may adopt the trait in follow-ups if their communities want it.
- **No new config fields.** TOML schema unchanged.
- **No new dependencies.**

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test --bin openab allow_list` — 3/3 passing
- [x] `cargo test --bin openab` — 512 passing; one pre-existing failure (`secrets::tests::resolve_exec_nonzero_exit`) also fails on clean `upstream/main`, unrelated to this PR
- [x] `cargo clippy --bin openab -- -D warnings` — clean
- [x] `cargo fmt --check` — formatting diff reported is on a pre-existing line (`socket_idle` test, `src/slack.rs:~2332`) that also reproduces on clean `upstream/main`; not introduced here

## Out of scope (follow-ups)

- File-watching / IdP-sync implementation of `AllowListSource` — lives in downstream forks
- Same trait pattern for `[discord].allowed_users` / `[gateway].allowed_users`
- Same pattern for `allowed_channels` / `trusted_bot_ids`

Closes #1109 (superseded by this trait-only direction)
