### PR TITLE
feat(ci): unified image repo with shared builder and tag-based variants

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -25,7 +25,6 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  ALL_VARIANTS: 'kiro,claude,codex,copilot,cursor,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore'
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────────

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -42,17 +42,19 @@ jobs:
 
       - name: Validate inputs and resolve matrix
         id: resolve
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
+          VARIANTS_INPUT: ${{ inputs.variants }}
+          BRANCH_INPUT: ${{ inputs.branch }}
         run: |
           set -euo pipefail
 
           # Validate tag format (alphanumeric, dots, dashes only)
-          TAG_INPUT="${{ inputs.tag }}"
           if [ -n "$TAG_INPUT" ]; then
             if ! echo "$TAG_INPUT" | grep -qE '^[a-zA-Z0-9._-]+$'; then
               echo "::error::Invalid tag format: $TAG_INPUT (allowed: alphanumeric, dots, dashes)"
               exit 1
             fi
-            # Disallow 'latest' as explicit tag input to prevent confusion
             if [ "$TAG_INPUT" = "latest" ]; then
               echo "::error::Cannot use 'latest' as tag input — latest is managed automatically for main branch builds"
               exit 1
@@ -61,13 +63,12 @@ jobs:
 
           # Resolve variants
           ALLOWED="kiro,claude,codex,copilot,cursor,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore"
-          if [ "${{ inputs.variants }}" = "all" ] || [ -z "${{ inputs.variants }}" ]; then
+          if [ "$VARIANTS_INPUT" = "all" ] || [ -z "$VARIANTS_INPUT" ]; then
             VARIANTS="$ALLOWED"
           else
-            VARIANTS="${{ inputs.variants }}"
-            # Validate each variant against allowlist
+            VARIANTS="$VARIANTS_INPUT"
             for v in $(echo "$VARIANTS" | tr ',' ' '); do
-              v=$(echo "$v" | xargs)  # trim whitespace
+              v=$(echo "$v" | xargs)
               if ! echo ",$ALLOWED," | grep -q ",$v,"; then
                 echo "::error::Unknown variant: $v (allowed: $ALLOWED)"
                 exit 1
@@ -96,8 +97,8 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-          - { os: linux/amd64, runner: ubuntu-latest }
-          - { os: linux/arm64, runner: ubuntu-24.04-arm }
+          - { os: linux/amd64, runner: ubuntu-latest, arch: amd64 }
+          - { os: linux/arm64, runner: ubuntu-24.04-arm, arch: arm64 }
     runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
@@ -123,9 +124,9 @@ jobs:
           target: builder
           platforms: ${{ matrix.platform.os }}
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/builder:${{ needs.matrix.outputs.tag }}-${{ matrix.platform.runner }}
-          cache-from: type=gha,scope=builder-${{ matrix.platform.os }}
-          cache-to: type=gha,scope=builder-${{ matrix.platform.os }},mode=max
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/builder:${{ needs.matrix.outputs.tag }}-${{ matrix.platform.arch }}
+          cache-from: type=gha,scope=builder-${{ matrix.platform.arch }}
+          cache-to: type=gha,scope=builder-${{ matrix.platform.arch }},mode=max
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Job 3: Build each agent variant (thin layers, parallel)
@@ -137,8 +138,8 @@ jobs:
       matrix:
         variant: ${{ fromJson(needs.matrix.outputs.variants) }}
         platform:
-          - { os: linux/amd64, runner: ubuntu-latest }
-          - { os: linux/arm64, runner: ubuntu-24.04-arm }
+          - { os: linux/amd64, runner: ubuntu-latest, arch: amd64 }
+          - { os: linux/arm64, runner: ubuntu-24.04-arm, arch: arm64 }
     runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
@@ -165,9 +166,11 @@ jobs:
           target: ${{ matrix.variant }}
           platforms: ${{ matrix.platform.os }}
           build-args: |
