### PR TITLE
ci(pre-beta): hourly build, gated on a commit in the last hour

### DIFF
--- a/.github/workflows/pre-beta-build.yml
+++ b/.github/workflows/pre-beta-build.yml
@@ -1,6 +1,8 @@
 name: Pre-Beta Build
 
 on:
+  schedule:
+    - cron: '0 * * * *'      # hourly; gate job skips the build if no commit in the last ~70min
   workflow_dispatch:
     inputs:
       agents:
@@ -15,7 +17,41 @@ env:
   ALL_AGENTS: 'kiro,claude,codex,copilot,cursor,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore'
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Skip scheduled run when no recent commits
+        uses: actions/github-script@v7
+        id: check
+        with:
+          script: |
+            // Manual runs always build.
+            if (context.eventName === 'workflow_dispatch') {
+              core.setOutput('should_run', 'true');
+              return;
+            }
+            // Scheduled run: build only if main got a commit in the last ~70min.
+            // 70 (not 60) absorbs GitHub's cron scheduling drift so a commit just
+            // before the hour isn't missed when the run fires a few minutes late.
+            const since = new Date(Date.now() - 70 * 60 * 1000).toISOString();
+            const { data: commits } = await github.rest.repos.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.repository.default_branch,
+              since,
+              per_page: 1,
+            });
+            const run = commits.length > 0;
+            core.info(`commits since ${since}: ${commits.length} -> should_run=${run}`);
+            core.setOutput('should_run', run ? 'true' : 'false');
+
   matrix:
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     outputs:
       agents: ${{ steps.resolve.outputs.agents }}

--- a/.github/workflows/pre-beta-build.yml
+++ b/.github/workflows/pre-beta-build.yml
@@ -41,7 +41,7 @@ jobs:
             const { data: commits } = await github.rest.repos.listCommits({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.payload.repository.default_branch,
+              sha: context.payload.repository?.default_branch || 'main',
               since,
               per_page: 1,
             });


### PR DESCRIPTION
## What problem does this solve?

We want the `pre-beta-<agent>` images rebuilt **hourly**, but only when there's actually new work on `main` — not 24 idle builds/day.

GitHub Actions has no native "schedule only if changed", so this adds the standard **schedule + gate job** pattern.

## Changes

- Add `schedule: cron '0 * * * *'` (hourly) alongside the existing `workflow_dispatch`.
- New `gate` job:
  - `workflow_dispatch` → always builds.
  - `schedule` → builds only if `listCommits(since = now - 70min)` on the default branch returns ≥1 commit.
- `matrix` job now `needs: gate` + `if: needs.gate.outputs.should_run == 'true'`. `build` (`needs: matrix`) and `tag` (`needs: [matrix, build]`) auto-skip when `matrix` is skipped — no other changes needed.

## Notes

- **70-min window (not 60)** absorbs GitHub's cron scheduling drift so a commit just before the hour isn't missed when the run fires a few minutes late.
- `since` filters by commit date (== push time for normal pushes to main); force-pushes of old commits could under-trigger — acceptable for pre-beta cadence.
- Quiet hour = gate exits in seconds with `should_run=false`, near-zero cost; no double-build storms.
- Schedules only run from the default branch, so this takes effect once merged.
- Manual `workflow_dispatch` behavior is unchanged.

## Verification

- YAML parses; job graph confirmed: `gate → matrix(if) → build → tag`, with skip cascade when the gate is false.