### PR TITLE
feat(gateway): support inbound LINE audio attachments for STT

### DIFF
--- a/docs/inbound-attachments.md
+++ b/docs/inbound-attachments.md
@@ -25,7 +25,7 @@ User sends media (photo/voice/file)
 | **Feishu** | ✅ | ✅ (STT) | ✅ (whitelist) | skipped | skipped |
 | **Google Chat** | ✅ | ✅ (STT) | ✅ (whitelist) | skipped | Drive files skipped |
 | **WeCom** | ✅ | — | ✅ (whitelist) | skipped | skipped |
-| **LINE** | ✅ (LINE-hosted only) | — | — | — | — |
+| **LINE** | ✅ (LINE-hosted only) | ✅ (STT, 1:1 only, LINE-hosted only) | — | — | — |
 | **Slack** | ✅ | ✅ (STT) | ✅ | — | skipped |
 
 ## Processing Pipeline
@@ -48,6 +48,10 @@ OpenAB can create the ACP image block, but downstream coding agents and selected
 2. Stored to filesystem (no transcoding)
 3. Core reads bytes → STT transcription (Whisper/Groq) → `[Voice message transcript]: ...`
 4. If STT disabled: silently skipped
+
+LINE-specific note:
+- LINE voice-message STT currently works in **1:1 chats only**.
+- LINE group/room voice messages are still blocked by mention gating because LINE does not attach mention metadata to audio messages.
 
 ### Text Files (Documents)
 

--- a/docs/line.md
+++ b/docs/line.md
@@ -82,6 +82,7 @@ In the LINE Developers Console → **Messaging API** tab → scan the QR code wi
 ### Supported
 
 - **1:1 chat** — send a message to the bot, get an AI agent response
+- **Inbound voice messages in 1:1 chat** — LINE-hosted audio messages are downloaded through the LINE Content API and forwarded to OpenAB as `audio` attachments, so the existing STT flow can transcribe them. This requires `[stt] enabled = true` in OpenAB core. See [STT (Speech-to-Text)](stt.md).
 - **Group chat** — add the bot to a group; it responds only when @-mentioned (see @mention gating below)
 - **Inbound images** — user-sent LINE images are downloaded through the LINE Content API and forwarded to OpenAB as image attachments
 - **Webhook signature validation** — HMAC-SHA256 via `LINE_CHANNEL_SECRET`
