### PR TITLE
feat(discord): add /auth slash command for device-flow auth

### DIFF
--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1686,6 +1686,21 @@ impl Handler {
             return;
         }
 
+        // DM-only — auth codes are sensitive; reject if not in a DM channel.
+        let is_dm = matches!(
+            cmd.channel_id.to_channel(&ctx.http).await,
+            Ok(serenity::model::channel::Channel::Private(_))
+        );
+        if !is_dm {
+            let response = CreateInteractionResponse::Message(
+                CreateInteractionResponseMessage::new()
+                    .content("🔒 `/auth` is only available in DMs for security. Please DM me and run `/auth` there.")
+                    .ephemeral(true),
+            );
+            let _ = cmd.create_response(&ctx.http, response).await;
+            return;
+        }
+
         // Single-flight guard — prevent concurrent /auth invocations.
         static AUTH_IN_PROGRESS: std::sync::atomic::AtomicBool =
             std::sync::atomic::AtomicBool::new(false);
@@ -1819,12 +1834,8 @@ impl Handler {
             let output = collected_lines.join("\n");
             let prefix = "🔐 **Agent Authentication**\n```\n";
             let suffix = "\n```\nFollow the instructions above. Waiting for authorization...";
-            let max_output = 2000 - prefix.len() - suffix.len();
-            let truncated = if output.len() > max_output {
-                &output[..max_output]
-            } else {
-                &output
-            };
+            let max_output_chars = 2000 - prefix.chars().count() - suffix.chars().count();
+            let truncated: String = output.chars().take(max_output_chars).collect();
             let msg = format!("{prefix}{truncated}{suffix}");
             let _ = http.create_followup_message(
                 &token,

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1711,7 +1711,7 @@ impl Handler {
         // Single-flight guard — prevent concurrent /auth invocations.
         static AUTH_IN_PROGRESS: std::sync::atomic::AtomicBool =
             std::sync::atomic::AtomicBool::new(false);
-        if AUTH_IN_PROGRESS.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        if AUTH_IN_PROGRESS.swap(true, std::sync::atomic::Ordering::Acquire) {
             let response = CreateInteractionResponse::Message(
                 CreateInteractionResponseMessage::new()
                     .content("⚠️ Authentication already in progress. Please wait for it to complete.")
@@ -1724,7 +1724,7 @@ impl Handler {
         let auth_cmd = match std::env::var("OPENAB_AGENT_AUTH_COMMAND") {
             Ok(val) if !val.is_empty() => val,
             _ => {
-                AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
+                AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::Release);
                 let response = CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
                         .content("⚠️ No auth command configured (`OPENAB_AGENT_AUTH_COMMAND` not set).")
@@ -1740,7 +1740,7 @@ impl Handler {
             CreateInteractionResponseMessage::new().ephemeral(true),
         );
         if let Err(e) = cmd.create_response(&ctx.http, defer).await {
-            AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
+            AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::Release);
             tracing::error!(error = %e, "failed to defer /auth response");
             return;
         }
@@ -1758,7 +1758,7 @@ impl Handler {
             struct AuthGuard;
             impl Drop for AuthGuard {
                 fn drop(&mut self) {
-                    AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
+                    AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::Release);
                 }
             }
             let _guard = AuthGuard;

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1899,21 +1899,10 @@ impl Handler {
             let output = collected_lines.join("\n");
             let prefix = "🔐 **Agent Authentication**\n```\n";
             let suffix = "\n```\nFollow the instructions above. Waiting for authorization...";
-            // Discord enforces the 2000-char limit in UTF-16 code units, so budget
-            // and truncate by UTF-16 units rather than Unicode scalar values.
-            let budget = 2000usize
-                .saturating_sub(prefix.encode_utf16().count())
-                .saturating_sub(suffix.encode_utf16().count());
-            let mut truncated = String::new();
-            let mut used = 0usize;
-            for ch in output.chars() {
-                let w = ch.len_utf16();
-                if used + w > budget {
-                    break;
-                }
-                used += w;
-                truncated.push(ch);
-            }
+            // Discord enforces the 2000-char limit in UTF-16 code units; budget and
+            // truncate by UTF-16 units rather than Unicode scalar values. See
+            // `truncate_to_utf16_budget` for the testable implementation.
+            let truncated = truncate_to_utf16_budget(&output, prefix, suffix, 2000);
             let msg = format!("{prefix}{truncated}{suffix}");
             let _ = http.create_followup_message(
                 &token,
@@ -1948,6 +1937,7 @@ impl Handler {
                     ).await;
                 }
                 Ok(Err(e)) => {
+                    tracing::error!(error = %e, "/auth: error waiting for auth process");
                     let _ = http.create_followup_message(
                         &token,
                         &CreateInteractionResponseFollowup::new()
@@ -2858,10 +2848,92 @@ fn turn_limit_warning_present(messages: &[(bool, &str)]) -> bool {
         .any(|(is_bot, content)| *is_bot && content.contains(BOT_TURN_LIMIT_WARNING_PREFIX))
 }
 
+/// Truncate `body` so that, prefixed by `prefix` and suffixed by `suffix`, the
+/// whole message fits within `limit` measured in **UTF-16 code units** — which
+/// is how Discord enforces its 2000-character message cap. Truncation only ever
+/// happens on a `char` boundary, so a multi-byte scalar (e.g. an emoji that
+/// encodes as a surrogate pair) is never split. Returns the truncated `body`
+/// (without prefix/suffix).
+///
+/// Extracted from `handle_auth_command` so the boundary arithmetic — which is
+/// easy to get wrong by conflating Unicode scalar count with UTF-16 code units —
+/// can be unit-tested in isolation.
+fn truncate_to_utf16_budget(body: &str, prefix: &str, suffix: &str, limit: usize) -> String {
+    let budget = limit
+        .saturating_sub(prefix.encode_utf16().count())
+        .saturating_sub(suffix.encode_utf16().count());
+    let mut truncated = String::new();
+    let mut used = 0usize;
+    for ch in body.chars() {
+        let w = ch.len_utf16();
+        if used + w > budget {
+            break;
+        }
+        used += w;
+        truncated.push(ch);
+    }
+    truncated
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::bot_turns::{TurnResult, HARD_BOT_TURN_LIMIT, BOT_TURN_LIMIT_WARNING_PREFIX};
+
+    // --- truncate_to_utf16_budget tests (#1185 /auth output relay) ---
+
+    /// Body shorter than the budget is returned unchanged.
+    #[test]
+    fn truncate_utf16_short_body_unchanged() {
+        assert_eq!(truncate_to_utf16_budget("hello", "", "", 2000), "hello");
+    }
+
+    /// prefix + suffix consume the budget; the body gets the remainder.
+    #[test]
+    fn truncate_utf16_respects_prefix_suffix_budget() {
+        // limit 10, prefix "pre" (3) + suffix "su" (2) = 5 → 5 ASCII units left.
+        assert_eq!(truncate_to_utf16_budget("abcdefghij", "pre", "su", 10), "abcde");
+    }
+
+    /// A supplementary-plane scalar counts as TWO UTF-16 code units, not one.
+    #[test]
+    fn truncate_utf16_counts_surrogate_pairs_as_two_units() {
+        // '🔐' (U+1F510) is one scalar but two UTF-16 units.
+        // Budget 5 → two emoji (4 units) fit; a third (→6) does not.
+        let out = truncate_to_utf16_budget("🔐🔐🔐", "", "", 5);
+        assert_eq!(out, "🔐🔐");
+        assert_eq!(out.encode_utf16().count(), 4);
+    }
+
+    /// A scalar is never split: a 2-unit emoji cannot fit a 1-unit budget.
+    #[test]
+    fn truncate_utf16_never_splits_a_scalar() {
+        assert_eq!(truncate_to_utf16_budget("🔐rest", "", "", 1), "");
+    }
+
+    /// When affixes alone exceed the limit, the budget saturates to zero.
+    #[test]
+    fn truncate_utf16_zero_budget_when_affixes_exceed_limit() {
+        assert_eq!(
+            truncate_to_utf16_budget("anything", "longprefix", "longsuffix", 4),
+            ""
+        );
+    }
+
+    /// The assembled message (prefix + body + suffix) never exceeds the limit,
+    /// even for output dense with multi-unit scalars — this is the regression
+    /// guard for the original `chars().count()` (scalar) miscount.
+    #[test]
+    fn truncate_utf16_assembled_total_within_limit() {
+        let prefix = "🔐 **Agent Authentication**\n```\n";
+        let suffix = "\n```\nFollow the instructions above. Waiting for authorization...";
+        let body = "https://example.com/device AB🔐CD\n".repeat(200);
+        let out = truncate_to_utf16_budget(&body, prefix, suffix, 2000);
+        let total = prefix.encode_utf16().count()
+            + out.encode_utf16().count()
+            + suffix.encode_utf16().count();
+        assert!(total <= 2000, "assembled total {total} exceeds 2000");
+    }
 
     // --- resolve_mentions tests ---
 

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1670,9 +1670,39 @@ impl Handler {
         ctx: &Context,
         cmd: &serenity::model::application::CommandInteraction,
     ) {
+        // Access control — only allowed users can trigger auth.
+        if is_denied_user(
+            false,
+            self.allow_all_users,
+            &self.allowed_users,
+            cmd.user.id.get(),
+        ) {
+            let response = CreateInteractionResponse::Message(
+                CreateInteractionResponseMessage::new()
+                    .content("🚫 You are not allowed to use this bot.")
+                    .ephemeral(true),
+            );
+            let _ = cmd.create_response(&ctx.http, response).await;
+            return;
+        }
+
+        // Single-flight guard — prevent concurrent /auth invocations.
+        static AUTH_IN_PROGRESS: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
+        if AUTH_IN_PROGRESS.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            let response = CreateInteractionResponse::Message(
+                CreateInteractionResponseMessage::new()
+                    .content("⚠️ Authentication already in progress. Please wait for it to complete.")
+                    .ephemeral(true),
+            );
+            let _ = cmd.create_response(&ctx.http, response).await;
+            return;
+        }
+
         let auth_cmd = match std::env::var("OPENAB_AGENT_AUTH_COMMAND") {
             Ok(val) if !val.is_empty() => val,
             _ => {
+                AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
                 let response = CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
                         .content("⚠️ No auth command configured (`OPENAB_AGENT_AUTH_COMMAND` not set).")
@@ -1688,6 +1718,7 @@ impl Handler {
             CreateInteractionResponseMessage::new().ephemeral(true),
         );
         if let Err(e) = cmd.create_response(&ctx.http, defer).await {
+            AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
             tracing::error!(error = %e, "failed to defer /auth response");
             return;
         }
@@ -1716,6 +1747,7 @@ impl Handler {
                             .ephemeral(true),
                         Vec::new(),
                     ).await;
+                    AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
                     return;
                 }
             };
@@ -1727,7 +1759,7 @@ impl Handler {
             let mut lines: Vec<String> = Vec::new();
 
             // Collect output from both streams until we find a URL or the process ends.
-            let collect = async {
+            {
                 let mut stdout_reader = stdout.map(|s| tokio::io::BufReader::new(s).lines());
                 let mut stderr_reader = stderr.map(|s| tokio::io::BufReader::new(s).lines());
 
@@ -1800,11 +1832,10 @@ impl Handler {
                         break;
                     }
                 }
-            };
-
-            collect.await;
+            } // readers dropped here; child still owns the pipes
 
             if lines.is_empty() {
+                let _ = child.kill().await;
                 let _ = http.create_followup_message(
                     &token,
                     &CreateInteractionResponseFollowup::new()
@@ -1812,12 +1843,21 @@ impl Handler {
                         .ephemeral(true),
                     Vec::new(),
                 ).await;
+                AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
                 return;
             }
 
-            // Send the captured output to the user
+            // Send the captured output to the user (truncate to fit Discord's 2000-char limit).
             let output = lines.join("\n");
-            let msg = format!("🔐 **Agent Authentication**\n```\n{}\n```\nFollow the instructions above. Waiting for authorization...", output);
+            let prefix = "🔐 **Agent Authentication**\n```\n";
+            let suffix = "\n```\nFollow the instructions above. Waiting for authorization...";
+            let max_output = 2000 - prefix.len() - suffix.len();
+            let truncated = if output.len() > max_output {
+                &output[..max_output]
+            } else {
+                &output
+            };
+            let msg = format!("{prefix}{truncated}{suffix}");
             let _ = http.create_followup_message(
                 &token,
                 &CreateInteractionResponseFollowup::new()
@@ -1868,6 +1908,7 @@ impl Handler {
                     ).await;
                 }
             }
+            AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
         });
     }
 

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1687,11 +1687,7 @@ impl Handler {
         }
 
         // DM-only — auth codes are sensitive; reject if not in a DM channel.
-        let is_dm = matches!(
-            cmd.channel_id.to_channel(&ctx.http).await,
-            Ok(serenity::model::channel::Channel::Private(_))
-        );
-        if !is_dm {
+        if cmd.guild_id.is_some() {
             let response = CreateInteractionResponse::Message(
                 CreateInteractionResponseMessage::new()
                     .content("🔒 `/auth` is only available in DMs for security. Please DM me and run `/auth` there.")
@@ -1746,6 +1742,17 @@ impl Handler {
             use tokio::process::Command as TokioCommand;
             use std::sync::Arc;
 
+            // Drop guard ensures AUTH_IN_PROGRESS is cleared even on panic.
+            struct AuthGuard;
+            impl Drop for AuthGuard {
+                fn drop(&mut self) {
+                    AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
+                }
+            }
+            let _guard = AuthGuard;
+
+            info!("/auth: starting auth command");
+
             let child = TokioCommand::new("sh")
                 .arg("-c")
                 .arg(&auth_cmd)
@@ -1756,6 +1763,7 @@ impl Handler {
             let mut child = match child {
                 Ok(c) => c,
                 Err(e) => {
+                    tracing::error!(error = %e, "/auth: failed to spawn auth command");
                     let _ = http.create_followup_message(
                         &token,
                         &CreateInteractionResponseFollowup::new()
@@ -1763,7 +1771,6 @@ impl Handler {
                             .ephemeral(true),
                         Vec::new(),
                     ).await;
-                    AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
                     return;
                 }
             };
@@ -1808,15 +1815,19 @@ impl Handler {
             // Wait for a URL to appear or 30-second timeout.
             tokio::select! {
                 _ = url_found.notified() => {
+                    info!("/auth: URL detected in output");
                     // Brief sleep to let trailing lines (code/instructions) be captured.
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                 }
-                _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
+                _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    warn!("/auth: 30s URL-collection window expired without detecting URL");
+                }
             }
 
             let collected_lines = lines.lock().unwrap().clone();
 
             if collected_lines.is_empty() {
+                warn!("/auth: no output captured, killing child process");
                 let _ = child.kill().await;
                 let _ = tokio::join!(stdout_task, stderr_task);
                 let _ = http.create_followup_message(
@@ -1826,7 +1837,6 @@ impl Handler {
                         .ephemeral(true),
                     Vec::new(),
                 ).await;
-                AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
                 return;
             }
 
@@ -1850,6 +1860,7 @@ impl Handler {
             let timeout = std::time::Duration::from_secs(14 * 60);
             match tokio::time::timeout(timeout, child.wait()).await {
                 Ok(Ok(status)) if status.success() => {
+                    info!("/auth: authentication successful");
                     let _ = http.create_followup_message(
                         &token,
                         &CreateInteractionResponseFollowup::new()
@@ -1859,6 +1870,7 @@ impl Handler {
                     ).await;
                 }
                 Ok(Ok(status)) => {
+                    warn!(%status, "/auth: authentication failed");
                     let _ = http.create_followup_message(
                         &token,
                         &CreateInteractionResponseFollowup::new()
@@ -1877,11 +1889,12 @@ impl Handler {
                     ).await;
                 }
                 Err(_) => {
+                    warn!("/auth: timed out waiting for authorization");
                     let _ = child.kill().await;
                     let _ = http.create_followup_message(
                         &token,
                         &CreateInteractionResponseFollowup::new()
-                            .content("⏰ Authentication timed out (15 min). Run `/auth` again to retry.")
+                            .content("⏰ Authentication timed out. Run `/auth` again to retry.")
                             .ephemeral(true),
                         Vec::new(),
                     ).await;
@@ -1890,7 +1903,6 @@ impl Handler {
 
             // Let background drain tasks complete.
             let _ = tokio::join!(stdout_task, stderr_task);
-            AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
         });
     }
 

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1846,7 +1846,8 @@ impl Handler {
             ).await;
 
             // Wait for the process to complete (user authorizes in browser).
-            let timeout = std::time::Duration::from_secs(15 * 60);
+            // Use 14min (not 15) to leave headroom for the Discord interaction token TTL.
+            let timeout = std::time::Duration::from_secs(14 * 60);
             match tokio::time::timeout(timeout, child.wait()).await {
                 Ok(Ok(status)) if status.success() => {
                     let _ = http.create_followup_message(

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1670,6 +1670,17 @@ impl Handler {
         ctx: &Context,
         cmd: &serenity::model::application::CommandInteraction,
     ) {
+        // Reject bot users — consistent with other slash-command handlers (e.g. /remind).
+        if cmd.user.bot {
+            let response = CreateInteractionResponse::Message(
+                CreateInteractionResponseMessage::new()
+                    .content("🤖 Bots cannot use `/auth`.")
+                    .ephemeral(true),
+            );
+            let _ = cmd.create_response(&ctx.http, response).await;
+            return;
+        }
+
         // Access control — only allowed users can trigger auth.
         if is_denied_user(
             false,
@@ -1736,6 +1747,7 @@ impl Handler {
 
         let http = ctx.http.clone();
         let token = cmd.token.clone();
+        let user_id = cmd.user.id.get();
 
         tokio::spawn(async move {
             use tokio::io::AsyncBufReadExt;
@@ -1751,7 +1763,7 @@ impl Handler {
             }
             let _guard = AuthGuard;
 
-            info!("/auth: starting auth command");
+            info!(user_id, "/auth: starting auth command");
 
             let child = TokioCommand::new("sh")
                 .arg("-c")
@@ -1789,7 +1801,7 @@ impl Handler {
                     let mut reader = tokio::io::BufReader::new(stdout).lines();
                     while let Ok(Some(line)) = reader.next_line().await {
                         let has_url = line.contains("http://") || line.contains("https://");
-                        lines_out.lock().unwrap().push(line);
+                        lines_out.lock().unwrap_or_else(|e| e.into_inner()).push(line);
                         if has_url {
                             url_found_out.notify_one();
                         }
@@ -1804,7 +1816,7 @@ impl Handler {
                     let mut reader = tokio::io::BufReader::new(stderr).lines();
                     while let Ok(Some(line)) = reader.next_line().await {
                         let has_url = line.contains("http://") || line.contains("https://");
-                        lines_err.lock().unwrap().push(line);
+                        lines_err.lock().unwrap_or_else(|e| e.into_inner()).push(line);
                         if has_url {
                             url_found_err.notify_one();
                         }
@@ -1812,19 +1824,60 @@ impl Handler {
                 }
             });
 
-            // Wait for a URL to appear or 30-second timeout.
+            // Wait for a URL to appear, the command to exit early, or a 30s timeout.
+            let mut early_exit: Option<std::io::Result<std::process::ExitStatus>> = None;
             tokio::select! {
                 _ = url_found.notified() => {
                     info!("/auth: URL detected in output");
                     // Brief sleep to let trailing lines (code/instructions) be captured.
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                 }
+                res = child.wait() => {
+                    // The auth command exited before printing a URL — fail fast
+                    // instead of waiting out the full collection window.
+                    warn!("/auth: auth command exited before a URL was detected");
+                    early_exit = Some(res);
+                }
                 _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
                     warn!("/auth: 30s URL-collection window expired without detecting URL");
                 }
             }
 
-            let collected_lines = lines.lock().unwrap().clone();
+            // Handle an early exit (the command terminated during the URL window).
+            if let Some(res) = early_exit {
+                let _ = tokio::join!(stdout_task, stderr_task);
+                let collected = lines
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .join("\n");
+                let detail = if collected.trim().is_empty() {
+                    String::new()
+                } else {
+                    let snippet: String = collected.chars().take(500).collect();
+                    format!("\n```\n{snippet}\n```")
+                };
+                let content = match res {
+                    Ok(status) if status.success() => {
+                        format!("✅ Auth command completed.{detail}")
+                    }
+                    Ok(status) => {
+                        format!(
+                            "❌ Auth command exited early ({status}) before producing a login URL.{detail}"
+                        )
+                    }
+                    Err(e) => format!("❌ Error waiting for auth command: {e}"),
+                };
+                let _ = http.create_followup_message(
+                    &token,
+                    &CreateInteractionResponseFollowup::new()
+                        .content(content)
+                        .ephemeral(true),
+                    Vec::new(),
+                ).await;
+                return;
+            }
+
+            let collected_lines = lines.lock().unwrap_or_else(|e| e.into_inner()).clone();
 
             if collected_lines.is_empty() {
                 warn!("/auth: no output captured, killing child process");
@@ -1833,7 +1886,7 @@ impl Handler {
                 let _ = http.create_followup_message(
                     &token,
                     &CreateInteractionResponseFollowup::new()
-                        .content("⚠️ Auth command produced no output.")
+                        .content("⚠️ Auth command produced no output within 30 seconds. Verify `OPENAB_AGENT_AUTH_COMMAND` is set and prints a login URL to stdout/stderr.")
                         .ephemeral(true),
                     Vec::new(),
                 ).await;
@@ -1844,8 +1897,21 @@ impl Handler {
             let output = collected_lines.join("\n");
             let prefix = "🔐 **Agent Authentication**\n```\n";
             let suffix = "\n```\nFollow the instructions above. Waiting for authorization...";
-            let max_output_chars = 2000 - prefix.chars().count() - suffix.chars().count();
-            let truncated: String = output.chars().take(max_output_chars).collect();
+            // Discord enforces the 2000-char limit in UTF-16 code units, so budget
+            // and truncate by UTF-16 units rather than Unicode scalar values.
+            let budget = 2000usize
+                .saturating_sub(prefix.encode_utf16().count())
+                .saturating_sub(suffix.encode_utf16().count());
+            let mut truncated = String::new();
+            let mut used = 0usize;
+            for ch in output.chars() {
+                let w = ch.len_utf16();
+                if used + w > budget {
+                    break;
+                }
+                used += w;
+                truncated.push(ch);
+            }
             let msg = format!("{prefix}{truncated}{suffix}");
             let _ = http.create_followup_message(
                 &token,

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1171,6 +1171,8 @@ impl EventHandler for Handler {
                     "delay",
                     "Delay before firing (e.g. 30m, 2h, 1d)",
                 ).required(true)),
+            CreateCommand::new("auth")
+                .description("Authenticate the backend agent (device flow)"),
             CreateCommand::new("export-thread")
                 .description("Download this thread as a text file")
                 .add_option(CreateCommandOption::new(
@@ -1258,6 +1260,9 @@ impl EventHandler for Handler {
             }
             Interaction::Command(cmd) if cmd.data.name == "export-thread" => {
                 self.handle_export_thread_command(&ctx, &cmd).await;
+            }
+            Interaction::Command(cmd) if cmd.data.name == "auth" => {
+                self.handle_auth_command(&ctx, &cmd).await;
             }
             Interaction::Component(comp) if comp.data.custom_id.starts_with("acp_config_") => {
                 self.handle_config_select(&ctx, &comp).await;
@@ -1658,6 +1663,212 @@ impl Handler {
         if let Err(e) = cmd.create_response(&ctx.http, response).await {
             tracing::error!(error = %e, "failed to respond to /remind command");
         }
+    }
+
+    async fn handle_auth_command(
+        &self,
+        ctx: &Context,
+        cmd: &serenity::model::application::CommandInteraction,
+    ) {
+        let auth_cmd = match std::env::var("OPENAB_AGENT_AUTH_COMMAND") {
+            Ok(val) if !val.is_empty() => val,
+            _ => {
+                let response = CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new()
+                        .content("⚠️ No auth command configured (`OPENAB_AGENT_AUTH_COMMAND` not set).")
+                        .ephemeral(true),
+                );
+                let _ = cmd.create_response(&ctx.http, response).await;
+                return;
+            }
+        };
+
+        // Acknowledge with a deferred ephemeral response so we have time to run the command.
+        let defer = CreateInteractionResponse::Defer(
+            CreateInteractionResponseMessage::new().ephemeral(true),
+        );
+        if let Err(e) = cmd.create_response(&ctx.http, defer).await {
+            tracing::error!(error = %e, "failed to defer /auth response");
+            return;
+        }
+
+        let http = ctx.http.clone();
+        let token = cmd.token.clone();
+
+        tokio::spawn(async move {
+            use tokio::io::AsyncBufReadExt;
+            use tokio::process::Command as TokioCommand;
+
+            let child = TokioCommand::new("sh")
+                .arg("-c")
+                .arg(&auth_cmd)
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn();
+
+            let mut child = match child {
+                Ok(c) => c,
+                Err(e) => {
+                    let _ = http.create_followup_message(
+                        &token,
+                        &CreateInteractionResponseFollowup::new()
+                            .content(format!("❌ Failed to start auth command: {e}"))
+                            .ephemeral(true),
+                        Vec::new(),
+                    ).await;
+                    return;
+                }
+            };
+
+            // Read stdout and stderr concurrently to capture device flow output.
+            let stdout = child.stdout.take();
+            let stderr = child.stderr.take();
+
+            let mut lines: Vec<String> = Vec::new();
+
+            // Collect output from both streams until we find a URL or the process ends.
+            let collect = async {
+                let mut stdout_reader = stdout.map(|s| tokio::io::BufReader::new(s).lines());
+                let mut stderr_reader = stderr.map(|s| tokio::io::BufReader::new(s).lines());
+
+                let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+
+                loop {
+                    if tokio::time::Instant::now() > deadline {
+                        break;
+                    }
+
+                    tokio::select! {
+                        line = async {
+                            match stdout_reader.as_mut() {
+                                Some(r) => r.next_line().await,
+                                None => Ok(None),
+                            }
+                        } => {
+                            match line {
+                                Ok(Some(l)) => {
+                                    lines.push(l.clone());
+                                    if l.contains("http://") || l.contains("https://") {
+                                        // Read a few more lines to capture the code
+                                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                                        while let Some(reader) = stdout_reader.as_mut() {
+                                            match tokio::time::timeout(
+                                                std::time::Duration::from_millis(200),
+                                                reader.next_line()
+                                            ).await {
+                                                Ok(Ok(Some(l))) => lines.push(l),
+                                                _ => break,
+                                            }
+                                        }
+                                        break;
+                                    }
+                                }
+                                Ok(None) => { stdout_reader = None; }
+                                Err(_) => { stdout_reader = None; }
+                            }
+                        }
+                        line = async {
+                            match stderr_reader.as_mut() {
+                                Some(r) => r.next_line().await,
+                                None => Ok(None),
+                            }
+                        } => {
+                            match line {
+                                Ok(Some(l)) => {
+                                    lines.push(l.clone());
+                                    if l.contains("http://") || l.contains("https://") {
+                                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                                        while let Some(reader) = stderr_reader.as_mut() {
+                                            match tokio::time::timeout(
+                                                std::time::Duration::from_millis(200),
+                                                reader.next_line()
+                                            ).await {
+                                                Ok(Ok(Some(l))) => lines.push(l),
+                                                _ => break,
+                                            }
+                                        }
+                                        break;
+                                    }
+                                }
+                                Ok(None) => { stderr_reader = None; }
+                                Err(_) => { stderr_reader = None; }
+                            }
+                        }
+                    }
+
+                    if stdout_reader.is_none() && stderr_reader.is_none() {
+                        break;
+                    }
+                }
+            };
+
+            collect.await;
+
+            if lines.is_empty() {
+                let _ = http.create_followup_message(
+                    &token,
+                    &CreateInteractionResponseFollowup::new()
+                        .content("⚠️ Auth command produced no output.")
+                        .ephemeral(true),
+                    Vec::new(),
+                ).await;
+                return;
+            }
+
+            // Send the captured output to the user
+            let output = lines.join("\n");
+            let msg = format!("🔐 **Agent Authentication**\n```\n{}\n```\nFollow the instructions above. Waiting for authorization...", output);
+            let _ = http.create_followup_message(
+                &token,
+                &CreateInteractionResponseFollowup::new()
+                    .content(msg)
+                    .ephemeral(true),
+                Vec::new(),
+            ).await;
+
+            // Wait for the process to complete (user authorizes in browser)
+            let timeout = std::time::Duration::from_secs(15 * 60);
+            match tokio::time::timeout(timeout, child.wait()).await {
+                Ok(Ok(status)) if status.success() => {
+                    let _ = http.create_followup_message(
+                        &token,
+                        &CreateInteractionResponseFollowup::new()
+                            .content("✅ Authentication successful!")
+                            .ephemeral(true),
+                        Vec::new(),
+                    ).await;
+                }
+                Ok(Ok(status)) => {
+                    let _ = http.create_followup_message(
+                        &token,
+                        &CreateInteractionResponseFollowup::new()
+                            .content(format!("❌ Authentication failed (exit code: {}).", status))
+                            .ephemeral(true),
+                        Vec::new(),
+                    ).await;
+                }
+                Ok(Err(e)) => {
+                    let _ = http.create_followup_message(
+                        &token,
+                        &CreateInteractionResponseFollowup::new()
+                            .content(format!("❌ Auth process error: {e}"))
+                            .ephemeral(true),
+                        Vec::new(),
+                    ).await;
+                }
+                Err(_) => {
+                    // Timeout — kill the process
+                    let _ = child.kill().await;
+                    let _ = http.create_followup_message(
+                        &token,
+                        &CreateInteractionResponseFollowup::new()
+                            .content("⏰ Authentication timed out (15 min). Run `/auth` again to retry.")
+                            .ephemeral(true),
+                        Vec::new(),
+                    ).await;
+                }
+            }
+        });
     }
 
     async fn handle_export_thread_command(

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1729,6 +1729,7 @@ impl Handler {
         tokio::spawn(async move {
             use tokio::io::AsyncBufReadExt;
             use tokio::process::Command as TokioCommand;
+            use std::sync::Arc;
 
             let child = TokioCommand::new("sh")
                 .arg("-c")
@@ -1752,90 +1753,57 @@ impl Handler {
                 }
             };
 
-            // Read stdout and stderr concurrently to capture device flow output.
             let stdout = child.stdout.take();
             let stderr = child.stderr.take();
 
-            let mut lines: Vec<String> = Vec::new();
+            let lines = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+            let url_found = Arc::new(tokio::sync::Notify::new());
 
-            // Collect output from both streams until we find a URL or the process ends.
-            {
-                let mut stdout_reader = stdout.map(|s| tokio::io::BufReader::new(s).lines());
-                let mut stderr_reader = stderr.map(|s| tokio::io::BufReader::new(s).lines());
-
-                let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
-
-                loop {
-                    if tokio::time::Instant::now() > deadline {
-                        break;
-                    }
-
-                    tokio::select! {
-                        line = async {
-                            match stdout_reader.as_mut() {
-                                Some(r) => r.next_line().await,
-                                None => Ok(None),
-                            }
-                        } => {
-                            match line {
-                                Ok(Some(l)) => {
-                                    lines.push(l.clone());
-                                    if l.contains("http://") || l.contains("https://") {
-                                        // Read a few more lines to capture the code
-                                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                                        while let Some(reader) = stdout_reader.as_mut() {
-                                            match tokio::time::timeout(
-                                                std::time::Duration::from_millis(200),
-                                                reader.next_line()
-                                            ).await {
-                                                Ok(Ok(Some(l))) => lines.push(l),
-                                                _ => break,
-                                            }
-                                        }
-                                        break;
-                                    }
-                                }
-                                Ok(None) => { stdout_reader = None; }
-                                Err(_) => { stdout_reader = None; }
-                            }
+            // Spawn background drain tasks — they run to EOF, keeping pipes open.
+            let lines_out = lines.clone();
+            let url_found_out = url_found.clone();
+            let stdout_task = tokio::spawn(async move {
+                if let Some(stdout) = stdout {
+                    let mut reader = tokio::io::BufReader::new(stdout).lines();
+                    while let Ok(Some(line)) = reader.next_line().await {
+                        let has_url = line.contains("http://") || line.contains("https://");
+                        lines_out.lock().unwrap().push(line);
+                        if has_url {
+                            url_found_out.notify_one();
                         }
-                        line = async {
-                            match stderr_reader.as_mut() {
-                                Some(r) => r.next_line().await,
-                                None => Ok(None),
-                            }
-                        } => {
-                            match line {
-                                Ok(Some(l)) => {
-                                    lines.push(l.clone());
-                                    if l.contains("http://") || l.contains("https://") {
-                                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                                        while let Some(reader) = stderr_reader.as_mut() {
-                                            match tokio::time::timeout(
-                                                std::time::Duration::from_millis(200),
-                                                reader.next_line()
-                                            ).await {
-                                                Ok(Ok(Some(l))) => lines.push(l),
-                                                _ => break,
-                                            }
-                                        }
-                                        break;
-                                    }
-                                }
-                                Ok(None) => { stderr_reader = None; }
-                                Err(_) => { stderr_reader = None; }
-                            }
-                        }
-                    }
-
-                    if stdout_reader.is_none() && stderr_reader.is_none() {
-                        break;
                     }
                 }
-            } // readers dropped here; child still owns the pipes
+            });
 
-            if lines.is_empty() {
+            let lines_err = lines.clone();
+            let url_found_err = url_found.clone();
+            let stderr_task = tokio::spawn(async move {
+                if let Some(stderr) = stderr {
+                    let mut reader = tokio::io::BufReader::new(stderr).lines();
+                    while let Ok(Some(line)) = reader.next_line().await {
+                        let has_url = line.contains("http://") || line.contains("https://");
+                        lines_err.lock().unwrap().push(line);
+                        if has_url {
+                            url_found_err.notify_one();
+                        }
+                    }
+                }
+            });
+
+            // Wait for a URL to appear or 30-second timeout.
+            tokio::select! {
+                _ = url_found.notified() => {
+                    // Brief sleep to let trailing lines (code/instructions) be captured.
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                }
+                _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
+            }
+
+            let collected_lines = lines.lock().unwrap().clone();
+
+            if collected_lines.is_empty() {
                 let _ = child.kill().await;
+                let _ = tokio::join!(stdout_task, stderr_task);
                 let _ = http.create_followup_message(
                     &token,
                     &CreateInteractionResponseFollowup::new()
@@ -1847,8 +1815,8 @@ impl Handler {
                 return;
             }
 
-            // Send the captured output to the user (truncate to fit Discord's 2000-char limit).
-            let output = lines.join("\n");
+            // Send the captured output (truncated to Discord's 2000-char limit).
+            let output = collected_lines.join("\n");
             let prefix = "🔐 **Agent Authentication**\n```\n";
             let suffix = "\n```\nFollow the instructions above. Waiting for authorization...";
             let max_output = 2000 - prefix.len() - suffix.len();
@@ -1866,7 +1834,7 @@ impl Handler {
                 Vec::new(),
             ).await;
 
-            // Wait for the process to complete (user authorizes in browser)
+            // Wait for the process to complete (user authorizes in browser).
             let timeout = std::time::Duration::from_secs(15 * 60);
             match tokio::time::timeout(timeout, child.wait()).await {
                 Ok(Ok(status)) if status.success() => {
@@ -1897,7 +1865,6 @@ impl Handler {
                     ).await;
                 }
                 Err(_) => {
-                    // Timeout — kill the process
                     let _ = child.kill().await;
                     let _ = http.create_followup_message(
                         &token,
@@ -1908,6 +1875,9 @@ impl Handler {
                     ).await;
                 }
             }
+
+            // Let background drain tasks complete.
+            let _ = tokio::join!(stdout_task, stderr_task);
             AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::SeqCst);
         });
     }

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1858,7 +1858,9 @@ impl Handler {
                 };
                 let content = match res {
                     Ok(status) if status.success() => {
-                        format!("✅ Auth command completed.{detail}")
+                        format!(
+                            "⚠️ Auth command exited (status 0) before a login URL was detected. Run `/auth` again to retry.{detail}"
+                        )
                     }
                     Ok(status) => {
                         format!(

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -168,6 +168,7 @@ Trigger the backend agent's device-flow authentication. OAB executes the command
 - `OPENAB_AGENT_AUTH_COMMAND` environment variable must be set
 - The auth command must use OAuth device flow (print URL + code to stdout, then block until authorized)
 - No interactive stdin input required (headless-compatible)
+- Must be invoked in a **DM** with the bot (rejected in guild channels/threads for security)
 
 **Timeout:** 15 minutes. If the user doesn't authorize within that window, the process is killed and the user is prompted to run `/auth` again.
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -170,7 +170,12 @@ Trigger the backend agent's device-flow authentication. OAB executes the command
 - No interactive stdin input required (headless-compatible)
 - Must be invoked in a **DM** with the bot (rejected in guild channels/threads for security)
 
-**Timeout:** 15 minutes. If the user doesn't authorize within that window, the process is killed and the user is prompted to run `/auth` again.
+**Timeout:** 14 minutes. If the user doesn't authorize within that window, the process is killed and the user is prompted to run `/auth` again. (Reduced from 15min to leave headroom for Discord's interaction token TTL.)
+
+**Behavior notes:**
+- Only users in the `allowed_users` list can invoke `/auth`
+- A 30-second URL-collection window waits for the auth command to print its URL. Slow-starting CLIs that take longer may show "no output".
+- Only one `/auth` flow can run at a time (single-flight). A second concurrent invocation is rejected with "already in progress".
 
 **Error cases:**
 - `OPENAB_AGENT_AUTH_COMMAND` not set → immediate error message

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,6 +1,6 @@
 # Slash Commands
 
-OpenAB registers Discord slash commands for session control. These work in both guild threads and DMs.
+OpenAB registers Discord slash commands for session control and agent management. Most work in both guild threads and DMs — the exception is `/auth`, which is **DM-only** for security (see [`/auth`](#auth) below).
 
 ## Commands
 
@@ -10,7 +10,7 @@ OpenAB registers Discord slash commands for session control. These work in both 
 | `/agents` | Select the agent mode via dropdown menu | Yes |
 | `/cancel` | Cancel the current in-flight operation | Yes |
 | `/reset` | Reset the conversation session (clear history, start fresh) | Yes |
-| `/auth` | Authenticate the backend agent via device flow | No |
+| `/auth` | Authenticate the backend agent via device flow (**DM-only**) | No |
 | `/remind` | Set a one-shot delayed reminder to mention users/roles | No |
 | `/export-thread` | Export thread/DM as `.txt` (default: last 100 messages) | No |
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -10,6 +10,7 @@ OpenAB registers Discord slash commands for session control. These work in both 
 | `/agents` | Select the agent mode via dropdown menu | Yes |
 | `/cancel` | Cancel the current in-flight operation | Yes |
 | `/reset` | Reset the conversation session (clear history, start fresh) | Yes |
+| `/auth` | Authenticate the backend agent via device flow | No |
 | `/remind` | Set a one-shot delayed reminder to mention users/roles | No |
 | `/export-thread` | Export thread/DM as `.txt` (default: last 100 messages) | No |
 
@@ -150,3 +151,28 @@ Set a one-shot delayed reminder that mentions users or roles in the channel afte
 "Review PR #42"
 cc @Alice @Bob
 ```
+
+## `/auth`
+
+Trigger the backend agent's device-flow authentication. OAB executes the command defined in `OPENAB_AGENT_AUTH_COMMAND`, captures the device code URL from stdout/stderr, and relays it to the user as an ephemeral Discord message.
+
+**Flow:**
+1. User runs `/auth`
+2. OAB executes `$OPENAB_AGENT_AUTH_COMMAND` (e.g. `codex login --device-auth`)
+3. OAB captures the device URL + code from the command's output
+4. OAB sends an ephemeral reply with the URL and code
+5. User opens the URL in their browser, enters the code
+6. The auth command exits successfully → OAB confirms "✅ Authentication successful!"
+
+**Requirements:**
+- `OPENAB_AGENT_AUTH_COMMAND` environment variable must be set
+- The auth command must use OAuth device flow (print URL + code to stdout, then block until authorized)
+- No interactive stdin input required (headless-compatible)
+
+**Timeout:** 15 minutes. If the user doesn't authorize within that window, the process is killed and the user is prompted to run `/auth` again.
+
+**Error cases:**
+- `OPENAB_AGENT_AUTH_COMMAND` not set → immediate error message
+- Auth command fails to start → error message
+- Auth command exits with non-zero → failure message with exit code
+- Timeout → process killed, retry prompt

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -174,11 +174,15 @@ Trigger the backend agent's device-flow authentication. OAB executes the command
 
 **Behavior notes:**
 - Only users in the `allowed_users` list can invoke `/auth`
+- Bot users are rejected — `/auth` is for human operators only
 - A 30-second URL-collection window waits for the auth command to print its URL. Slow-starting CLIs that take longer may show "no output".
 - Only one `/auth` flow can run at a time (single-flight). A second concurrent invocation is rejected with "already in progress".
 
 **Error cases:**
 - `OPENAB_AGENT_AUTH_COMMAND` not set → immediate error message
+- Invoked by a bot user → rejected
+- Invoked outside a DM (in a guild channel/thread) → rejected for security
 - Auth command fails to start → error message
+- Auth command exits **before** printing a login URL (within the 30s window) → warning that no URL was produced, with a retry prompt
 - Auth command exits with non-zero → failure message with exit code
 - Timeout → process killed, retry prompt


### PR DESCRIPTION
## Summary

Adds `/auth` Discord slash command that executes `$OPENAB_AGENT_AUTH_COMMAND` and relays the device-flow URL + code back to the user via ephemeral DM.

## Flow Diagram

```
┌─────────────┐         ┌──────────────┐         ┌────────────────────┐
│  Discord    │         │     OAB      │         │  Auth CLI          │
│  (User DM)  │         │  (Handler)   │         │  (e.g. codex       │
│             │         │              │         │   login --device)  │
└──────┬──────┘         └──────┬───────┘         └─────────┬──────────┘
       │                       │                           │
       │  /auth                │                           │
       ├──────────────────────▶│                           │
       │                       │                           │
       │  [access check]       │                           │
       │  [DM-only check]      │                           │
       │  [single-flight]      │                           │
       │                       │                           │
       │  defer (ephemeral)    │                           │
       │◀──────────────────────┤                           │
       │                       │                           │
       │                       │  sh -c $AUTH_CMD          │
       │                       ├──────────────────────────▶│
       │                       │                           │
       │                       │  stdout: URL + code       │
       │                       │◀──────────────────────────┤
       │                       │                           │
       │  🔐 URL + code        │                           │
       │◀──────────────────────┤                           │
       │                       │                           │
       │                       │      (process blocks,     │
       │  [user opens URL,     │       polling OAuth       │
       │   enters code in      │       server...)          │
       │   browser]            │                           │
       │                       │                           │
       │                       │  exit 0                   │
       │                       │◀──────────────────────────┤
       │                       │                           │
       │  ✅ Authenticated!    │                           │
       │◀──────────────────────┤                           │
       │                       │                           │
```

## Security Controls

```
/auth invoked
  │
  ├─ is_denied_user? ──▶ 🚫 rejected
  │
  ├─ guild_id.is_some()? ──▶ 🔒 DM-only
  │
  ├─ AUTH_IN_PROGRESS? ──▶ ⚠️ already running
  │
  ├─ OPENAB_AGENT_AUTH_COMMAND unset? ──▶ ⚠️ not configured
  │
  └─ ✅ proceed with deferred ephemeral + spawn
```

## Architecture

- **Drain tasks**: Separate `tokio::spawn` for stdout/stderr → run to EOF (no SIGPIPE)
- **URL detection**: `tokio::sync::Notify` (cancellation-safe)
- **Single-flight**: `static AtomicBool` + `Drop` guard (panic-safe)
- **DM check**: `cmd.guild_id.is_some()` (local field, no API call)
- **Truncation**: `chars().take()` (UTF-8-safe, Discord 2000-char limit)
- **Timeout**: 14 min (leaves headroom for Discord interaction token TTL)
- **Tracing**: info/warn at key lifecycle points

## Changes

- `crates/openab-core/src/discord.rs` — Register + implement `/auth`
- `docs/slash-commands.md` — Full documentation

## Review History

6 commits, 5 review rounds, 3 reviewers (擺渡/口渡/覺渡/普渡), all LGTM ✅