### PR TITLE
build: make pre-seed a default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serenity = { version = "0.12", default-features = false, features = ["client", "
 
 [features]
 # Default: core only (Discord + Slack). Gateway ships as separate binary.
-default = ["discord", "slack", "secrets-aws", "agentcore", "config-s3"]
+default = ["discord", "slack", "secrets-aws", "agentcore", "config-s3", "pre-seed"]
 
 # Opt-in: compile all gateway adapters into a single unified binary
 unified = ["telegram", "line", "feishu", "googlechat", "wecom", "teams"]


### PR DESCRIPTION
Makes `pre-seed` a default feature instead of opt-in. Its deps (`aws-sdk-s3`, `flate2`, `tar`) are already compiled for other default features (`config-s3`, `secrets-aws`). No reason to gate a core boot-time capability behind a feature flag.

`[hooks.pre_seed]` now works in all builds — standard and unified — without extra flags.