### PR TITLE
docs: add Helm image tag usage to all agent docs

### DIFF
--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -19,23 +19,29 @@ helm install openab openab/openab \
   --set-string 'agents.claude.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agents.claude.command=claude-agent-acp \
   --set agents.claude.workingDir=/home/node \
-  --set agents.claude.image.tag=beta-claude
+  --set image.tag=beta
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
 
 ### Image Tag
 
-Use `--set agents.claude.image.tag=<version>-claude` to pin the image version.
-The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+Use `--set image.tag=<version>` to set the image version globally.
+The chart auto-appends `-<agent>` to produce the final tag (see [image-tags.md](image-tags.md) for full details).
 
-| Example | Description |
-|---------|-------------|
-| `beta-claude` | Floating beta channel (latest pre-release) |
-| `0.9.0-beta.2-claude` | Pinned to exact version |
-| `stable-claude` | Floating stable channel |
+| Tag | Resolves to | Description |
+|-----|-------------|-------------|
+| `beta` | `beta-claude` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2` | `0.9.0-beta.2-claude` | Pinned to exact version |
+| `0.9` | `0.9-claude` | Latest patch in minor (floating) |
+| `stable` | `stable-claude` | Floating stable channel |
 
-> ⚠️ There is no `latest` tag — you must include the `-claude` agent suffix.
+To override a single agent's image instead of the global tag:
+```bash
+--set agents.claude.image=ghcr.io/openabdev/openab:beta-claude
+```
+
+> ⚠️ There is no `latest` tag. Use `beta` or `stable`, or pin to an exact version.
 
 ## Manual config.toml
 

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -18,10 +18,24 @@ helm install openab openab/openab \
   --set agents.claude.discord.botToken="$DISCORD_BOT_TOKEN" \
   --set-string 'agents.claude.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agents.claude.command=claude-agent-acp \
-  --set agents.claude.workingDir=/home/node
+  --set agents.claude.workingDir=/home/node \
+  --set agents.claude.image.tag=beta-claude
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
+
+### Image Tag
+
+Use `--set agents.claude.image.tag=<version>-claude` to pin the image version.
+The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+
+| Example | Description |
+|---------|-------------|
+| `beta-claude` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2-claude` | Pinned to exact version |
+| `stable-claude` | Floating stable channel |
+
+> ⚠️ There is no `latest` tag — you must include the `-claude` agent suffix.
 
 ## Manual config.toml
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -22,10 +22,24 @@ helm install openab openab/openab \
   --set agents.codex.discord.botToken="$DISCORD_BOT_TOKEN" \
   --set-string 'agents.codex.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agents.codex.command=codex-acp \
-  --set agents.codex.workingDir=/home/node
+  --set agents.codex.workingDir=/home/node \
+  --set agents.codex.image.tag=beta-codex
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
+
+### Image Tag
+
+Use `--set agents.codex.image.tag=<version>-codex` to pin the image version.
+The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+
+| Example | Description |
+|---------|-------------|
+| `beta-codex` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2-codex` | Pinned to exact version |
+| `stable-codex` | Floating stable channel |
+
+> ⚠️ There is no `latest` tag — you must include the `-codex` agent suffix.
 
 ## Manual config.toml
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -23,23 +23,29 @@ helm install openab openab/openab \
   --set-string 'agents.codex.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agents.codex.command=codex-acp \
   --set agents.codex.workingDir=/home/node \
-  --set agents.codex.image.tag=beta-codex
+  --set image.tag=beta
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
 
 ### Image Tag
 
-Use `--set agents.codex.image.tag=<version>-codex` to pin the image version.
-The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+Use `--set image.tag=<version>` to set the image version globally.
+The chart auto-appends `-<agent>` to produce the final tag (see [image-tags.md](image-tags.md) for full details).
 
-| Example | Description |
-|---------|-------------|
-| `beta-codex` | Floating beta channel (latest pre-release) |
-| `0.9.0-beta.2-codex` | Pinned to exact version |
-| `stable-codex` | Floating stable channel |
+| Tag | Resolves to | Description |
+|-----|-------------|-------------|
+| `beta` | `beta-codex` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2` | `0.9.0-beta.2-codex` | Pinned to exact version |
+| `0.9` | `0.9-codex` | Latest patch in minor (floating) |
+| `stable` | `stable-codex` | Floating stable channel |
 
