### PR TITLE
fix(session): surface diagnostic on empty 0-token end_turn

### DIFF
--- a/crates/openab-core/src/acp/mod.rs
+++ b/crates/openab-core/src/acp/mod.rs
@@ -6,4 +6,4 @@ pub mod protocol;
 
 pub use connection::ContentBlock;
 pub use pool::SessionPool;
-pub use protocol::{classify_notification, AcpEvent};
+pub use protocol::{classify_notification, parse_turn_result, AcpEvent, TurnResult};

--- a/crates/openab-core/src/acp/protocol.rs
+++ b/crates/openab-core/src/acp/protocol.rs
@@ -200,6 +200,47 @@ pub fn parse_config_options(result: &Value) -> Vec<ConfigOption> {
     options
 }
 
+// --- ACP prompt result parsing ---
+
+/// Parsed fields from the `session/prompt` final response `result` object.
+/// All fields are optional — agents may omit `usage` entirely.
+#[derive(Debug, Clone, Default)]
+pub struct TurnResult {
+    pub stop_reason: Option<String>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
+}
+
+impl TurnResult {
+    /// Returns true when the turn ended normally but produced zero output —
+    /// a strong signal of silent provider/auth failure.
+    pub fn is_silent_failure(&self) -> bool {
+        matches!(
+            (self.stop_reason.as_deref(), self.output_tokens),
+            (Some("end_turn"), Some(0))
+        )
+    }
+}
+
+/// Parse `stopReason` and `usage` from a `session/prompt` result value.
+pub fn parse_turn_result(result: &Value) -> TurnResult {
+    let stop_reason = result
+        .get("stopReason")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let usage = result.get("usage");
+    let input_tokens = usage.and_then(|u| u.get("inputTokens")).and_then(|v| v.as_u64());
+    let output_tokens = usage.and_then(|u| u.get("outputTokens")).and_then(|v| v.as_u64());
+    let total_tokens = usage.and_then(|u| u.get("totalTokens")).and_then(|v| v.as_u64());
+    TurnResult {
+        stop_reason,
+        input_tokens,
+        output_tokens,
+        total_tokens,
+    }
+}
+
 // --- ACP notification classification ---
 
 #[derive(Debug)]
