### PR TITLE
feat(oabctl): ecsctl integration + manifest v2 + OABFleet

### DIFF
--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -13,6 +13,7 @@ aws-config = "1.5"
 aws-sdk-ecs = "1.53"
 aws-sdk-s3 = "1.65"
 aws-sdk-ssm = "1.52"
+ecsctl = { git = "https://github.com/oablab/ecsctl.git", branch = "master" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -13,7 +13,7 @@ aws-config = "1.5"
 aws-sdk-ecs = "1.53"
 aws-sdk-s3 = "1.65"
 aws-sdk-ssm = "1.52"
-ecsctl = { git = "https://github.com/oablab/ecsctl.git", branch = "master" }
+ecsctl = { git = "https://github.com/oablab/ecsctl.git", rev = "90a6cd1" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/operator/README.md
+++ b/operator/README.md
@@ -32,7 +32,7 @@ oabctl delete oabservice kiro-01 --cluster default --namespace prod
 ## Manifest Schema
 
 ```yaml
-apiVersion: oab.dev/v1
+apiVersion: oab.dev/v2
 kind: OABService
 metadata:
   name: kiro-01
@@ -73,7 +73,7 @@ spec:
 
 ## JSON Schema
 
-The manifest schema is defined in [`schema/oabservice-v1.json`](schema/oabservice-v1.json) for IDE validation.
+The manifest schema is defined in [`schema/oabservice-v2.json`](schema/oabservice-v2.json) for IDE validation.
 
 ## Commands
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -102,6 +102,10 @@ spec:
 
 Each agent inherits from `template` and can override: `image`, `resources`, `bootstrapFrom`, `secrets`.
 
+**Notes:**
+- `runtime` is shared across all agents in a fleet (not overridable per-agent)
+- `${name}` is interpolated in `configFrom`, `bootstrapFrom`, and secret values (replaced with agent name)
+
 ## JSON Schema
 
 The manifest schema is defined in [`schema/oabservice-v2.json`](schema/oabservice-v2.json) for IDE validation.

--- a/operator/README.md
+++ b/operator/README.md
@@ -75,6 +75,20 @@ spec:
 
 The manifest schema is defined in [`schema/oabservice-v2.json`](schema/oabservice-v2.json) for IDE validation.
 
+## State Store
+
+`oabctl` uses an S3 bucket as its control plane state store (similar to Terraform's S3 backend):
+
+```
+s3://<bucket>/
+  manifests/{namespace}/{name}.yaml   ← desired state (generation tracked)
+```
+
+- **Default bucket:** `oab-control-plane`
+- **Override:** set `OAB_CONTROL_PLANE_BUCKET` env var
+- Each `oabctl apply` increments the `generation` counter in the stored manifest
+- This enables drift detection and rollback tracking in future versions
+
 ## Commands
 
 | Command | Description |

--- a/operator/README.md
+++ b/operator/README.md
@@ -1,6 +1,6 @@
-# oabctl — OAB Agent Provisioner for ECS
+# oabctl — OAB Agent Provisioner
 
-CLI tool that provisions and manages OpenAB agents on Amazon ECS Fargate.
+CLI tool that provisions and manages OpenAB agents on Amazon ECS Fargate (with Kubernetes support planned).
 
 ## Quick Start
 
@@ -14,18 +14,20 @@ oabctl apply -f examples/kiro-01.yaml
 # List running agents
 oabctl get oabservice
 
+# Shell into an agent
+oabctl exec kiro-01 -- bash
+
+# Copy files
+oabctl cp model.bin kiro-01:/data/
+oabctl cp kiro-01:/logs/out.log ./
+
+# Sync directories (bidirectional)
+oabctl sync ./config kiro-01:/app/config/
+oabctl sync kiro-01:/data/ ./backup/
+
 # Delete an agent
 oabctl delete oabservice kiro-01 --cluster default --namespace prod
 ```
-
-## Prerequisites
-
-1. **AWS credentials** — IAM role/profile with permissions for ECS, SSM, S3
-2. **S3 bucket** — `oab-control-plane` (manifests + rendered config)
-3. **ECS cluster** — default cluster or specify with `--cluster`
-4. **VPC** — subnets + security groups for Fargate tasks
-5. **ECR image** — OAB container image pushed to ECR
-6. **SSM parameters** — bot tokens stored at `/oab/{namespace}/{name}/discord-token`
 
 ## Manifest Schema
 
@@ -36,31 +38,42 @@ metadata:
   name: kiro-01
   namespace: prod
 spec:
-  capacityProvider: FARGATE_SPOT   # FARGATE or FARGATE_SPOT
-  cpu: 256                         # vCPU units
-  memory: 512                      # MB
-  taskDefinition:
-    image: <ecr-image-uri>
-  bootstrapFrom: s3://...          # agent HOME archive (memory, state)
-  networking:
-    subnets: [subnet-xxx]
-    securityGroups: [sg-xxx]
+  image: <ecr-image-uri>
+  resources:
+    cpu: "256"          # vCPU units
+    memory: "512"       # MB
+  configFrom: s3://...  # agent config.toml (external)
+  bootstrapFrom: s3://... # agent HOME archive (memory, state)
   secrets:
-    - name: DISCORD_TOKEN
-      valueFrom: /oab/prod/kiro-01/discord-token
-  config:
-    channels:
-      - type: discord
-    backend:
-      type: bedrock
-      model_id: anthropic.claude-sonnet-4-20250514
-      region: us-east-1
-    steering:
-      system_prompt: "..."
-    features:
-      stt: false
-      cronjob: true
+    DISCORD_TOKEN: /oab/prod/kiro-01/discord-token
+  runtime:
+    type: ecs           # or: kubernetes
+    capacityProvider: FARGATE_SPOT
+    networking:
+      subnets: [subnet-xxx]
+      securityGroups: [sg-xxx]
 ```
+
+### Design Principles
+
+- **Manifest = infra desired state** — what image, how much CPU, where to run
+- **Agent config is external** — `configFrom` points to a `config.toml` managed separately
+- **Runtime-agnostic spec** — same `image`, `resources`, `secrets` regardless of ECS or K8S
+- **Runtime-specific block** — networking, capacity provider, node selectors live under `runtime`
+
+### Kubernetes Runtime (planned)
+
+```yaml
+  runtime:
+    type: kubernetes
+    nodeSelector:
+      workload: agents
+    serviceAccount: oab-agent
+```
+
+## JSON Schema
+
+The manifest schema is defined in [`schema/oabservice-v1.json`](schema/oabservice-v1.json) for IDE validation.
 
 ## Commands
 
@@ -69,15 +82,23 @@ spec:
 | `oabctl apply -f <file\|dir>` | Create or update agents from manifests |
 | `oabctl get oabservice [name]` | List agents and their ECS status |
 | `oabctl delete oabservice <name>` | Teardown agent (ECS + S3 cleanup) |
+| `oabctl exec <agent> -- <cmd>` | Execute command in agent container |
+| `oabctl cp <src> <dst>` | Copy files to/from agent containers |
+| `oabctl sync <src> <dst>` | Sync directories (bidirectional) |
+
+## Prerequisites
+
+1. **AWS credentials** — IAM role/profile with ECS, SSM, S3 permissions
+2. **S3 bucket** — `oab-control-plane` (manifests + config)
+3. **ECS cluster** — default cluster or specify with `--cluster`
+4. **VPC** — subnets + security groups for Fargate tasks
+5. **ECR image** — OAB container image pushed to ECR
+6. **SSM parameters** — bot tokens stored at paths referenced in `secrets`
+7. **Container requirements** — `curl` or `wget` (+ `tar` for sync)
 
 ## How It Works
 
-1. `oabctl apply` validates the manifest, renders `config.toml` from `spec.config`, uploads to S3 at an immutable path (`config/{ns}/{name}/{generation}/`), registers an ECS task definition, and creates/updates the ECS service.
-
-2. ECS maintains the desired state — restarts failed tasks, handles rolling deployments. No separate controller needed.
-
-3. On task startup, `entrypoint.sh` downloads the bootstrap archive and rendered config from S3, then starts OpenAB.
-
-## Architecture
-
-See [ADR: ECS Control Plane](../docs/adr/ecs-control-plane.md) for the full design.
+1. `oabctl apply` validates the manifest, uploads to S3, registers an ECS task definition, and creates/updates the ECS service.
+2. ECS maintains the desired state — restarts failed tasks, handles rolling deployments.
+3. On task startup, `entrypoint.sh` downloads the bootstrap archive and config from S3, then starts OpenAB.
+4. `exec`/`cp`/`sync` use the `ecsctl` library for container operations via ECS Exec + S3 presigned URLs.

--- a/operator/README.md
+++ b/operator/README.md
@@ -71,6 +71,37 @@ spec:
     serviceAccount: oab-agent
 ```
 
+### Fleet Manifest
+
+Deploy multiple agents from a single file using `OABFleet`:
+
+```yaml
+apiVersion: oab.dev/v2
+kind: OABFleet
+metadata:
+  name: law-shi-team
+  namespace: prod
+spec:
+  template:
+    image: <ecr-image-uri>
+    resources: { cpu: "256", memory: "512" }
+    runtime:
+      type: ecs
+      capacityProvider: FARGATE_SPOT
+      networking: { subnets: [...], securityGroups: [...] }
+  agents:
+    - name: chaodu
+      configFrom: s3://.../chaodu/config.toml
+    - name: pudu
+      configFrom: s3://.../pudu/config.toml
+    - name: openclaw
+      configFrom: s3://.../openclaw/config.toml
+      image: <different-image>        # override template
+      resources: { cpu: "1024", memory: "2048" }  # override
+```
+
+Each agent inherits from `template` and can override: `image`, `resources`, `bootstrapFrom`, `secrets`.
+
 ## JSON Schema
 
 The manifest schema is defined in [`schema/oabservice-v2.json`](schema/oabservice-v2.json) for IDE validation.

--- a/operator/README.md
+++ b/operator/README.md
@@ -89,7 +89,7 @@ The manifest schema is defined in [`schema/oabservice-v2.json`](schema/oabservic
 ## Prerequisites
 
 1. **AWS credentials** — IAM role/profile with ECS, SSM, S3 permissions
-2. **S3 bucket** — `oab-control-plane` (manifests + config)
+2. **S3 bucket** — `oab-control-plane` (or set `OAB_CONTROL_PLANE_BUCKET` env var)
 3. **ECS cluster** — default cluster or specify with `--cluster`
 4. **VPC** — subnets + security groups for Fargate tasks
 5. **ECR image** — OAB container image pushed to ECR

--- a/operator/examples/fleet.yaml
+++ b/operator/examples/fleet.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=../schema/oabservice-v2.json
+apiVersion: oab.dev/v2
+kind: OABFleet
+metadata:
+  name: law-shi-team
+  namespace: prod
+spec:
+  template:
+    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
+    resources:
+      cpu: "256"
+      memory: "512"
+    secrets:
+      DISCORD_TOKEN: /oab/prod/${name}/discord-token
+    runtime:
+      type: ecs
+      capacityProvider: FARGATE_SPOT
+      networking:
+        subnets: [subnet-aaa, subnet-bbb]
+        securityGroups: [sg-oab]
+  agents:
+    - name: chaodu
+      configFrom: s3://oab-control-plane/config/prod/chaodu/config.toml
+    - name: pudu
+      configFrom: s3://oab-control-plane/config/prod/pudu/config.toml
+    - name: baidu
+      configFrom: s3://oab-control-plane/config/prod/baidu/config.toml
+    - name: juedu
+      configFrom: s3://oab-control-plane/config/prod/juedu/config.toml
+    - name: koudu
+      configFrom: s3://oab-control-plane/config/prod/koudu/config.toml
+    - name: xdu
+      configFrom: s3://oab-control-plane/config/prod/xdu/config.toml
+    - name: zdu
+      configFrom: s3://oab-control-plane/config/prod/zdu/config.toml
+    - name: kiro-01
+      configFrom: s3://oab-control-plane/config/prod/kiro-01/config.toml
+    - name: kiro-02
+      configFrom: s3://oab-control-plane/config/prod/kiro-02/config.toml
+      resources:
+        cpu: "512"
+        memory: "1024"
+    - name: openclaw
+      configFrom: s3://oab-control-plane/config/prod/openclaw/config.toml
+      image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openclaw:latest
+      resources:
+        cpu: "1024"
+        memory: "2048"

--- a/operator/examples/kiro-01.yaml
+++ b/operator/examples/kiro-01.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema/oabservice-v2.json
 apiVersion: oab.dev/v2
 kind: OABService
 metadata:

--- a/operator/examples/kiro-01.yaml
+++ b/operator/examples/kiro-01.yaml
@@ -4,28 +4,18 @@ metadata:
   name: kiro-01
   namespace: prod
 spec:
-  capacityProvider: FARGATE_SPOT
-  cpu: 256
-  memory: 512
-  taskDefinition:
-    image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
+  image: 123456789.dkr.ecr.us-east-1.amazonaws.com/openab:latest
+  resources:
+    cpu: "256"
+    memory: "512"
+  configFrom: s3://oab-control-plane/config/prod/kiro-01/config.toml
   bootstrapFrom: s3://oab-backups/agents/kiro-01/latest.tar.gz
-  networking:
-    subnets: [subnet-aaa, subnet-bbb]
-    securityGroups: [sg-oab]
-    assignPublicIp: false
   secrets:
-    - name: DISCORD_TOKEN
-      valueFrom: /oab/prod/kiro-01/discord-token
-  config:
-    channels:
-      - type: discord
-    backend:
-      type: bedrock
-      model_id: anthropic.claude-sonnet-4-20250514
-      region: us-east-1
-    steering:
-      system_prompt: "You are Kiro, an AI agent running on OpenAB."
-    features:
-      stt: false
-      cronjob: true
+    DISCORD_TOKEN: /oab/prod/kiro-01/discord-token
+  runtime:
+    type: ecs
+    capacityProvider: FARGATE_SPOT
+    networking:
+      subnets: [subnet-aaa, subnet-bbb]
+      securityGroups: [sg-oab]
+      assignPublicIp: false

--- a/operator/examples/kiro-01.yaml
+++ b/operator/examples/kiro-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: oab.dev/v1
+apiVersion: oab.dev/v2
 kind: OABService
 metadata:
   name: kiro-01

--- a/operator/schema/oabservice-v1.json
+++ b/operator/schema/oabservice-v1.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://oab.dev/schemas/oabservice-v1.json",
+  "title": "OABService",
+  "description": "Declarative manifest for deploying an OpenAB agent",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {
+      "const": "oab.dev/v1"
+    },
+    "kind": {
+      "const": "OABService"
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["name", "namespace"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "Agent name (DNS-compatible)"
+        },
+        "namespace": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "Logical namespace (e.g. prod, staging)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "type": "object",
+      "required": ["image", "resources", "runtime"],
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Container image URI"
+        },
+        "resources": {
+          "type": "object",
+          "required": ["cpu", "memory"],
+          "properties": {
+            "cpu": {
+              "type": "string",
+              "description": "CPU units (e.g. '256' for ECS, '256m' for K8S)",
+              "examples": ["256", "512", "1024"]
+            },
+            "memory": {
+              "type": "string",
+              "description": "Memory (e.g. '512' for ECS MB, '512Mi' for K8S)",
+              "examples": ["512", "1024", "2048"]
+            }
+          },
+          "additionalProperties": false
+        },
+        "configFrom": {
+          "type": "string",
+          "description": "S3 URI to agent config.toml"
+        },
+        "bootstrapFrom": {
+          "type": "string",
+          "description": "S3 URI to agent home archive (memory, state)"
+        },
+        "secrets": {
+          "type": "object",
+          "description": "Map of env var name → SSM parameter path",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "runtime": {
+          "type": "object",
+          "required": ["type"],
+          "oneOf": [
+            { "$ref": "#/$defs/ecsRuntime" },
+            { "$ref": "#/$defs/kubernetesRuntime" }
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "ecsRuntime": {
+      "type": "object",
+      "required": ["type", "networking"],
+      "properties": {
+        "type": { "const": "ecs" },
+        "capacityProvider": {
+          "type": "string",
+          "enum": ["FARGATE", "FARGATE_SPOT"],
+          "default": "FARGATE"
+        },
+        "networking": {
+          "type": "object",
+          "required": ["subnets", "securityGroups"],
+          "properties": {
+            "subnets": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 1
+            },
+            "securityGroups": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 1
+            },
+            "assignPublicIp": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "kubernetesRuntime": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "kubernetes" },
+        "nodeSelector": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "serviceAccount": {
+          "type": "string"
+        },
+        "tolerations": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/operator/schema/oabservice-v2.json
+++ b/operator/schema/oabservice-v2.json
@@ -1,121 +1,135 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://oab.dev/schemas/oabservice-v2.json",
-  "title": "OABService",
-  "description": "Declarative manifest for deploying an OpenAB agent (v2)",
-  "type": "object",
-  "required": ["apiVersion", "kind", "metadata", "spec"],
-  "properties": {
-    "apiVersion": {
-      "const": "oab.dev/v2"
+  "title": "OAB Manifest",
+  "description": "Declarative manifest for OpenAB Service or Fleet (v2)",
+  "oneOf": [
+    { "$ref": "#/$defs/oabService" },
+    { "$ref": "#/$defs/oabFleet" }
+  ],
+  "$defs": {
+    "oabService": {
+      "type": "object",
+      "required": ["apiVersion", "kind", "metadata", "spec"],
+      "properties": {
+        "apiVersion": { "const": "oab.dev/v2" },
+        "kind": { "const": "OABService" },
+        "metadata": { "$ref": "#/$defs/metadata" },
+        "spec": { "$ref": "#/$defs/serviceSpec" }
+      },
+      "additionalProperties": false
     },
-    "kind": {
-      "const": "OABService"
+    "oabFleet": {
+      "type": "object",
+      "required": ["apiVersion", "kind", "metadata", "spec"],
+      "properties": {
+        "apiVersion": { "const": "oab.dev/v2" },
+        "kind": { "const": "OABFleet" },
+        "metadata": { "$ref": "#/$defs/fleetMetadata" },
+        "spec": { "$ref": "#/$defs/fleetSpec" }
+      },
+      "additionalProperties": false
     },
     "metadata": {
       "type": "object",
       "required": ["name", "namespace"],
       "properties": {
-        "name": {
-          "type": "string",
-          "pattern": "^[a-z0-9][a-z0-9-]*$",
-          "description": "Agent name (DNS-compatible)"
-        },
-        "namespace": {
-          "type": "string",
-          "pattern": "^[a-z0-9][a-z0-9-]*$",
-          "description": "Logical namespace (e.g. prod, staging)"
-        },
-        "generation": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "System-managed generation number (auto-incremented on apply)"
+        "name": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "namespace": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "generation": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "fleetMetadata": {
+      "type": "object",
+      "required": ["name", "namespace"],
+      "properties": {
+        "name": { "type": "string" },
+        "namespace": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "serviceSpec": {
+      "type": "object",
+      "required": ["image", "resources", "configFrom", "runtime"],
+      "properties": {
+        "image": { "type": "string" },
+        "resources": { "$ref": "#/$defs/resources" },
+        "configFrom": { "type": "string" },
+        "bootstrapFrom": { "type": "string" },
+        "secrets": { "type": "object", "additionalProperties": { "type": "string" } },
+        "runtime": { "$ref": "#/$defs/runtime" }
+      },
+      "additionalProperties": false
+    },
+    "fleetSpec": {
+      "type": "object",
+      "required": ["template", "agents"],
+      "properties": {
+        "template": { "$ref": "#/$defs/fleetTemplate" },
+        "agents": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/agentOverride" }
         }
       },
       "additionalProperties": false
     },
-    "spec": {
+    "fleetTemplate": {
       "type": "object",
-      "required": ["image", "resources", "configFrom", "runtime"],
+      "required": ["image", "runtime"],
       "properties": {
-        "image": {
-          "type": "string",
-          "description": "Container image URI"
-        },
-        "resources": {
-          "type": "object",
-          "required": ["cpu", "memory"],
-          "properties": {
-            "cpu": {
-              "type": "string",
-              "description": "CPU units (ECS: '256','512','1024','2048','4096'; K8S: '256m')",
-              "examples": ["256", "512", "1024"]
-            },
-            "memory": {
-              "type": "string",
-              "description": "Memory (ECS: '512','1024' in MB; K8S: '512Mi')",
-              "examples": ["512", "1024", "2048"]
-            }
-          },
-          "additionalProperties": false
-        },
-        "configFrom": {
-          "type": "string",
-          "description": "S3 URI to agent config.toml (required)"
-        },
-        "bootstrapFrom": {
-          "type": "string",
-          "description": "S3 URI to agent home archive (memory, state)"
-        },
-        "secrets": {
-          "type": "object",
-          "description": "Map of env var name → SSM parameter path",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "runtime": {
-          "type": "object",
-          "required": ["type"],
-          "oneOf": [
-            { "$ref": "#/$defs/ecsRuntime" },
-            { "$ref": "#/$defs/kubernetesRuntime" }
-          ]
-        }
+        "image": { "type": "string" },
+        "resources": { "$ref": "#/$defs/resources" },
+        "bootstrapFrom": { "type": "string" },
+        "secrets": { "type": "object", "additionalProperties": { "type": "string" } },
+        "runtime": { "$ref": "#/$defs/runtime" }
       },
       "additionalProperties": false
-    }
-  },
-  "additionalProperties": false,
-  "$defs": {
+    },
+    "agentOverride": {
+      "type": "object",
+      "required": ["name", "configFrom"],
+      "properties": {
+        "name": { "type": "string" },
+        "configFrom": { "type": "string" },
+        "image": { "type": "string" },
+        "resources": { "$ref": "#/$defs/resources" },
+        "bootstrapFrom": { "type": "string" },
+        "secrets": { "type": "object", "additionalProperties": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "resources": {
+      "type": "object",
+      "required": ["cpu", "memory"],
+      "properties": {
+        "cpu": { "type": "string" },
+        "memory": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "runtime": {
+      "type": "object",
+      "required": ["type"],
+      "oneOf": [
+        { "$ref": "#/$defs/ecsRuntime" },
+        { "$ref": "#/$defs/kubernetesRuntime" }
+      ]
+    },
     "ecsRuntime": {
       "type": "object",
       "required": ["type", "networking"],
       "properties": {
         "type": { "const": "ecs" },
-        "capacityProvider": {
-          "type": "string",
-          "enum": ["FARGATE", "FARGATE_SPOT"],
-          "default": "FARGATE"
-        },
+        "capacityProvider": { "type": "string", "enum": ["FARGATE", "FARGATE_SPOT"] },
         "networking": {
           "type": "object",
           "required": ["subnets", "securityGroups"],
           "properties": {
-            "subnets": {
-              "type": "array",
-              "items": { "type": "string" },
-              "minItems": 1
-            },
-            "securityGroups": {
-              "type": "array",
-              "items": { "type": "string" },
-              "minItems": 1
-            },
-            "assignPublicIp": {
-              "type": "boolean",
-              "default": false
-            }
+            "subnets": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+            "securityGroups": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+            "assignPublicIp": { "type": "boolean" }
           },
           "additionalProperties": false
         }
@@ -127,25 +141,9 @@
       "required": ["type"],
       "properties": {
         "type": { "const": "kubernetes" },
-        "nodeSelector": {
-          "type": "object",
-          "additionalProperties": { "type": "string" }
-        },
-        "serviceAccount": {
-          "type": "string"
-        },
-        "tolerations": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "key": { "type": "string" },
-              "operator": { "type": "string", "enum": ["Exists", "Equal"] },
-              "value": { "type": "string" },
-              "effect": { "type": "string", "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute"] }
-            }
-          }
-        }
+        "nodeSelector": { "type": "object", "additionalProperties": { "type": "string" } },
+        "serviceAccount": { "type": "string" },
+        "tolerations": { "type": "array", "items": { "type": "object" } }
       },
       "additionalProperties": false
     }

--- a/operator/schema/oabservice-v2.json
+++ b/operator/schema/oabservice-v2.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://oab.dev/schemas/oabservice-v1.json",
+  "$id": "https://oab.dev/schemas/oabservice-v2.json",
   "title": "OABService",
-  "description": "Declarative manifest for deploying an OpenAB agent",
+  "description": "Declarative manifest for deploying an OpenAB agent (v2)",
   "type": "object",
   "required": ["apiVersion", "kind", "metadata", "spec"],
   "properties": {
     "apiVersion": {
-      "const": "oab.dev/v1"
+      "const": "oab.dev/v2"
     },
     "kind": {
       "const": "OABService"
@@ -25,13 +25,18 @@
           "type": "string",
           "pattern": "^[a-z0-9][a-z0-9-]*$",
           "description": "Logical namespace (e.g. prod, staging)"
+        },
+        "generation": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "System-managed generation number (auto-incremented on apply)"
         }
       },
       "additionalProperties": false
     },
     "spec": {
       "type": "object",
-      "required": ["image", "resources", "runtime"],
+      "required": ["image", "resources", "configFrom", "runtime"],
       "properties": {
         "image": {
           "type": "string",
@@ -43,12 +48,12 @@
           "properties": {
             "cpu": {
               "type": "string",
-              "description": "CPU units (e.g. '256' for ECS, '256m' for K8S)",
+              "description": "CPU units (ECS: '256','512','1024','2048','4096'; K8S: '256m')",
               "examples": ["256", "512", "1024"]
             },
             "memory": {
               "type": "string",
-              "description": "Memory (e.g. '512' for ECS MB, '512Mi' for K8S)",
+              "description": "Memory (ECS: '512','1024' in MB; K8S: '512Mi')",
               "examples": ["512", "1024", "2048"]
             }
           },
@@ -56,7 +61,7 @@
         },
         "configFrom": {
           "type": "string",
-          "description": "S3 URI to agent config.toml"
+          "description": "S3 URI to agent config.toml (required)"
         },
         "bootstrapFrom": {
           "type": "string",
@@ -131,7 +136,15 @@
         },
         "tolerations": {
           "type": "array",
-          "items": { "type": "object" }
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": { "type": "string" },
+              "operator": { "type": "string", "enum": ["Exists", "Equal"] },
+              "value": { "type": "string" },
+              "effect": { "type": "string", "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute"] }
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -77,7 +77,7 @@ async fn apply_ecs(
 
     // Read current generation from S3 manifest (if exists), increment
     let manifest_key = format!("manifests/{}/{}.yaml", m.metadata.namespace, m.metadata.name);
-    let current_gen = match s3.get_object().bucket(bucket).key(&manifest_key).send().await {
+    let current_gen = match s3.get_object().bucket(&bucket).key(&manifest_key).send().await {
         Ok(resp) => {
             let bytes = resp.body.collect().await?.into_bytes();
             let existing: OABServiceManifest = serde_yaml::from_slice(&bytes)?;
@@ -92,7 +92,7 @@ async fn apply_ecs(
     manifest_to_store["metadata"]["generation"] = serde_yaml::Value::Number(generation.into());
     let manifest_yaml = serde_yaml::to_string(&manifest_to_store)?;
     s3.put_object()
-        .bucket(bucket)
+        .bucket(&bucket)
         .key(&manifest_key)
         .body(ByteStream::from(manifest_yaml.into_bytes()))
         .send()

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -1,4 +1,4 @@
-use crate::manifest::OABServiceManifest;
+use crate::manifest::{OABServiceManifest, Runtime};
 use anyhow::{Context, Result};
 use aws_sdk_ecs::types::{
     AssignPublicIp, AwsVpcConfiguration, CapacityProviderStrategyItem, ContainerDefinition,
@@ -20,8 +20,15 @@ pub async fn run(aws_config: &aws_config::SdkConfig, file_path: &str) -> Result<
 
     for m in &manifests {
         m.validate()?;
-        println!("  Applying {}...", m.metadata.name);
-        apply_one(&ecs, &s3, m).await?;
+        match &m.spec.runtime {
+            Runtime::Ecs(_) => {
+                println!("  Applying {} (ECS)...", m.metadata.name);
+                apply_ecs(&ecs, &s3, m).await?;
+            }
+            Runtime::Kubernetes(_) => {
+                anyhow::bail!("Kubernetes runtime not yet implemented");
+            }
+        }
     }
 
     println!("\n{} service(s) applied.", manifests.len());
@@ -51,11 +58,16 @@ fn parse_manifest(path: &Path) -> Result<OABServiceManifest> {
         .with_context(|| format!("failed to parse {}", path.display()))
 }
 
-async fn apply_one(
+async fn apply_ecs(
     ecs: &aws_sdk_ecs::Client,
     s3: &aws_sdk_s3::Client,
     m: &OABServiceManifest,
 ) -> Result<()> {
+    let ecs_rt = match &m.spec.runtime {
+        Runtime::Ecs(rt) => rt,
+        _ => unreachable!(),
+    };
+
     let service_name = m.ecs_service_name();
     let bucket = "oab-control-plane";
 
@@ -71,25 +83,10 @@ async fn apply_one(
     };
     let generation = current_gen + 1;
 
-    // 1. Render config.toml and upload to S3 (immutable path)
-    let config_toml = render_config_toml(&m.spec.config);
-    let config_key = format!(
-        "config/{}/{}/{}/config.toml",
-        m.metadata.namespace, m.metadata.name, generation
-    );
-    s3.put_object()
-        .bucket(bucket)
-        .key(&config_key)
-        .body(ByteStream::from(config_toml.into_bytes()))
-        .send()
-        .await
-        .context("failed to upload config to S3")?;
-
-    // 2. Upload manifest to S3 (record of desired state, with updated generation)
+    // 1. Upload manifest to S3 (record of desired state)
     let mut manifest_to_store = serde_yaml::to_value(m)?;
     manifest_to_store["metadata"]["generation"] = serde_yaml::Value::Number(generation.into());
     let manifest_yaml = serde_yaml::to_string(&manifest_to_store)?;
-    let manifest_key = format!("manifests/{}/{}.yaml", m.metadata.namespace, m.metadata.name);
     s3.put_object()
         .bucket(bucket)
         .key(&manifest_key)
@@ -98,49 +95,32 @@ async fn apply_one(
         .await
         .context("failed to upload manifest to S3")?;
 
-    // 3. Register task definition
-    let config_s3_path = format!("s3://{}/{}", bucket, config_key);
-    let task_def_family = service_name.clone();
-
+    // 2. Build environment variables
     let mut env_vars = vec![
-        KeyValuePair::builder()
-            .name("NAMESPACE")
-            .value(&m.metadata.namespace)
-            .build(),
-        KeyValuePair::builder()
-            .name("NAME")
-            .value(&m.metadata.name)
-            .build(),
-        KeyValuePair::builder()
-            .name("CONFIG_S3_PATH")
-            .value(&config_s3_path)
-            .build(),
+        KeyValuePair::builder().name("NAMESPACE").value(&m.metadata.namespace).build(),
+        KeyValuePair::builder().name("NAME").value(&m.metadata.name).build(),
     ];
+    if let Some(ref config_from) = m.spec.config_from {
+        env_vars.push(KeyValuePair::builder().name("CONFIG_S3_PATH").value(config_from).build());
+    }
     if let Some(ref bootstrap) = m.spec.bootstrap_from {
-        env_vars.push(
-            KeyValuePair::builder()
-                .name("BOOTSTRAP_FROM")
-                .value(bootstrap)
-                .build(),
-        );
+        env_vars.push(KeyValuePair::builder().name("BOOTSTRAP_FROM").value(bootstrap).build());
     }
 
+    // 3. Build secrets from map
     let secrets: Vec<Secret> = m
         .spec
         .secrets
         .iter()
-        .map(|s| {
-            Secret::builder()
-                .name(&s.name)
-                .value_from(&s.value_from)
-                .build()
-                .unwrap()
+        .map(|(name, ssm_path)| {
+            Secret::builder().name(name).value_from(ssm_path).build().unwrap()
         })
         .collect();
 
+    // 4. Register task definition
     let container = ContainerDefinition::builder()
         .name("openab")
-        .image(&m.spec.task_definition.image)
+        .image(&m.spec.image)
         .essential(true)
         .set_environment(Some(env_vars))
         .set_secrets(if secrets.is_empty() { None } else { Some(secrets) })
@@ -148,11 +128,11 @@ async fn apply_one(
 
     let task_def = ecs
         .register_task_definition()
-        .family(&task_def_family)
+        .family(&service_name)
         .requires_compatibilities(aws_sdk_ecs::types::Compatibility::Fargate)
         .network_mode(aws_sdk_ecs::types::NetworkMode::Awsvpc)
-        .cpu(m.spec.cpu.to_string())
-        .memory(m.spec.memory.to_string())
+        .cpu(&m.spec.resources.cpu)
+        .memory(&m.spec.resources.memory)
         .container_definitions(container)
         .send()
         .await
@@ -164,16 +144,16 @@ async fn apply_one(
         .unwrap_or_default()
         .to_string();
 
-    // 4. Create or update ECS service
-    let assign_ip = if m.spec.networking.assign_public_ip {
+    // 5. Create or update ECS service
+    let assign_ip = if ecs_rt.networking.assign_public_ip {
         AssignPublicIp::Enabled
     } else {
         AssignPublicIp::Disabled
     };
 
     let vpc_config = AwsVpcConfiguration::builder()
-        .set_subnets(Some(m.spec.networking.subnets.clone()))
-        .set_security_groups(Some(m.spec.networking.security_groups.clone()))
+        .set_subnets(Some(ecs_rt.networking.subnets.clone()))
+        .set_security_groups(Some(ecs_rt.networking.security_groups.clone()))
         .assign_public_ip(assign_ip)
         .build()?;
 
@@ -196,7 +176,6 @@ async fn apply_one(
         .is_some_and(|s| s.status() == Some("ACTIVE"));
 
     if service_active {
-        // Update existing service
         ecs.update_service()
             .cluster("default")
             .service(&service_name)
@@ -207,9 +186,8 @@ async fn apply_one(
             .context("failed to update ECS service")?;
         println!("  ✓ {} updated", m.metadata.name);
     } else {
-        // Create new service
         let cap_strategy = CapacityProviderStrategyItem::builder()
-            .capacity_provider(&m.spec.capacity_provider)
+            .capacity_provider(&ecs_rt.capacity_provider)
             .weight(1)
             .build()?;
 
@@ -225,53 +203,9 @@ async fn apply_one(
             .context("failed to create ECS service")?;
         println!(
             "  ✓ {} created ({}, {}cpu/{}mem)",
-            m.metadata.name, m.spec.capacity_provider, m.spec.cpu, m.spec.memory
+            m.metadata.name, ecs_rt.capacity_provider, m.spec.resources.cpu, m.spec.resources.memory
         );
     }
 
     Ok(())
-}
-
-fn render_config_toml(config: &crate::manifest::AgentConfig) -> String {
-    let mut out = String::new();
-
-    if let Some(ref backend) = config.backend {
-        out.push_str("[backend]\n");
-        out.push_str(&format!("type = \"{}\"\n", backend.backend_type));
-        if let Some(ref model) = backend.model_id {
-            out.push_str(&format!("model_id = \"{}\"\n", model));
-        }
-        if let Some(ref region) = backend.region {
-            out.push_str(&format!("region = \"{}\"\n", region));
-        }
-        out.push('\n');
-    }
-
-    for (i, ch) in config.channels.iter().enumerate() {
-        out.push_str("[[channels]]\n");
-        out.push_str(&format!("type = \"{}\"\n", ch.channel_type));
-        for (k, v) in &ch.extra {
-            if let serde_yaml::Value::String(s) = v {
-                out.push_str(&format!("{} = \"{}\"\n", k, s));
-            }
-        }
-        if i < config.channels.len() - 1 {
-            out.push('\n');
-        }
-    }
-
-    if let Some(ref steering) = config.steering {
-        out.push_str("\n[steering]\n");
-        if let Some(ref prompt) = steering.system_prompt {
-            out.push_str(&format!("system_prompt = \"\"\"\n{}\n\"\"\"\n", prompt));
-        }
-    }
-
-    if let Some(ref features) = config.features {
-        out.push_str("\n[features]\n");
-        out.push_str(&format!("stt = {}\n", features.stt));
-        out.push_str(&format!("cronjob = {}\n", features.cronjob));
-    }
-
-    out
 }

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -1,4 +1,4 @@
-use crate::manifest::{OABServiceManifest, Runtime};
+use crate::manifest::{OABFleetManifest, OABServiceManifest, RawManifest, Runtime};
 use anyhow::{Context, Result};
 use aws_sdk_ecs::types::{
     AssignPublicIp, AwsVpcConfiguration, CapacityProviderStrategyItem, ContainerDefinition,
@@ -45,20 +45,39 @@ fn load_manifests(path: &Path) -> Result<Vec<OABServiceManifest>> {
             let entry = entry?;
             let p = entry.path();
             if p.extension().is_some_and(|e| e == "yaml" || e == "yml") {
-                manifests.push(parse_manifest(&p)?);
+                manifests.extend(parse_manifest_file(&p)?);
             }
         }
     } else {
-        manifests.push(parse_manifest(path)?);
+        manifests.extend(parse_manifest_file(path)?);
     }
     Ok(manifests)
 }
 
-fn parse_manifest(path: &Path) -> Result<OABServiceManifest> {
+/// Parse a YAML file — returns one or more OABServiceManifests (fleet expands to many)
+fn parse_manifest_file(path: &Path) -> Result<Vec<OABServiceManifest>> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
-    serde_yaml::from_str(&content)
-        .with_context(|| format!("failed to parse {}", path.display()))
+
+    // Detect kind first
+    let raw: RawManifest = serde_yaml::from_str(&content)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    match raw.kind.as_str() {
+        "OABService" => {
+            let m: OABServiceManifest = serde_yaml::from_str(&content)
+                .with_context(|| format!("failed to parse OABService {}", path.display()))?;
+            Ok(vec![m])
+        }
+        "OABFleet" => {
+            let fleet: OABFleetManifest = serde_yaml::from_str(&content)
+                .with_context(|| format!("failed to parse OABFleet {}", path.display()))?;
+            fleet.validate()?;
+            println!("  Fleet '{}': expanding {} agents...", fleet.metadata.name, fleet.spec.agents.len());
+            Ok(fleet.expand())
+        }
+        other => anyhow::bail!("unsupported kind '{}' in {}", other, path.display()),
+    }
 }
 
 async fn apply_ecs(

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -72,7 +72,8 @@ async fn apply_ecs(
     };
 
     let service_name = m.ecs_service_name();
-    let bucket = "oab-control-plane";
+    let bucket = std::env::var("OAB_CONTROL_PLANE_BUCKET")
+        .unwrap_or_else(|_| "oab-control-plane".to_string());
 
     // Read current generation from S3 manifest (if exists), increment
     let manifest_key = format!("manifests/{}/{}.yaml", m.metadata.namespace, m.metadata.name);

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -18,17 +18,20 @@ pub async fn run(aws_config: &aws_config::SdkConfig, file_path: &str) -> Result<
     let ecs = aws_sdk_ecs::Client::new(aws_config);
     let s3 = aws_sdk_s3::Client::new(aws_config);
 
+    // Validate ALL manifests before applying any (prevent partial apply)
     for m in &manifests {
         m.validate()?;
-        match &m.spec.runtime {
-            Runtime::Ecs(_) => {
-                println!("  Applying {} (ECS)...", m.metadata.name);
-                apply_ecs(&ecs, &s3, m).await?;
-            }
-            Runtime::Kubernetes(_) => {
-                anyhow::bail!("Kubernetes runtime not yet implemented");
-            }
+        if matches!(&m.spec.runtime, Runtime::Kubernetes(_)) {
+            anyhow::bail!(
+                "Kubernetes runtime not yet implemented (manifest: {})",
+                m.metadata.name
+            );
         }
+    }
+
+    for m in &manifests {
+        println!("  Applying {} (ECS)...", m.metadata.name);
+        apply_ecs(&ecs, &s3, m).await?;
     }
 
     println!("\n{} service(s) applied.", manifests.len());
@@ -100,8 +103,8 @@ async fn apply_ecs(
         KeyValuePair::builder().name("NAMESPACE").value(&m.metadata.namespace).build(),
         KeyValuePair::builder().name("NAME").value(&m.metadata.name).build(),
     ];
-    if let Some(ref config_from) = m.spec.config_from {
-        env_vars.push(KeyValuePair::builder().name("CONFIG_S3_PATH").value(config_from).build());
+    if !m.spec.config_from.is_empty() {
+        env_vars.push(KeyValuePair::builder().name("CONFIG_S3_PATH").value(&m.spec.config_from).build());
     }
     if let Some(ref bootstrap) = m.spec.bootstrap_from {
         env_vars.push(KeyValuePair::builder().name("BOOTSTRAP_FROM").value(bootstrap).build());

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -43,6 +43,28 @@ enum Commands {
         #[arg(long, default_value = "prod")]
         namespace: String,
     },
+    /// Execute a command in an agent container (via ecsctl)
+    Exec {
+        /// Agent name (alias)
+        agent: String,
+        /// Command to run
+        #[arg(last = true)]
+        command: Vec<String>,
+    },
+    /// Copy files to/from agent containers (via ecsctl)
+    Cp {
+        /// Source path (local or agent:/path)
+        src: String,
+        /// Destination path (local or agent:/path)
+        dst: String,
+    },
+    /// Sync a local directory to an agent container (via ecsctl)
+    Sync {
+        /// Source directory
+        src: String,
+        /// Destination (agent:/path)
+        dst: String,
+    },
 }
 
 #[tokio::main]
@@ -55,6 +77,18 @@ async fn main() -> anyhow::Result<()> {
         Commands::Get { resource, name, cluster } => get::run(&config, &resource, name.as_deref(), &cluster).await,
         Commands::Delete { resource, name, cluster, namespace } => {
             delete::run(&config, &resource, &name, &cluster, &namespace).await
+        }
+        // TODO: Wire up ecsctl library once its API is refactored for library use.
+        // Blocked on: oablab/ecsctl library API readiness (functions currently
+        // shell out to `aws` CLI and print directly to stderr).
+        Commands::Exec { agent, command } => {
+            anyhow::bail!("exec not yet implemented — pending ecsctl library API refactor")
+        }
+        Commands::Cp { src, dst } => {
+            anyhow::bail!("cp not yet implemented — pending ecsctl library API refactor")
+        }
+        Commands::Sync { src, dst } => {
+            anyhow::bail!("sync not yet implemented — pending ecsctl library API refactor")
         }
     }
 }

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -47,8 +47,8 @@ enum Commands {
     Exec {
         /// Agent name (alias)
         agent: String,
-        /// Command to run
-        #[arg(last = true)]
+        /// Command to run (default: /bin/sh). Use -- to separate args.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
     },
     /// Copy files to/from agent containers (via ecsctl)
@@ -58,11 +58,11 @@ enum Commands {
         /// Destination path (local or agent:/path)
         dst: String,
     },
-    /// Sync a local directory to an agent container (via ecsctl)
+    /// Sync directories between local machine and agent containers (via ecsctl)
     Sync {
-        /// Source directory
+        /// Source: local dir or agent:/path
         src: String,
-        /// Destination (agent:/path)
+        /// Destination: agent:/path or local dir
         dst: String,
     },
 }
@@ -78,17 +78,48 @@ async fn main() -> anyhow::Result<()> {
         Commands::Delete { resource, name, cluster, namespace } => {
             delete::run(&config, &resource, &name, &cluster, &namespace).await
         }
-        // TODO: Wire up ecsctl library once its API is refactored for library use.
-        // Blocked on: oablab/ecsctl library API readiness (functions currently
-        // shell out to `aws` CLI and print directly to stderr).
         Commands::Exec { agent, command } => {
-            anyhow::bail!("exec not yet implemented — pending ecsctl library API refactor")
+            let resolved = ecsctl::alias::resolve(&config, &agent).await?;
+            let cmd = if command.is_empty() {
+                None
+            } else {
+                // Preserve quoting: each arg that contains spaces gets quoted
+                let joined = command.iter().map(|a| {
+                    if a.contains(' ') || a.contains('"') || a.contains('\'') {
+                        format!("\"{}\"", a.replace('"', "\\\""))
+                    } else {
+                        a.clone()
+                    }
+                }).collect::<Vec<_>>().join(" ");
+                Some(joined)
+            };
+            ecsctl::exec::run(&config, &resolved, cmd.as_deref()).await
         }
         Commands::Cp { src, dst } => {
-            anyhow::bail!("cp not yet implemented — pending ecsctl library API refactor")
+            let src = ecsctl::alias::resolve_remote(&config, &src).await?;
+            let dst = ecsctl::alias::resolve_remote(&config, &dst).await?;
+            eprintln!("⇄ Copying {} → {} ...", src, dst);
+            ecsctl::cp::run(&config, &src, &dst, None, 60).await?;
+            eprintln!("✓ Done");
+            Ok(())
         }
         Commands::Sync { src, dst } => {
-            anyhow::bail!("sync not yet implemented — pending ecsctl library API refactor")
+            let src = ecsctl::alias::resolve_remote(&config, &src).await?;
+            let dst = ecsctl::alias::resolve_remote(&config, &dst).await?;
+            let src_remote = src.contains(':') && !src.starts_with('/');
+            let dst_remote = dst.contains(':') && !dst.starts_with('/');
+            eprintln!("⇄ Syncing {} → {} ...", src, dst);
+            match (src_remote, dst_remote) {
+                (false, true) => {
+                    ecsctl::sync::run(&config, &src, &dst, None, 60).await?;
+                }
+                (true, false) => {
+                    ecsctl::sync::run_download(&config, &src, &dst, None, 60).await?;
+                }
+                _ => anyhow::bail!("exactly one of src/dst must be a remote path (agent:/path)"),
+            }
+            eprintln!("✓ Done");
+            Ok(())
         }
     }
 }

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -83,13 +83,9 @@ async fn main() -> anyhow::Result<()> {
             let cmd = if command.is_empty() {
                 None
             } else {
-                // Preserve quoting: each arg that contains spaces gets quoted
+                // Join args with single-quote escaping to prevent shell interpretation
                 let joined = command.iter().map(|a| {
-                    if a.contains(' ') || a.contains('"') || a.contains('\'') {
-                        format!("\"{}\"", a.replace('"', "\\\""))
-                    } else {
-                        a.clone()
-                    }
+                    format!("'{}'", a.replace('\'', "'\\''"))
                 }).collect::<Vec<_>>().join(" ");
                 Some(joined)
             };
@@ -106,8 +102,8 @@ async fn main() -> anyhow::Result<()> {
         Commands::Sync { src, dst } => {
             let src = ecsctl::alias::resolve_remote(&config, &src).await?;
             let dst = ecsctl::alias::resolve_remote(&config, &dst).await?;
-            let src_remote = src.contains(':') && !src.starts_with('/');
-            let dst_remote = dst.contains(':') && !dst.starts_with('/');
+            let src_remote = ecsctl::cp::is_remote(&src);
+            let dst_remote = ecsctl::cp::is_remote(&dst);
             eprintln!("⇄ Syncing {} → {} ...", src, dst);
             match (src_remote, dst_remote) {
                 (false, true) => {

--- a/operator/src/manifest.rs
+++ b/operator/src/manifest.rs
@@ -99,8 +99,12 @@ impl OABFleetManifest {
             let resources = agent.resources.clone()
                 .or(self.spec.template.resources.clone())
                 .unwrap_or(Resources { cpu: "256".into(), memory: "512".into() });
-            let secrets = agent.secrets.clone()
+            let base_secrets = agent.secrets.clone()
                 .unwrap_or_else(|| self.spec.template.secrets.clone());
+            // Interpolate ${name} in secret values
+            let secrets = base_secrets.into_iter().map(|(k, v)| {
+                (k, v.replace("${name}", &agent.name))
+            }).collect();
 
             OABServiceManifest {
                 api_version: self.api_version.clone(),
@@ -114,9 +118,10 @@ impl OABFleetManifest {
                     image: agent.image.clone()
                         .unwrap_or_else(|| self.spec.template.image.clone()),
                     resources,
-                    config_from: agent.config_from.clone(),
+                    config_from: agent.config_from.replace("${name}", &agent.name),
                     bootstrap_from: agent.bootstrap_from.clone()
-                        .or(self.spec.template.bootstrap_from.clone()),
+                        .or(self.spec.template.bootstrap_from.clone())
+                        .map(|s| s.replace("${name}", &agent.name)),
                     secrets,
                     runtime: self.spec.template.runtime.clone(),
                 },

--- a/operator/src/manifest.rs
+++ b/operator/src/manifest.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -20,27 +21,41 @@ pub struct Metadata {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Spec {
-    #[serde(default = "default_capacity_provider")]
-    pub capacity_provider: String,
-    pub cpu: i32,
-    pub memory: i32,
-    pub task_definition: TaskDefinition,
+    pub image: String,
+    pub resources: Resources,
+    #[serde(default)]
+    pub config_from: Option<String>,
     #[serde(default)]
     pub bootstrap_from: Option<String>,
-    pub networking: Networking,
-    pub config: AgentConfig,
     #[serde(default)]
-    pub secrets: Vec<SecretRef>,
+    pub secrets: HashMap<String, String>,
+    pub runtime: Runtime,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct TaskDefinition {
-    pub image: String,
+pub struct Resources {
+    pub cpu: String,
+    pub memory: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum Runtime {
+    Ecs(EcsRuntime),
+    Kubernetes(KubernetesRuntime),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Networking {
+pub struct EcsRuntime {
+    #[serde(default = "default_capacity_provider")]
+    pub capacity_provider: String,
+    pub networking: EcsNetworking,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsNetworking {
     pub subnets: Vec<String>,
     pub security_groups: Vec<String>,
     #[serde(default)]
@@ -49,53 +64,11 @@ pub struct Networking {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SecretRef {
-    pub name: String,
-    pub value_from: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct AgentConfig {
+pub struct KubernetesRuntime {
     #[serde(default)]
-    pub channels: Vec<ChannelConfig>,
+    pub node_selector: HashMap<String, String>,
     #[serde(default)]
-    pub backend: Option<BackendConfig>,
-    #[serde(default)]
-    pub steering: Option<SteeringConfig>,
-    #[serde(default)]
-    pub features: Option<FeaturesConfig>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct ChannelConfig {
-    #[serde(rename = "type")]
-    pub channel_type: String,
-    #[serde(flatten)]
-    pub extra: std::collections::HashMap<String, serde_yaml::Value>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct BackendConfig {
-    #[serde(rename = "type")]
-    pub backend_type: String,
-    #[serde(default)]
-    pub model_id: Option<String>,
-    #[serde(default)]
-    pub region: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct SteeringConfig {
-    #[serde(default)]
-    pub system_prompt: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct FeaturesConfig {
-    #[serde(default)]
-    pub stt: bool,
-    #[serde(default)]
-    pub cronjob: bool,
+    pub service_account: Option<String>,
 }
 
 fn default_capacity_provider() -> String {
@@ -116,15 +89,25 @@ impl OABServiceManifest {
         if self.metadata.namespace.is_empty() {
             anyhow::bail!("metadata.namespace is required");
         }
-        let valid_cp = ["FARGATE", "FARGATE_SPOT"];
-        if !valid_cp.contains(&self.spec.capacity_provider.as_str()) {
-            anyhow::bail!("capacityProvider must be FARGATE or FARGATE_SPOT");
+        if self.spec.image.is_empty() {
+            anyhow::bail!("spec.image is required");
         }
-        if self.spec.networking.subnets.is_empty() {
-            anyhow::bail!("networking.subnets must not be empty");
-        }
-        if self.spec.networking.security_groups.is_empty() {
-            anyhow::bail!("networking.securityGroups must not be empty");
+        match &self.spec.runtime {
+            Runtime::Ecs(ecs) => {
+                let valid_cp = ["FARGATE", "FARGATE_SPOT"];
+                if !valid_cp.contains(&ecs.capacity_provider.as_str()) {
+                    anyhow::bail!("runtime.capacityProvider must be FARGATE or FARGATE_SPOT");
+                }
+                if ecs.networking.subnets.is_empty() {
+                    anyhow::bail!("runtime.networking.subnets must not be empty");
+                }
+                if ecs.networking.security_groups.is_empty() {
+                    anyhow::bail!("runtime.networking.securityGroups must not be empty");
+                }
+            }
+            Runtime::Kubernetes(_) => {
+                // K8S validation: minimal for now
+            }
         }
         Ok(())
     }

--- a/operator/src/manifest.rs
+++ b/operator/src/manifest.rs
@@ -1,6 +1,14 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Top-level manifest that can be either OABService or OABFleet
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RawManifest {
+    pub api_version: String,
+    pub kind: String,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OABServiceManifest {
@@ -8,6 +16,113 @@ pub struct OABServiceManifest {
     pub kind: String,
     pub metadata: Metadata,
     pub spec: Spec,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OABFleetManifest {
+    pub api_version: String,
+    pub kind: String,
+    pub metadata: FleetMetadata,
+    pub spec: FleetSpec,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FleetMetadata {
+    pub name: String,
+    pub namespace: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FleetSpec {
+    pub template: FleetTemplate,
+    pub agents: Vec<AgentOverride>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FleetTemplate {
+    pub image: String,
+    #[serde(default)]
+    pub resources: Option<Resources>,
+    #[serde(default)]
+    pub bootstrap_from: Option<String>,
+    #[serde(default)]
+    pub secrets: HashMap<String, String>,
+    pub runtime: Runtime,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentOverride {
+    pub name: String,
+    pub config_from: String,
+    #[serde(default)]
+    pub resources: Option<Resources>,
+    #[serde(default)]
+    pub bootstrap_from: Option<String>,
+    #[serde(default)]
+    pub secrets: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub image: Option<String>,
+}
+
+impl OABFleetManifest {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.api_version != "oab.dev/v2" {
+            anyhow::bail!("unsupported apiVersion: {} (expected oab.dev/v2)", self.api_version);
+        }
+        if self.kind != "OABFleet" {
+            anyhow::bail!("unsupported kind: {}", self.kind);
+        }
+        if self.metadata.name.is_empty() {
+            anyhow::bail!("metadata.name is required");
+        }
+        if self.spec.agents.is_empty() {
+            anyhow::bail!("spec.agents must not be empty");
+        }
+        for agent in &self.spec.agents {
+            if agent.name.is_empty() {
+                anyhow::bail!("each agent must have a name");
+            }
+            if agent.config_from.is_empty() {
+                anyhow::bail!("agent '{}': configFrom is required", agent.name);
+            }
+        }
+        Ok(())
+    }
+
+    /// Expand fleet into individual OABService manifests
+    pub fn expand(&self) -> Vec<OABServiceManifest> {
+        self.spec.agents.iter().map(|agent| {
+            let resources = agent.resources.clone()
+                .or(self.spec.template.resources.clone())
+                .unwrap_or(Resources { cpu: "256".into(), memory: "512".into() });
+            let secrets = agent.secrets.clone()
+                .unwrap_or_else(|| self.spec.template.secrets.clone());
+
+            OABServiceManifest {
+                api_version: self.api_version.clone(),
+                kind: "OABService".to_string(),
+                metadata: Metadata {
+                    name: agent.name.clone(),
+                    namespace: self.metadata.namespace.clone(),
+                    generation: 0,
+                },
+                spec: Spec {
+                    image: agent.image.clone()
+                        .unwrap_or_else(|| self.spec.template.image.clone()),
+                    resources,
+                    config_from: agent.config_from.clone(),
+                    bootstrap_from: agent.bootstrap_from.clone()
+                        .or(self.spec.template.bootstrap_from.clone()),
+                    secrets,
+                    runtime: self.spec.template.runtime.clone(),
+                },
+            }
+        }).collect()
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -31,20 +146,20 @@ pub struct Spec {
     pub runtime: Runtime,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Resources {
     pub cpu: String,
     pub memory: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum Runtime {
     Ecs(EcsRuntime),
     Kubernetes(KubernetesRuntime),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EcsRuntime {
     #[serde(default = "default_capacity_provider")]
@@ -52,7 +167,7 @@ pub struct EcsRuntime {
     pub networking: EcsNetworking,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EcsNetworking {
     pub subnets: Vec<String>,
@@ -61,7 +176,7 @@ pub struct EcsNetworking {
     pub assign_public_ip: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct KubernetesRuntime {
     #[serde(default)]

--- a/operator/src/manifest.rs
+++ b/operator/src/manifest.rs
@@ -23,8 +23,7 @@ pub struct Metadata {
 pub struct Spec {
     pub image: String,
     pub resources: Resources,
-    #[serde(default)]
-    pub config_from: Option<String>,
+    pub config_from: String,
     #[serde(default)]
     pub bootstrap_from: Option<String>,
     #[serde(default)]
@@ -69,16 +68,21 @@ pub struct KubernetesRuntime {
     pub node_selector: HashMap<String, String>,
     #[serde(default)]
     pub service_account: Option<String>,
+    #[serde(default)]
+    pub tolerations: Vec<serde_yaml::Value>,
 }
 
 fn default_capacity_provider() -> String {
     "FARGATE".to_string()
 }
 
+/// Valid ECS Fargate CPU/memory combinations
+const VALID_ECS_CPU: &[&str] = &["256", "512", "1024", "2048", "4096"];
+
 impl OABServiceManifest {
     pub fn validate(&self) -> anyhow::Result<()> {
-        if self.api_version != "oab.dev/v1" {
-            anyhow::bail!("unsupported apiVersion: {}", self.api_version);
+        if self.api_version != "oab.dev/v2" {
+            anyhow::bail!("unsupported apiVersion: {} (expected oab.dev/v2)", self.api_version);
         }
         if self.kind != "OABService" {
             anyhow::bail!("unsupported kind: {}", self.kind);
@@ -92,6 +96,9 @@ impl OABServiceManifest {
         if self.spec.image.is_empty() {
             anyhow::bail!("spec.image is required");
         }
+        if self.spec.config_from.is_empty() {
+            anyhow::bail!("spec.configFrom is required");
+        }
         match &self.spec.runtime {
             Runtime::Ecs(ecs) => {
                 let valid_cp = ["FARGATE", "FARGATE_SPOT"];
@@ -104,9 +111,15 @@ impl OABServiceManifest {
                 if ecs.networking.security_groups.is_empty() {
                     anyhow::bail!("runtime.networking.securityGroups must not be empty");
                 }
+                if !VALID_ECS_CPU.contains(&self.spec.resources.cpu.as_str()) {
+                    anyhow::bail!(
+                        "spec.resources.cpu must be one of {:?} for ECS runtime",
+                        VALID_ECS_CPU
+                    );
+                }
             }
             Runtime::Kubernetes(_) => {
-                // K8S validation: minimal for now
+                // K8S: cpu/memory format validated at deploy time by K8S API
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

Complete overhaul of `oabctl`: integrates `ecsctl` library for container ops, redesigns manifest schema (`oab.dev/v2`), and adds fleet support for batch agent deployment.

## New Commands

```bash
oabctl apply -f kiro-01.yaml          # deploy single agent
oabctl apply -f fleet.yaml            # deploy fleet (10+ agents)
oabctl exec kiro-01 -- bash            # shell into container
oabctl cp model.bin kiro-01:/data/     # copy files to/from agent
oabctl sync ./config kiro-01:/app/     # bidirectional directory sync
```

## Manifest Schema (oab.dev/v2)

### OABService — single agent
```yaml
apiVersion: oab.dev/v2
kind: OABService
metadata:
  name: kiro-01
  namespace: prod
spec:
  image: <ecr-uri>
  resources: { cpu: "256", memory: "512" }
  configFrom: s3://.../config.toml
  secrets:
    DISCORD_TOKEN: /oab/prod/kiro-01/discord-token
  runtime:
    type: ecs
    capacityProvider: FARGATE_SPOT
    networking: { subnets: [...], securityGroups: [...] }
```

### OABFleet — batch deploy
```yaml
apiVersion: oab.dev/v2
kind: OABFleet
metadata:
  name: law-shi-team
  namespace: prod
spec:
  template:
    image: <ecr-uri>
    resources: { cpu: "256", memory: "512" }
    secrets:
      DISCORD_TOKEN: /oab/prod/${name}/discord-token
    runtime: { type: ecs, ... }
  agents:
    - name: chaodu
      configFrom: s3://.../chaodu/config.toml
    - name: openclaw
      configFrom: s3://.../openclaw/config.toml
      image: <different-image>
      resources: { cpu: "1024", memory: "2048" }
```

**Fleet features:**
- Template inheritance with per-agent overrides (`image`, `resources`, `bootstrapFrom`, `secrets`)
- `${name}` interpolation in `configFrom`, `bootstrapFrom`, and secret values
- Runtime shared across fleet (homogeneous infra)
- Validate-all-before-apply (no partial deploys)

## Architecture

```
oabctl apply/get/delete  →  direct aws-sdk-ecs
oabctl exec/cp/sync      →  ecsctl library (pinned rev)
OABFleet                 →  expand to OABService[] at parse time
```

## Key Design Decisions

- `oab.dev/v2` clean break (no v1 migration — pre-release)
- Config externalized via `configFrom` S3 URI (required)
- Runtime abstraction: `ecs` | `kubernetes` (K8S planned)
- ECS CPU validated at manifest level (256/512/1024/2048/4096)
- Exec uses single-quote POSIX shell escape
- S3 state bucket configurable via `OAB_CONTROL_PLANE_BUCKET` env var
- JSON Schema supports both OABService and OABFleet

## Files Changed

- `operator/src/manifest.rs` — v2 schema structs + OABFleet + expand()
- `operator/src/apply.rs` — kind dispatch + fleet expansion + ECS apply
- `operator/src/main.rs` — exec/cp/sync via ecsctl library
- `operator/schema/oabservice-v2.json` — JSON Schema (Service + Fleet)
- `operator/examples/kiro-01.yaml` — single agent example
- `operator/examples/fleet.yaml` — fleet example (10 agents)
- `operator/README.md` — full documentation
- `operator/Cargo.toml` — ecsctl dep (pinned rev)