-> ⚠️ There is no `latest` tag — you must include the `-codex` agent suffix.
+To override a single agent's image instead of the global tag:
+```bash
+--set agents.codex.image=ghcr.io/openabdev/openab:beta-codex
+```
+
+> ⚠️ There is no `latest` tag. Use `beta` or `stable`, or pin to an exact version.
 
 ## Manual config.toml
 

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -132,8 +132,22 @@ helm install openab-copilot openab/openab \
   --set 'agents.copilot.args={--acp,--stdio}' \
   --set agents.copilot.persistence.enabled=true \
   --set agents.copilot.workingDir=/home/node \
-  --set 'agents.copilot.env.COPILOT_GITHUB_TOKEN=github_pat_YOUR_TOKEN_HERE'  # optional, see Authentication
+  --set 'agents.copilot.env.COPILOT_GITHUB_TOKEN=github_pat_YOUR_TOKEN_HERE' \
+  --set agents.copilot.image.tag=beta-copilot
 ```
+
+### Image Tag
+
+Use `--set agents.copilot.image.tag=<version>-copilot` to pin the image version.
+The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+
+| Example | Description |
+|---------|-------------|
+| `beta-copilot` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2-copilot` | Pinned to exact version |
+| `stable-copilot` | Floating stable channel |
+
+> ⚠️ There is no `latest` tag — you must include the `-copilot` agent suffix.
 
 ## Model Selection
 

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -133,21 +133,29 @@ helm install openab-copilot openab/openab \
   --set agents.copilot.persistence.enabled=true \
   --set agents.copilot.workingDir=/home/node \
   --set 'agents.copilot.env.COPILOT_GITHUB_TOKEN=github_pat_YOUR_TOKEN_HERE' \
-  --set agents.copilot.image.tag=beta-copilot
+  --set image.tag=beta
 ```
+
+> `COPILOT_GITHUB_TOKEN` is optional — see Authentication section below.
 
 ### Image Tag
 
-Use `--set agents.copilot.image.tag=<version>-copilot` to pin the image version.
-The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+Use `--set image.tag=<version>` to set the image version globally.
+The chart auto-appends `-<agent>` to produce the final tag (see [image-tags.md](image-tags.md) for full details).
 
-| Example | Description |
-|---------|-------------|
-| `beta-copilot` | Floating beta channel (latest pre-release) |
-| `0.9.0-beta.2-copilot` | Pinned to exact version |
-| `stable-copilot` | Floating stable channel |
+| Tag | Resolves to | Description |
+|-----|-------------|-------------|
+| `beta` | `beta-copilot` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2` | `0.9.0-beta.2-copilot` | Pinned to exact version |
+| `0.9` | `0.9-copilot` | Latest patch in minor (floating) |
+| `stable` | `stable-copilot` | Floating stable channel |
 
-> ⚠️ There is no `latest` tag — you must include the `-copilot` agent suffix.
+To override a single agent's image instead of the global tag:
+```bash
+--set agents.copilot.image=ghcr.io/openabdev/openab:beta-copilot
+```
+
+> ⚠️ There is no `latest` tag. Use `beta` or `stable`, or pin to an exact version.
 
 ## Model Selection
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -66,8 +66,22 @@ helm install openab openab/openab \
   --set agents.cursor.command=cursor-agent \
   --set 'agents.cursor.args={acp}' \
   --set agents.cursor.persistence.enabled=true \
