### PR TITLE
feat(config): support s3:// config source via -c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,7 +173,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.2",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
@@ -218,6 +224,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -226,12 +233,50 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
+ "http 0.2.12",
  "http 1.4.2",
+ "http-body 0.4.6",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.137.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd7213994e2ff9382ff100403b78c30d1b74cdfcd8fa9d0d1dc3a94a5c4874"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.11.0",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -342,19 +387,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.2",
+ "p256",
  "percent-encoding",
  "sha2 0.11.0",
+ "subtle",
  "time",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -369,11 +419,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-checksums"
+version = "0.64.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "md-5",
+ "pin-project-lite",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -591,7 +674,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -621,6 +704,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +724,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -845,6 +940,12 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -884,6 +985,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +1013,18 @@ dependencies = [
  "once_cell",
  "phf 0.11.3",
  "winnow",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -971,6 +1094,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +1120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -997,7 +1132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1020,10 +1155,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "emojis"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4d5d50b0b58df5173d8ff1192b4d1422ceae5d981b30d4b6f8ed1d673a2bc4"
+dependencies = [
+ "phf 0.13.1",
+]
 
 [[package]]
 name = "equivalent"
@@ -1057,6 +1235,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1265,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1189,6 +1383,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1240,6 +1435,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +1488,17 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1780,6 +1997,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +2025,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "memchr"
@@ -1920,13 +2156,19 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openab"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "axum",
  "clap",
  "openab-core",
  "openab-gateway",
+ "reqwest",
+ "serde",
+ "serde_json",
  "serenity",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1940,6 +2182,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-credential-types",
+ "aws-sdk-s3",
  "aws-sdk-secretsmanager",
  "aws-sigv4",
  "base64",
@@ -1947,6 +2190,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "cron",
+ "emojis",
  "futures-util",
  "hex",
  "http 1.4.2",
@@ -1990,12 +2234,13 @@ dependencies = [
  "hmac 0.12.1",
  "image",
  "jsonwebtoken",
+ "parking_lot",
  "prost",
  "quick-xml",
  "reqwest",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "subtle",
  "tokio",
@@ -2018,6 +2263,18 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2053,6 +2310,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,6 +2341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2119,6 +2394,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2413,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "png"
@@ -2165,6 +2459,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2454,6 +2757,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +2963,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +3142,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,6 +3197,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2915,6 +3263,22 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3366,7 +3730,7 @@ dependencies = [
  "rand 0.8.6",
  "rustls 0.22.4",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "url",
  "utf-8",
@@ -3384,7 +3748,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serenity = { version = "0.12", default-features = false, features = ["client", "
 
 [features]
 # Default: core only (Discord + Slack). Gateway ships as separate binary.
-default = ["discord", "slack", "secrets-aws", "agentcore"]
+default = ["discord", "slack", "secrets-aws", "agentcore", "config-s3"]
 
 # Opt-in: compile all gateway adapters into a single unified binary
 unified = ["telegram", "line", "feishu", "googlechat", "wecom", "teams"]
@@ -36,6 +36,7 @@ slack = ["openab-core/slack"]
 # Core optional features
 secrets-aws = ["openab-core/secrets-aws"]
 agentcore = ["openab-core/agentcore"]
+config-s3 = ["openab-core/config-s3"]
 
 # Gateway adapters (each pulls in the gateway crate + axum for embedded server)
 telegram = ["dep:openab-gateway", "dep:axum", "openab-gateway/telegram"]

--- a/crates/openab-core/Cargo.toml
+++ b/crates/openab-core/Cargo.toml
@@ -37,6 +37,7 @@ emojis = "0.8"
 sha2 = "0.10"
 tempfile = "3.27.0"
 aws-sdk-secretsmanager = { version = "1", optional = true }
+aws-sdk-s3 = { version = "1", optional = true }
 aws-config = { version = "1", optional = true }
 aws-sigv4 = { version = "1", optional = true }
 aws-credential-types = { version = "1", optional = true }
@@ -48,8 +49,9 @@ http = { version = "1", optional = true }
 libc = "0.2"
 
 [features]
-default = ["discord", "slack", "secrets-aws", "agentcore"]
+default = ["discord", "slack", "secrets-aws", "agentcore", "config-s3"]
 discord = ["dep:serenity"]
 slack = []
 secrets-aws = ["dep:aws-sdk-secretsmanager", "dep:aws-config"]
+config-s3 = ["dep:aws-sdk-s3", "dep:aws-config"]
 agentcore = ["dep:aws-config", "dep:aws-sigv4", "dep:aws-credential-types", "dep:urlencoding", "dep:hex", "dep:http", "dep:rustls", "dep:tokio-rustls", "dep:webpki-roots"]

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -990,6 +990,27 @@ pub async fn load_config_raw_from_s3(uri: &str) -> anyhow::Result<String> {
     )
 }
 
+/// Load raw config text from any supported source, dispatching on the scheme:
+/// a local file path, an `http(s)://` URL, or an `s3://<bucket>/<key>` URI.
+/// Env vars are expanded (`${VAR}`) but secrets are NOT resolved.
+///
+/// Centralizing scheme dispatch here keeps the binary entrypoint decoupled from
+/// the set of supported config sources.
+pub async fn load_config_raw_from_source(source: &str) -> anyhow::Result<String> {
+    if source.starts_with("https://") {
+        tracing::info!(url = %source, "fetching remote config");
+        load_config_raw_from_url(source).await
+    } else if source.starts_with("http://") {
+        tracing::warn!(url = %source, "fetching remote config over plaintext HTTP — use HTTPS in production");
+        load_config_raw_from_url(source).await
+    } else if source.starts_with("s3://") {
+        tracing::info!(uri = %source, "fetching config from S3");
+        load_config_raw_from_s3(source).await
+    } else {
+        load_config_raw(Path::new(source))
+    }
+}
+
 /// Parse config from already-expanded text.
 pub fn parse_config_str(expanded: &str, source: &str) -> anyhow::Result<Config> {
     parse_config_inner(expanded, source)

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -925,6 +925,70 @@ pub async fn load_config_raw_from_url(url: &str) -> anyhow::Result<String> {
     Ok(expand_env_vars(&raw))
 }
 
+/// Parse an `s3://<bucket>/<key>` URI into its bucket and key components.
+///
+/// Kept un-gated (independent of the `config-s3` feature) so URI parsing can be
+/// unit-tested without pulling in the AWS SDK.
+pub fn parse_s3_uri(uri: &str) -> anyhow::Result<(String, String)> {
+    let rest = uri
+        .strip_prefix("s3://")
+        .ok_or_else(|| anyhow::anyhow!("invalid s3:// URI '{uri}' — must start with s3://"))?;
+    let (bucket, key) = rest
+        .split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("invalid s3:// URI '{uri}' — expected s3://<bucket>/<key>"))?;
+    if bucket.is_empty() || key.is_empty() {
+        anyhow::bail!("invalid s3:// URI '{uri}' — bucket and key must both be non-empty");
+    }
+    Ok((bucket.to_string(), key.to_string()))
+}
+
+/// Load raw config text from an `s3://<bucket>/<key>` URI
+/// (env vars expanded but secrets NOT resolved).
+///
+/// Credentials/region are resolved via the standard AWS provider chain
+/// (env vars, shared config, IRSA / Pod Identity / instance role), mirroring
+/// how `aws-sm://` secret references are resolved.
+#[cfg(feature = "config-s3")]
+pub async fn load_config_raw_from_s3(uri: &str) -> anyhow::Result<String> {
+    let (bucket, key) = parse_s3_uri(uri)?;
+    let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .load()
+        .await;
+    let client = aws_sdk_s3::Client::new(&sdk_config);
+    let resp = client
+        .get_object()
+        .bucket(&bucket)
+        .key(&key)
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to fetch S3 config from {uri}: {e}"))?;
+    let data = resp
+        .body
+        .collect()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to read S3 object body from {uri}: {e}"))?
+        .into_bytes();
+    const MAX_CONFIG_BYTES: usize = 1024 * 1024;
+    if data.len() > MAX_CONFIG_BYTES {
+        anyhow::bail!(
+            "S3 config from {uri} exceeds 1 MiB limit ({} bytes)",
+            data.len()
+        );
+    }
+    let raw = String::from_utf8(data.to_vec())
+        .map_err(|e| anyhow::anyhow!("S3 config from {uri} is not valid UTF-8: {e}"))?;
+    Ok(expand_env_vars(&raw))
+}
+
+/// Fallback when built without the `config-s3` feature: report a clear error
+/// instead of failing to compile callers that dispatch on the `s3://` scheme.
+#[cfg(not(feature = "config-s3"))]
+pub async fn load_config_raw_from_s3(uri: &str) -> anyhow::Result<String> {
+    anyhow::bail!(
+        "config source '{uri}' uses the s3:// scheme, but openab was built without the 'config-s3' feature"
+    )
+}
+
 /// Parse config from already-expanded text.
 pub fn parse_config_str(expanded: &str, source: &str) -> anyhow::Result<Config> {
     parse_config_inner(expanded, source)
@@ -1117,6 +1181,36 @@ command = "echo"
         let result = expand_env_vars("token=${AB_TEST_VAR}");
         assert_eq!(result, "token=hello");
         std::env::remove_var("AB_TEST_VAR");
+    }
+
+    #[test]
+    fn parse_s3_uri_splits_bucket_and_key() {
+        let (bucket, key) = parse_s3_uri("s3://my-bucket/path/to/config.toml").unwrap();
+        assert_eq!(bucket, "my-bucket");
+        assert_eq!(key, "path/to/config.toml");
+    }
+
+    #[test]
+    fn parse_s3_uri_handles_single_segment_key() {
+        let (bucket, key) = parse_s3_uri("s3://bkt/config.toml").unwrap();
+        assert_eq!(bucket, "bkt");
+        assert_eq!(key, "config.toml");
+    }
+
+    #[test]
+    fn parse_s3_uri_rejects_wrong_scheme() {
+        assert!(parse_s3_uri("https://example.com/config.toml").is_err());
+        assert!(parse_s3_uri("config.toml").is_err());
+    }
+
+    #[test]
+    fn parse_s3_uri_rejects_missing_key() {
+        // no '/' after bucket
+        assert!(parse_s3_uri("s3://only-bucket").is_err());
+        // empty key
+        assert!(parse_s3_uri("s3://bucket/").is_err());
+        // empty bucket
+        assert!(parse_s3_uri("s3:///key").is_err());
     }
 
     #[test]

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -888,6 +888,25 @@ fn expand_env_vars(raw: &str) -> String {
     .into_owned()
 }
 
+/// Maximum accepted size for a remotely-fetched config document (URL or S3).
+const MAX_CONFIG_BYTES: usize = 1024 * 1024;
+
+/// Finalize raw config bytes fetched from a remote source: enforce the size
+/// cap, validate UTF-8, and expand `${ENV}` references. Shared by the URL and
+/// S3 loaders so both behave identically (and so this logic is unit-testable
+/// offline, without a network or the AWS SDK).
+fn finalize_config_bytes(bytes: &[u8], source: &str) -> anyhow::Result<String> {
+    if bytes.len() > MAX_CONFIG_BYTES {
+        anyhow::bail!(
+            "config from {source} exceeds 1 MiB limit ({} bytes)",
+            bytes.len()
+        );
+    }
+    let raw = std::str::from_utf8(bytes)
+        .map_err(|e| anyhow::anyhow!("config from {source} is not valid UTF-8: {e}"))?;
+    Ok(expand_env_vars(raw))
+}
+
 /// Load raw config text from a file path (env vars expanded but secrets NOT resolved).
 pub fn load_config_raw(path: &Path) -> anyhow::Result<String> {
     let raw = std::fs::read_to_string(path)
@@ -913,16 +932,7 @@ pub async fn load_config_raw_from_url(url: &str) -> anyhow::Result<String> {
         .bytes()
         .await
         .map_err(|e| anyhow::anyhow!("failed to read response body from {url}: {e}"))?;
-    const MAX_CONFIG_BYTES: usize = 1024 * 1024;
-    if bytes.len() > MAX_CONFIG_BYTES {
-        anyhow::bail!(
-            "remote config from {url} exceeds 1 MiB limit ({} bytes)",
-            bytes.len()
-        );
-    }
-    let raw = String::from_utf8(bytes.to_vec())
-        .map_err(|e| anyhow::anyhow!("remote config from {url} is not valid UTF-8: {e}"))?;
-    Ok(expand_env_vars(&raw))
+    finalize_config_bytes(&bytes, url)
 }
 
 /// Parse an `s3://<bucket>/<key>` URI into its bucket and key components.
@@ -968,16 +978,7 @@ pub async fn load_config_raw_from_s3(uri: &str) -> anyhow::Result<String> {
         .await
         .map_err(|e| anyhow::anyhow!("failed to read S3 object body from {uri}: {e}"))?
         .into_bytes();
-    const MAX_CONFIG_BYTES: usize = 1024 * 1024;
-    if data.len() > MAX_CONFIG_BYTES {
-        anyhow::bail!(
-            "S3 config from {uri} exceeds 1 MiB limit ({} bytes)",
-            data.len()
-        );
-    }
-    let raw = String::from_utf8(data.to_vec())
-        .map_err(|e| anyhow::anyhow!("S3 config from {uri} is not valid UTF-8: {e}"))?;
-    Ok(expand_env_vars(&raw))
+    finalize_config_bytes(&data, uri)
 }
 
 /// Fallback when built without the `config-s3` feature: report a clear error
@@ -1211,6 +1212,35 @@ command = "echo"
         assert!(parse_s3_uri("s3://bucket/").is_err());
         // empty bucket
         assert!(parse_s3_uri("s3:///key").is_err());
+    }
+
+    #[test]
+    fn finalize_config_bytes_accepts_at_limit() {
+        let at_limit = vec![b'a'; MAX_CONFIG_BYTES];
+        assert!(finalize_config_bytes(&at_limit, "test").is_ok());
+    }
+
+    #[test]
+    fn finalize_config_bytes_rejects_oversize() {
+        let oversize = vec![b'a'; MAX_CONFIG_BYTES + 1];
+        let err = finalize_config_bytes(&oversize, "test").unwrap_err();
+        assert!(err.to_string().contains("exceeds 1 MiB limit"));
+    }
+
+    #[test]
+    fn finalize_config_bytes_rejects_invalid_utf8() {
+        // 0xFF is never valid in UTF-8
+        let bad = [0xff, 0xfe, 0xfd];
+        let err = finalize_config_bytes(&bad, "test").unwrap_err();
+        assert!(err.to_string().contains("not valid UTF-8"));
+    }
+
+    #[test]
+    fn finalize_config_bytes_expands_env() {
+        std::env::set_var("AB_FINALIZE_TEST", "world");
+        let out = finalize_config_bytes(b"hello=${AB_FINALIZE_TEST}", "test").unwrap();
+        assert_eq!(out, "hello=world");
+        std::env::remove_var("AB_FINALIZE_TEST");
     }
 
     #[test]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -17,11 +17,52 @@ openab run -c https://example.com/config.toml
 
 # Remote URL via HTTP (warns — avoid in production; config contains secrets)
 openab run -c http://internal.example.com/config.toml
+
+# Amazon S3 (or S3-compatible) object
+openab run -c s3://my-bucket/path/to/config.toml
 ```
 
 Remote config is fetched via HTTP GET with a 10-second timeout and a 1 MiB response size limit. Environment variable expansion (`${VAR}`) works identically on both local and remote config content.
 
 > **Security best practice:** Never hardcode secrets in remote config files. Use environment variable references like `bot_token = "${DISCORD_BOT_TOKEN}"` and inject the actual values via local environment variables or Kubernetes Secrets. For centralized secret management with rotation and audit, use `[secrets.refs]` with AWS Secrets Manager or an exec provider — see [secrets-management.md](secrets-management.md). OpenAB expands `${VAR}` identically for both local and remote config.
+
+### `s3://` config source
+
+`openab run -c s3://<bucket>/<key>` fetches the config object directly from Amazon S3
+(requires a build with the `config-s3` feature, which is on by default). The same
+1 MiB size cap, UTF-8 validation, and `${VAR}` expansion apply as for HTTP(S) sources.
+
+**Credential & region resolution** uses the standard AWS provider chain — the same
+mechanism as `aws-sm://` secret references:
+
+- environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`),
+- shared config/credentials files (`~/.aws/...`),
+- container/instance roles: **IRSA / EKS Pod Identity** (Kubernetes) or the **ECS task role** / EC2 instance role.
+
+There is no `[s3]` config section for this: the credentials needed to *fetch* the
+config cannot live *inside* the config you are fetching. Configure the bootstrap S3
+access via the environment/role above.
+
+**Minimum IAM policy** — scope the role to only the config prefix, never `Resource: "*"`:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["s3:GetObject"],
+  "Resource": "arn:aws:s3:::my-bucket/path/to/*"
+}
+```
+
+> **Secrets still never belong in the config object.** The `s3://` loader does not
+> resolve secrets — it only fetches text and expands `${VAR}`. Keep secrets out of the
+> S3 object and inject them via env vars / `[secrets.refs]` as above.
+
+> **S3-compatible stores (Cloudflare R2, MinIO):** R2 generally works by setting
+> `AWS_ENDPOINT_URL_S3` (plus R2 keys and `AWS_REGION=auto`). MinIO and some others
+> additionally require path-style addressing, which the standard AWS env vars do not
+> cover yet — explicit endpoint / path-style support is tracked as a follow-up. Only
+> point the endpoint at trusted hosts; a poisoned endpoint env var could redirect the
+> fetch to a malicious server.
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,18 +176,7 @@ async fn main() -> anyhow::Result<()> {
     let config_source = config_arg.unwrap_or_else(|| "config.toml".into());
 
     // First pass: load config (env vars expanded, secrets NOT resolved yet)
-    let raw_expanded = if config_source.starts_with("https://") {
-        info!(url = %config_source, "fetching remote config");
-        config::load_config_raw_from_url(&config_source).await?
-    } else if config_source.starts_with("http://") {
-        warn!(url = %config_source, "fetching remote config over plaintext HTTP — use HTTPS in production");
-        config::load_config_raw_from_url(&config_source).await?
-    } else if config_source.starts_with("s3://") {
-        info!(uri = %config_source, "fetching config from S3");
-        config::load_config_raw_from_s3(&config_source).await?
-    } else {
-        config::load_config_raw(&PathBuf::from(&config_source))?
-    };
+    let raw_expanded = config::load_config_raw_from_source(&config_source).await?;
 
     let mut cfg = config::parse_config_str(&raw_expanded, &config_source)?;
     info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ struct Cli {
 enum Commands {
     /// Run the bot (default)
     Run {
-        /// Config file path or URL (default: config.toml)
+        /// Config file path or URL — local path, https://, http://, or s3://<bucket>/<key> (default: config.toml)
         #[arg(short = 'c', long = "config", value_name = "CONFIG")]
         config: Option<String>,
     },
@@ -182,6 +182,9 @@ async fn main() -> anyhow::Result<()> {
     } else if config_source.starts_with("http://") {
         warn!(url = %config_source, "fetching remote config over plaintext HTTP — use HTTPS in production");
         config::load_config_raw_from_url(&config_source).await?
+    } else if config_source.starts_with("s3://") {
+        info!(uri = %config_source, "fetching config from S3");
+        config::load_config_raw_from_s3(&config_source).await?
     } else {
         config::load_config_raw(&PathBuf::from(&config_source))?
     };


### PR DESCRIPTION
## What problem does this solve?

`openab run -c <source>` already loads config from `https://`, `http://`, and local paths, but **not** `s3://`. This means deploying with config stored in S3 requires an extra mechanism (an initContainer `aws s3 cp`, or baking the config into a ConfigMap) to get `config.toml` into the container.

This PR lets openab fetch its config directly from S3 — the **same `-c` mechanism across ECS, Kubernetes, and local runs**. It came out of a design discussion on `oabctl`'s K8s backend, where "let openab itself support `s3://`" emerged as a cleaner alternative to the initContainer pattern.

Discord Discussion URL: discussed in the maintainer Discord thread with @pahud.hsieh (the PR Discussion URL Check is skipped for the maintainer bot account).

## At a Glance

```
openab run -c <source>
        │
        ├─ https:// | http://  → reqwest (existing)
        ├─ s3://<bucket>/<key>  → aws-sdk-s3 get_object  ← NEW
        └─ <path>               → local file (existing)
                 │
                 ▼
        expand ${ENV} → parse config.toml
```

Credentials/region resolve via the standard AWS provider chain (env, shared config, IRSA / Pod Identity / instance role) — exactly like the existing `aws-sm://` secret references.

## Prior Art & Industry Research

Not applicable — small, self-contained feature extending an existing config-source loader. It mirrors the established in-repo patterns: the `https://` loader (`load_config_raw_from_url`) and the `aws-sm://` secret resolver (`secrets-aws` feature + `aws-config` provider chain).

## Proposed Solution

- **`crates/openab-core/Cargo.toml`**: add `aws-sdk-s3` as an optional dep behind a new `config-s3` feature (`["dep:aws-sdk-s3", "dep:aws-config"]`), included in `default`. Mirrors the existing `secrets-aws` pattern; `aws-config` was already a dependency.
- **`crates/openab-core/src/config.rs`**:
  - `parse_s3_uri()` — ungated, unit-tested `s3://<bucket>/<key>` parser with validation.
  - `load_config_raw_from_s3()` (feature-gated) — `get_object` → 1 MiB cap → UTF-8 → `${ENV}` expansion, mirroring `load_config_raw_from_url`.
  - a `#[cfg(not(feature = "config-s3"))]` stub that returns a clear error, so callers don't need to gate.
- **`src/main.rs`**: dispatch `s3://` to the new loader; forward the `config-s3` feature; update `-c` help text.
- **root `Cargo.toml`**: forward `config-s3` to `openab-core` and add to `default`.

## Why this approach?

openab's `-c` is already a pluggable config-source loader, so adding a scheme is the lowest-friction option. Doing the fetch **in openab** (rather than an initContainer or oabctl baking a ConfigMap) means one identical mechanism on every runtime, keeps S3 as a single source of truth, and reuses the AWS provider chain already used for `aws-sm://`. The feature flag keeps it opt-out for builds that don't want the S3 SDK.

## Alternatives Considered

- **initContainer `aws s3 cp`** (K8s only) — extra container + shared volume, K8s-specific, doesn't help ECS/local.
- **oabctl-fetched ConfigMap** — cloud-agnostic and good for local/multi-cloud, but doesn't keep S3 as source of truth and is a separate code path. (This remains complementary — both can coexist; see the oabctl K8s ADR.)

## Validation

Rust changes:
- [x] `parse_s3_uri` logic type-checks (`rustc --emit=metadata`)
- [x] `cargo metadata` OK — manifests + feature graph valid
- [x] `cargo tree` confirms `config-s3` (default) pulls `aws-sdk-s3 v1.137.0`; `--no-default-features` excludes it (stub path compiles)
- [x] 4 unit tests added for `parse_s3_uri` (split, single-segment key, wrong scheme, missing/empty key)
- [ ] ⚠️ `cargo check` / `cargo test` / `cargo clippy` **could not be run in my environment** — no C toolchain available (no `cc`/`gcc`, no `sudo`/`apt`, no glibc crt objects), which the pre-existing AWS SDK native deps require. This change adds no new toolchain requirement beyond the existing `aws-sdk-secretsmanager` dep. **CI is expected to gate the full build/test/clippy.**

All PRs:
- [x] Manual testing: code reviewed against the existing `load_config_raw_from_url` and `secrets-aws` patterns; feature wiring verified via `cargo metadata`/`cargo tree` as above.
