### PR TITLE
fix(pr-review): skip pull_request path for fork PRs (avoid read-only-token 403)

### DIFF
--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -20,6 +20,13 @@ jobs:
   poll-and-review:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # On pull_request events from forks, GITHUB_TOKEN is read-only, so writing
+    # the commit status 403s and the run fails. Skip the event-driven path for
+    # fork PRs — the scheduled cron (full permissions) still reviews them.
+    # schedule/workflow_dispatch always run; same-repo PRs run on the event.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Find PRs needing review
         id: poll


### PR DESCRIPTION
## Problem

#1218 added `pull_request: [opened, synchronize, reopened]` to `pr-bot-review.yml`. But **fork** PRs run `pull_request` with a **read-only `GITHUB_TOKEN`**, so the job's `POST /statuses` call returns `403 Resource not accessible by integration` and the **run fails**.

Observed immediately on fork PR #1190 (`brettchien`, cross-repo): https://github.com/openabdev/openab/actions/runs/28275655386

This is worse than the original 'waiting on cron' state — it's a red failing run on every fork-PR push.

## Fix

Guard the job so the `pull_request` path only runs for **same-repo** PRs:

```yaml
if: >-
  github.event_name != 'pull_request' ||
  github.event.pull_request.head.repo.full_name == github.repository
```

- `schedule` / `workflow_dispatch` → always run (full token; reviews all PRs incl. forks, as before).
- `pull_request` from **same-repo** branch → run (token has `statuses: write`) → prompt status on rebase/push.
- `pull_request` from **fork** → **skipped** (neutral, not failed); the cron poller still reviews it with full permissions.

Net: keeps the #1218 speedup for same-repo PRs (the common case) while forks behave exactly as they did before #1218 (handled by cron), with no failing runs.

## Verification

YAML parses; job `if` guard confirmed. No other logic changed.