-  --set agents.cursor.workingDir=/home/agent
+  --set agents.cursor.workingDir=/home/agent \
+  --set agents.cursor.image.tag=beta-cursor
 ```
+
+### Image Tag
+
+Use `--set agents.cursor.image.tag=<version>-cursor` to pin the image version.
+The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+
+| Example | Description |
+|---------|-------------|
+| `beta-cursor` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2-cursor` | Pinned to exact version |
+| `stable-cursor` | Floating stable channel |
+
+> ⚠️ There is no `latest` tag — you must include the `-cursor` agent suffix.
 
 ## Model Selection
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -67,21 +67,27 @@ helm install openab openab/openab \
   --set 'agents.cursor.args={acp}' \
   --set agents.cursor.persistence.enabled=true \
   --set agents.cursor.workingDir=/home/agent \
-  --set agents.cursor.image.tag=beta-cursor
+  --set image.tag=beta
 ```
 
 ### Image Tag
 
-Use `--set agents.cursor.image.tag=<version>-cursor` to pin the image version.
-The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+Use `--set image.tag=<version>` to set the image version globally.
+The chart auto-appends `-<agent>` to produce the final tag (see [image-tags.md](image-tags.md) for full details).
 
-| Example | Description |
-|---------|-------------|
-| `beta-cursor` | Floating beta channel (latest pre-release) |
-| `0.9.0-beta.2-cursor` | Pinned to exact version |
-| `stable-cursor` | Floating stable channel |
+| Tag | Resolves to | Description |
+|-----|-------------|-------------|
+| `beta` | `beta-cursor` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2` | `0.9.0-beta.2-cursor` | Pinned to exact version |
+| `0.9` | `0.9-cursor` | Latest patch in minor (floating) |
+| `stable` | `stable-cursor` | Floating stable channel |
 
-> ⚠️ There is no `latest` tag — you must include the `-cursor` agent suffix.
+To override a single agent's image instead of the global tag:
+```bash
+--set agents.cursor.image=ghcr.io/openabdev/openab:beta-cursor
+```
+
+> ⚠️ There is no `latest` tag. Use `beta` or `stable`, or pin to an exact version.
 
 ## Model Selection
 

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -21,7 +21,7 @@ helm install openab openab/openab \
   --set agents.gemini.command=gemini \
   --set agents.gemini.args='{--acp}' \
   --set agents.gemini.workingDir=/home/node \
-  --set agents.gemini.image.tag=beta-gemini
+  --set image.tag=beta
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
@@ -30,16 +30,22 @@ helm install openab openab/openab \
 
 ### Image Tag
 
-Use `--set agents.gemini.image.tag=<version>-gemini` to pin the image version.
-The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+Use `--set image.tag=<version>` to set the image version globally.
+The chart auto-appends `-<agent>` to produce the final tag (see [image-tags.md](image-tags.md) for full details).
 
-| Example | Description |
-|---------|-------------|
-| `beta-gemini` | Floating beta channel (latest pre-release) |
-| `0.9.0-beta.2-gemini` | Pinned to exact version |
-| `stable-gemini` | Floating stable channel |
+| Tag | Resolves to | Description |
+|-----|-------------|-------------|
+| `beta` | `beta-gemini` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2` | `0.9.0-beta.2-gemini` | Pinned to exact version |
+| `0.9` | `0.9-gemini` | Latest patch in minor (floating) |
+| `stable` | `stable-gemini` | Floating stable channel |
 
-> ⚠️ There is no `latest` tag — you must include the `-gemini` agent suffix.
+To override a single agent's image instead of the global tag:
+```bash
+--set agents.gemini.image=ghcr.io/openabdev/openab:beta-gemini
+```
+
+> ⚠️ There is no `latest` tag. Use `beta` or `stable`, or pin to an exact version.
 
 ## Manual config.toml
 

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -20,12 +20,26 @@ helm install openab openab/openab \
   --set-string 'agents.gemini.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agents.gemini.command=gemini \
   --set agents.gemini.args='{--acp}' \
-  --set agents.gemini.workingDir=/home/node
+  --set agents.gemini.workingDir=/home/node \
+  --set agents.gemini.image.tag=beta-gemini
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
 > 
 > (Optional) `agents.gemini.args='{--acp}'` could be modified as `{--model,gemini-3-pro-preview,--acp}` if specific model is required. Otherwise, the default value will be 'Auto (Gemini 3)'.
+
+### Image Tag
+
+Use `--set agents.gemini.image.tag=<version>-gemini` to pin the image version.
+The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+
+| Example | Description |
+|---------|-------------|
+| `beta-gemini` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2-gemini` | Pinned to exact version |
+| `stable-gemini` | Floating stable channel |
+
+> ⚠️ There is no `latest` tag — you must include the `-gemini` agent suffix.
 
 ## Manual config.toml
 

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -21,10 +21,24 @@ helm install openab openab/openab \
   --set agents.grok.command=grok \
   --set-string 'agents.grok.args[0]=agent' \
   --set-string 'agents.grok.args[1]=stdio' \