-            BUILDER_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/builder:${{ needs.matrix.outputs.tag }}-${{ matrix.platform.runner }}
+            BUILDER_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/builder:${{ needs.matrix.outputs.tag }}-${{ matrix.platform.arch }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=builder-${{ matrix.platform.os }}
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/builder:${{ needs.matrix.outputs.tag }}-${{ matrix.platform.arch }}
+            type=gha,scope=builder-${{ matrix.platform.arch }}
 
       - name: Export digest
         run: |
@@ -178,7 +181,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.variant }}-${{ matrix.platform.runner }}
+          name: digests-${{ matrix.variant }}-${{ matrix.platform.arch }}
           path: /tmp/digests/*
           retention-days: 1
 
@@ -209,7 +212,6 @@ jobs:
             echo "::error::Expected 2 digests (amd64 + arm64), got $COUNT"
             exit 1
           fi
-          # Validate digest format (64 hex chars)
           for f in /tmp/digests/*; do
             name=$(basename "$f")
             if ! echo "$name" | grep -qE '^[a-f0-9]{64}$'; then
@@ -227,6 +229,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest list
+        env:
+          BRANCH_INPUT: ${{ inputs.branch }}
         run: |
           IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           TAG="${{ needs.matrix.outputs.tag }}"
@@ -243,7 +247,7 @@ jobs:
               -t "${IMAGE}:${TAG}" \
               $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
 
-            if [ "${{ inputs.branch }}" = "main" ]; then
+            if [ "$BRANCH_INPUT" = "main" ]; then
               docker buildx imagetools create \
                 -t "${IMAGE}:latest" \
                 $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
@@ -251,6 +255,8 @@ jobs:
           fi
 
       - name: Summary
+        env:
+          BRANCH_INPUT: ${{ inputs.branch }}
         run: |
           IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           TAG="${{ needs.matrix.outputs.tag }}"
@@ -258,7 +264,7 @@ jobs:
           echo "### 📦 \`${IMAGE}:${TAG}-${VARIANT}\`" >> "$GITHUB_STEP_SUMMARY"
           if [ "${VARIANT}" = "kiro" ]; then
             echo "### 📦 \`${IMAGE}:${TAG}\` (default)" >> "$GITHUB_STEP_SUMMARY"
-            if [ "${{ inputs.branch }}" = "main" ]; then
+            if [ "$BRANCH_INPUT" = "main" ]; then
               echo "### 📦 \`${IMAGE}:latest\`" >> "$GITHUB_STEP_SUMMARY"
             fi
           fi

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: build-images-${{ github.event.inputs.tag || 'snapshot' }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -25,7 +29,7 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────────
-  # Job 1: Resolve matrix and tag
+  # Job 1: Resolve matrix and tag, validate inputs
   # ─────────────────────────────────────────────────────────────────────────────
   matrix:
     runs-on: ubuntu-latest
@@ -37,26 +41,55 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
-      - name: Resolve matrix and tag
+      - name: Validate inputs and resolve matrix
         id: resolve
         run: |
+          set -euo pipefail
+
+          # Validate tag format (alphanumeric, dots, dashes only)
+          TAG_INPUT="${{ inputs.tag }}"
+          if [ -n "$TAG_INPUT" ]; then
+            if ! echo "$TAG_INPUT" | grep -qE '^[a-zA-Z0-9._-]+$'; then
+              echo "::error::Invalid tag format: $TAG_INPUT (allowed: alphanumeric, dots, dashes)"
+              exit 1
+            fi
+            # Disallow 'latest' as explicit tag input to prevent confusion
+            if [ "$TAG_INPUT" = "latest" ]; then
+              echo "::error::Cannot use 'latest' as tag input — latest is managed automatically for main branch builds"
+              exit 1
+            fi
+          fi
+
+          # Resolve variants
+          ALLOWED="kiro,claude,codex,copilot,cursor,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore"
           if [ "${{ inputs.variants }}" = "all" ] || [ -z "${{ inputs.variants }}" ]; then
-            VARIANTS="${{ env.ALL_VARIANTS }}"
+            VARIANTS="$ALLOWED"
           else
             VARIANTS="${{ inputs.variants }}"
+            # Validate each variant against allowlist
+            for v in $(echo "$VARIANTS" | tr ',' ' '); do
+              v=$(echo "$v" | xargs)  # trim whitespace
+              if ! echo ",$ALLOWED," | grep -q ",$v,"; then
+                echo "::error::Unknown variant: $v (allowed: $ALLOWED)"
+                exit 1
+              fi
+            done
           fi
+
+          # Convert to JSON array
           JSON=$(echo "$VARIANTS" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R . | jq -sc .)
           echo "variants=${JSON}" >> "$GITHUB_OUTPUT"
 
-          if [ -n "${{ inputs.tag }}" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          # Resolve tag
+          if [ -n "$TAG_INPUT" ]; then
+            echo "tag=$TAG_INPUT" >> "$GITHUB_OUTPUT"
           else
             SHA=$(git rev-parse --short HEAD)
             echo "tag=snapshot-${SHA}" >> "$GITHUB_OUTPUT"
           fi
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # Job 2: Build shared builder layer (once per arch)
+  # Job 2: Build shared builder and push to registry (once per arch)
   # ─────────────────────────────────────────────────────────────────────────────
   build-core:
     needs: matrix
@@ -83,23 +116,17 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build builder stage and export
+      - name: Build builder stage and push to registry
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.unified
           target: builder
           platforms: ${{ matrix.platform.os }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/builder:${{ needs.matrix.outputs.tag }}-${{ matrix.platform.runner }}
           cache-from: type=gha,scope=builder-${{ matrix.platform.os }}
           cache-to: type=gha,scope=builder-${{ matrix.platform.os }},mode=max
-          outputs: type=docker,dest=/tmp/builder.tar
-
-      - name: Upload builder image
-        uses: actions/upload-artifact@v4
-        with:
-          name: builder-${{ matrix.platform.runner }}
-          path: /tmp/builder.tar
-          retention-days: 1
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Job 3: Build each agent variant (thin layers, parallel)
@@ -130,15 +157,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download builder image
-        uses: actions/download-artifact@v4
-        with:
-          name: builder-${{ matrix.platform.runner }}
-          path: /tmp
-
-      - name: Load builder image
-        run: docker load -i /tmp/builder.tar
-
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
@@ -147,11 +165,10 @@ jobs:
           file: Dockerfile.unified
           target: ${{ matrix.variant }}
           platforms: ${{ matrix.platform.os }}
+          build-args: |
+            BUILDER_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/builder:${{ needs.matrix.outputs.tag }}-${{ matrix.platform.runner }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: |
-            type=gha,scope=builder-${{ matrix.platform.os }}
-            type=gha,scope=${{ matrix.variant }}-${{ matrix.platform.os }}
-          cache-to: type=gha,scope=${{ matrix.variant }}-${{ matrix.platform.os }},mode=max
+          cache-from: type=gha,scope=builder-${{ matrix.platform.os }}
 
       - name: Export digest
         run: |
@@ -186,6 +203,22 @@ jobs:
           pattern: digests-${{ matrix.variant }}-*
           merge-multiple: true
 
+      - name: Validate digest count
+        run: |
+          COUNT=$(ls -1 /tmp/digests/ | wc -l)
+          if [ "$COUNT" -ne 2 ]; then
+            echo "::error::Expected 2 digests (amd64 + arm64), got $COUNT"
+            exit 1
+          fi
+          # Validate digest format (64 hex chars)
+          for f in /tmp/digests/*; do
+            name=$(basename "$f")
+            if ! echo "$name" | grep -qE '^[a-f0-9]{64}$'; then
+              echo "::error::Invalid digest format: $name"
+              exit 1
+            fi
+          done
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v4
@@ -205,12 +238,17 @@ jobs:
             -t "${IMAGE}:${TAG}-${VARIANT}" \
             $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
 
-          # For kiro (default): also tag as <version> and latest
+          # For kiro (default): also tag as <version> and latest (only from main)
           if [ "${VARIANT}" = "kiro" ]; then
             docker buildx imagetools create \
               -t "${IMAGE}:${TAG}" \
-              -t "${IMAGE}:latest" \
               $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
+
+            if [ "${{ inputs.branch }}" = "main" ]; then
+              docker buildx imagetools create \
+                -t "${IMAGE}:latest" \
+                $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
+            fi
           fi
 
       - name: Summary
@@ -221,5 +259,7 @@ jobs:
           echo "### 📦 \`${IMAGE}:${TAG}-${VARIANT}\`" >> "$GITHUB_STEP_SUMMARY"
           if [ "${VARIANT}" = "kiro" ]; then
             echo "### 📦 \`${IMAGE}:${TAG}\` (default)" >> "$GITHUB_STEP_SUMMARY"
-            echo "### 📦 \`${IMAGE}:latest\`" >> "$GITHUB_STEP_SUMMARY"
+            if [ "${{ inputs.branch }}" = "main" ]; then
+              echo "### 📦 \`${IMAGE}:latest\`" >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,225 @@
+name: Build Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build (default: main)'
+        required: false
+        type: string
+        default: 'main'
+      variants:
+        description: 'Variants to build (comma-separated, or "all")'
+        required: false
+        type: string
+        default: 'all'
+      tag:
+        description: 'Image tag version prefix (default: snapshot-<short-sha>)'
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  ALL_VARIANTS: 'kiro,claude,codex,copilot,cursor,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore'
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 1: Resolve matrix and tag
+  # ─────────────────────────────────────────────────────────────────────────────
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      variants: ${{ steps.resolve.outputs.variants }}
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Resolve matrix and tag
+        id: resolve
+        run: |
+          if [ "${{ inputs.variants }}" = "all" ] || [ -z "${{ inputs.variants }}" ]; then
+            VARIANTS="${{ env.ALL_VARIANTS }}"
+          else
+            VARIANTS="${{ inputs.variants }}"
+          fi
+          JSON=$(echo "$VARIANTS" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R . | jq -sc .)
+          echo "variants=${JSON}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            SHA=$(git rev-parse --short HEAD)
+            echo "tag=snapshot-${SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 2: Build shared builder layer (once per arch)
+  # ─────────────────────────────────────────────────────────────────────────────
+  build-core:
+    needs: matrix
+    strategy:
+      fail-fast: true
+      matrix:
+        platform:
+          - { os: linux/amd64, runner: ubuntu-latest }
+          - { os: linux/arm64, runner: ubuntu-24.04-arm }
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build builder stage and export
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.unified
+          target: builder
+          platforms: ${{ matrix.platform.os }}
+          cache-from: type=gha,scope=builder-${{ matrix.platform.os }}
+          cache-to: type=gha,scope=builder-${{ matrix.platform.os }},mode=max
+          outputs: type=docker,dest=/tmp/builder.tar
+
+      - name: Upload builder image
+        uses: actions/upload-artifact@v4
+        with:
+          name: builder-${{ matrix.platform.runner }}
+          path: /tmp/builder.tar
+          retention-days: 1
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 3: Build each agent variant (thin layers, parallel)
+  # ─────────────────────────────────────────────────────────────────────────────
+  build-agents:
+    needs: [matrix, build-core]
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJson(needs.matrix.outputs.variants) }}
+        platform:
+          - { os: linux/amd64, runner: ubuntu-latest }
+          - { os: linux/arm64, runner: ubuntu-24.04-arm }
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download builder image
+        uses: actions/download-artifact@v4
+        with:
+          name: builder-${{ matrix.platform.runner }}
+          path: /tmp
+
+      - name: Load builder image
+        run: docker load -i /tmp/builder.tar
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.unified
+          target: ${{ matrix.variant }}
+          platforms: ${{ matrix.platform.os }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: |
+            type=gha,scope=builder-${{ matrix.platform.os }}
+            type=gha,scope=${{ matrix.variant }}-${{ matrix.platform.os }}
+          cache-to: type=gha,scope=${{ matrix.variant }}-${{ matrix.platform.os }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.variant }}-${{ matrix.platform.runner }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 4: Create multi-arch manifest for each variant
+  # ─────────────────────────────────────────────────────────────────────────────
+  merge-manifests:
+    needs: [matrix, build-agents]
+    strategy:
+      matrix:
+        variant: ${{ fromJson(needs.matrix.outputs.variants) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.variant }}-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          TAG="${{ needs.matrix.outputs.tag }}"
+          VARIANT="${{ matrix.variant }}"
+
+          # Tag: <version>-<agent>
+          docker buildx imagetools create \
+            -t "${IMAGE}:${TAG}-${VARIANT}" \
+            $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
+
+          # For kiro (default): also tag as <version> and latest
+          if [ "${VARIANT}" = "kiro" ]; then
+            docker buildx imagetools create \
+              -t "${IMAGE}:${TAG}" \
+              -t "${IMAGE}:latest" \
+              $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
+          fi
+
+      - name: Summary
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          TAG="${{ needs.matrix.outputs.tag }}"
+          VARIANT="${{ matrix.variant }}"
+          echo "### 📦 \`${IMAGE}:${TAG}-${VARIANT}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${VARIANT}" = "kiro" ]; then
+            echo "### 📦 \`${IMAGE}:${TAG}\` (default)" >> "$GITHUB_STEP_SUMMARY"
+            echo "### 📦 \`${IMAGE}:latest\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/docker-smoke-test-unified.yml
+++ b/.github/workflows/docker-smoke-test-unified.yml
@@ -1,0 +1,44 @@
+name: Docker Smoke Test (Unified)
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile.unified'
+      - 'src/**'
+      - 'crates/**'
+      - 'Cargo.*'
+      - 'openab-agent/**'
+      - 'agy-acp/**'
+
+jobs:
+  smoke-test-unified:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { name: kiro, agent: "kiro-cli" }
+          - { name: claude, agent: "claude" }
+          - { name: codex, agent: "codex-acp" }
+          - { name: copilot, agent: "copilot" }
+          - { name: cursor, agent: "cursor-agent" }
+          - { name: gemini, agent: "gemini" }
+          - { name: grok, agent: "grok" }
+          - { name: hermes, agent: "hermes-acp" }
+          - { name: mimocode, agent: "mimo" }
+          - { name: opencode, agent: "opencode" }
+          - { name: antigravity, agent: "agy-acp" }
+          - { name: pi, agent: "pi-acp" }
+          - { name: native, agent: "openab-agent" }
+          - { name: agentcore, agent: "openab" }
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build unified target
+        run: docker build --target ${{ matrix.target.name }} -t openab-unified-${{ matrix.target.name }} -f Dockerfile.unified .
+
+      - name: Verify openab binary exists
+        run: docker run --rm --entrypoint which openab-unified-${{ matrix.target.name }} openab
+
+      - name: Verify agent CLI exists
+        run: docker run --rm --entrypoint which openab-unified-${{ matrix.target.name }} ${{ matrix.target.agent }}

--- a/.github/workflows/docker-smoke-test-unified.yml
+++ b/.github/workflows/docker-smoke-test-unified.yml
@@ -11,7 +11,26 @@ on:
       - 'agy-acp/**'
 
 jobs:
+  # Build the shared builder stage once, then test agent targets using cache
+  build-builder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build builder stage
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.unified
+          target: builder
+          load: true
+          tags: openab-builder:local
+          cache-to: type=gha,scope=unified-smoke-builder,mode=max
+
   smoke-test-unified:
+    needs: build-builder
     strategy:
       fail-fast: false
       matrix:
@@ -34,11 +53,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: docker/setup-buildx-action@v3
+
       - name: Build unified target
-        run: docker build --target ${{ matrix.target.name }} -t openab-unified-${{ matrix.target.name }} -f Dockerfile.unified .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.unified
+          target: ${{ matrix.target.name }}
+          load: true
+          tags: openab-unified-${{ matrix.target.name }}:test
+          cache-from: type=gha,scope=unified-smoke-builder
 
       - name: Verify openab binary exists
-        run: docker run --rm --entrypoint which openab-unified-${{ matrix.target.name }} openab
+        run: docker run --rm --entrypoint which openab-unified-${{ matrix.target.name }}:test openab
 
       - name: Verify agent CLI exists
-        run: docker run --rm --entrypoint which openab-unified-${{ matrix.target.name }} ${{ matrix.target.agent }}
+        run: docker run --rm --entrypoint which openab-unified-${{ matrix.target.name }}:test ${{ matrix.target.agent }}

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -7,13 +7,12 @@
 # =============================================================================
 # Stage: builder — compile openab binary (unified mode)
 # =============================================================================
-FROM rust:1-bookworm AS builder
+ARG BUILDER_IMAGE=rust:1-bookworm
+FROM ${BUILDER_IMAGE} AS builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/openab-core/Cargo.toml crates/openab-core/Cargo.toml
 COPY crates/openab-gateway/Cargo.toml crates/openab-gateway/Cargo.toml
-COPY openab-agent/ openab-agent/
-COPY agy-acp/ agy-acp/
 RUN mkdir -p src crates/openab-core/src crates/openab-gateway/src \
     && echo 'fn main() {}' > src/main.rs \
     && echo '' > crates/openab-core/src/lib.rs \
@@ -24,9 +23,11 @@ COPY crates/ crates/
 COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs \
     && cargo build --release --features unified
-# Also build openab-agent (used by native variant)
+# Build openab-agent (used by native variant) — copied late to avoid cache busts
+COPY openab-agent/ openab-agent/
 RUN cd openab-agent && cargo build --release
-# Also build agy-acp adapter (used by antigravity variant)
+# Build agy-acp adapter (used by antigravity variant) — copied late to avoid cache busts
+COPY agy-acp/ agy-acp/
 RUN cd agy-acp && cargo build --release
 
 # =============================================================================
@@ -304,7 +305,7 @@ ENV HOME=/home/agent
 WORKDIR /home/agent
 COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
 COPY --from=builder --chown=agent:agent /build/agy-acp/target/release/agy-acp /usr/local/bin/agy-acp
-RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent
+RUN mkdir -p /home/agent/.agy && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -152,7 +152,8 @@ RUN ARCH=$(dpkg --print-architecture) && \
     curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \
       -o /tmp/cursor.tar.gz && \
     tar xzf /tmp/cursor.tar.gz -C /opt && \
-    ln -s /opt/cursor-agent-cli/bin/cursor-agent /usr/local/bin/cursor-agent && \
+    mv /opt/dist-package /opt/cursor-agent && \
+    ln -s /opt/cursor-agent/cursor-agent /usr/local/bin/cursor-agent && \
     rm /tmp/cursor.tar.gz
 ENV HOME=/home/agent
 WORKDIR /home/agent

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -50,7 +50,7 @@ RUN useradd -m -s /bin/bash -u 1000 agent
 # =============================================================================
 FROM node:22-bookworm-slim AS base-node
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl procps ripgrep tini bubblewrap socat unzip \
+      ca-certificates curl procps ripgrep tini bubblewrap socat unzip git \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -25,10 +25,10 @@ RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/li
     && cargo build --release --features unified
 # Build openab-agent (used by native variant) — copied late to avoid cache busts
 COPY openab-agent/ openab-agent/
-RUN cd openab-agent && cargo build --release
+RUN cd openab-agent && printf '\n[workspace]\n' >> Cargo.toml && cargo build --release
 # Build agy-acp adapter (used by antigravity variant) — copied late to avoid cache busts
 COPY agy-acp/ agy-acp/
-RUN cd agy-acp && cargo build --release
+RUN cd agy-acp && printf '\n[workspace]\n' >> Cargo.toml && cargo build --release
 
 # =============================================================================
 # Stage: base-debian — shared runtime base for debian-based agents

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -1,0 +1,367 @@
+# Dockerfile.unified — Single multi-target Dockerfile for all OpenAB agent variants.
+# Usage: docker build --target <agent> -t ghcr.io/openabdev/openab:<tag>-<agent> .
+#
+# The shared builder compiles the openab binary once (unified mode, superset).
+# Each agent target is a thin runtime layer that installs only the agent CLI.
+
+# =============================================================================
+# Stage: builder — compile openab binary (unified mode)
+# =============================================================================
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY crates/openab-core/Cargo.toml crates/openab-core/Cargo.toml
+COPY crates/openab-gateway/Cargo.toml crates/openab-gateway/Cargo.toml
+COPY openab-agent/ openab-agent/
+COPY agy-acp/ agy-acp/
+RUN mkdir -p src crates/openab-core/src crates/openab-gateway/src \
+    && echo 'fn main() {}' > src/main.rs \
+    && echo '' > crates/openab-core/src/lib.rs \
+    && echo '' > crates/openab-gateway/src/lib.rs \
+    && cargo build --release --features unified \
+    && rm -rf src crates/openab-core/src crates/openab-gateway/src
+COPY crates/ crates/
+COPY src/ src/
+RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs \
+    && cargo build --release --features unified
+# Also build openab-agent (used by native variant)
+RUN cd openab-agent && cargo build --release
+# Also build agy-acp adapter (used by antigravity variant)
+RUN cd agy-acp && cargo build --release
+
+# =============================================================================
+# Stage: base-debian — shared runtime base for debian-based agents
+# =============================================================================
+FROM debian:bookworm-slim AS base-debian
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl procps ripgrep tini git unzip \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+RUN useradd -m -s /bin/bash -u 1000 agent
+
+# =============================================================================
+# Stage: base-node — shared runtime base for node-based agents
+# =============================================================================
+FROM node:22-bookworm-slim AS base-node
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl procps ripgrep tini bubblewrap socat unzip \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+# =============================================================================
+# Target: kiro (default)
+# =============================================================================
+FROM base-debian AS kiro
+ARG KIRO_CLI_VERSION=2.8.1
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "arm64" ]; then URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-aarch64-linux.zip"; \
+    else URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-x86_64-linux.zip"; fi && \
+    curl --proto '=https' --tlsv1.2 -sSf --retry 3 --retry-delay 5 "$URL" -o /tmp/kirocli.zip && \
+    unzip /tmp/kirocli.zip -d /tmp && \
+    cp /tmp/kirocli/bin/* /usr/local/bin/ && \
+    chmod +x /usr/local/bin/kiro-cli* && \
+    rm -rf /tmp/kirocli /tmp/kirocli.zip
+RUN mkdir -p /home/agent/.local/share/kiro-cli /home/agent/.kiro && \
+    chown -R agent:agent /home/agent
+ENV HOME=/home/agent
+WORKDIR /home/agent
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="kiro-cli acp --trust-all-tools"
+ENV OPENAB_AGENT_AUTH_COMMAND="kiro-cli login --use-device-flow"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: claude
+# =============================================================================
+FROM base-node AS claude
+ARG CLAUDE_AGENT_ACP_VERSION=0.45.0
+ARG CLAUDE_CODE_VERSION=2.1.179
+RUN npm install -g @agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION} @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} --retry 3
+ENV CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude
+ENV HOME=/home/node
+WORKDIR /home/node
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/node/.claude && chown -R node:node /home/node
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="claude"
+ENV OPENAB_AGENT_AUTH_COMMAND="claude auth login"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: codex
+# =============================================================================
+FROM base-node AS codex
+ARG CODEX_ACP_VERSION=0.16.0
+ARG CODEX_VERSION=0.141.0
+RUN npm install -g @zed-industries/codex-acp@${CODEX_ACP_VERSION} @openai/codex@${CODEX_VERSION} --retry 3
+ENV HOME=/home/node
+WORKDIR /home/node
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/node/.codex && chown -R node:node /home/node
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="codex-acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="codex login --device-auth"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: copilot
+# =============================================================================
+FROM base-node AS copilot
+ARG COPILOT_VERSION=1.0.63
+RUN npm install -g @github/copilot@${COPILOT_VERSION} --retry 3
+ENV HOME=/home/node
+WORKDIR /home/node
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/node/.copilot && chown -R node:node /home/node
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="copilot --acp --stdio"
+ENV OPENAB_AGENT_AUTH_COMMAND="copilot login"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: cursor
+# =============================================================================
+FROM base-debian AS cursor
+ARG CURSOR_VERSION=2026.06.19-20-24-33-653a7fb
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "arm64" ]; then ARCH=arm64; else ARCH=x64; fi && \
+    curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz" \
+      -o /tmp/cursor.tar.gz && \
+    tar xzf /tmp/cursor.tar.gz -C /opt && \
+    ln -s /opt/cursor-agent-cli/bin/cursor-agent /usr/local/bin/cursor-agent && \
+    rm /tmp/cursor.tar.gz
+ENV HOME=/home/agent
+WORKDIR /home/agent
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/agent/.cursor && chown -R agent:agent /home/agent
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="cursor-agent acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="cursor-agent login"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: gemini
+# =============================================================================
+FROM base-node AS gemini
+ARG GEMINI_CLI_VERSION=0.47.0
+RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} --retry 3
+ENV HOME=/home/node
+WORKDIR /home/node
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/node/.gemini && chown -R node:node /home/node
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="gemini --acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="gemini auth"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: grok
+# =============================================================================
+FROM base-debian AS grok
+ARG GROK_VERSION=0.1.220
+ARG GROK_SHA256_AMD64=98d331d64dfc4fb1dae862475218cccdd195f76839b8361a0678af2fd388364b
+ARG GROK_SHA256_ARM64=3b15efc258f4219d01736acee70c575a8167f970cb4d497a3b0c218440db58ff
+ARG TARGETPLATFORM
+RUN set -eux; \
+    case "${TARGETPLATFORM:-linux/amd64}" in \
+      "linux/amd64") arch=x86_64; sha="${GROK_SHA256_AMD64}" ;; \
+      "linux/arm64") arch=aarch64; sha="${GROK_SHA256_ARM64}" ;; \
+      *) echo "Unsupported platform: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-${GROK_VERSION}-linux-${arch}" \
+      -o /tmp/grok && \
+    echo "${sha}  /tmp/grok" | sha256sum -c - && \
+    install -m 0755 /tmp/grok /usr/local/bin/grok && \
+    rm /tmp/grok
+ENV HOME=/home/agent
+WORKDIR /home/agent
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/agent/.grok && chown -R agent:agent /home/agent
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="grok agent stdio"
+ENV OPENAB_AGENT_AUTH_COMMAND="grok login --device-auth"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: hermes
+# =============================================================================
+FROM python:3.12-slim-bookworm AS hermes
+RUN useradd -m -u 1000 agent
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl procps ripgrep tini git ffmpeg unzip xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+ARG HERMES_INSTALL_COMMIT=2bd1977d8fad185c9b4be47884f7e87f1add0ce3
+ARG HERMES_INSTALL_SHA256=dbd9d555ed4ac67bd1fc71ba6a39b410cf2af0ebcfd8f4889e086af78c9ddcaa
+RUN curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HERMES_INSTALL_COMMIT}/scripts/install.sh" \
+      -o /tmp/install-hermes.sh && \
+    echo "${HERMES_INSTALL_SHA256}  /tmp/install-hermes.sh" | sha256sum -c - && \
+    HERMES_HOME=/home/agent/.hermes bash /tmp/install-hermes.sh && \
+    rm /tmp/install-hermes.sh && \
+    (test -d /root/.local/share/uv && chmod -R a+rX /root/.local/share/uv && chmod a+rx /root /root/.local /root/.local/share || true) && \
+    ln -sf /usr/local/lib/hermes-agent/venv/bin/hermes-acp /usr/local/bin/hermes-acp
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+ENV HOME=/home/agent
+WORKDIR /home/agent
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
+RUN chown -R agent:agent /home/agent
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="hermes-acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="hermes auth add"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: mimocode
+# =============================================================================
+FROM base-node AS mimocode
+ARG MIMOCODE_VERSION=0.1.1
+RUN npm install -g @mimo-ai/cli@${MIMOCODE_VERSION} --retry 3
+ENV HOME=/home/node
+WORKDIR /home/node
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/node/.mimo && chown -R node:node /home/node
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="mimo acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="mimo auth login --provider mimo --method \"MiMo Auto (free)\""
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: opencode
+# =============================================================================
+FROM base-node AS opencode
+ARG OPENCODE_VERSION=1.17.9
+RUN npm install -g opencode-ai@${OPENCODE_VERSION} --retry 3
+ENV HOME=/home/node
+WORKDIR /home/node
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/node/.opencode && chown -R node:node /home/node
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="opencode acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="opencode auth login"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: antigravity
+# =============================================================================
+FROM base-debian AS antigravity
+ENV AGY_VERSION=1.0.10
+RUN ARCH=$(dpkg --print-architecture) && \
+    case "$ARCH" in \
+      amd64) ASSET="agy_cli_linux_x64.tar.gz" ;; \
+      arm64) ASSET="agy_cli_linux_arm64.tar.gz" ;; \
+      *) echo "unsupported arch: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/google-antigravity/antigravity-cli/releases/download/${AGY_VERSION}/${ASSET}" \
+      | tar -xz -C /usr/local/bin && \
+    mv /usr/local/bin/antigravity /usr/local/bin/agy && \
+    chmod +x /usr/local/bin/agy
+ENV HOME=/home/agent
+WORKDIR /home/agent
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
+COPY --from=builder --chown=agent:agent /build/agy-acp/target/release/agy-acp /usr/local/bin/agy-acp
+RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="agy-acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="agy auth"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: pi
+# =============================================================================
+FROM base-node AS pi
+ARG PI_ACP_VERSION=0.0.31
+ARG PI_CODING_AGENT_VERSION=0.79.9
+RUN npm install -g pi-acp@${PI_ACP_VERSION} @earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION} --retry 3
+ENV HOME=/home/node
+WORKDIR /home/node
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/node/.pi && chown -R node:node /home/node
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="openab-agent"
+ENV OPENAB_AGENT_AUTH_COMMAND="pi /login"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: native
+# =============================================================================
+FROM base-debian AS native
+ENV HOME=/home/agent
+WORKDIR /home/agent
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
+COPY --from=builder --chown=agent:agent /build/openab-agent/target/release/openab-agent /usr/local/bin/openab-agent
+RUN mkdir -p /home/agent/.openab && chown -R agent:agent /home/agent
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="openab-agent"
+ENV OPENAB_AGENT_AUTH_COMMAND="openab-agent auth codex-oauth --no-browser"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
+# Target: agentcore (minimal — no agent CLI bundled)
+# =============================================================================
+FROM debian:bookworm-slim AS agentcore
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates tini \
+    && rm -rf /var/lib/apt/lists/*
+RUN useradd -m -s /bin/bash -u 1000 agent
+ENV HOME=/home/agent
+WORKDIR /home/agent
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]


### PR DESCRIPTION
## Summary

Consolidate all Docker images into a single repo (`ghcr.io/openabdev/openab`) with tag-based variants.

Closes #1174

## Changes

### `Dockerfile.unified`
- **Shared builder stage**: compiles the `openab` binary once in unified mode (superset)
- **Per-agent targets**: 14 thin runtime layers that only install the agent CLI
- Also compiles `openab-agent` (for native) and `agy-acp` (for antigravity) in the builder

### `.github/workflows/build-images.yml`
New workflow replacing the per-variant approach in `snapshot-build.yml`:
- **Job 1** (`build-core`): shared Rust builder, 1× per arch (~8-10 min)
- **Job 2** (`build-agents`): 14 agent variants in parallel, thin layers (~2 min each)
- **Job 3** (`merge-manifests`): multi-arch manifest per variant (~1 min)

### Tag strategy
```
ghcr.io/openabdev/openab:<version>-<agent>   # per agent
ghcr.io/openabdev/openab:<version>           # default (kiro)
ghcr.io/openabdev/openab:latest              # latest default
```

### Agents
kiro, claude, codex, copilot, cursor, gemini, grok, hermes, mimocode, opencode, antigravity, pi, native, agentcore

## Performance
~12 min total build time (vs ~140 min today with 14 independent builds)

## What's NOT in this PR (follow-ups)
- Deprecate/remove old `snapshot-build.yml` (after validation)
- Remove individual `Dockerfile.<agent>` files (after migration period)
- Update Helm chart `_helpers.tpl` to use `<tag>-<agent>` format
- Update docs
