### PR TITLE
feat(ambient): implement ambient mode batch flush dispatcher

### DIFF
--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -259,6 +259,8 @@ impl AmbientDispatcher {
     }
 
     /// Check if a channel is currently mid-flush.
+    /// Used by v2 rate-limiting (min_flush_interval_seconds) — kept for forward compat.
+    #[allow(dead_code)]
     pub async fn is_flushing(&self, channel_id: &str) -> bool {
         let channels = self.channels.lock().await;
         channels
@@ -348,7 +350,14 @@ async fn ambient_consumer_loop(
         let flush_timeout = Duration::from_secs(config.flush_timeout_seconds);
         let _flushing_guard = FlushingGuard::new(Arc::clone(&flushing), flush_timeout);
 
-        // Reset post_guard for this flush cycle.
+        // Check post_guard BEFORE building payload (mention may have cancelled during accumulation).
+        if !post_guard.can_post() {
+            while rx.try_recv().is_ok() {}
+            debug!(channel_id = %channel_id, "ambient flush cancelled by mention during accumulation, buffer drained");
+            continue;
+        }
+
+        // Reset post_guard for this flush cycle — safe now because we checked first.
         post_guard.reset();
 
         // Build the batch payload.

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -358,8 +358,10 @@ async fn ambient_consumer_loop(
 
         // Check post_guard BEFORE building payload (mention may have cancelled during accumulation).
         if !post_guard.can_post() {
-            while rx.try_recv().is_ok() {}
-            debug!(channel_id = %channel_id, "ambient flush cancelled by mention during accumulation, buffer drained");
+            // Don't drain — messages buffered after the mention are still valid
+            // for the next batch cycle. The current batch is discarded but future
+            // messages will be picked up when the loop restarts and reset() clears.
+            debug!(channel_id = %channel_id, "ambient flush cancelled by mention during accumulation");
             continue;
         }
 
@@ -406,9 +408,7 @@ async fn ambient_consumer_loop(
 
         // Check post_guard before dispatching (mention may have cancelled).
         if !post_guard.can_post() {
-            // Drain any remaining buffered messages so stale context is discarded.
-            while rx.try_recv().is_ok() {}
-            debug!(channel_id = %channel_id, "ambient flush cancelled by mention, buffer drained");
+            debug!(channel_id = %channel_id, "ambient flush cancelled by mention before dispatch");
             continue;
         }
 

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -45,8 +45,6 @@ Rules:
 /// A single message buffered for ambient dispatch.
 #[derive(Debug)]
 pub struct AmbientMessage {
-    /// Serialised SenderContext JSON.
-    pub sender_json: String,
     /// Author display name.
     pub sender_name: String,
     /// User-visible prompt text.
@@ -299,6 +297,10 @@ async fn ambient_consumer_loop(
             }
         };
 
+        // Reset post_guard at the start of each batch cycle. This ensures a
+        // previous cancellation doesn't permanently block future cycles.
+        post_guard.reset();
+
         // Compute jittered deadline: flush_interval ± 20%
         // Guard: interval must be >= 1s to avoid gen_range panic on empty range.
         let base_secs = config.flush_interval_seconds.max(1);
@@ -360,9 +362,6 @@ async fn ambient_consumer_loop(
             debug!(channel_id = %channel_id, "ambient flush cancelled by mention during accumulation, buffer drained");
             continue;
         }
-
-        // Reset post_guard for this flush cycle — safe now because we checked first.
-        post_guard.reset();
 
         // Build the batch payload.
         let session_key = format!("ambient:{}:{}", channel_ref.platform, channel_id);

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -248,17 +248,12 @@ impl AmbientDispatcher {
 
     /// Discard the ambient buffer for a channel (called when @mention arrives).
     /// Also cancels any in-flight ambient response via the post_guard.
+    /// The consumer will drain buffered messages when it sees the cancellation.
     pub async fn discard_buffer(&self, channel_id: &str) {
         let channels = self.channels.lock().await;
         if let Some(state) = channels.get(channel_id) {
-            // Cancel any in-flight post.
+            // Cancel any in-flight post — consumer drains the buffer on next check.
             state.post_guard.cancel();
-
-            // Drain the mpsc channel (discard all buffered messages).
-            // We create a temp receiver by closing and re-opening — simpler to
-            // just drain via try_recv pattern. But since we only have the sender,
-            // we signal cancellation and let the consumer handle it.
-            // The consumer checks post_guard.can_post() before posting.
             debug!(channel_id, "ambient buffer discard requested (mention arrived)");
         }
     }
@@ -392,7 +387,9 @@ async fn ambient_consumer_loop(
 
         // Check post_guard before dispatching (mention may have cancelled).
         if !post_guard.can_post() {
-            debug!(channel_id = %channel_id, "ambient flush cancelled by mention");
+            // Drain any remaining buffered messages so stale context is discarded.
+            while rx.try_recv().is_ok() {}
+            debug!(channel_id = %channel_id, "ambient flush cancelled by mention, buffer drained");
             continue;
         }
 
@@ -465,4 +462,54 @@ fn build_ambient_payload(batch: &[AmbientMessage]) -> Vec<ContentBlock> {
 /// Check if a response is the NO_REPLY sentinel.
 pub fn is_no_reply(response: &str) -> bool {
     response.trim().to_lowercase() == NO_REPLY_SENTINEL
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_no_reply_exact() {
+        assert!(is_no_reply("[NO_REPLY]"));
+        assert!(is_no_reply("[no_reply]"));
+        assert!(is_no_reply("[No_Reply]"));
+    }
+
+    #[test]
+    fn is_no_reply_with_whitespace() {
+        assert!(is_no_reply("  [NO_REPLY]  "));
+        assert!(is_no_reply("\n[no_reply]\n"));
+        assert!(is_no_reply("\t [NO_REPLY] \t"));
+    }
+
+    #[test]
+    fn is_no_reply_rejects_partial() {
+        assert!(!is_no_reply("NO_REPLY"));
+        assert!(!is_no_reply("[NO_REPLY] sure"));
+        assert!(!is_no_reply("I have [NO_REPLY] for you"));
+        assert!(!is_no_reply(""));
+    }
+
+    #[test]
+    fn post_guard_lifecycle() {
+        let guard = PostGuard::new();
+        assert!(guard.can_post());
+
+        guard.cancel();
+        assert!(!guard.can_post());
+
+        guard.reset();
+        assert!(guard.can_post());
+    }
+
+    #[test]
+    fn post_guard_double_cancel() {
+        let guard = PostGuard::new();
+        guard.cancel();
+        guard.cancel();
+        assert!(!guard.can_post());
+
+        guard.reset();
+        assert!(guard.can_post());
+    }
 }

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -346,11 +346,12 @@ impl AmbientDispatcher {
 
     /// Discard the ambient buffer for a channel (called when @mention arrives).
     /// Also cancels any in-flight ambient response via the post_guard.
-    /// The consumer will drain buffered messages when it sees the cancellation.
+    /// The consumer discards the current batch; remaining buffered messages
+    /// carry into the next cycle.
     pub async fn discard_buffer(&self, channel_id: &str) {
         let channels = self.channels.lock().await;
         if let Some(state) = channels.get(channel_id) {
-            // Cancel any in-flight post — consumer drains the buffer on next check.
+            // Cancel any in-flight post — consumer discards current batch on next check.
             state.post_guard.cancel();
             debug!(channel_id, "ambient buffer discard requested (mention arrived)");
         }

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -1,0 +1,461 @@
+//! Ambient Mode — batch flush dispatcher for passive channel listening.
+//!
+//! See ADR: docs/adr/ambient.md for full design rationale.
+//!
+//! Ambient mode listens to all messages in configured channels (without @mention)
+//! and periodically flushes them as a batch to the LLM. The agent replies only
+//! when it has something valuable to add; otherwise it returns `[NO_REPLY]`.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rand::Rng;
+use tokio::sync::{Mutex, Semaphore};
+use tracing::{debug, info, warn};
+
+use crate::acp::ContentBlock;
+use crate::adapter::{ChannelRef, ChatAdapter, MessageRef};
+use crate::config::AmbientConfig;
+use crate::dispatch::DispatchTarget;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Sentinel value the agent returns when it has nothing to add.
+const NO_REPLY_SENTINEL: &str = "[no_reply]";
+
+/// System instruction prepended to every ambient batch.
+const AMBIENT_SYSTEM_INSTRUCTION: &str = r#"You are in ambient mode. Below is a batch of recent messages from the channel. You are passively observing the conversation.
+
+Rules:
+- If you have nothing valuable to add, reply EXACTLY: [NO_REPLY]
+- Only reply when you can provide meaningful help, context, or corrections
+- Do not reply to other bot messages unless directly relevant to a human's question
+- Keep replies concise and natural — you are joining an ongoing conversation, not starting one
+- Do not acknowledge that you are in ambient mode
+"#;
+
+// ---------------------------------------------------------------------------
+// AmbientMessage — lighter than BufferedMessage for ambient buffering
+// ---------------------------------------------------------------------------
+
+/// A single message buffered for ambient dispatch.
+#[derive(Debug)]
+pub struct AmbientMessage {
+    /// Serialised SenderContext JSON.
+    pub sender_json: String,
+    /// Author display name.
+    pub sender_name: String,
+    /// User-visible prompt text.
+    pub prompt: String,
+    /// Attachment blocks.
+    pub extra_blocks: Vec<ContentBlock>,
+    /// When this message arrived.
+    pub arrived_at: Instant,
+}
+
+// ---------------------------------------------------------------------------
+// FlushingGuard — RAII guard for the per-channel flushing flag with timeout
+// ---------------------------------------------------------------------------
+
+/// RAII guard that sets an `AtomicBool` to true on creation and resets to false
+/// on drop. Also spawns a safety timeout that forcibly resets if the guard is
+/// held too long (e.g., consumer panic under a catch_unwind or OOM).
+struct FlushingGuard {
+    flag: Arc<AtomicBool>,
+    _timeout_handle: tokio::task::JoinHandle<()>,
+}
+
+impl FlushingGuard {
+    fn new(flag: Arc<AtomicBool>, timeout: Duration) -> Self {
+        flag.store(true, Ordering::Release);
+        let flag_clone = Arc::clone(&flag);
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(timeout).await;
+            if flag_clone.swap(false, Ordering::AcqRel) {
+                warn!("ambient flush timeout exceeded, force-resetting flushing flag");
+            }
+        });
+        Self {
+            flag,
+            _timeout_handle: handle,
+        }
+    }
+}
+
+impl Drop for FlushingGuard {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::Release);
+        self._timeout_handle.abort();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PostGuard — atomic check-and-post to prevent TOCTOU race
+// ---------------------------------------------------------------------------
+
+/// Per-channel post guard. The ambient consumer acquires it before posting;
+/// the mention path invalidates it to cancel an in-flight ambient response.
+#[derive(Debug)]
+pub struct PostGuard {
+    cancelled: AtomicBool,
+}
+
+impl PostGuard {
+    pub fn new() -> Self {
+        Self {
+            cancelled: AtomicBool::new(false),
+        }
+    }
+
+    /// Cancel any pending ambient post for this channel.
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    /// Check if posting is still allowed. Returns false if cancelled.
+    pub fn can_post(&self) -> bool {
+        !self.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Reset for next flush cycle.
+    pub fn reset(&self) {
+        self.cancelled.store(false, Ordering::Release);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ChannelState — per-channel ambient state
+// ---------------------------------------------------------------------------
+
+struct ChannelState {
+    tx: tokio::sync::mpsc::Sender<AmbientMessage>,
+    flushing: Arc<AtomicBool>,
+    post_guard: Arc<PostGuard>,
+    _consumer: tokio::task::JoinHandle<()>,
+}
+
+// ---------------------------------------------------------------------------
+// AmbientDispatcher
+// ---------------------------------------------------------------------------
+
+/// Manages ambient mode across all configured channels.
+///
+/// Each enabled channel gets its own mpsc channel and consumer task.
+/// The consumer accumulates messages and flushes them as a batch when
+/// a time or count trigger fires.
+pub struct AmbientDispatcher {
+    config: AmbientConfig,
+    channels: Mutex<HashMap<String, ChannelState>>,
+    /// Channel IDs that have ambient mode enabled (pre-parsed for fast lookup).
+    enabled_channels: HashSet<u64>,
+    /// Global semaphore limiting concurrent flush operations.
+    flush_semaphore: Arc<Semaphore>,
+}
+
+impl AmbientDispatcher {
+    /// Create a new AmbientDispatcher from config.
+    ///
+    /// Does NOT start consumer tasks — those are spawned lazily on first message
+    /// or eagerly via `start_channel`.
+    pub fn new(config: AmbientConfig) -> Self {
+        let enabled_channels: HashSet<u64> = config
+            .discord
+            .channels
+            .iter()
+            .filter_map(|s| s.parse().ok())
+            .collect();
+        let flush_semaphore = Arc::new(Semaphore::new(config.max_concurrent_flushes));
+        Self {
+            config,
+            channels: Mutex::new(HashMap::new()),
+            enabled_channels,
+            flush_semaphore,
+        }
+    }
+
+    /// Check if ambient mode is active and this channel is in the allowlist.
+    pub fn is_ambient_channel(&self, channel_id: u64) -> bool {
+        self.config.enabled && !self.enabled_channels.is_empty() && self.enabled_channels.contains(&channel_id)
+    }
+
+    /// Whether bot messages are allowed in the ambient buffer.
+    pub fn allow_bot_messages(&self) -> bool {
+        self.config.discord.allow_bot_messages
+    }
+
+    /// Submit a message to the ambient buffer for a channel.
+    ///
+    /// Returns Ok(()) if buffered, Err if the channel consumer is dead.
+    pub async fn submit(
+        &self,
+        channel_id: &str,
+        channel_ref: ChannelRef,
+        adapter: Arc<dyn ChatAdapter>,
+        target: Arc<dyn DispatchTarget>,
+        msg: AmbientMessage,
+    ) {
+        let mut channels = self.channels.lock().await;
+
+        // Lazily spawn consumer if not yet started for this channel.
+        if !channels.contains_key(channel_id) {
+            let (tx, rx) = tokio::sync::mpsc::channel(self.config.flush_hard_cap);
+            let flushing = Arc::new(AtomicBool::new(false));
+            let post_guard = Arc::new(PostGuard::new());
+
+            let consumer = tokio::spawn(ambient_consumer_loop(
+                channel_id.to_string(),
+                channel_ref.clone(),
+                rx,
+                self.config.clone(),
+                Arc::clone(&self.flush_semaphore),
+                Arc::clone(&flushing),
+                Arc::clone(&post_guard),
+                adapter,
+                target,
+            ));
+
+            channels.insert(
+                channel_id.to_string(),
+                ChannelState {
+                    tx,
+                    flushing,
+                    post_guard,
+                    _consumer: consumer,
+                },
+            );
+        }
+
+        let state = channels.get(channel_id).unwrap();
+        // Non-blocking try_send — if buffer is full (hard_cap), drop the message.
+        if let Err(e) = state.tx.try_send(msg) {
+            debug!(
+                channel_id,
+                "ambient buffer full, dropping message: {}",
+                e
+            );
+        }
+    }
+
+    /// Discard the ambient buffer for a channel (called when @mention arrives).
+    /// Also cancels any in-flight ambient response via the post_guard.
+    pub async fn discard_buffer(&self, channel_id: &str) {
+        let channels = self.channels.lock().await;
+        if let Some(state) = channels.get(channel_id) {
+            // Cancel any in-flight post.
+            state.post_guard.cancel();
+
+            // Drain the mpsc channel (discard all buffered messages).
+            // We create a temp receiver by closing and re-opening — simpler to
+            // just drain via try_recv pattern. But since we only have the sender,
+            // we signal cancellation and let the consumer handle it.
+            // The consumer checks post_guard.can_post() before posting.
+            debug!(channel_id, "ambient buffer discard requested (mention arrived)");
+        }
+    }
+
+    /// Check if a channel is currently mid-flush.
+    pub async fn is_flushing(&self, channel_id: &str) -> bool {
+        let channels = self.channels.lock().await;
+        channels
+            .get(channel_id)
+            .map(|s| s.flushing.load(Ordering::Acquire))
+            .unwrap_or(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ambient_consumer_loop
+// ---------------------------------------------------------------------------
+
+/// Per-channel consumer that accumulates messages and flushes them as a batch.
+async fn ambient_consumer_loop(
+    channel_id: String,
+    channel_ref: ChannelRef,
+    mut rx: tokio::sync::mpsc::Receiver<AmbientMessage>,
+    config: AmbientConfig,
+    flush_semaphore: Arc<Semaphore>,
+    flushing: Arc<AtomicBool>,
+    post_guard: Arc<PostGuard>,
+    adapter: Arc<dyn ChatAdapter>,
+    target: Arc<dyn DispatchTarget>,
+) {
+    info!(channel_id = %channel_id, "ambient consumer started");
+
+    loop {
+        // Wait for first message (blocks until one arrives or channel closes).
+        let first = match rx.recv().await {
+            Some(msg) => msg,
+            None => {
+                info!(channel_id = %channel_id, "ambient consumer channel closed, exiting");
+                return;
+            }
+        };
+
+        // Compute jittered deadline: flush_interval ± 20%
+        let base = Duration::from_secs(config.flush_interval_seconds);
+        let jitter_range = base.as_millis() as f64 * 0.2;
+        let jitter_ms = rand::thread_rng().gen_range(-jitter_range..jitter_range) as i64;
+        let interval = Duration::from_millis((base.as_millis() as i64 + jitter_ms).max(1000) as u64);
+        let deadline = tokio::time::Instant::now() + interval;
+
+        let mut batch = vec![first];
+
+        // Accumulate until trigger fires.
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break; // Timer expired.
+            }
+
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Some(msg)) => {
+                    batch.push(msg);
+                    if batch.len() >= config.flush_max_messages {
+                        break;
+                    }
+                    if batch.len() >= config.flush_hard_cap {
+                        break;
+                    }
+                }
+                Ok(None) => break, // Channel closed.
+                Err(_) => break,   // Timer expired.
+            }
+        }
+
+        let batch_size = batch.len();
+        debug!(
+            channel_id = %channel_id,
+            batch_size,
+            "ambient flush triggered"
+        );
+
+        // Acquire global concurrency permit.
+        let _permit = match flush_semaphore.acquire().await {
+            Ok(permit) => permit,
+            Err(_) => {
+                warn!(channel_id = %channel_id, "flush semaphore closed, exiting");
+                return;
+            }
+        };
+
+        // Set flushing flag with safety timeout.
+        let flush_timeout = Duration::from_secs(config.flush_timeout_seconds);
+        let _flushing_guard = FlushingGuard::new(Arc::clone(&flushing), flush_timeout);
+
+        // Reset post_guard for this flush cycle.
+        post_guard.reset();
+
+        // Build the batch payload.
+        let session_key = format!("ambient:{}:{}", channel_ref.platform, channel_id);
+        let content_blocks = build_ambient_payload(&batch);
+
+        // Ensure session exists.
+        if let Err(e) = target.ensure_session(&session_key, None).await {
+            warn!(
+                channel_id = %channel_id,
+                error = %e,
+                "failed to create ambient session, discarding batch"
+            );
+            continue;
+        }
+
+        // Dispatch batch to agent. For ambient mode, we use stream_prompt_blocks
+        // with a dummy reaction controller (enabled=false) to suppress all reactions.
+        // The NO_REPLY check must be handled at a higher level (response filtering).
+        //
+        // TODO(ambient-v2): implement response capture mode so we can intercept
+        // [NO_REPLY] before the message is posted. For v1, the system prompt
+        // strongly instructs the agent, and we accept that rare false-positives
+        // may briefly appear before being deleted.
+        let dummy_msg_ref = MessageRef {
+            channel: channel_ref.clone(),
+            message_id: String::new(),
+        };
+        let reactions = Arc::new(crate::reactions::StatusReactionController::new(
+            false, // disabled — no reactions for ambient
+            Arc::clone(&adapter),
+            dummy_msg_ref,
+            crate::config::ReactionEmojis::default(),
+            crate::config::ReactionTiming::default(),
+        ));
+
+        // Check post_guard before dispatching (mention may have cancelled).
+        if !post_guard.can_post() {
+            debug!(channel_id = %channel_id, "ambient flush cancelled by mention");
+            continue;
+        }
+
+        match target
+            .stream_prompt_blocks(
+                &adapter,
+                &session_key,
+                content_blocks,
+                &channel_ref,
+                reactions,
+                false, // other_bot_present
+                None,  // no streaming recipient
+            )
+            .await
+        {
+            Ok(()) => {
+                debug!(channel_id = %channel_id, "ambient flush dispatched");
+            }
+            Err(e) => {
+                warn!(
+                    channel_id = %channel_id,
+                    error = %e,
+                    "ambient flush failed, discarding batch"
+                );
+            }
+        }
+
+        // _flushing_guard drops here → resets flag
+        // _permit drops here → releases semaphore
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Payload construction
+// ---------------------------------------------------------------------------
+
+/// Build the content blocks for an ambient batch dispatch.
+fn build_ambient_payload(batch: &[AmbientMessage]) -> Vec<ContentBlock> {
+    let mut blocks = Vec::new();
+
+    // System instruction.
+    blocks.push(ContentBlock::Text {
+        text: AMBIENT_SYSTEM_INSTRUCTION.to_string(),
+    });
+
+    // Format batch as conversation transcript.
+    let mut transcript = String::from("[Ambient batch — ");
+    transcript.push_str(&batch.len().to_string());
+    transcript.push_str(" new messages]\n");
+
+    for msg in batch {
+        transcript.push_str(&msg.sender_name);
+        transcript.push_str(": ");
+        transcript.push_str(&msg.prompt);
+        transcript.push('\n');
+    }
+
+    transcript.push_str("\n[End of batch — reply only if you can add meaningful value.\n Otherwise reply exactly: [NO_REPLY]]");
+
+    blocks.push(ContentBlock::Text { text: transcript });
+
+    // Append any attachment blocks from messages.
+    for msg in batch {
+        blocks.extend(msg.extra_blocks.iter().cloned());
+    }
+
+    blocks
+}
+
+/// Check if a response is the NO_REPLY sentinel.
+pub fn is_no_reply(response: &str) -> bool {
+    response.trim().to_lowercase() == NO_REPLY_SENTINEL
+}

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -20,6 +20,9 @@ use crate::adapter::{ChannelRef, ChatAdapter, MessageRef};
 use crate::config::AmbientConfig;
 use crate::dispatch::DispatchTarget;
 
+use anyhow::Result;
+use async_trait::async_trait;
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -128,6 +131,86 @@ impl PostGuard {
     /// Reset for next flush cycle.
     pub fn reset(&self) {
         self.cancelled.store(false, Ordering::Release);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AmbientCaptureAdapter — intercepts send_message for [NO_REPLY] filtering
+// ---------------------------------------------------------------------------
+
+/// Wraps a real `ChatAdapter` and intercepts `send_message` to suppress
+/// `[NO_REPLY]` responses before they reach the channel.
+struct AmbientCaptureAdapter {
+    inner: Arc<dyn ChatAdapter>,
+}
+
+#[async_trait]
+impl ChatAdapter for AmbientCaptureAdapter {
+    fn platform(&self) -> &'static str {
+        self.inner.platform()
+    }
+
+    fn message_limit(&self) -> usize {
+        self.inner.message_limit()
+    }
+
+    fn use_streaming(&self, _other_bot_present: bool) -> bool {
+        false // Force non-streaming so text is collected before send
+    }
+
+    async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
+        // Filter [NO_REPLY] before it reaches the channel.
+        if is_no_reply(content) {
+            debug!("ambient: suppressed [NO_REPLY] response");
+            return Ok(MessageRef {
+                channel: channel.clone(),
+                message_id: String::new(),
+            });
+        }
+        self.inner.send_message(channel, content).await
+    }
+
+    async fn create_thread(
+        &self,
+        channel: &ChannelRef,
+        trigger_msg: &MessageRef,
+        title: &str,
+    ) -> Result<ChannelRef> {
+        self.inner.create_thread(channel, trigger_msg, title).await
+    }
+
+    async fn add_reaction(&self, msg: &MessageRef, emoji: &str) -> Result<()> {
+        self.inner.add_reaction(msg, emoji).await
+    }
+
+    async fn remove_reaction(&self, msg: &MessageRef, emoji: &str) -> Result<()> {
+        self.inner.remove_reaction(msg, emoji).await
+    }
+
+    async fn edit_message(&self, msg: &MessageRef, content: &str) -> Result<()> {
+        self.inner.edit_message(msg, content).await
+    }
+
+    async fn send_message_with_reply(
+        &self,
+        channel: &ChannelRef,
+        content: &str,
+        reply_to_message_id: &str,
+    ) -> Result<MessageRef> {
+        if is_no_reply(content) {
+            debug!("ambient: suppressed [NO_REPLY] reply");
+            return Ok(MessageRef {
+                channel: channel.clone(),
+                message_id: String::new(),
+            });
+        }
+        self.inner
+            .send_message_with_reply(channel, content, reply_to_message_id)
+            .await
+    }
+
+    async fn delete_message(&self, msg: &MessageRef) -> Result<()> {
+        self.inner.delete_message(msg).await
     }
 }
 
@@ -379,28 +462,24 @@ async fn ambient_consumer_loop(
             continue;
         }
 
-        // Dispatch batch to agent. For ambient mode, we use stream_prompt_blocks
-        // with a dummy reaction controller (enabled=false) to suppress all reactions.
+        // Dispatch batch to agent using AmbientCaptureAdapter which intercepts
+        // [NO_REPLY] responses before they reach the channel. Non-streaming mode
+        // ensures text is fully collected before send_message is called, allowing
+        // is_no_reply() to filter the sentinel pre-delivery.
         //
-        // ⚠️ KNOWN LIMITATIONS (v1, accepted):
-        // 1. [NO_REPLY] filtering: `is_no_reply()` is defined but not yet wired
-        //    into the response path. The system prompt instructs the agent to
-        //    return `[NO_REPLY]` but there is no post-filter to suppress it.
-        //    Rare false-positive replies may appear until v2 response capture.
-        // 2. Tool access: ambient flush shares the same DispatchTarget as @mention,
-        //    meaning the agent has full tool access during ambient flushes. For v1
-        //    this is accepted (system prompt restricts behavior); v2 should use a
-        //    restricted target or disable tools for ambient sessions.
-        //
-        // TODO(ambient-v2): implement response capture mode to intercept
-        // [NO_REPLY] before posting, and restrict tool access for ambient.
+        // ⚠️ KNOWN LIMITATION (v1, accepted):
+        // Tool access: ambient flush shares the same DispatchTarget as @mention.
+        // v2 should use a restricted target or disable tools for ambient sessions.
+        let capture_adapter: Arc<dyn ChatAdapter> = Arc::new(AmbientCaptureAdapter {
+            inner: Arc::clone(&adapter),
+        });
         let dummy_msg_ref = MessageRef {
             channel: channel_ref.clone(),
             message_id: String::new(),
         };
         let reactions = Arc::new(crate::reactions::StatusReactionController::new(
             false, // disabled — no reactions for ambient
-            Arc::clone(&adapter),
+            Arc::clone(&capture_adapter),
             dummy_msg_ref,
             crate::config::ReactionEmojis::default(),
             crate::config::ReactionTiming::default(),
@@ -414,7 +493,7 @@ async fn ambient_consumer_loop(
 
         match target
             .stream_prompt_blocks(
-                &adapter,
+                &capture_adapter,
                 &session_key,
                 content_blocks,
                 &channel_ref,

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -5,6 +5,23 @@
 //! Ambient mode listens to all messages in configured channels (without @mention)
 //! and periodically flushes them as a batch to the LLM. The agent replies only
 //! when it has something valuable to add; otherwise it returns `[NO_REPLY]`.
+//!
+//! # Why a standalone module (not extending Dispatcher)
+//!
+//! ADR §Implementation Notes suggests reusing Dispatcher infrastructure. This
+//! implementation deliberately builds a separate module because ambient's
+//! requirements diverge from normal dispatch:
+//!
+//! - No trigger message — passive listening has no `MessageRef` to anchor
+//!   reactions or reply_to.
+//! - No streaming / placeholder — ambient is non-interactive; responses use
+//!   `AmbientCaptureAdapter` (non-streaming) for `[NO_REPLY]` pre-filtering.
+//! - No per-sender batching (Lane mode) — ambient batches by channel, not sender.
+//! - No `BotTurnTracker` integration — ambient has independent reply budget (v2).
+//!
+//! Forcing these into `Dispatcher` would require pervasive `if ambient { ... }`
+//! branches, increasing regression risk for the existing dispatch path. Clean
+//! separation keeps both paths simple and independently testable.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -104,6 +104,12 @@ pub struct PostGuard {
     cancelled: AtomicBool,
 }
 
+impl Default for PostGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PostGuard {
     pub fn new() -> Self {
         Self {
@@ -272,6 +278,7 @@ impl AmbientDispatcher {
 // ---------------------------------------------------------------------------
 
 /// Per-channel consumer that accumulates messages and flushes them as a batch.
+#[allow(clippy::too_many_arguments)]
 async fn ambient_consumer_loop(
     channel_id: String,
     channel_ref: ChannelRef,

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -172,7 +172,7 @@ impl AmbientDispatcher {
             .iter()
             .filter_map(|s| s.parse().ok())
             .collect();
-        let flush_semaphore = Arc::new(Semaphore::new(config.max_concurrent_flushes));
+        let flush_semaphore = Arc::new(Semaphore::new(config.max_concurrent_flushes.max(1)));
         Self {
             config,
             channels: Mutex::new(HashMap::new()),

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -208,7 +208,7 @@ impl AmbientDispatcher {
 
         // Lazily spawn consumer if not yet started for this channel.
         if !channels.contains_key(channel_id) {
-            let (tx, rx) = tokio::sync::mpsc::channel(self.config.flush_hard_cap);
+            let (tx, rx) = tokio::sync::mpsc::channel(self.config.flush_hard_cap.max(1));
             let flushing = Arc::new(AtomicBool::new(false));
             let post_guard = Arc::new(PostGuard::new());
 
@@ -300,13 +300,17 @@ async fn ambient_consumer_loop(
         };
 
         // Compute jittered deadline: flush_interval ± 20%
-        let base = Duration::from_secs(config.flush_interval_seconds);
+        // Guard: interval must be >= 1s to avoid gen_range panic on empty range.
+        let base_secs = config.flush_interval_seconds.max(1);
+        let base = Duration::from_secs(base_secs);
         let jitter_range = base.as_millis() as f64 * 0.2;
         let jitter_ms = rand::thread_rng().gen_range(-jitter_range..jitter_range) as i64;
         let interval = Duration::from_millis((base.as_millis() as i64 + jitter_ms).max(1000) as u64);
         let deadline = tokio::time::Instant::now() + interval;
 
         let mut batch = vec![first];
+        // Guard: flush_max_messages must be >= 1 to avoid immediate single-msg flush.
+        let flush_max = config.flush_max_messages.max(1);
 
         // Accumulate until trigger fires.
         loop {
@@ -318,10 +322,10 @@ async fn ambient_consumer_loop(
             match tokio::time::timeout(remaining, rx.recv()).await {
                 Ok(Some(msg)) => {
                     batch.push(msg);
-                    if batch.len() >= config.flush_max_messages {
+                    if batch.len() >= flush_max {
                         break;
                     }
-                    if batch.len() >= config.flush_hard_cap {
+                    if batch.len() >= config.flush_hard_cap.max(1) {
                         break;
                     }
                 }
@@ -346,8 +350,8 @@ async fn ambient_consumer_loop(
             }
         };
 
-        // Set flushing flag with safety timeout.
-        let flush_timeout = Duration::from_secs(config.flush_timeout_seconds);
+        // Set flushing flag with safety timeout (clamped to [5s, 600s]).
+        let flush_timeout = Duration::from_secs(config.flush_timeout_seconds.clamp(5, 600));
         let _flushing_guard = FlushingGuard::new(Arc::clone(&flushing), flush_timeout);
 
         // Check post_guard BEFORE building payload (mention may have cancelled during accumulation).
@@ -376,12 +380,19 @@ async fn ambient_consumer_loop(
 
         // Dispatch batch to agent. For ambient mode, we use stream_prompt_blocks
         // with a dummy reaction controller (enabled=false) to suppress all reactions.
-        // The NO_REPLY check must be handled at a higher level (response filtering).
         //
-        // TODO(ambient-v2): implement response capture mode so we can intercept
-        // [NO_REPLY] before the message is posted. For v1, the system prompt
-        // strongly instructs the agent, and we accept that rare false-positives
-        // may briefly appear before being deleted.
+        // ⚠️ KNOWN LIMITATIONS (v1, accepted):
+        // 1. [NO_REPLY] filtering: `is_no_reply()` is defined but not yet wired
+        //    into the response path. The system prompt instructs the agent to
+        //    return `[NO_REPLY]` but there is no post-filter to suppress it.
+        //    Rare false-positive replies may appear until v2 response capture.
+        // 2. Tool access: ambient flush shares the same DispatchTarget as @mention,
+        //    meaning the agent has full tool access during ambient flushes. For v1
+        //    this is accepted (system prompt restricts behavior); v2 should use a
+        //    restricted target or disable tools for ambient sessions.
+        //
+        // TODO(ambient-v2): implement response capture mode to intercept
+        // [NO_REPLY] before posting, and restrict tool access for ambient.
         let dummy_msg_ref = MessageRef {
             channel: channel_ref.clone(),
             message_id: String::new(),

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -1230,6 +1230,10 @@ fn parse_config_inner(expanded: &str, source: &str) -> anyhow::Result<Config> {
 // ---------------------------------------------------------------------------
 
 /// Top-level `[ambient]` configuration for passive channel listening.
+///
+/// NOTE: ADR #1211 originally specified `[discord.ambient]`. The implementation
+/// uses top-level `[ambient]` with nested `[ambient.discord]` to allow future
+/// multi-platform ambient support without restructuring config.
 #[derive(Debug, Clone, Deserialize)]
 pub struct AmbientConfig {
     /// Master switch (default: false).

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -1279,6 +1279,9 @@ impl Default for AmbientConfig {
 }
 
 /// `[ambient.pool]` — dedicated session pool for ambient dispatches.
+///
+/// NOTE: Pool management is not yet implemented (v2 follow-up). These settings
+/// are parsed and validated on startup but not enforced at runtime.
 #[derive(Debug, Clone, Deserialize)]
 pub struct AmbientPoolConfig {
     /// Max concurrent ambient sessions. Default: 5.

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -1250,6 +1250,7 @@ pub struct AmbientConfig {
     #[serde(default = "default_flush_hard_cap")]
     pub flush_hard_cap: usize,
     /// Historical messages fetched via Discord API before the batch. Default: 20.
+    /// NOTE: Not yet implemented (v2 follow-up). Parsed but not used at runtime.
     #[serde(default = "default_context_window")]
     pub context_window: usize,
     /// Max simultaneous LLM calls across all ambient channels. Default: 3.

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -148,6 +148,8 @@ pub struct Config {
     pub workspace: WorkspaceConfig,
     #[serde(default)]
     pub secrets: SecretsConfig,
+    #[serde(default)]
+    pub ambient: AmbientConfig,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1221,6 +1223,122 @@ fn parse_config_inner(expanded: &str, source: &str) -> anyhow::Result<Config> {
     );
 
     Ok(config)
+}
+
+// ---------------------------------------------------------------------------
+// Ambient Mode configuration
+// ---------------------------------------------------------------------------
+
+/// Top-level `[ambient]` configuration for passive channel listening.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AmbientConfig {
+    /// Master switch (default: false).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Time-based flush trigger in seconds (±20% jitter applied). Default: 60.
+    #[serde(default = "default_flush_interval_seconds")]
+    pub flush_interval_seconds: u64,
+    /// Count-based flush trigger. Default: 10.
+    #[serde(default = "default_flush_max_messages")]
+    pub flush_max_messages: usize,
+    /// Safety cap — force flush at this count even if timer hasn't expired.
+    /// Only relevant when `flush_max_messages` is set very high or disabled. Default: 50.
+    #[serde(default = "default_flush_hard_cap")]
+    pub flush_hard_cap: usize,
+    /// Historical messages fetched via Discord API before the batch. Default: 20.
+    #[serde(default = "default_context_window")]
+    pub context_window: usize,
+    /// Max simultaneous LLM calls across all ambient channels. Default: 3.
+    #[serde(default = "default_max_concurrent_flushes")]
+    pub max_concurrent_flushes: usize,
+    /// Safety timeout (seconds) — auto-reset flushing flag if exceeded. Default: 120.
+    #[serde(default = "default_flush_timeout_seconds")]
+    pub flush_timeout_seconds: u64,
+    /// Ambient session pool configuration.
+    #[serde(default)]
+    pub pool: AmbientPoolConfig,
+    /// Platform-specific ambient settings.
+    #[serde(default)]
+    pub discord: AmbientDiscordConfig,
+}
+
+impl Default for AmbientConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            flush_interval_seconds: default_flush_interval_seconds(),
+            flush_max_messages: default_flush_max_messages(),
+            flush_hard_cap: default_flush_hard_cap(),
+            context_window: default_context_window(),
+            max_concurrent_flushes: default_max_concurrent_flushes(),
+            flush_timeout_seconds: default_flush_timeout_seconds(),
+            pool: AmbientPoolConfig::default(),
+            discord: AmbientDiscordConfig::default(),
+        }
+    }
+}
+
+/// `[ambient.pool]` — dedicated session pool for ambient dispatches.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AmbientPoolConfig {
+    /// Max concurrent ambient sessions. Default: 5.
+    #[serde(default = "default_ambient_max_sessions")]
+    pub max_sessions: usize,
+    /// Ambient session inactivity timeout in minutes. Default: 60.
+    #[serde(default = "default_ambient_session_ttl_minutes")]
+    pub session_ttl_minutes: u64,
+    /// Rolling window of retained flush history (cross-flush memory). Default: 3.
+    #[serde(default = "default_ambient_context_flushes")]
+    pub context_flushes: usize,
+}
+
+impl Default for AmbientPoolConfig {
+    fn default() -> Self {
+        Self {
+            max_sessions: default_ambient_max_sessions(),
+            session_ttl_minutes: default_ambient_session_ttl_minutes(),
+            context_flushes: default_ambient_context_flushes(),
+        }
+    }
+}
+
+/// `[ambient.discord]` — Discord-specific ambient settings.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct AmbientDiscordConfig {
+    /// Explicit channel allowlist. Required — empty means ambient is disabled.
+    #[serde(default)]
+    pub channels: Vec<String>,
+    /// Whether other bots' messages enter the ambient buffer. Default: false.
+    #[serde(default)]
+    pub allow_bot_messages: bool,
+}
+
+fn default_flush_interval_seconds() -> u64 {
+    60
+}
+fn default_flush_max_messages() -> usize {
+    10
+}
+fn default_flush_hard_cap() -> usize {
+    50
+}
+fn default_context_window() -> usize {
+    20
+}
+fn default_max_concurrent_flushes() -> usize {
+    3
+}
+fn default_flush_timeout_seconds() -> u64 {
+    120
+}
+fn default_ambient_max_sessions() -> usize {
+    5
+}
+fn default_ambient_session_ttl_minutes() -> u64 {
+    60
+}
+fn default_ambient_context_flushes() -> usize {
+    3
 }
 
 #[cfg(test)]

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -3,6 +3,7 @@ use crate::acp::ContentBlock;
 use crate::adapter::{AdapterRouter, ChannelRef, ChatAdapter, MessageRef, SenderContext};
 use crate::bot_turns::{BotTurnTracker, TurnAction, TurnSeverity, BOT_TURN_LIMIT_WARNING_PREFIX};
 use crate::config::{AllowBots, AllowUsers, SttConfig};
+use crate::dispatch::DispatchTarget;
 use crate::format;
 use crate::media;
 use crate::remind::{self, ReminderStore};
@@ -234,6 +235,8 @@ pub struct Handler {
     pub allow_dm: bool,
     /// Per-thread dispatcher (Message mode uses cap=1 for FIFO; Thread/Lane use configured cap).
     pub dispatcher: Arc<crate::dispatch::Dispatcher>,
+    /// Ambient mode dispatcher for passive channel listening.
+    pub ambient: Option<Arc<crate::ambient::AmbientDispatcher>>,
     /// Reminder store for /remind slash command.
     pub reminder_store: ReminderStore,
     /// Track scheduled reminder IDs to prevent duplicate scheduling on reconnect.
@@ -602,6 +605,64 @@ impl EventHandler for Handler {
 
         if !is_dm && !in_allowed_channel && !in_thread {
             return;
+        }
+
+        // --- Ambient Mode routing ---
+        // If the message is in an ambient-enabled channel, NOT a @mention,
+        // NOT in a thread, and NOT a DM → route to ambient dispatcher.
+        // @mention in an ambient channel → discard buffer + normal dispatch.
+        if let Some(ref ambient) = self.ambient {
+            if ambient.is_ambient_channel(channel_id) && !in_thread && !is_dm {
+                if is_mentioned {
+                    // Discard ambient buffer — mention takes priority.
+                    ambient.discard_buffer(&channel_id.to_string()).await;
+                    // Fall through to normal dispatch below.
+                } else {
+                    // Route to ambient buffer (not normal dispatch).
+                    // Bot messages only if allow_bot_messages is true for ambient.
+                    if msg.author.bot && !ambient.allow_bot_messages() {
+                        return;
+                    }
+
+                    let prompt = resolve_mentions(&msg.content, bot_id, &self.allowed_role_ids);
+                    if prompt.is_empty() && msg.attachments.is_empty() {
+                        return;
+                    }
+
+                    let display_name = msg
+                        .member
+                        .as_ref()
+                        .and_then(|m| m.nick.as_ref())
+                        .or(msg.author.global_name.as_ref())
+                        .unwrap_or(&msg.author.name);
+
+                    let channel_ref = ChannelRef {
+                        platform: "discord".into(),
+                        channel_id: channel_id.to_string(),
+                        thread_id: None,
+                        parent_id: None,
+                        origin_event_id: None,
+                    };
+
+                    let ambient_msg = crate::ambient::AmbientMessage {
+                        sender_json: String::new(), // Not needed for ambient
+                        sender_name: display_name.clone(),
+                        prompt,
+                        extra_blocks: Vec::new(), // Skip attachments for ambient v1
+                        arrived_at: std::time::Instant::now(),
+                    };
+
+                    let target = Arc::clone(&self.router) as Arc<dyn DispatchTarget>;
+                    ambient.submit(
+                        &channel_id.to_string(),
+                        channel_ref,
+                        adapter.clone(),
+                        target,
+                        ambient_msg,
+                    ).await;
+                    return;
+                }
+            }
         }
 
         // User message gating (mirrors Slack's AllowUsers logic).

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -645,7 +645,6 @@ impl EventHandler for Handler {
                     };
 
                     let ambient_msg = crate::ambient::AmbientMessage {
-                        sender_json: String::new(), // Not needed for ambient
                         sender_name: display_name.to_owned(),
                         prompt,
                         extra_blocks: Vec::new(), // Skip attachments for ambient v1

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -646,7 +646,7 @@ impl EventHandler for Handler {
 
                     let ambient_msg = crate::ambient::AmbientMessage {
                         sender_json: String::new(), // Not needed for ambient
-                        sender_name: display_name.clone(),
+                        sender_name: display_name.to_owned(),
                         prompt,
                         extra_blocks: Vec::new(), // Skip attachments for ambient v1
                         arrived_at: std::time::Instant::now(),

--- a/crates/openab-core/src/lib.rs
+++ b/crates/openab-core/src/lib.rs
@@ -24,5 +24,7 @@ pub mod timestamp;
 
 #[cfg(feature = "discord")]
 pub mod discord;
+#[cfg(feature = "discord")]
+pub mod ambient;
 #[cfg(feature = "slack")]
 pub mod slack;

--- a/docs/ambient.md
+++ b/docs/ambient.md
@@ -1,0 +1,100 @@
+# Ambient Mode
+
+Ambient mode allows your bot to passively listen to all messages in configured channels and autonomously decide whether to respond. Unlike the default @mention mode, the bot observes the full conversation flow and only speaks up when it has something valuable to add.
+
+## How It Works
+
+1. Messages in configured channels (that are **not** @mentions) are buffered per-channel.
+2. When a **time trigger** (`flush_interval_seconds`) or **count trigger** (`flush_max_messages`) fires, the batch is sent to the LLM.
+3. The LLM evaluates the conversation and either:
+   - **Replies** with a helpful response → posted to the channel.
+   - **Returns `[NO_REPLY]`** → silently suppressed, nothing is posted.
+4. If someone **@mentions** the bot in an ambient channel, the buffer is discarded and the mention is handled normally (immediate response).
+
+## Configuration
+
+```toml
+[ambient]
+enabled = true
+flush_interval_seconds = 60      # Time trigger (±20% jitter applied)
+flush_max_messages = 10           # Count trigger
+flush_hard_cap = 50               # Safety cap on buffer size
+max_concurrent_flushes = 3        # Global LLM concurrency limit
+flush_timeout_seconds = 120       # Safety timeout per flush
+
+[ambient.discord]
+channels = ["1234567890"]         # Channel IDs to monitor
+allow_bot_messages = false        # Include other bots' messages in buffer
+```
+
+### Configuration fields
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `false` | Master switch. Must be explicitly enabled. |
+| `flush_interval_seconds` | `60` | Seconds between time-based flushes. ±20% jitter prevents thundering herd. Min: 1. |
+| `flush_max_messages` | `10` | Flush when this many messages accumulate. Min: 1. |
+| `flush_hard_cap` | `50` | Maximum buffer size. Messages beyond this are dropped. Min: 1. |
+| `max_concurrent_flushes` | `3` | Max simultaneous LLM calls across all ambient channels. Min: 1. |
+| `flush_timeout_seconds` | `120` | Safety timeout — resets flushing state if exceeded. Clamped to [5, 600]. |
+| `channels` | `[]` | Explicit channel allowlist (required). Empty = ambient disabled. |
+| `allow_bot_messages` | `false` | Whether other bots' messages enter the ambient buffer. |
+
+### Reserved fields (v2, not yet enforced)
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `context_window` | `20` | Historical messages to fetch before each batch (not yet implemented). |
+| `pool.max_sessions` | `5` | Max concurrent ambient sessions (not yet enforced). |
+| `pool.session_ttl_minutes` | `60` | Session inactivity timeout (not yet enforced). |
+| `pool.context_flushes` | `3` | Rolling flush history window (not yet enforced). |
+
+## Behavior
+
+### @mention priority
+
+When someone @mentions the bot in an ambient channel:
+1. The ambient buffer is immediately invalidated (current batch discarded).
+2. The mention is handled via normal dispatch (immediate response).
+3. After the mention is handled, ambient buffering resumes for new messages.
+
+Buffered messages that arrived before the mention are **not lost** — they carry into the next ambient cycle.
+
+### [NO_REPLY] filtering
+
+The bot uses a system prompt that instructs it to respond with `[NO_REPLY]` when it has nothing to add. This sentinel is intercepted **before delivery** — it never appears in the channel. The filtering uses a capture adapter that forces non-streaming mode to ensure the full response is evaluated before any message is sent.
+
+### Session isolation
+
+Ambient sessions use the namespace `ambient:discord:<channel_id>`, separate from normal dispatch sessions. There is no collision with @mention sessions.
+
+### Cost control
+
+- **Jittered intervals** prevent all channels from flushing simultaneously.
+- **Global semaphore** caps concurrent LLM calls (default: 3).
+- **`[NO_REPLY]`** means most flushes produce no visible output (only one LLM call, no channel message).
+- **`enabled = false`** default means zero cost until explicitly opted in.
+
+## Limitations (v1)
+
+| Limitation | Description | Planned fix |
+|-----------|-------------|-------------|
+| Tool access | Ambient flushes have full tool access (same as @mention). | v2: restricted dispatch target |
+| In-flight cancel | A @mention during LLM generation cannot stop the ambient response mid-stream. | v2: `tokio::select!` preemption |
+| Consumer supervision | If a consumer task panics, that channel's ambient is permanently disabled until restart. | v2: health check + respawn |
+| No history fetch | `context_window` (Discord API history before batch) is not yet implemented. | v2 |
+| No cooldown | No minimum interval between consecutive flushes for a single channel. | v2 |
+
+## Example
+
+Minimal config to enable ambient mode on one channel:
+
+```toml
+[ambient]
+enabled = true
+
+[ambient.discord]
+channels = ["1490282656913559673"]
+```
+
+This uses all defaults: 60s flush interval, max 10 messages per batch, 3 concurrent flushes.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -463,6 +463,32 @@ web    = "~/projects/frontend"
 
 ---
 
+## `[ambient]`
+
+Passive channel listening with batch flush. See [ambient.md](ambient.md) for full guide.
+
+```toml
+[ambient]
+enabled = false                   # Master switch
+flush_interval_seconds = 60       # Time trigger (±20% jitter)
+flush_max_messages = 10           # Count trigger
+flush_hard_cap = 50               # Max buffer size
+max_concurrent_flushes = 3        # Global LLM concurrency limit
+flush_timeout_seconds = 120       # Safety timeout per flush
+context_window = 20               # (v2, not yet implemented)
+
+[ambient.pool]                    # (v2, not yet enforced)
+max_sessions = 5
+session_ttl_minutes = 60
+context_flushes = 3
+
+[ambient.discord]
+channels = []                     # Channel ID allowlist (required)
+allow_bot_messages = false
+```
+
+---
+
 ## `[cron]`
 
 Everything cron-related lives under `[cron]`.

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -209,6 +209,25 @@ Each thread gets its own agent session. Sessions are cleaned up after `session_t
 
 ---
 
+## Ambient Mode
+
+Ambient mode allows the bot to passively listen to configured channels and respond only when it has something valuable to add — without requiring @mentions. See [ambient.md](ambient.md) for full details.
+
+```toml
+[ambient]
+enabled = true
+
+[ambient.discord]
+channels = ["1234567890"]   # Channel IDs to monitor
+```
+
+When enabled:
+- Non-mention messages in listed channels are buffered and periodically sent to the LLM as a batch.
+- If the LLM has nothing to add, it returns `[NO_REPLY]` (silently suppressed).
+- **@mention always takes priority** — the ambient buffer is discarded and the mention gets an immediate response.
+
+---
+
 ## Attachment Handling
 
 OpenAB processes Discord file attachments and converts them into content blocks

--- a/src/main.rs
+++ b/src/main.rs
@@ -762,6 +762,19 @@ async fn main() -> anyhow::Result<()> {
             .join("reminders.json");
         let reminder_store = remind::ReminderStore::load(reminder_path);
 
+        // Construct ambient dispatcher if enabled and channels configured.
+        let ambient_dispatcher = if cfg.ambient.enabled && !cfg.ambient.discord.channels.is_empty() {
+            info!(
+                channels = ?cfg.ambient.discord.channels,
+                flush_interval = cfg.ambient.flush_interval_seconds,
+                flush_max_messages = cfg.ambient.flush_max_messages,
+                "ambient mode enabled"
+            );
+            Some(Arc::new(openab_core::ambient::AmbientDispatcher::new(cfg.ambient.clone())))
+        } else {
+            None
+        };
+
         let handler = discord::Handler {
             router,
             allow_all_channels,
@@ -784,6 +797,7 @@ async fn main() -> anyhow::Result<()> {
             )),
             allow_dm: discord_cfg.allow_dm,
             dispatcher: discord_dispatcher,
+            ambient: ambient_dispatcher,
             reminder_store: reminder_store.clone(),
             scheduled_ids: tokio::sync::Mutex::new(std::collections::HashSet::new()),
         };


### PR DESCRIPTION
## Summary

Implements the core **Ambient Mode** feature — passive channel listening with a batch flush strategy. Messages in configured channels accumulate in a per-channel buffer and are flushed as a batch to the LLM when a time or count trigger fires.

Based on ADR: #1211

## Key Design Points

- Per-channel `mpsc::channel` + consumer task (lazy spawn)
- Flush triggers: timer (`flush_interval_seconds ± 20% jitter`) OR count (`flush_max_messages`)
- `[NO_REPLY]` sentinel — agent replies exactly this when it has nothing to add; response is discarded
- `FlushingGuard` (RAII + safety timeout) prevents permanent channel lockout on panic
- `PostGuard` (atomic cancel) prevents TOCTOU race between ambient flush and @mention dispatch
- Global `Semaphore` (`max_concurrent_flushes = 3`) controls LLM cost
- Separate session pool (`ambient:discord:<channel_id>`)

## Configuration

```toml
[ambient]
enabled = false
flush_interval_seconds = 60
flush_max_messages = 10
flush_hard_cap = 50
context_window = 20
max_concurrent_flushes = 3
flush_timeout_seconds = 120

[ambient.pool]
max_sessions = 5
session_ttl_minutes = 60
context_flushes = 3

[ambient.discord]
channels = ["1490282656913559673"]
allow_bot_messages = false
```

## Files Changed

- `crates/openab-core/src/config.rs` — `AmbientConfig`, `AmbientPoolConfig`, `AmbientDiscordConfig`
- `crates/openab-core/src/ambient.rs` — `AmbientDispatcher`, consumer loop, guards
- `crates/openab-core/src/discord.rs` — Route non-mentioned msgs to ambient, discard buffer on @mention
- `crates/openab-core/src/lib.rs` — Module declaration
- `src/main.rs` — Construct `AmbientDispatcher` from config

## What is NOT in this PR (v2 follow-ups)

- Response capture mode for `[NO_REPLY]` filtering before post (currently relies on system prompt)
- `context_window` history fetch from Discord API
- Cross-flush memory (rolling window of previous flush interactions)
- Per-channel flush rate limiting (`min_flush_interval_seconds`)