-  --set agents.grok.workingDir=/home/agent
+  --set agents.grok.workingDir=/home/agent \
+  --set agents.grok.image.tag=beta-grok
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
+
+### Image Tag
+
+Use `--set agents.grok.image.tag=<version>-grok` to pin the image version.
+The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+
+| Example | Description |
+|---------|-------------|
+| `beta-grok` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2-grok` | Pinned to exact version |
+| `stable-grok` | Floating stable channel |
+
+> ⚠️ There is no `latest` tag — you must include the `-grok` agent suffix.
 
 ## Manual config.toml
 

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -22,23 +22,29 @@ helm install openab openab/openab \
   --set-string 'agents.grok.args[0]=agent' \
   --set-string 'agents.grok.args[1]=stdio' \
   --set agents.grok.workingDir=/home/agent \
-  --set agents.grok.image.tag=beta-grok
+  --set image.tag=beta
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
 
 ### Image Tag
 
-Use `--set agents.grok.image.tag=<version>-grok` to pin the image version.
-The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+Use `--set image.tag=<version>` to set the image version globally.
+The chart auto-appends `-<agent>` to produce the final tag (see [image-tags.md](image-tags.md) for full details).
 
-| Example | Description |
-|---------|-------------|
-| `beta-grok` | Floating beta channel (latest pre-release) |
-| `0.9.0-beta.2-grok` | Pinned to exact version |
-| `stable-grok` | Floating stable channel |
+| Tag | Resolves to | Description |
+|-----|-------------|-------------|
+| `beta` | `beta-grok` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2` | `0.9.0-beta.2-grok` | Pinned to exact version |
+| `0.9` | `0.9-grok` | Latest patch in minor (floating) |
+| `stable` | `stable-grok` | Floating stable channel |
 
