### PR TITLE
Docs(opencode): add API key provider config example

### DIFF
--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -211,7 +211,7 @@ kubectl exec -it deployment/openab-opencode -- bash -c 'cat > /home/node/opencod
     "opencode-go": {
       "options": {
         "baseURL": "https://opencode.ai/zen/go/v1",
-        "apiKey": "${OPENCODE_API_KEY}"
+        "apiKey": "{env:OPENCODE_API_KEY}"
       },
       "models": {
         "deepseek-v4-flash": {}
@@ -224,6 +224,11 @@ EOF'
 ```
 
 > Inject `OPENCODE_API_KEY` via a Kubernetes Secret as an environment variable.
+>
+> Note: shell-style `${OPENCODE_API_KEY}` would also work in this specific
+> heredoc (bash expands it before writing), but only here. `{env:VAR}` is the
+> form that works everywhere.
+
 
 ### 2. Restart to pick up config
 

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -193,6 +193,44 @@ kubectl rollout restart deployment/openab-opencode
 
 > **Important:** Do NOT set a custom `baseURL` or provider override for xAI. The built-in xAI provider handles routing correctly. A stale `~/.config/opencode/opencode.json` with `baseURL: "http://localhost:9090/v1"` (from xai-proxy setups) will break xAI — delete it if present.
 
+## Example: API Key Providers
+
+For providers that use API keys instead of OAuth (e.g. opencode-go, custom
+OpenAI-compatible endpoints), the config needs the full `provider` block with
+`options.apiKey`:
+
+### 1. Set the model and API key
+
+Create `opencode.json` in the working directory (`/home/node`). The key
+difference from OAuth providers is the `provider.options.apiKey` field:
+
+```bash
+kubectl exec -it deployment/openab-opencode -- bash -c 'cat > /home/node/opencode.json << EOF
+{
+  "provider": {
+    "opencode-go": {
+      "options": {
+        "baseURL": "https://opencode.ai/zen/go/v1",
+        "apiKey": "${OPENCODE_API_KEY}"
+      },
+      "models": {
+        "deepseek-v4-flash": {}
+      }
+    }
+  },
+  "model": "opencode-go/deepseek-v4-flash"
+}
+EOF'
+```
+
+> Inject `OPENCODE_API_KEY` via a Kubernetes Secret as an environment variable.
+
+### 2. Restart to pick up config
+
+```bash
+kubectl rollout restart deployment/openab-opencode
+```
+
 ## Notes
 
 - **Tool authorization**: OpenCode handles tool authorization internally and never emits `session/request_permission` — all tools run without user confirmation, equivalent to `--trust-all-tools` on other backends.

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -228,6 +228,9 @@ EOF'
 > Note: shell-style `${OPENCODE_API_KEY}` would also work in this specific
 > heredoc (bash expands it before writing), but only here. `{env:VAR}` is the
 > form that works everywhere.
+>
+> See the [opencode env var docs](https://opencode.ai/docs/config/#env-vars)
+> for the full `{env:VAR}` syntax and provider block schema.
 
 
 ### 2. Restart to pick up config


### PR DESCRIPTION
## What problem does this solve?

The existing `docs/opencode.md` examples (Ollama Cloud, xAI Grok) only cover OAuth-based providers. API-key-based providers like opencode-go require a different config structure — the full `provider.options.apiKey` block — which is not documented anywhere. Users hit this gap immediately when trying to set up API-key providers.

Closes #1200

## At a Glance

N/A — docs-only change.

## Prior Art & Industry Research

Not applicable — docs-only change, adding a missing config example.

## Proposed Solution

Add a new `## Example: API Key Providers` section to `docs/opencode.md`, placed after the existing xAI Grok example and before `## Notes`. The example uses opencode-go as a representative API-key provider, showing:

- The full `provider.options.apiKey` + `models` block
- `${OPENCODE_API_KEY}` env var expansion
- Restart step to pick up config

## Why this approach?

Follows the exact same structure and conventions as the existing two provider examples (authenticate → set config → restart → verify). Uses `kubectl exec` + heredoc format consistent with the rest of the doc. Minimal, focused — one realistic example covers the pattern for all API-key providers.

## Alternatives Considered

- Adding a generic "Provider Config Reference" section: too much scope for a single example gap. A focused, copy-pasteable example is more useful to users who already understand the OAuth examples.
- Including `kubectl create secret` step: unnecessary noise — Kubernetes Secret creation is covered elsewhere and varies by deployment.

## Validation

- [x] Links are valid (all internal links point to existing anchors or docs)
- [x] Renders correctly in GitHub preview (standard markdown, code block)
- [x] `kubectl exec` heredoc syntax matches existing examples (unquoted `<< EOF` allows env var expansion)
- [x] JSON schema matches the opencode.json spec as documented at [opencode.ai](http://opencode.ai/)
- [x] Discord Discussion URL: https://discord.com/channels/1491295327620169908/1520318436507648130