### PR TITLE
ci: add Pre-Beta Build workflow for pre-beta-<agent> tags

### DIFF
--- a/.github/workflows/pre-beta-build.yml
+++ b/.github/workflows/pre-beta-build.yml
@@ -1,0 +1,129 @@
+name: Pre-Beta Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      agents:
+        description: 'Agents to build (comma-separated, or "all")'
+        required: false
+        type: string
+        default: 'all'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  ALL_AGENTS: 'kiro,claude,codex,copilot,cursor,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore'
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      agents: ${{ steps.resolve.outputs.agents }}
+    steps:
+      - name: Resolve agent matrix
+        id: resolve
+        run: |
+          if [ "${{ inputs.agents }}" = "all" ] || [ -z "${{ inputs.agents }}" ]; then
+            AGENTS="${{ env.ALL_AGENTS }}"
+          else
+            AGENTS="${{ inputs.agents }}"
+          fi
+          JSON=$(echo "$AGENTS" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R . | jq -sc .)
+          echo "agents=${JSON}" >> "$GITHUB_OUTPUT"
+          echo "Building: $AGENTS"
+
+  build:
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        agent: ${{ fromJson(needs.matrix.outputs.agents) }}
+        platform:
+          - { os: linux/amd64, runner: ubuntu-latest, arch: amd64 }
+          - { os: linux/arm64, runner: ubuntu-24.04-arm, arch: arm64 }
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.unified
+          target: ${{ matrix.agent }}
+          platforms: ${{ matrix.platform.os }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: |
+            type=gha,scope=pre-beta-${{ matrix.agent }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,scope=pre-beta-${{ matrix.agent }}-${{ matrix.platform.arch }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.agent }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  tag:
+    needs: [matrix, build]
+    strategy:
+      matrix:
+        agent: ${{ fromJson(needs.matrix.outputs.agents) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.agent }}-*
+          merge-multiple: true
+
+      - name: Create manifest and tag
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          AGENT="${{ matrix.agent }}"
+          SHORT_SHA=$(echo "${{ github.sha }}" | head -c 7)
+
+          # Map "default" target name to "kiro" for tagging
+          if [ "$AGENT" = "default" ]; then
+            AGENT="kiro"
+          fi
+
+          DIGESTS=$(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
+
+          docker buildx imagetools create \
+            -t "${IMAGE}:pre-beta-${AGENT}" \
+            -t "${IMAGE}:${SHORT_SHA}-${AGENT}" \
+            ${DIGESTS}
+
+          echo "### 📦 \`${IMAGE}:pre-beta-${AGENT}\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Single workflow_dispatch that builds all 14 agent variants from `Dockerfile.unified` and tags them as `pre-beta-<agent>`.

## Usage

```bash
# All agents
gh workflow run 'Pre-Beta Build'

# Specific agents
gh workflow run 'Pre-Beta Build' -f agents=kiro,codex,mimocode
```

## Tags produced

```
ghcr.io/openabdev/openab:pre-beta-kiro
ghcr.io/openabdev/openab:pre-beta-codex
ghcr.io/openabdev/openab:pre-beta-mimocode
... (14 total)
+ <sha>-<agent> traceability tags
```

## Why

Previously required 14 separate Snapshot Build dispatches with manual tag overrides. This is one command.