-> ⚠️ There is no `latest` tag — you must include the `-grok` agent suffix.
+To override a single agent's image instead of the global tag:
+```bash
+--set agents.grok.image=ghcr.io/openabdev/openab:beta-grok
+```
+
+> ⚠️ There is no `latest` tag. Use `beta` or `stable`, or pin to an exact version.
 
 ## Manual config.toml
 

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -21,10 +21,24 @@ helm install openab openab/openab \
   --set agents.hermes.discord.botToken="$DISCORD_BOT_TOKEN" \
   --set-string 'agents.hermes.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agents.hermes.command=hermes-acp \
-  --set agents.hermes.workingDir=/home/agent
+  --set agents.hermes.workingDir=/home/agent \
+  --set agents.hermes.image.tag=beta-hermes
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
+
+### Image Tag
+
+Use `--set agents.hermes.image.tag=<version>-hermes` to pin the image version.
+The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+
+| Example | Description |
+|---------|-------------|
+| `beta-hermes` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2-hermes` | Pinned to exact version |
+| `stable-hermes` | Floating stable channel |
+
+> ⚠️ There is no `latest` tag — you must include the `-hermes` agent suffix.
 
 ## Manual config.toml
 

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -22,23 +22,29 @@ helm install openab openab/openab \
   --set-string 'agents.hermes.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agents.hermes.command=hermes-acp \
   --set agents.hermes.workingDir=/home/agent \
-  --set agents.hermes.image.tag=beta-hermes
+  --set image.tag=beta
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
 
 ### Image Tag
 
-Use `--set agents.hermes.image.tag=<version>-hermes` to pin the image version.
-The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+Use `--set image.tag=<version>` to set the image version globally.
+The chart auto-appends `-<agent>` to produce the final tag (see [image-tags.md](image-tags.md) for full details).
 
-| Example | Description |
-|---------|-------------|
-| `beta-hermes` | Floating beta channel (latest pre-release) |
-| `0.9.0-beta.2-hermes` | Pinned to exact version |
-| `stable-hermes` | Floating stable channel |
+| Tag | Resolves to | Description |
+|-----|-------------|-------------|
+| `beta` | `beta-hermes` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2` | `0.9.0-beta.2-hermes` | Pinned to exact version |
+| `0.9` | `0.9-hermes` | Latest patch in minor (floating) |
+| `stable` | `stable-hermes` | Floating stable channel |
 
-> ⚠️ There is no `latest` tag — you must include the `-hermes` agent suffix.
+To override a single agent's image instead of the global tag:
+```bash
+--set agents.hermes.image=ghcr.io/openabdev/openab:beta-hermes
+```
+
+> ⚠️ There is no `latest` tag. Use `beta` or `stable`, or pin to an exact version.
 
 ## Manual config.toml
 

--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -19,21 +19,27 @@ helm repo update
 helm install openab openab/openab \
   --set agents.kiro.discord.botToken="$DISCORD_BOT_TOKEN" \
   --set-string 'agents.kiro.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
-  --set agents.kiro.image.tag=beta-kiro
+  --set image.tag=beta
 ```
 
 ### Image Tag
 
-Use `--set agents.kiro.image.tag=<version>-kiro` to pin the image version.
-The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+Use `--set image.tag=<version>` to set the image version globally.
+The chart auto-appends `-<agent>` to produce the final tag (see [image-tags.md](image-tags.md) for full details).
 
-| Example | Description |
-|---------|-------------|
-| `beta-kiro` | Floating beta channel (latest pre-release) |
-| `0.9.0-beta.2-kiro` | Pinned to exact version |
-| `stable-kiro` | Floating stable channel |
+| Tag | Resolves to | Description |
+|-----|-------------|-------------|
+| `beta` | `beta-kiro` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2` | `0.9.0-beta.2-kiro` | Pinned to exact version |
+| `0.9` | `0.9-kiro` | Latest patch in minor (floating) |
+| `stable` | `stable-kiro` | Floating stable channel |
 
-> ⚠️ There is no `latest` tag — you must include the `-kiro` agent suffix.
+To override a single agent's image instead of the global tag:
+```bash
+--set agents.kiro.image=ghcr.io/openabdev/openab:beta-kiro
+```
+
+> ⚠️ There is no `latest` tag. Use `beta` or `stable`, or pin to an exact version.
 
 ## Manual config.toml
 

--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -18,8 +18,22 @@ helm repo update
 
 helm install openab openab/openab \
   --set agents.kiro.discord.botToken="$DISCORD_BOT_TOKEN" \
