### PR TITLE
ci(pr-review): trigger OpenAB PR Review on PR events, not just cron

### DIFF
--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -1,6 +1,8 @@
 name: PR Review (Scheduled)
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: '*/5 * * * *'
   workflow_dispatch: {}


### PR DESCRIPTION
## What problem does this solve?

`OpenAB PR Review` is a **required** status posted only by the `*/5` cron poller in `pr-bot-review.yml`. GitHub throttles scheduled workflows (observed: actual runs hours apart, not every 5 min), so after a push or **rebase** the new head SHA sits in **"Expected — Waiting for status to be reported"** for a long time, blocking the PR.

## Change

Add a `pull_request` trigger so the review runs promptly on every head change:

```yaml
on:
  pull_request:
    types: [opened, synchronize, reopened]
  schedule:
    - cron: '*/5 * * * *'   # kept as safety net
  workflow_dispatch: {}
```

## Why this is safe (no other changes)

- **Per-SHA dedup**: the job already skips PRs whose current head SHA was already reviewed, so event-driven runs only review the PR that actually changed.
- **Cron kept** as a backstop (catches fork PRs where the event-triggered `GITHUB_TOKEN` is read-only and can't write statuses, plus anything missed).
- **Concurrency left as-is** (`pr-review-poller`, cancel-in-progress): for this repo (same-repo branches, low PR velocity) cross-PR cancellation effectively never happens; and cancelling a superseded same-PR review is the desired behavior (review the latest SHA).

## Effect

A rebase/push now posts `OpenAB PR Review` within a minute or two instead of waiting on the throttled cron.

## Note

For **fork** PRs, `pull_request` runs with a read-only token and can't write the status — those continue to be handled by the cron poller (which runs with full permissions). Same-repo PRs (the common case) post promptly.