@@ -97,17 +98,19 @@ In the LINE Developers Console → **Messaging API** tab → scan the QR code wi
 - **Reactions** — LINE Bot API does not support message reactions.
 - **@mention gating** — Supported (zero-config). In group/room chats the gateway only forwards messages where the bot is explicitly @-mentioned (LINE's native `mentionees[].isSelf` signal). 1:1 DMs are always forwarded. No env var is needed.
   - *Limitation — non-text messages*: LINE only attaches mention data to text messages. Images, videos, stickers, files, and location messages in groups are silently dropped because they cannot carry an @-mention.
+  - *Limitation — group voice messages*: LINE voice/audio messages in groups and rooms are also dropped today because audio messages do not carry mention metadata. This PR only enables inbound voice STT for 1:1 chats.
   - *Limitation — `@All`*: A group-wide `@All` mention does **not** trigger the bot; only a direct `@BotName` mention does.
   - *Breaking change*: This gating is always active. Deployments that previously relied on the bot responding to all group messages will need to @-mention the bot after upgrading.
 - **Markdown rendering** — LINE uses its own text formatting. Agent replies are sent as plain text.
 - **External-content images** — LINE image messages backed by `contentProvider.type = "external"` are not downloaded yet.
+- **External-content audio** — LINE audio messages backed by `contentProvider.type = "external"` are not downloaded yet.
 
 ## Environment Variables
 
 | Variable | Required | Description |
 |---|---|---|
 | `LINE_CHANNEL_SECRET` | Yes | Channel secret for webhook signature validation |
-| `LINE_CHANNEL_ACCESS_TOKEN` | Yes | Channel access token for Reply/Push Message API and LINE-hosted image downloads |
+| `LINE_CHANNEL_ACCESS_TOKEN` | Yes | Channel access token for Reply/Push Message API and LINE-hosted image/audio downloads |
 
 ## Troubleshooting
 
@@ -115,6 +118,12 @@ In the LINE Developers Console → **Messaging API** tab → scan the QR code wi
 - Verify webhook URL is correct and shows ✅ in LINE Developers Console
 - Check **Use webhook** is ON and **Auto-reply messages** is OFF
 - Check gateway logs: `kubectl logs -l app=openab-gateway`
+
+**Voice message doesn't transcribe:**
+- Confirm you sent the voice message in a **1:1 chat**, not a group or room
+- Confirm `[stt] enabled = true` in your OpenAB config
+- Confirm the STT provider is configured correctly; see [STT (Speech-to-Text)](stt.md)
+- Check gateway logs for `media stored` and OpenAB logs for downstream dispatch
 
 **"Invalid signature" in gateway logs:**
 - Verify `LINE_CHANNEL_SECRET` matches the value in LINE Developers Console

--- a/docs/stt.md
+++ b/docs/stt.md
@@ -1,6 +1,6 @@
 # Speech-to-Text (STT) for Voice Messages
 
-openab can automatically transcribe voice message attachments (Discord, Feishu, and other gateway platforms) and forward the transcript to your ACP agent as text.
+openab can automatically transcribe voice message attachments (Discord, Feishu, LINE 1:1 chat, and other gateway platforms) and forward the transcript to your ACP agent as text.
 
 ## Quick Start
 
@@ -24,7 +24,7 @@ api_key = "${GROQ_API_KEY}"
 ## How It Works
 
 ```
-Voice message (Discord .ogg, Feishu opus/ogg, etc.)
+Voice message (Discord .ogg, Feishu opus/ogg, LINE .m4a/.ogg, etc.)
        │
        ▼
   openab downloads the audio file
@@ -41,6 +41,9 @@ Voice message (Discord .ogg, Feishu opus/ogg, etc.)
 ```
 
 The transcript is prepended to the prompt as a `ContentBlock::Text`, so the downstream agent (Kiro CLI, Claude Code, etc.) sees it as regular text input.
+
+Platform note:
+- LINE voice-message STT is currently supported in **1:1 chat only**. Group/room audio is still filtered out by LINE mention gating rules.
 
 ## Configuration Reference
 

--- a/gateway/src/adapters/line.rs
+++ b/gateway/src/adapters/line.rs
@@ -286,7 +286,7 @@ async fn build_gateway_event_from_line_event(
                 );
                 attachments.push(Attachment {
                     attachment_type: "audio".into(),
-                    filename: format!("line_{}.ogg", msg.id),
+                    filename: format!("line_{}.audio", msg.id),
                     mime_type: "audio/ogg".into(),
                     data: String::new(),
                     size: 0,
@@ -303,7 +303,7 @@ async fn build_gateway_event_from_line_event(
                     warn!(message_id = %msg.id, "LINE audio received but LINE_CHANNEL_ACCESS_TOKEN is not configured");
                     attachments.push(Attachment {
                         attachment_type: "audio".into(),
-                        filename: format!("line_{}.ogg", msg.id),
+                        filename: format!("line_{}.audio", msg.id),
                         mime_type: "audio/ogg".into(),
                         data: String::new(),
                         size: 0,
@@ -537,7 +537,7 @@ pub async fn download_line_audio(
         Err(e) => {
             warn!(message_id, error = %e, "LINE audio download failed");
             return rejected(
-                format!("line_{}.ogg", message_id),
+                format!("line_{}.audio", message_id),
                 "audio/ogg".into(),
                 0,
                 "download failed: network error".into(),
@@ -549,7 +549,7 @@ pub async fn download_line_audio(
         let http_status = resp.status().as_u16();
         warn!(message_id, status = %resp.status(), "LINE audio download failed");
         return rejected(
-            format!("line_{}.ogg", message_id),
+            format!("line_{}.audio", message_id),
             "audio/ogg".into(),
             0,
             format!("download failed: HTTP {http_status}"),

--- a/gateway/src/adapters/line.rs
+++ b/gateway/src/adapters/line.rs
@@ -1,4 +1,6 @@
-use crate::media::{format_bytes, resize_and_compress, IMAGE_MAX_DOWNLOAD};
+use crate::media::{
+    audio_extension, format_bytes, resize_and_compress, AUDIO_MAX_DOWNLOAD, IMAGE_MAX_DOWNLOAD,
+};
 use crate::schema::*;
 use crate::store;
 use axum::extract::State;
@@ -192,7 +194,6 @@ async fn process_line_webhook_events(
     }
 }
 
-
 fn sanitize_line_external_url_for_log(url: &str) -> String {
     reqwest::Url::parse(url)
         .ok()
@@ -211,7 +212,7 @@ async fn build_gateway_event_from_line_event(
     }
 
     let msg = event.message.as_ref()?;
-    if msg.message_type != "text" && msg.message_type != "image" {
+    if msg.message_type != "text" && msg.message_type != "image" && msg.message_type != "audio" {
         return None;
     }
 
@@ -242,10 +243,7 @@ async fn build_gateway_event_from_line_event(
                     data: String::new(),
                     size: 0,
                     path: None,
-                    status: Some(
-                        "unsupported format: external content not supported"
-                            .into(),
-                    ),
+                    status: Some("unsupported format: external content not supported".into()),
                 });
             }
             _ => {
@@ -262,9 +260,55 @@ async fn build_gateway_event_from_line_event(
                         data: String::new(),
                         size: 0,
                         path: None,
-                        status: Some(
-                            "configuration error: service not configured".into(),
-                        ),
+                        status: Some("configuration error: service not configured".into()),
+                    });
+                }
+            }
+        }
+    }
+
+    if msg.message_type == "audio" {
+        match msg
+            .content_provider
+            .as_ref()
+            .map(|provider| provider.provider_type.as_str())
+        {
+            Some("external") => {
+                let original = msg
+                    .content_provider
+                    .as_ref()
+                    .and_then(|provider| provider.original_content_url.as_deref())
+                    .unwrap_or("unknown");
+                warn!(
+                    message_id = %msg.id,
+                    external_content_host = %sanitize_line_external_url_for_log(original),
+                    "LINE external audio content is not supported yet"
+                );
+                attachments.push(Attachment {
+                    attachment_type: "audio".into(),
+                    filename: format!("line_{}.ogg", msg.id),
+                    mime_type: "audio/ogg".into(),
+                    data: String::new(),
+                    size: 0,
+                    path: None,
+                    status: Some("unsupported format: external content not supported".into()),
+                });
+            }
+            _ => {
+                if let Some(access_token) = line_access_token {
+                    attachments.push(
+                        download_line_audio(client, access_token, &msg.id, data_api_base).await,
+                    );
+                } else {
+                    warn!(message_id = %msg.id, "LINE audio received but LINE_CHANNEL_ACCESS_TOKEN is not configured");
+                    attachments.push(Attachment {
+                        attachment_type: "audio".into(),
+                        filename: format!("line_{}.ogg", msg.id),
+                        mime_type: "audio/ogg".into(),
+                        data: String::new(),
+                        size: 0,
+                        path: None,
+                        status: Some("configuration error: service not configured".into()),
                     });
                 }
             }
@@ -396,11 +440,14 @@ pub async fn download_line_image(
         if let Ok(size) = cl.to_str().unwrap_or("0").parse::<u64>() {
             if size > IMAGE_MAX_DOWNLOAD {
                 warn!(message_id, size, "LINE image Content-Length exceeds limit");
-                return rejected(size, format!(
-                    "size exceeded: {} exceeds {}",
-                    format_bytes(size),
-                    format_bytes(IMAGE_MAX_DOWNLOAD)
-                ));
+                return rejected(
+                    size,
+                    format!(
+                        "size exceeded: {} exceeds {}",
+                        format_bytes(size),
+                        format_bytes(IMAGE_MAX_DOWNLOAD)
+                    ),
+                );
             }
         }
     }
@@ -419,11 +466,14 @@ pub async fn download_line_image(
         if body.len() as u64 > IMAGE_MAX_DOWNLOAD {
             let body_size = body.len() as u64;
             warn!(message_id, size = body_size, "LINE image exceeds limit");
-            return rejected(body_size, format!(
-                "size exceeded: {} exceeds {}",
-                format_bytes(body_size),
-                format_bytes(IMAGE_MAX_DOWNLOAD)
-            ));
+            return rejected(
+                body_size,
+                format!(
+                    "size exceeded: {} exceeds {}",
+                    format_bytes(body_size),
+                    format_bytes(IMAGE_MAX_DOWNLOAD)
+                ),
+            );
         }
     }
 
@@ -453,6 +503,136 @@ pub async fn download_line_image(
         mime_type: mime,
         data: String::new(),
         size: compressed.len() as u64,
+        path: Some(path),
+        status: None,
+    }
+}
+
+pub async fn download_line_audio(
+    client: &reqwest::Client,
+    access_token: &str,
+    message_id: &str,
+    api_base: &str,
+) -> Attachment {
+    let rejected = |filename: String, mime_type: String, size: u64, reason: String| Attachment {
+        attachment_type: "audio".into(),
+        filename,
+        mime_type,
+        data: String::new(),
+        size,
+        path: None,
+        status: Some(reason),
+    };
+
+    let mut resp = match client
+        .get(format!(
+            "{}/v2/bot/message/{}/content",
+            api_base, message_id
+        ))
+        .bearer_auth(access_token)
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            warn!(message_id, error = %e, "LINE audio download failed");
+            return rejected(
+                format!("line_{}.ogg", message_id),
+                "audio/ogg".into(),
+                0,
+                "download failed: network error".into(),
+            );
+        }
+    };
+
+    if !resp.status().is_success() {
+        let http_status = resp.status().as_u16();
+        warn!(message_id, status = %resp.status(), "LINE audio download failed");
+        return rejected(
+            format!("line_{}.ogg", message_id),
+            "audio/ogg".into(),
+            0,
+            format!("download failed: HTTP {http_status}"),
+        );
+    }
+
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("audio/ogg")
+        .to_string();
+    let filename = format!("line_{}.{}", message_id, audio_extension(&content_type));
+
+    if let Some(cl) = resp.headers().get(reqwest::header::CONTENT_LENGTH) {
+        if let Ok(size) = cl.to_str().unwrap_or("0").parse::<u64>() {
+            if size > AUDIO_MAX_DOWNLOAD {
+                warn!(message_id, size, "LINE audio Content-Length exceeds limit");
+                return rejected(
+                    filename.clone(),
+                    content_type.clone(),
+                    size,
+                    format!(
+                        "size exceeded: {} exceeds {}",
+                        format_bytes(size),
+                        format_bytes(AUDIO_MAX_DOWNLOAD)
+                    ),
+                );
+            }
+        }
+    }
+
+    let mut body = Vec::new();
+    loop {
+        let chunk = match resp.chunk().await {
+            Ok(Some(chunk)) => chunk,
+            Ok(None) => break,
+            Err(e) => {
+                warn!(message_id, error = %e, "LINE audio download failed while reading body");
+                return rejected(
+                    filename.clone(),
+                    content_type.clone(),
+                    0,
+                    "download failed: body read error".into(),
+                );
+            }
+        };
+        body.extend_from_slice(&chunk);
+        if body.len() as u64 > AUDIO_MAX_DOWNLOAD {
+            let body_size = body.len() as u64;
+            warn!(message_id, size = body_size, "LINE audio exceeds limit");
+            return rejected(
+                filename.clone(),
+                content_type.clone(),
+                body_size,
+                format!(
+                    "size exceeded: {} exceeds {}",
+                    format_bytes(body_size),
+                    format_bytes(AUDIO_MAX_DOWNLOAD)
+                ),
+            );
+        }
+    }
+
+    let path = match store::store_media(&body).await {
+        Some(p) => p,
+        None => {
+            warn!(message_id, "LINE audio store failed");
+            return rejected(
+                filename,
+                content_type,
+                body.len() as u64,
+                "processing failed: storage error".into(),
+            );
+        }
+    };
+
+    Attachment {
+        attachment_type: "audio".into(),
+        filename,
+        mime_type: content_type,
+        data: String::new(),
+        size: body.len() as u64,
         path: Some(path),
         status: None,
     }
@@ -643,9 +823,156 @@ mod tests {
         assert_eq!(gateway_event.content.attachments.len(), 1);
 
         let att = &gateway_event.content.attachments[0];
-        assert!(att.status.is_none(), "successful download should have no status");
+        assert!(
+            att.status.is_none(),
+            "successful download should have no status"
+        );
         let path = att.path.clone().expect("path should be stored");
         let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn build_gateway_event_from_line_audio_attaches_downloaded_audio() {
+        let server = MockServer::start().await;
+        let audio_bytes = b"OggS-test-audio".to_vec();
+
+        let _mock = Mock::given(method("GET"))
+            .and(path("/v2/bot/message/msg_audio/content"))
+            .and(header("authorization", "Bearer line_token"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "audio/ogg")
+                    .set_body_bytes(audio_bytes),
+            )
+            .mount_as_scoped(&server)
+            .await;
+
+        let event: LineEvent = serde_json::from_value(serde_json::json!({
+            "type": "message",
+            "replyToken": "reply123",
+            "source": {"type": "user", "userId": "U123"},
+            "message": {
+                "id": "msg_audio",
+                "type": "audio",
+                "contentProvider": {"type": "line"}
+            }
+        }))
+        .unwrap();
+
+        let gateway_event = build_gateway_event_from_line_event(
+            &event,
+            &reqwest::Client::new(),
+            Some("line_token"),
+            &server.uri(),
+        )
+        .await
+        .expect("audio event should produce a gateway event");
+
+        assert_eq!(gateway_event.platform, "line");
+        assert_eq!(gateway_event.content.text, "");
+        assert_eq!(gateway_event.content.attachments.len(), 1);
+
+        let att = &gateway_event.content.attachments[0];
+        assert_eq!(att.attachment_type, "audio");
+        assert_eq!(att.mime_type, "audio/ogg");
+        assert!(att.filename.ends_with(".ogg"));
+        assert!(
+            att.status.is_none(),
+            "successful download should have no status"
+        );
+        let path = att.path.clone().expect("path should be stored");
+        let stored = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(stored, b"OggS-test-audio");
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn build_gateway_event_from_line_audio_mp4_uses_m4a_filename() {
+        let server = MockServer::start().await;
+        let audio_bytes = b"ftypM4A-test-audio".to_vec();
+
+        let _mock = Mock::given(method("GET"))
+            .and(path("/v2/bot/message/msg_audio_m4a/content"))
+            .and(header("authorization", "Bearer line_token"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "audio/mp4")
+                    .set_body_bytes(audio_bytes),
+            )
+            .mount_as_scoped(&server)
+            .await;
+
+        let event: LineEvent = serde_json::from_value(serde_json::json!({
+            "type": "message",
+            "replyToken": "reply123",
+            "source": {"type": "user", "userId": "U123"},
+            "message": {
+                "id": "msg_audio_m4a",
+                "type": "audio",
+                "contentProvider": {"type": "line"}
+            }
+        }))
+        .unwrap();
+
+        let gateway_event = build_gateway_event_from_line_event(
+            &event,
+            &reqwest::Client::new(),
+            Some("line_token"),
+            &server.uri(),
+        )
+        .await
+        .expect("audio event should produce a gateway event");
+
+        let att = &gateway_event.content.attachments[0];
+        assert_eq!(att.attachment_type, "audio");
+        assert_eq!(att.mime_type, "audio/mp4");
+        assert!(att.filename.ends_with(".m4a"));
+        assert!(
+            att.status.is_none(),
+            "successful download should have no status"
+        );
+        let path = att.path.clone().expect("path should be stored");
+        let stored = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(stored, b"ftypM4A-test-audio");
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn download_line_audio_rejects_oversized_content_length() {
+        let server = MockServer::start().await;
+
+        let _mock = Mock::given(method("GET"))
+            .and(path("/v2/bot/message/msg_audio_big/content"))
+            .and(header("authorization", "Bearer line_token"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "audio/ogg")
+                    .insert_header("content-length", (AUDIO_MAX_DOWNLOAD + 1).to_string())
+                    .set_body_bytes(vec![0u8; AUDIO_MAX_DOWNLOAD as usize + 1]),
+            )
+            .mount_as_scoped(&server)
+            .await;
+
+        let attachment = download_line_audio(
+            &reqwest::Client::new(),
+            "line_token",
+            "msg_audio_big",
+            &server.uri(),
+        )
+        .await;
+
+        assert_eq!(attachment.attachment_type, "audio");
+        assert!(attachment.path.is_none());
+        assert!(attachment.status.is_some());
+        let reason = attachment.status.unwrap();
+        assert!(
+            reason.contains("size exceeded"),
+            "expected size exceeded reason, got: {reason}"
+        );
+        assert!(
+            reason.contains("exceeds"),
+            "expected size limit message, got: {reason}"
+        );
     }
 
     #[tokio::test]
@@ -674,8 +1001,14 @@ mod tests {
 
         assert!(attachment.status.is_some());
         let reason = attachment.status.unwrap();
-        assert!(reason.contains("size exceeded"), "expected size exceeded reason, got: {reason}");
-        assert!(reason.contains("exceeds"), "expected size limit message, got: {reason}");
+        assert!(
+            reason.contains("size exceeded"),
+            "expected size exceeded reason, got: {reason}"
+        );
+        assert!(
+            reason.contains("exceeds"),
+            "expected size limit message, got: {reason}"
+        );
     }
 
     #[tokio::test]
@@ -705,7 +1038,47 @@ mod tests {
         let gw = result.expect("external image event should not be dropped");
         assert_eq!(gw.content.attachments.len(), 1);
         let att = &gw.content.attachments[0];
-        assert!(att.status.is_some(), "external image should have status set");
+        assert!(
+            att.status.is_some(),
+            "external image should have status set"
+        );
+        let reason = att.status.as_deref().unwrap();
+        assert!(reason.contains("unsupported format"), "got: {reason}");
+        assert!(reason.contains("external"), "got: {reason}");
+    }
+
+    #[tokio::test]
+    async fn external_audio_produces_status_attachment_not_dropped() {
+        let event: LineEvent = serde_json::from_value(serde_json::json!({
+            "type": "message",
+            "source": {"type": "user", "userId": "U_human"},
+            "message": {
+                "id": "msg_audio_ext",
+                "type": "audio",
+                "contentProvider": {
+                    "type": "external",
+                    "originalContentUrl": "https://example.com/voice.ogg"
+                }
+            }
+        }))
+        .unwrap();
+
+        let result = build_gateway_event_from_line_event(
+            &event,
+            &reqwest::Client::new(),
+            None,
+            LINE_DATA_API_BASE,
+        )
+        .await;
+
+        let gw = result.expect("external audio event should not be dropped");
+        assert_eq!(gw.content.attachments.len(), 1);
+        let att = &gw.content.attachments[0];
+        assert_eq!(att.attachment_type, "audio");
+        assert!(
+            att.status.is_some(),
+            "external audio should have status set"
+        );
         let reason = att.status.as_deref().unwrap();
         assert!(reason.contains("unsupported format"), "got: {reason}");
         assert!(reason.contains("external"), "got: {reason}");
@@ -735,6 +1108,36 @@ mod tests {
         let gw = result.expect("image event with missing token should not be dropped");
         assert_eq!(gw.content.attachments.len(), 1);
         let att = &gw.content.attachments[0];
+        assert!(att.status.is_some(), "missing token should have status set");
+        let reason = att.status.as_deref().unwrap();
+        assert!(reason.contains("configuration error"), "got: {reason}");
+    }
+
+    #[tokio::test]
+    async fn missing_access_token_for_audio_produces_status_attachment_not_dropped() {
+        let event: LineEvent = serde_json::from_value(serde_json::json!({
+            "type": "message",
+            "source": {"type": "user", "userId": "U_human"},
+            "message": {
+                "id": "msg_audio_notoken",
+                "type": "audio",
+                "contentProvider": {"type": "line"}
+            }
+        }))
+        .unwrap();
+
+        let result = build_gateway_event_from_line_event(
+            &event,
+            &reqwest::Client::new(),
+            None,
+            LINE_DATA_API_BASE,
+        )
+        .await;
+
+        let gw = result.expect("audio event with missing token should not be dropped");
+        assert_eq!(gw.content.attachments.len(), 1);
+        let att = &gw.content.attachments[0];
+        assert_eq!(att.attachment_type, "audio");
         assert!(att.status.is_some(), "missing token should have status set");
         let reason = att.status.as_deref().unwrap();
         assert!(reason.contains("configuration error"), "got: {reason}");

--- a/gateway/src/media.rs
+++ b/gateway/src/media.rs
@@ -59,9 +59,9 @@ pub fn audio_extension(content_type: &str) -> &'static str {
 /// Check if a filename has a text-like extension suitable for reading as UTF-8.
 pub fn is_text_extension(filename: &str) -> bool {
     const TEXT_EXTS: &[&str] = &[
-        "txt", "csv", "log", "md", "json", "jsonl", "yaml", "yml", "toml", "xml", "rs", "py",
-        "js", "ts", "jsx", "tsx", "go", "java", "c", "cpp", "h", "hpp", "rb", "sh", "bash",
-        "sql", "html", "css", "ini", "cfg", "conf",
+        "txt", "csv", "log", "md", "json", "jsonl", "yaml", "yml", "toml", "xml", "rs", "py", "js",
+        "ts", "jsx", "tsx", "go", "java", "c", "cpp", "h", "hpp", "rb", "sh", "bash", "sql",
+        "html", "css", "ini", "cfg", "conf",
     ];
     let ext = filename.rsplit('.').next().unwrap_or("").to_lowercase();
     TEXT_EXTS.contains(&ext.as_str())
@@ -130,5 +130,13 @@ mod tests {
         assert!(is_text_extension("data.csv"));
         assert!(!is_text_extension("archive.zip"));
         assert!(!is_text_extension("photo.jpg"));
+    }
+
+    #[test]
+    fn audio_extension_detects_common_line_formats() {
+        assert_eq!(audio_extension("audio/ogg"), "ogg");
+        assert_eq!(audio_extension("audio/mpeg"), "mp3");
+        assert_eq!(audio_extension("audio/mp4"), "m4a");
+        assert_eq!(audio_extension("audio/x-m4a"), "m4a");
     }
 }


### PR DESCRIPTION
## What problem does this solve?

OpenAB already has a shared gateway audio-transcription path, but the LINE adapter never emits `audio` attachments.

Today, a LINE user can send a voice message and:

- the webhook arrives
- the LINE adapter rejects it because it only accepts `text` and `image`
- the existing gateway STT flow never runs

Closes #1161

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1517703363481833562

## At a Glance

```text
LINE user sends voice message (1:1 chat)
        │
        ▼
LINE Platform (webhook event: message.type = "audio")
        │
        ▼
openab-gateway LINE adapter
  ├─ gate: accept "text" | "image" | "audio"  ← NEW
  ├─ check contentProvider.type
  │     ├─ "external" → reject w/ status attachment (unsupported)
  │     └─ "line" (default) ↓
  ├─ download_line_audio()
  │     ├─ GET {data_api}/v2/bot/message/{id}/content
  │     ├─ check Content-Length ≤ 20MB
  │     ├─ stream body, enforce 20MB cap
  │     ├─ store::store_media(bytes) → local path
  │     └─ return Attachment { type: "audio", path, mime, ... }
  │
  ▼
GatewayEvent { attachments: [audio] }
        │
        ▼
OpenAB shared STT path (already existed)
  ├─ read audio bytes from stored path
  ├─ POST /audio/transcriptions (Whisper/Groq)
  └─ inject transcript as ContentBlock::Text
        │
        ▼
Downstream ACP agent (Kiro CLI, Claude Code, etc.)
  └─ sees: "[Voice message transcript]: ..."
        │
        ▼
Normal agent reply → LINE Reply/Push API → user
```

## Prior Art & Industry Research

**OpenClaw:**

- OpenClaw centralizes transcription in a shared media pipeline and keeps platform adapters focused on normalizing inbound attachments rather than embedding provider-specific STT logic in each adapter.
- That pattern maps well to OpenAB's existing gateway architecture, where the LINE adapter can stay thin and reuse the shared STT path.

**Hermes Agent:**

- Hermes documents voice transcription as a cross-platform capability instead of a LINE-specific path.
- This reinforces the same design choice: normalize inbound audio in the adapter, then hand it off to a common transcription layer.

**Other references (optional):**

- LINE Messaging API supports inbound audio message events and content download by message ID.

## Proposed Solution

- accept `message.type = "audio"` in the LINE gateway adapter
- download LINE-hosted audio from the standard content endpoint
- store the bytes as a gateway `audio` attachment
- reuse the existing OpenAB STT flow unchanged
- preserve rejected-attachment behavior for unsupported or misconfigured cases
- use a neutral `.audio` fallback filename for audio download/error attachments when the real MIME type is unavailable
- document LINE inbound voice-message support and its current scope in:
  - `docs/line.md`
  - `docs/inbound-attachments.md`
  - `docs/stt.md`

## Why this approach?

- It is the smallest change that unlocks LINE voice-message STT while aligning with OpenAB's current architecture.
- It follows the same high-level pattern as OpenClaw and Hermes: adapters normalize media, shared code handles transcription.
- It avoids duplicating provider-specific STT logic inside the LINE adapter.

Tradeoffs and limitations:

- This PR only enables inbound STT, not voice replies.
- `contentProvider.type = "external"` audio remains unsupported.
- LINE group/room voice messages are still blocked by current mention-gating behavior, so this PR intentionally scopes support to 1:1 chat.

## Alternatives Considered

- Add a LINE-specific STT call directly inside the adapter.
  - Rejected because it would duplicate the existing shared STT path and create platform-specific behavior drift.
- Expand this PR into a broader LINE media / mention-gating overhaul.
  - Rejected to keep the PR focused and easier to review.

## Validation

- [x] `cargo fmt`
- [x] `cargo check` passes in `gateway`
- [x] `cargo test adapters::line::tests -- --nocapture`
- [x] `cargo clippy -- -D warnings` in `gateway`
- [x] Manual testing

Note: a few neighboring line-wrapping changes are from `cargo fmt` applied around the modified LINE adapter code.

Manual testing performed in local WSL deployment:

- rebuilt `openab-gateway`
- restarted the local gateway service
- verified `openab-line.service` reconnected
- confirmed a real LINE 1:1 voice message entered the existing STT flow successfully
- confirmed repeated Traditional Chinese voice-message tests succeeded
- confirmed 3 sequential voice messages were dispatched and replied in order