-  --set-string 'agents.kiro.discord.allowedChannels[0]=YOUR_CHANNEL_ID'
+  --set-string 'agents.kiro.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.kiro.image.tag=beta-kiro
 ```
+
+### Image Tag
+
+Use `--set agents.kiro.image.tag=<version>-kiro` to pin the image version.
+The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+
+| Example | Description |
+|---------|-------------|
+| `beta-kiro` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2-kiro` | Pinned to exact version |
+| `stable-kiro` | Floating stable channel |
+
+> ⚠️ There is no `latest` tag — you must include the `-kiro` agent suffix.
 
 ## Manual config.toml
 

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -41,10 +41,24 @@ helm install openab openab/openab \
   --set agents.opencode.discord.botToken="$DISCORD_BOT_TOKEN" \
   --set-string 'agents.opencode.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agents.opencode.workingDir=/home/node \
-  --set agents.opencode.pool.maxSessions=3
+  --set agents.opencode.pool.maxSessions=3 \
+  --set agents.opencode.image.tag=beta-opencode
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
+
+### Image Tag
+
+Use `--set agents.opencode.image.tag=<version>-opencode` to pin the image version.
+The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+
+| Example | Description |
+|---------|-------------|
+| `beta-opencode` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2-opencode` | Pinned to exact version |
+| `stable-opencode` | Floating stable channel |
+
+> ⚠️ There is no `latest` tag — you must include the `-opencode` agent suffix.
 
 ## Manual config.toml
 

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -42,23 +42,29 @@ helm install openab openab/openab \
   --set-string 'agents.opencode.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
   --set agents.opencode.workingDir=/home/node \
   --set agents.opencode.pool.maxSessions=3 \
-  --set agents.opencode.image.tag=beta-opencode
+  --set image.tag=beta
 ```
 
 > Set `agents.kiro.enabled=false` to disable the default Kiro agent.
 
 ### Image Tag
 
-Use `--set agents.opencode.image.tag=<version>-opencode` to pin the image version.
-The tag format is `<version>-<agent>` (see [image-tags.md](image-tags.md) for full details).
+Use `--set image.tag=<version>` to set the image version globally.
+The chart auto-appends `-<agent>` to produce the final tag (see [image-tags.md](image-tags.md) for full details).
 
-| Example | Description |
-|---------|-------------|
-| `beta-opencode` | Floating beta channel (latest pre-release) |
-| `0.9.0-beta.2-opencode` | Pinned to exact version |
-| `stable-opencode` | Floating stable channel |
+| Tag | Resolves to | Description |
+|-----|-------------|-------------|
+| `beta` | `beta-opencode` | Floating beta channel (latest pre-release) |
+| `0.9.0-beta.2` | `0.9.0-beta.2-opencode` | Pinned to exact version |
+| `0.9` | `0.9-opencode` | Latest patch in minor (floating) |
+| `stable` | `stable-opencode` | Floating stable channel |
 
-> ⚠️ There is no `latest` tag — you must include the `-opencode` agent suffix.
+To override a single agent's image instead of the global tag:
+```bash
+--set agents.opencode.image=ghcr.io/openabdev/openab:beta-opencode
+```
+
+> ⚠️ There is no `latest` tag. Use `beta` or `stable`, or pin to an exact version.
 
 ## Manual config.toml
 


### PR DESCRIPTION
## Summary

Document `--set agents.<name>.image.tag=<version>-<agent>` in the Helm Install section of all 9 agent platform docs.

Since v0.9.0-beta.2 introduced the unified image architecture, each agent doc now shows how to specify the image tag with examples:

| Tag | Description |
|-----|-------------|
| `beta-<agent>` | Floating beta channel |
| `0.9.0-beta.2-<agent>` | Pinned to exact version |
| `stable-<agent>` | Floating stable channel |

## Files changed

- `docs/kiro.md`
- `docs/codex.md`
- `docs/claude-code.md`
- `docs/copilot.md`
- `docs/cursor.md`
- `docs/gemini.md`
- `docs/grok.md`
- `docs/hermes.md`
- `docs/opencode.md`

Each doc now includes:
1. `--set agents.<name>.image.tag=beta-<agent>` in the example helm install command
2. An "Image Tag" subsection with tag format table and link to `image-tags.md`
3. Warning that there is no `latest` tag