### PR TITLE
fix(adapter): surface error on agent EOF without final response

### DIFF
--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -812,8 +812,21 @@ impl AdapterRouter {
                         let notification = tokio::select! {
                             msg = rx.recv() => match msg {
                                 Some(n) => n,
-                                // Reader saw EOF and already drained pending; nothing to abandon.
-                                None => break,
+                                // Reader saw EOF: the agent's stdout closed before it sent
+                                // a final response. For ACP-native agents this is normal
+                                // completion (the final response already broke the loop above),
+                                // but bridged agents that crash on a backend error (e.g. HTTP
+                                // 500 / quota exhausted) exit without ever emitting an ACP error
+                                // notification — leaving response_error None. Surface that as an
+                                // explicit error instead of falling through to "_(no response)_".
+                                // The text_buf guard preserves any partial text already streamed.
+                                None => {
+                                    if response_error.is_none() && text_buf.is_empty() {
+                                        response_error =
+                                            Some("Agent process exited unexpectedly".into());
+                                    }
+                                    break;
+                                }
                             },
                             _ = tokio::time::sleep(liveness_check_interval) => {
                                 if !conn.alive() {

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -812,16 +812,26 @@ impl AdapterRouter {
                         let notification = tokio::select! {
                             msg = rx.recv() => match msg {
                                 Some(n) => n,
-                                // Reader saw EOF: the agent's stdout closed before it sent
-                                // a final response. For ACP-native agents this is normal
-                                // completion (the final response already broke the loop above),
-                                // but bridged agents that crash on a backend error (e.g. HTTP
-                                // 500 / quota exhausted) exit without ever emitting an ACP error
-                                // notification — leaving response_error None. Surface that as an
-                                // explicit error instead of falling through to "_(no response)_".
-                                // The text_buf guard preserves any partial text already streamed.
+                                // Reader saw EOF: the agent's stdout closed. A *successful*
+                                // turn is always signalled by the id-bearing JSON-RPC response to
+                                // `session/prompt`, which breaks the loop at the id branch below
+                                // *before* any EOF — so reaching this arm means the turn ended
+                                // without a final response, i.e. the agent terminated abnormally
+                                // (bridged agents that crash on a backend error such as HTTP 500 /
+                                // quota exhausted exit without ever emitting an ACP error
+                                // notification). Surface that as an explicit error instead of
+                                // falling through to "_(no response)_" or, worse, presenting a
+                                // partially-streamed buffer as a complete answer.
+                                //
+                                // Do NOT gate on `text_buf.is_empty()`: the buffer is pre-seeded
+                                // on session reset (the expiry notice) and, in send-once mode,
+                                // carries inter-tool narration that is sliced off before delivery —
+                                // so a non-empty buffer is not evidence the turn completed. When
+                                // partial text *was* streamed, `final_content` prepends the warning
+                                // to it (⚠️ … \n\n <partial>), preserving the output while flagging
+                                // the truncation.
                                 None => {
-                                    if response_error.is_none() && text_buf.is_empty() {
+                                    if response_error.is_none() {
                                         response_error =
                                             Some("Agent process exited unexpectedly".into());
                                     }


### PR DESCRIPTION


## What problem does this solve?

When a bridged (non-ACP-native) agent crashes on a backend error, OpenAB shows the user a vague `_(no response)_` (or, worse, a partially-streamed buffer presented as a complete answer) instead of the real failure reason.

agy does not natively speak ACP — we bridge it. So when an AI backend (e.g. Gemini) returns HTTP 500 or a quota-exhausted error, agy can crash/exit **without first emitting an ACP final response carrying that error**. The failure chain:

1. AI backend returns HTTP 500 / quota exhausted.
2. agy crashes/exits — never sends an ACP error notification.
3. OpenAB's ACP stdout pipe reaches EOF.
4. The recv loop's `rx.recv() -> None` branch breaks out, but `response_error` is still `None`.
5. `final_content` is empty → falls through to the `_(no response)_` sentinel.

The user is left with no idea their request hit a quota limit or server error.

This was surfaced in the OpenAB community discussion. Because agy itself doesn't support ACP, the bridging layer (OpenAB side) must supply a sensible error on pipe EOF rather than letting it fall through.

Closes #<!-- issue number if one is filed -->

Discord Discussion URL:  https://discord.com/channels/1491295327620169908/1519250661664100455

## At a Glance

```
Before:
  backend 500/quota  ->  agy crashes (no ACP error)  ->  pipe EOF
        ->  recv() == None  ->  break (response_error stays None)
        ->  final_content empty  ->  "_(no response)_"   [user confused]

After:
  backend 500/quota  ->  agy crashes (no ACP error)  ->  pipe EOF
        ->  recv() == None  ->  response_error = "Agent process exited unexpectedly"
        ->  final_content: "⚠️ Agent process exited unexpectedly"   [empty buffer]
                        or "⚠️ Agent process exited unexpectedly\n\n<partial text>"  [partial stream]

Termination paths:
  liveness check sees dead process   -> "⚠️ Agent process died"               (already handled)
  pipe EOF, no final response        -> "⚠️ Agent process exited unexpectedly" (THIS FIX)
  agent sends proper ACP error       -> "⚠️ Server Error ... quota exceeded"   (already handled)
```

## Prior Art & Industry Research

Not applicable — defensive bug fix on the ACP bridge. Adds error surfacing on an existing `break`
path; no new architecture, dependency, or protocol. It makes the EOF branch consistent with the
sibling `!conn.alive()` branch, which already sets `response_error = "Agent process died"`.

## Proposed Solution

In `crates/openab-core/src/adapter.rs`, the recv loop EOF branch records an explicit error when the
pipe closes without a final response and no error was already recorded:

```rust
None => {
    if response_error.is_none() {
        response_error = Some("Agent process exited unexpectedly".into());
    }
    break;
}
```

The downstream `final_content` builder already renders `response_error` as `⚠️ {err}` (standalone
when there is no body, or prepended to any partial content), so no other change is needed.

## Why this approach?

- **Smallest correct fix on the bridge side.** agy can't be relied on to emit an ACP error before
  crashing, so the bridge detects the abnormal EOF itself, mirroring the existing
  `!conn.alive()` branch.
- **No buffer-content guard.** An earlier revision gated this on `text_buf.is_empty()`. Multi-model
  mob review (Codex + a Claude multi-finder review) showed that guard is unsound: it is defeated by
  the session-reset pre-seed (`text_buf` already holds the expiry notice), by send-once mode (the
  delivered body is a post-`answer_start` slice, not the full buffer), and by native streaming
  (partial text shown as a complete answer). The guard is also unnecessary: a **successful** turn is
  always signalled by the id-bearing JSON-RPC response to `session/prompt`, which breaks the recv
  loop *before* EOF — so the EOF branch is reachable only on abnormal termination, regardless of
  buffer contents. When partial text was streamed, `final_content` prepends the warning to it,
  preserving the output while flagging the truncation.

## Alternatives Considered

- **Gate on `text_buf.is_empty()` (earlier revision):** rejected after mob review — masks crashes on
  reset turns, send-once tool turns, and native-streaming partials (see above).
- **Synthetic final-response timeout instead of acting on EOF:** rejected — EOF already definitively
  signals the pipe closed; a timeout only adds latency for the same outcome.
- **Fix only agy (emit ACP error before exit):** rejected as the sole fix — agy isn't guaranteed to
  emit an error before crashing, so the bridge must be robust to silent EOF. A complementary agy-side
  fix is still worthwhile but out of scope for this repo.

## Known Issues / Follow-ups

- **Reaction emoji on crashed turns** (pre-existing, deferred): the EOF-injected `response_error`
  drives the `⚠️` message banner but not `delivery_failed`, so dispatch still reacts with success
  (🆗) rather than error (❌). This gap is shared with the existing `Agent process died` /
  hard-timeout / coded-error branches — this PR only joins the pattern. Recommended as a separate PR
  that wires `response_error → ❌` uniformly for all error branches.

## Validation

Rust changes:
- [x] `cargo build -p openab-core` passes
- [x] `cargo test -p openab-core --lib adapter` — 43 passed, 0 failed
- [x] `adapter.rs` clippy-clean
- [x] Multi-model mob review (Codex + Claude multi-finder): converged to LGTM after the
      `text_buf.is_empty()` guard was dropped

CI note:
- The `check` job (`cargo clippy --workspace -- -D warnings`) is currently RED on
  `crates/openab-core/src/pre_seed.rs:289` (`manual_is_multiple_of`, rust-1.96 lint) — **pre-existing
  on main** (landed via #1189/#1196/#1197), not part of this diff. The merge gate will stay red until
  main is fixed; flagging for maintainers.

All PRs:
- [ ] Manual testing — reproduce by forcing a bridged agent to exit on a backend 500/quota error and
      confirm the user sees `⚠️ Agent process exited unexpectedly` (with any partial text preserved)
      instead of `_(no response)_`. No automated test seam exists for this deeply-nested recv loop;
      the sibling error paths are likewise covered only by manual repro against a live agent.
