### PR TITLE
fix(ctl): resolve thread for single-adapter bots so set/get thread.name works

### DIFF
--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -201,7 +201,9 @@ fn resolve_platform(
     platforms: &[String],
 ) -> Option<String> {
     if let Some(platform) = registry.get(thread_id) {
-        return Some(platform.clone());
+        if platforms.contains(platform) {
+            return Some(platform.clone());
+        }
     }
     if platforms.len() == 1 {
         return Some(platforms[0].clone());
@@ -412,12 +414,23 @@ mod tests {
 
     #[test]
     fn resolve_platform_registry_hit_wins_over_fallback() {
-        // Registry takes precedence even when a single-adapter fallback exists.
+        // Registry takes precedence when the platform is still configured.
+        let r = reg(&[("123", "slack")]);
+        let platforms = vec!["discord".to_string(), "slack".to_string()];
+        assert_eq!(
+            resolve_platform("123", &r, &platforms).as_deref(),
+            Some("slack")
+        );
+    }
+
+    #[test]
+    fn resolve_platform_stale_registry_entry_falls_through() {
+        // Stale registry entry pointing to unconfigured platform falls through to fallback.
         let r = reg(&[("123", "slack")]);
         let platforms = vec!["discord".to_string()];
         assert_eq!(
             resolve_platform("123", &r, &platforms).as_deref(),
-            Some("slack")
+            Some("discord")
         );
     }
 

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -175,10 +175,38 @@ impl RuntimeHandler {
     /// Resolve which adapter to use for a given thread_id.
     async fn resolve(&self, thread_id: Option<&str>) -> Option<(Arc<dyn ChatAdapter>, String)> {
         let tid = thread_id?;
-        let platform = self.registry.read().await.get(tid).cloned()?;
+        let platform = {
+            let registry = self.registry.read().await;
+            let platforms: Vec<String> = self.adapters.keys().cloned().collect();
+            resolve_platform(tid, &registry, &platforms)?
+        };
         let adapter = self.adapters.get(&platform)?.clone();
         Some((adapter, tid.to_string()))
     }
+}
+
+/// Decide which platform should handle a control request for `thread_id`.
+///
+/// 1. Exact registry hit — the thread was recorded during message dispatch.
+/// 2. Single-adapter fallback — if exactly one adapter is configured there is
+///    no ambiguity, so resolve to it even without a registry entry. This makes
+///    `openab set/get --thread <id>` work for single-platform bots (the common
+///    case) without depending on the registry being populated.
+///
+/// Returns `None` only when the thread is unknown AND multiple adapters are
+/// configured (genuinely ambiguous), or when no adapters are configured.
+fn resolve_platform(
+    thread_id: &str,
+    registry: &std::collections::HashMap<String, String>,
+    platforms: &[String],
+) -> Option<String> {
+    if let Some(platform) = registry.get(thread_id) {
+        return Some(platform.clone());
+    }
+    if platforms.len() == 1 {
+        return Some(platforms[0].clone());
+    }
+    None
 }
 
 #[async_trait::async_trait]
@@ -338,6 +366,60 @@ pub async fn send_request_to(path: &PathBuf, req: &Request) -> anyhow::Result<Re
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn reg(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn resolve_platform_registry_hit() {
+        let r = reg(&[("123", "discord")]);
+        let platforms = vec!["discord".to_string(), "slack".to_string()];
+        assert_eq!(
+            resolve_platform("123", &r, &platforms).as_deref(),
+            Some("discord")
+        );
+    }
+
+    #[test]
+    fn resolve_platform_single_adapter_fallback() {
+        // No registry entry, but only one adapter -> resolve to it.
+        let r = reg(&[]);
+        let platforms = vec!["discord".to_string()];
+        assert_eq!(
+            resolve_platform("999", &r, &platforms).as_deref(),
+            Some("discord")
+        );
+    }
+
+    #[test]
+    fn resolve_platform_multi_adapter_miss_is_none() {
+        // No registry entry and multiple adapters -> genuinely ambiguous.
+        let r = reg(&[]);
+        let platforms = vec!["discord".to_string(), "slack".to_string()];
+        assert_eq!(resolve_platform("999", &r, &platforms), None);
+    }
+
+    #[test]
+    fn resolve_platform_no_adapters_is_none() {
+        let r = reg(&[]);
+        let platforms: Vec<String> = vec![];
+        assert_eq!(resolve_platform("999", &r, &platforms), None);
+    }
+
+    #[test]
+    fn resolve_platform_registry_hit_wins_over_fallback() {
+        // Registry takes precedence even when a single-adapter fallback exists.
+        let r = reg(&[("123", "slack")]);
+        let platforms = vec!["discord".to_string()];
+        assert_eq!(
+            resolve_platform("123", &r, &platforms).as_deref(),
+            Some("slack")
+        );
+    }
 
     #[test]
     fn request_serialization() {


### PR DESCRIPTION
## What problem does this solve?

`openab set thread.name "..." --thread <id>` always fails with `✗ unknown thread (use --thread or register via message dispatch)` — for every thread, even with `--thread`.

`RuntimeHandler::resolve()` requires a hit in an in-memory `thread_id → platform` registry, but that registry is **never populated** (`register_thread` is dead code with zero call sites). So `set/get thread.name` can never succeed.

Refs #1215 (full root-cause analysis).

## Fix

For a **single-platform bot** there is no ambiguity about which adapter owns a thread, so resolve to the only configured adapter even without a registry entry. This fixes the common case (e.g. Discord-only bots) immediately.

The decision is extracted into a pure, unit-tested helper:

```rust
fn resolve_platform(thread_id, registry, platforms) -> Option<String> {
    // 1. exact registry hit (forward-compatible with future dispatch registration)
    // 2. single-adapter fallback (fixes single-platform bots)
    // 3. None only when unknown AND multiple adapters (ambiguous), or no adapters
}
```

## Scope

- **In scope:** single-adapter fallback — fixes single-platform bots now, no cross-crate changes, low risk.
- **Follow-up (not this PR):** populating the registry from the dispatch path so multi-adapter bots resolve threads they've seen. That requires threading the registry/callback from the `openab` bin into the `openab-core` dispatcher — tracked in #1215.

## Backward-compat / safety

- Registry hit still takes precedence (path 1), so this is forward-compatible once dispatch registration lands.
- Multi-adapter bots with an unknown thread still return `None` (unchanged behavior — no wrong-adapter routing).
- No change to non-`thread.name` paths.

## Tests

5 new unit tests for `resolve_platform` (registry hit, single-adapter fallback, multi-adapter miss → None, no adapters → None, registry-precedence-over-fallback). Verified locally:
- `cargo fmt --check` clean
- `cargo clippy -- -D warnings` clean
- `cargo test --bin openab ctl::` → 7 passed