### PR TITLE
fix: bump CLI versions — kiro 2.8.1, codex 0.141.0, codex-acp 0.16.0, claude 2.1.179, gemini 0.47.0, copilot 1.0.63, cursor 2026.06.19, opencode 1.17.9, antigravity 1.0.10, pi 0.79.9, hermes v2026.6.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install kiro-cli (auto-detect arch, copy binary directly)
-ARG KIRO_CLI_VERSION=2.5.0
+ARG KIRO_CLI_VERSION=2.8.1
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-aarch64-linux.zip"; \
     else URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-x86_64-linux.zip"; fi && \

--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -19,7 +19,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install agy (Google Antigravity CLI) — pinned to v1.0.4
-ENV AGY_VERSION=1.0.6
+ENV AGY_VERSION=1.0.10
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) ASSET="agy_cli_linux_x64.tar.gz" ;; \

--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -18,7 +18,7 @@ RUN touch src/main.rs && cargo build --release
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps tini unzip && rm -rf /var/lib/apt/lists/*
 
-# Install agy (Google Antigravity CLI) — pinned to v1.0.4
+# Install agy (Google Antigravity CLI) — pinned version
 ENV AGY_VERSION=1.0.10
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # Without CLAUDE_CODE_EXECUTABLE the adapter uses its own bundled SDK cli.js,
 # ignoring the globally installed claude-code binary (see #418).
 ARG CLAUDE_AGENT_ACP_VERSION=0.45.0
-ARG CLAUDE_CODE_VERSION=2.1.177
+ARG CLAUDE_CODE_VERSION=2.1.179
 RUN npm install -g @agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION} @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} --retry 3
 ENV CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude
 

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 
 # Pre-install codex-acp and codex CLI globally
 ARG CODEX_ACP_VERSION=0.15.0
-ARG CODEX_VERSION=0.137.0
+ARG CODEX_VERSION=0.141.0
 RUN npm install -g @zed-industries/codex-acp@${CODEX_ACP_VERSION} @openai/codex@${CODEX_VERSION} --retry 3
 
 # Install gh CLI

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini bubblewrap unzip && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally
-ARG CODEX_ACP_VERSION=0.15.0
+ARG CODEX_ACP_VERSION=0.16.0
 ARG CODEX_VERSION=0.141.0
 RUN npm install -g @zed-industries/codex-acp@${CODEX_ACP_VERSION} @openai/codex@${CODEX_VERSION} --retry 3
 

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)
-ARG COPILOT_VERSION=1.0.60
+ARG COPILOT_VERSION=1.0.63
 RUN npm install -g @github/copilot@${COPILOT_VERSION} --retry 3
 
 # Install gh CLI (for auth and token management)

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # URL scheme scraped from Cursor's official downloads page — no apt/yum package exists.
 # If Cursor changes this pattern, the build fails with curl 404. Monitor
 # https://cursor.com/cli or https://docs.cursor.com/cli for version/URL updates.
-ARG CURSOR_VERSION=2026.06.04-5fd875e
+ARG CURSOR_VERSION=2026.06.19-20-24-33-653a7fb
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
     curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -11,7 +11,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)
-ARG GEMINI_CLI_VERSION=0.44.1
+ARG GEMINI_CLI_VERSION=0.47.0
 RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} --retry 3
 
 # Install gh CLI

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -19,8 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Hermes Agent — pinned to known commit with checksum verification
 # Root install uses FHS layout: binary at /usr/local/bin/hermes, code at /usr/local/lib/hermes-agent
 # HERMES_HOME points to agent user's data dir for OAuth tokens and config
-ARG HERMES_INSTALL_COMMIT=a5c12f5f593b0d5c11bf0adb15074cc50fbffaee
-ARG HERMES_INSTALL_SHA256=19a04f56496727de6492683bb89fa7e716ed29a22966f022e48679f0e1853652
+ARG HERMES_INSTALL_COMMIT=2bd1977d8fad185c9b4be47884f7e87f1add0ce3
+ARG HERMES_INSTALL_SHA256=dbd9d555ed4ac67bd1fc71ba6a39b410cf2af0ebcfd8f4889e086af78c9ddcaa
 RUN curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HERMES_INSTALL_COMMIT}/scripts/install.sh" \
       -o /tmp/install-hermes.sh && \
     echo "${HERMES_INSTALL_SHA256}  /tmp/install-hermes.sh" | sha256sum -c - && \

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -36,7 +36,7 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install opencode
-ARG OPENCODE_VERSION=1.17.3
+ARG OPENCODE_VERSION=1.17.9
 RUN npm install -g opencode-ai@${OPENCODE_VERSION} --retry 3
 
 # Install gh CLI (matches Dockerfile.claude / Dockerfile.gemini / Dockerfile.codex)

--- a/Dockerfile.pi
+++ b/Dockerfile.pi
@@ -12,8 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 
 # Install pi-acp adapter and Pi coding agent CLI.
 # The Pi coding agent npm package was renamed from @mariozechner/pi-coding-agent to @earendil-works/pi-coding-agent.
-ARG PI_ACP_VERSION=0.0.27
-ARG PI_CODING_AGENT_VERSION=0.78.1
+ARG PI_ACP_VERSION=0.0.31
+ARG PI_CODING_AGENT_VERSION=0.79.9
 RUN npm install -g pi-acp@${PI_ACP_VERSION} @earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION} --retry 3
 
 # Install gh CLI (matches other Dockerfiles)


### PR DESCRIPTION
## Summary

Bump all pinned CLI versions in Dockerfiles after investigating latest releases and upstream bug trackers.

Discord Discussion URL: N/A

## Changes

| Dockerfile | CLI | Old | New | Notes |
|---|---|---|---|---|
| `Dockerfile` | kiro-cli | 2.5.0 | **2.8.1** | No public issue tracker; stable manifest confirmed |
| `Dockerfile.codex` | `@openai/codex` | 0.137.0 | **0.141.0** | Image gen regression + pytest hang are app/TUI only; ACP headless unaffected |
| `Dockerfile.codex` | `@zed-industries/codex-acp` | 0.15.0 | **0.16.0** | macOS ARM64 code-sign bug (#325) doesn't affect Linux npm install; ACP 0.14.0 protocol update |
| `Dockerfile.claude` | `@anthropic-ai/claude-code` | 2.1.177 | **2.1.179** | ⚠️ Safe ceiling — 2.1.181+ has streaming aborts, sub-agent notification drops, and sandbox regressions on Linux |
| `Dockerfile.gemini` | `@google/gemini-cli` | 0.44.1 | **0.47.0** | Auth loop bug is OAuth personal flow only; openab uses API key auth |
| `Dockerfile.copilot` | `@github/copilot` | 1.0.60 | **1.0.63** | No public issue tracker; 3 patch versions, low risk |
| `Dockerfile.cursor` | Cursor Agent CLI | 2026.06.04-5fd875e | **2026.06.19-20-24-33-653a7fb** | Download URL returns HTTP 200 for both x64 and arm64 |
| `Dockerfile.opencode` | `opencode-ai` | 1.17.3 | **1.17.9** | Only cosmetic/TUI bugs; headless safe |
| `Dockerfile.antigravity` | Antigravity CLI (`agy`) | 1.0.6 | **1.0.10** | ARM64 compat improvements, permission engine fixes, no regressions |
| `Dockerfile.pi` | `@earendil-works/pi-coding-agent` | 0.78.1 | **0.79.9** | No public issue tracker (404). Also bumps `pi-acp` 0.0.27→0.0.31 |
| `Dockerfile.hermes` | Hermes Agent | commit `a5c12f5` | **v2026.6.19** (`2bd1977`) | Major release (v0.17.0): background subagents, memory batch ops, auth hardening. Open bugs are desktop/TUI/plugins only |

## NOT updated (intentionally)

| Dockerfile | Dependency | Pinned | Why |
|---|---|---|---|
| `Dockerfile.claude` | `claude-agent-acp` | 0.45.0 | Still current |
| `Dockerfile.mimocode` | `@mimo-ai/cli` | 0.1.1 | Already at latest |

## claude-code risk assessment

**Latest is 2.1.185 but safe ceiling is 2.1.179.** Serious Linux regressions in 2.1.181–2.1.185:

- [#69759](https://github.com/anthropics/claude-code/issues/69759): Pre-first-byte streaming aborts on custom `ANTHROPIC_BASE_URL` (proxy/gateway), large-context — regression from 2.1.179
- [#69732](https://github.com/anthropics/claude-code/issues/69732): Background sub-agent completion notifications dropped/misrouted (2.1.179→2.1.183 regression) — **directly affects openab multi-agent orchestration**
- [#69358](https://github.com/anthropics/claude-code/issues/69358): No Response From API constantly on 2.1.181/2.1.183 (Linux, Anthropic API)
- [#69118](https://github.com/anthropics/claude-code/issues/69118): Sandbox default-deny model broken — allowUnsandboxedCommands no longer blocks unlisted commands

**2.1.179 is the last version before these regressions.** Bumping from 2.1.177 → 2.1.179 gives us the mid-stream connection fix without the streaming/notification/sandbox breakage.

## codex risk assessment

Open bugs on 0.141.0 (all LOW risk for openab):
- [#29180](https://github.com/openai/codex/issues/29180): Image gen not saved to disk (Linux) — openab does not use image generation
- [#29176](https://github.com/openai/codex/issues/29176): Pytest output hangs — interactive TUI issue, not ACP headless
- [#29186](https://github.com/openai/codex/issues/29186): remote-control start fails on Alpine — openab uses Debian bookworm

## codex-acp risk assessment

- **Risk: LOW** — [#325](https://github.com/zed-industries/codex-acp/issues/325): macOS ARM64 binary invalid code signature + V8 crash — only affects native macOS binary, not Linux npm install path used by openab. Release includes ACP 0.14.0 protocol update and thread store improvements.

## gemini-cli risk assessment

- [#28018](https://github.com/google-gemini/gemini-cli/issues/28018): Auth infinite loop — OAuth personal flow only; openab uses API key auth
- Nightly release failures (#28051, #28056) are CI/CD issues, do not affect stable 0.47.0

## antigravity risk assessment

- **Risk: LOW** — 4 patch versions (1.0.6→1.0.10). Key fixes: ARM64 device compat, permission engine regex escaping, env flag parsing. Open issues (#457 quota lockout, #453 Windows crash) do not affect Linux/container/headless.

## pi risk assessment

- **Risk: LOW** — No public issue tracker (repo returns 404). Bumping pi-acp 0.0.27→0.0.31 and pi-coding-agent 0.78.1→0.79.9. Both are patch-level increments with no known regressions.

## hermes risk assessment

- **Risk: MEDIUM** — Very large jump (~1,276 commits). However, pinned to the official stable release tag `v2026.6.19` (v0.17.0). All open bugs are desktop/TUI/plugins — none affect the headless `hermes-acp` path used by openab. Key improvements: background subagents, auth hardening, memory tool batch ops. Install script SHA256 verified.

## mimocode risk assessment

- **Risk: N/A** — Already at latest (0.1.1). Open bugs are TUI/Windows/regional (#1154 403 in mainland China affects mimo-free bootstrap; openab uses explicit API key auth). No version bump needed.

## How to verify

```bash
# kiro-cli
curl -fsSL https://prod.download.cli.kiro.dev/stable/latest/manifest.json | jq -r .version

# npm packages
npm view @openai/codex version
npm view @zed-industries/codex-acp version
npm view @anthropic-ai/claude-code version
npm view @google/gemini-cli version
npm view @github/copilot version
npm view opencode-ai version
npm view @mimo-ai/cli version
npm view @earendil-works/pi-coding-agent version
npm view pi-acp version

# cursor (both arches)
curl -sI "https://downloads.cursor.com/lab/2026.06.19-20-24-33-653a7fb/linux/x64/agent-cli-package.tar.gz" -o /dev/null -w "%{http_code}"
curl -sI "https://downloads.cursor.com/lab/2026.06.19-20-24-33-653a7fb/linux/arm64/agent-cli-package.tar.gz" -o /dev/null -w "%{http_code}"

# antigravity
gh api repos/google-antigravity/antigravity-cli/releases/latest --jq .tag_name

# hermes
gh api repos/NousResearch/hermes-agent/releases/tags/v2026.6.19 --jq .tag_name
```

Ref: #573
