### PR TITLE
ci: reduce redundant smoke test runs

### DIFF
--- a/.github/workflows/docker-smoke-test-unified.yml
+++ b/.github/workflows/docker-smoke-test-unified.yml
@@ -2,7 +2,7 @@ name: Docker Smoke Test (Unified)
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'Dockerfile.unified'
       - 'src/**'

--- a/.github/workflows/docker-smoke-test-unified.yml
+++ b/.github/workflows/docker-smoke-test-unified.yml
@@ -2,6 +2,7 @@ name: Docker Smoke Test (Unified)
 
 on:
   pull_request:
+    types: [opened, synchronize, ready_for_review]
     paths:
       - 'Dockerfile.unified'
       - 'src/**'
@@ -10,9 +11,14 @@ on:
       - 'openab-agent/**'
       - 'agy-acp/**'
 
+concurrency:
+  group: smoke-test-unified-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   # Build the shared builder stage once, then test agent targets using cache
   build-builder:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docker-smoke-test-unified.yml
+++ b/.github/workflows/docker-smoke-test-unified.yml
@@ -36,6 +36,7 @@ jobs:
           cache-to: type=gha,scope=unified-smoke-builder,mode=max
 
   smoke-test-unified:
+    if: github.event.pull_request.draft == false
     needs: build-builder
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -2,14 +2,20 @@ name: Docker Smoke Test
 
 on:
   pull_request:
+    types: [opened, synchronize, ready_for_review]
     paths:
       - 'Dockerfile*'
       - 'src/**'
       - 'crates/**'
       - 'Cargo.*'
 
+concurrency:
+  group: smoke-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   smoke-test:
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -2,7 +2,7 @@ name: Docker Smoke Test
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'Dockerfile*'
       - 'src/**'


### PR DESCRIPTION
## Summary

Addresses #1192 — reduces redundant CI runs during active PR development.

### Changes

- **Concurrency group + cancel-in-progress**: New pushes to the same PR automatically cancel any in-progress smoke test run, preventing overlapping builds.
- **Draft PR skip**: Smoke tests only run when the PR is marked ready for review (`opened`, `synchronize`, `ready_for_review` event types + `draft == false` condition).

Applied to both:
- `docker-smoke-test.yml` (14 variant matrix)
- `docker-smoke-test-unified.yml` (14 target matrix)

### Testing

- YAML syntax validated
- No functional changes to the test steps themselves

Closes #1192