### PR TITLE
ci: add Snapshot Build workflow (parallel matrix)

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -1,0 +1,158 @@
+name: Snapshot Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build (default: main)'
+        required: false
+        type: string
+        default: 'main'
+      variant:
+        description: 'Dockerfile variant'
+        required: false
+        type: choice
+        options:
+          - default
+          - agentcore
+          - antigravity
+          - claude
+          - codex
+          - copilot
+          - cursor
+          - gemini
+          - grok
+          - hermes
+          - mimocode
+          - native
+          - opencode
+          - pi
+        default: 'default'
+      tag:
+        description: 'Image tag (default: snapshot-<short-sha>)'
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      dockerfile: ${{ steps.df.outputs.file }}
+      suffix: ${{ steps.df.outputs.suffix }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Resolve Dockerfile
+        id: df
+        run: |
+          if [ "${{ inputs.variant }}" = "default" ]; then
+            echo "file=Dockerfile" >> "$GITHUB_OUTPUT"
+            echo "suffix=" >> "$GITHUB_OUTPUT"
+          else
+            echo "file=Dockerfile.${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
+            echo "suffix=-${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            SHA=$(git rev-parse --short HEAD)
+            echo "tag=snapshot-${SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: resolve
+    strategy:
+      matrix:
+        platform:
+          - { os: linux/amd64, runner: ubuntu-latest }
+          - { os: linux/arm64, runner: ubuntu-24.04-arm }
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ needs.resolve.outputs.dockerfile }}
+          platforms: ${{ matrix.platform.os }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ needs.resolve.outputs.suffix }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=snapshot-${{ inputs.variant }}-${{ matrix.platform.os }}
+          cache-to: type=gha,scope=snapshot-${{ inputs.variant }}-${{ matrix.platform.os }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform.runner }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  merge:
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ needs.resolve.outputs.suffix }}"
+          docker buildx imagetools create \
+            -t "${IMAGE}:${{ needs.resolve.outputs.tag }}" \
+            $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
+
+      - name: Summary
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ needs.resolve.outputs.suffix }}"
+          echo "### 📦 Snapshot Image Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`${IMAGE}:${{ needs.resolve.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch: \`${{ inputs.branch }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Variant: \`${{ inputs.variant }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -8,26 +8,11 @@ on:
         required: false
         type: string
         default: 'main'
-      variant:
-        description: 'Dockerfile variant'
+      variants:
+        description: 'Variants to build (comma-separated, or "all")'
         required: false
-        type: choice
-        options:
-          - default
-          - agentcore
-          - antigravity
-          - claude
-          - codex
-          - copilot
-          - cursor
-          - gemini
-          - grok
-          - hermes
-          - mimocode
-          - native
-          - opencode
-          - pi
-        default: 'default'
+        type: string
+        default: 'all'
       tag:
         description: 'Image tag (default: snapshot-<short-sha>)'
         required: false
@@ -36,33 +21,33 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  ALL_VARIANTS: 'default,agentcore,antigravity,claude,codex,copilot,cursor,gemini,grok,hermes,mimocode,native,opencode,pi'
 
 jobs:
-  resolve:
+  matrix:
     runs-on: ubuntu-latest
     outputs:
-      dockerfile: ${{ steps.df.outputs.file }}
-      suffix: ${{ steps.df.outputs.suffix }}
-      tag: ${{ steps.tag.outputs.tag }}
+      variants: ${{ steps.resolve.outputs.variants }}
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
-      - name: Resolve Dockerfile
-        id: df
+      - name: Resolve matrix and tag
+        id: resolve
         run: |
-          if [ "${{ inputs.variant }}" = "default" ]; then
-            echo "file=Dockerfile" >> "$GITHUB_OUTPUT"
-            echo "suffix=" >> "$GITHUB_OUTPUT"
+          # Resolve variants
+          if [ "${{ inputs.variants }}" = "all" ] || [ -z "${{ inputs.variants }}" ]; then
+            VARIANTS="${{ env.ALL_VARIANTS }}"
           else
-            echo "file=Dockerfile.${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
-            echo "suffix=-${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
+            VARIANTS="${{ inputs.variants }}"
           fi
+          # Convert to JSON array
+          JSON=$(echo "$VARIANTS" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R . | jq -sc .)
+          echo "variants=${JSON}" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve tag
-        id: tag
-        run: |
+          # Resolve tag
           if [ -n "${{ inputs.tag }}" ]; then
             echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
           else