@@ -402,5 +443,56 @@ mod tests {
         let opts = parse_config_options(&result);
         assert_eq!(opts.len(), 1);
         assert_eq!(opts[0].id, "model");
+    }
+
+    // --- parse_turn_result tests ---
+
+    #[test]
+    fn turn_result_silent_failure() {
+        let result = json!({"stopReason": "end_turn", "usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}});
+        let tr = parse_turn_result(&result);
+        assert_eq!(tr.stop_reason.as_deref(), Some("end_turn"));
+        assert_eq!(tr.output_tokens, Some(0));
+        assert!(tr.is_silent_failure());
+    }
+
+    #[test]
+    fn turn_result_silent_failure_with_nonzero_input() {
+        let result = json!({"stopReason": "end_turn", "usage": {"inputTokens": 150, "outputTokens": 0, "totalTokens": 150}});
+        let tr = parse_turn_result(&result);
+        assert_eq!(tr.input_tokens, Some(150));
+        assert_eq!(tr.output_tokens, Some(0));
+        assert!(tr.is_silent_failure());
+    }
+
+    #[test]
+    fn turn_result_nonzero_output_not_failure() {
+        let result = json!({"stopReason": "end_turn", "usage": {"inputTokens": 10, "outputTokens": 50, "totalTokens": 60}});
+        let tr = parse_turn_result(&result);
+        assert!(!tr.is_silent_failure());
+    }
+
+    #[test]
+    fn turn_result_missing_usage_not_failure() {
+        let result = json!({"stopReason": "end_turn"});
+        let tr = parse_turn_result(&result);
+        assert_eq!(tr.stop_reason.as_deref(), Some("end_turn"));
+        assert_eq!(tr.output_tokens, None);
+        assert!(!tr.is_silent_failure());
+    }
+
+    #[test]
+    fn turn_result_empty_object() {
+        let tr = parse_turn_result(&json!({}));
+        assert_eq!(tr.stop_reason, None);
+        assert_eq!(tr.output_tokens, None);
+        assert!(!tr.is_silent_failure());
+    }
+
+    #[test]
+    fn turn_result_different_stop_reason_not_failure() {
+        let result = json!({"stopReason": "max_tokens", "usage": {"inputTokens": 10, "outputTokens": 0, "totalTokens": 10}});
+        let tr = parse_turn_result(&result);
+        assert!(!tr.is_silent_failure());
     }
 }

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -1898,6 +1898,8 @@ mod tests {
 #[cfg(test)]
 mod directive_tests {
     use super::parse_output_directives;
+    use super::{classify_empty_turn, SILENT_FAILURE_MSG};
+    use crate::acp::TurnResult;
 
     #[test]
     fn parse_reply_to_directive() {

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -1045,7 +1045,7 @@ impl AdapterRouter {
                                 total_tokens = ?turn_result.total_tokens,
                                 "agent returned empty turn (0 output tokens) — likely provider/model/auth failure"
                             );
-                            "⚠️ The agent did not produce a response. This usually indicates a backend configuration issue — not an intentional empty reply. Please try again later.".to_string()
+                            SILENT_FAILURE_MSG.to_string()
                         } else {
                             "_(no response)_".to_string()
                         }
@@ -1355,6 +1355,26 @@ impl ToolEntry {
 /// Maximum number of finished tool entries to show individually
 /// during streaming before collapsing into a summary line.
 const TOOL_COLLAPSE_THRESHOLD: usize = 3;
+
+// --- Empty-turn classification (pure helper, unit-testable) ---
+
+/// Message to show the consumer when a silent failure is detected.
+pub(crate) const SILENT_FAILURE_MSG: &str = "⚠️ The agent did not produce a response. This usually indicates a backend configuration issue — not an intentional empty reply. Please try again later.";
+
+/// Classify what to display when the composed body is empty.
+/// Returns the final content string for the consumer.
+pub(crate) fn classify_empty_turn(
+    response_error: Option<&str>,
+    turn_result: &TurnResult,
+) -> String {
+    if let Some(err) = response_error {
+        format!("⚠️ {err}")
+    } else if turn_result.is_silent_failure() {
+        SILENT_FAILURE_MSG.to_string()
+    } else {
+        "_(no response)_".to_string()
+    }
+}
 
 fn compose_display(
     tool_lines: &[ToolEntry],
@@ -2032,5 +2052,74 @@ mod directive_tests {
         let (directives, content) = parse_output_directives(input);
         assert_eq!(directives.reply_to, Some("456".to_string()));
         assert_eq!(content, "看看 [[這個]] 怎麼樣");
+    }
+
+    // --- classify_empty_turn: adapter-level finalization tests ---
+
+    #[test]
+    fn empty_turn_silent_failure_produces_diagnostic() {
+        let tr = TurnResult {
+            stop_reason: Some("end_turn".into()),
+            output_tokens: Some(0),
+            input_tokens: Some(0),
+            total_tokens: Some(0),
+        };
+        let result = classify_empty_turn(None, &tr);
+        assert_eq!(result, SILENT_FAILURE_MSG);
+    }
+
+    #[test]
+    fn empty_turn_silent_failure_nonzero_input_still_diagnostic() {
+        let tr = TurnResult {
+            stop_reason: Some("end_turn".into()),
+            output_tokens: Some(0),
+            input_tokens: Some(150),
+            total_tokens: Some(150),
+        };
+        let result = classify_empty_turn(None, &tr);
+        assert_eq!(result, SILENT_FAILURE_MSG);
+    }
+
+    #[test]
+    fn empty_turn_response_error_takes_precedence() {
+        let tr = TurnResult {
+            stop_reason: Some("end_turn".into()),
+            output_tokens: Some(0),
+            input_tokens: Some(0),
+            total_tokens: Some(0),
+        };
+        let result = classify_empty_turn(Some("Agent process died"), &tr);
+        assert_eq!(result, "⚠️ Agent process died");
+    }
+
+    #[test]
+    fn empty_turn_missing_usage_shows_no_response() {
+        let tr = TurnResult::default();
+        let result = classify_empty_turn(None, &tr);
+        assert_eq!(result, "_(no response)_");
+    }
+
+    #[test]
+    fn empty_turn_nonzero_output_shows_no_response() {
+        let tr = TurnResult {
+            stop_reason: Some("end_turn".into()),
+            output_tokens: Some(50),
+            input_tokens: Some(10),
+            total_tokens: Some(60),
+        };
+        let result = classify_empty_turn(None, &tr);
+        assert_eq!(result, "_(no response)_");
+    }
+
+    #[test]
+    fn empty_turn_different_stop_reason_shows_no_response() {
+        let tr = TurnResult {
+            stop_reason: Some("max_tokens".into()),
+            output_tokens: Some(0),
+            input_tokens: Some(10),
+            total_tokens: Some(10),
+        };
+        let result = classify_empty_turn(None, &tr);
+        assert_eq!(result, "_(no response)_");
     }
 }

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use std::sync::Arc;
 use tracing::{error, warn};
 
-use crate::acp::{classify_notification, AcpEvent, ContentBlock, SessionPool};
+use crate::acp::{classify_notification, parse_turn_result, AcpEvent, ContentBlock, SessionPool, TurnResult};
 use crate::config::{ReactionsConfig, ToolDisplay};
 use crate::error_display::{format_coded_error, format_user_error};
 use crate::format;
@@ -807,6 +807,7 @@ impl AdapterRouter {
                     // messages and abandons cleanly on dead agent / hard ceiling
                     // so late responses cannot leak into the next prompt.
                     let mut response_error: Option<String> = None;
+                    let mut turn_result = TurnResult::default();
                     let prompt_start = tokio::time::Instant::now();
                     loop {
                         let notification = tokio::select! {
@@ -843,6 +844,9 @@ impl AdapterRouter {
                             }
                             if let Some(ref err) = notification.error {
                                 response_error = Some(format_coded_error(err.code, &err.message, err.data_message()));
+                            }
+                            if let Some(ref result) = notification.result {
+                                turn_result = parse_turn_result(result);
                             }
                             break;
                         }
@@ -1033,6 +1037,15 @@ impl AdapterRouter {
                     let final_content = if final_content.is_empty() {
                         if let Some(err) = response_error {
                             format!("⚠️ {err}")
+                        } else if turn_result.is_silent_failure() {
+                            warn!(
+                                stop_reason = ?turn_result.stop_reason,
+                                input_tokens = ?turn_result.input_tokens,
+                                output_tokens = ?turn_result.output_tokens,
+                                total_tokens = ?turn_result.total_tokens,
+                                "agent returned empty turn (0 output tokens) — likely provider/model/auth failure"
+                            );
+                            "⚠️ The agent did not produce a response. This usually indicates a backend configuration issue — not an intentional empty reply. Please try again later.".to_string()
                         } else {
                             "_(no response)_".to_string()
                         }

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -1035,9 +1035,7 @@ impl AdapterRouter {
                     let final_content =
                         compose_display(&tool_lines, &text_buf, false, tool_display);
                     let final_content = if final_content.is_empty() {
-                        if let Some(err) = response_error {
-                            format!("⚠️ {err}")
-                        } else if turn_result.is_silent_failure() {
+                        if turn_result.is_silent_failure() {
                             warn!(
                                 stop_reason = ?turn_result.stop_reason,
                                 input_tokens = ?turn_result.input_tokens,
@@ -1045,10 +1043,8 @@ impl AdapterRouter {
                                 total_tokens = ?turn_result.total_tokens,
                                 "agent returned empty turn (0 output tokens) — likely provider/model/auth failure"
                             );
-                            SILENT_FAILURE_MSG.to_string()
-                        } else {
-                            "_(no response)_".to_string()
                         }
+                        classify_empty_turn(response_error.as_deref(), &turn_result)
                     } else if let Some(err) = response_error {
                         format!("⚠️ {err}\n\n{final_content}")
                     } else {


### PR DESCRIPTION
## What problem does this solve?

When an ACP agent ends a turn with `stopReason: "end_turn"` + `outputTokens: 0` + empty body (typically a silent provider/auth failure), OpenAB renders the unhelpful `_(no response)_` placeholder. Operators get no signal about *why* the turn was empty.

Closes #1212

## At a Glance

```
Before:
  end_turn + 0 output tokens + empty body → "_(no response)_"  [user confused]

After:
  end_turn + 0 output tokens + empty body →
    Consumer: "⚠️ The agent did not produce a response. This usually indicates
              a backend configuration issue — not an intentional empty reply.
              Please try again later."
    Backend:  WARN log with stop_reason, input/output/total tokens
```

## Proposed Solution

Three-way classification for empty turns (no change to non-empty turns):

| Category | Trigger | Log Level | Consumer Message |
|----------|---------|-----------|-----------------|
| Protocol/System Error | JSON-RPC `error` field, agent crash | `ERROR` | `⚠️ {err}` (unchanged) |
| Silent Failure (new) | `end_turn` + `outputTokens == Some(0)` + empty body | `WARN` | Dedicated user-friendly message |
| Thought-only | Empty body + (`outputTokens > 0` OR usage absent) | `DEBUG` | `_(no response)_` (unchanged) |

### Implementation

1. **`protocol.rs`** — Add `TurnResult` struct + `parse_turn_result()` helper to extract `stopReason`/`usage` from the `session/prompt` result.
2. **`adapter.rs`** — Parse the already-forwarded id-bearing terminal response in the `rx.recv()` loop. Use `TurnResult::is_silent_failure()` in the empty-turn branch.
3. **`connection.rs`** — No changes needed (already forwards id-bearing responses to subscriber).

### Safety / backward-compat

- Non-empty turns: completely untouched
- `usage` absent: falls through to `_(no response)_` (no false positives)
- Agent dies before result: existing death paths handle it
- JSON-RPC error present: existing `response_error` path takes precedence

## Tests

6 unit tests in `protocol.rs`:
1. `end_turn` + 0 tokens → `is_silent_failure() == true`
2. `end_turn` + 0 output + nonzero input → still silent failure
3. `end_turn` + nonzero output → not failure
4. Missing `usage` → not failure (no false positive)
5. Empty result object → not failure
6. Different `stop_reason` (e.g. `max_tokens`) + 0 output → not failure

## Follow-up items (out of scope)

- Log dedup/rate-limit for repeated silent failures in same session
- Add `model` field to WARN log line
- Optional config flag to suppress diagnostic

## CI coverage requirement

Changes to `_resp_rx` handling or `AcpEvent` enum should trigger integration tests for notify stream terminal event handling. This PR only touches the adapter-level classification — no connection lifecycle changes.