@@ -71,9 +56,11 @@ jobs:
           fi
 
   build:
-    needs: resolve
+    needs: matrix
     strategy:
+      fail-fast: false
       matrix:
+        variant: ${{ fromJson(needs.matrix.outputs.variants) }}
         platform:
           - { os: linux/amd64, runner: ubuntu-latest }
           - { os: linux/arm64, runner: ubuntu-24.04-arm }
@@ -94,16 +81,27 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve Dockerfile
+        id: df
+        run: |
+          if [ "${{ matrix.variant }}" = "default" ]; then
+            echo "file=Dockerfile" >> "$GITHUB_OUTPUT"
+            echo "suffix=" >> "$GITHUB_OUTPUT"
+          else
+            echo "file=Dockerfile.${{ matrix.variant }}" >> "$GITHUB_OUTPUT"
+            echo "suffix=-${{ matrix.variant }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ${{ needs.resolve.outputs.dockerfile }}
+          file: ${{ steps.df.outputs.file }}
           platforms: ${{ matrix.platform.os }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ needs.resolve.outputs.suffix }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=snapshot-${{ inputs.variant }}-${{ matrix.platform.os }}
-          cache-to: type=gha,scope=snapshot-${{ inputs.variant }}-${{ matrix.platform.os }},mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ steps.df.outputs.suffix }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=snapshot-${{ matrix.variant }}-${{ matrix.platform.os }}
+          cache-to: type=gha,scope=snapshot-${{ matrix.variant }}-${{ matrix.platform.os }},mode=max
 
       - name: Export digest
         run: |
@@ -114,22 +112,34 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.platform.runner }}
+          name: digests-${{ matrix.variant }}-${{ matrix.platform.runner }}
           path: /tmp/digests/*
           retention-days: 1
 
   merge:
-    needs: [resolve, build]
+    needs: [matrix, build]
+    strategy:
+      matrix:
+        variant: ${{ fromJson(needs.matrix.outputs.variants) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
+      - name: Resolve suffix
+        id: df
+        run: |
+          if [ "${{ matrix.variant }}" = "default" ]; then
+            echo "suffix=" >> "$GITHUB_OUTPUT"
+          else
+            echo "suffix=-${{ matrix.variant }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ matrix.variant }}-*
           merge-multiple: true
 
       - uses: docker/setup-buildx-action@v3
@@ -142,17 +152,12 @@ jobs:
 
       - name: Create manifest list
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ needs.resolve.outputs.suffix }}"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ steps.df.outputs.suffix }}"
           docker buildx imagetools create \
-            -t "${IMAGE}:${{ needs.resolve.outputs.tag }}" \
+            -t "${IMAGE}:${{ needs.matrix.outputs.tag }}" \
             $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
 
       - name: Summary
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ needs.resolve.outputs.suffix }}"
-          echo "### 📦 Snapshot Image Published" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`${IMAGE}:${{ needs.resolve.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Branch: \`${{ inputs.branch }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Variant: \`${{ inputs.variant }}\`" >> "$GITHUB_STEP_SUMMARY"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ steps.df.outputs.suffix }}"
+          echo "### 📦 \`${IMAGE}:${{ needs.matrix.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` workflow to build any branch × all variants in parallel without bumping the beta tag.

## Inputs

| Input | Default | Description |
|-------|---------|-------------|
| `branch` | `main` | Branch to build |
| `variants` | `all` | Comma-separated list or `all` for full matrix |
| `tag` | `snapshot-<sha>` | Custom image tag (optional) |

## Usage

```bash
# Build ALL 14 variants from main in parallel
gh workflow run snapshot-build.yml -f branch=main -f tag=pre-beta

# Build specific variants only
gh workflow run snapshot-build.yml -f branch=main -f variants=kiro,claude,codex -f tag=pre-beta

# Single variant
gh workflow run snapshot-build.yml -f branch=main -f variants=claude -f tag=test
```

## Architecture

- 14 variants × 2 platforms (amd64 + arm64) = up to 28 parallel build jobs
- Per-variant manifest merge produces multi-arch images
- `fail-fast: false` — one variant failure doesn't cancel others
- GHA cache scoped per variant + platform

## Why

Need a way to build images from `main` for pre-beta testing without promoting to beta. PR Preview requires a PR number; Release PR bumps the version. This fills the gap.