### PR TITLE
feat: add Devin CLI agent backend support

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -62,7 +62,7 @@ jobs:
           fi
 
           # Resolve variants
-          ALLOWED="kiro,claude,codex,copilot,cursor,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore"
+          ALLOWED="kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore"
           if [ "$VARIANTS_INPUT" = "all" ] || [ -z "$VARIANTS_INPUT" ]; then
             VARIANTS="$ALLOWED"
           else

--- a/.github/workflows/build-operator.yml
+++ b/.github/workflows/build-operator.yml
@@ -30,7 +30,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   # All agent variants built from Dockerfile.unified targets.
-  AGENTS: "kiro,claude,codex,copilot,cursor,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore"
+  AGENTS: "kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore"
 
 jobs:
   resolve-tag:

--- a/.github/workflows/docker-smoke-test-unified.yml
+++ b/.github/workflows/docker-smoke-test-unified.yml
@@ -47,6 +47,7 @@ jobs:
           - { name: codex, agent: "codex-acp" }
           - { name: copilot, agent: "copilot" }
           - { name: cursor, agent: "cursor-agent" }
+          - { name: devin, agent: "devin" }
           - { name: gemini, agent: "gemini" }
           - { name: grok, agent: "grok" }
           - { name: hermes, agent: "hermes-acp" }

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -31,6 +31,7 @@ jobs:
           - { dockerfile: Dockerfile.mimocode, suffix: "-mimocode", agent: "mimo", agent_args: "acp", build_args: "" }
           - { dockerfile: Dockerfile.hermes, suffix: "-hermes", agent: "hermes-acp", agent_args: "", build_args: "" }
           - { dockerfile: Dockerfile.grok, suffix: "-grok", agent: "grok", agent_args: "agent stdio", build_args: "" }
+          - { dockerfile: Dockerfile.devin, suffix: "-devin", agent: "devin", agent_args: "acp", build_args: "" }
           - { dockerfile: Dockerfile.antigravity, suffix: "-antigravity", agent: "agy-acp", agent_args: "", build_args: "" }
           - { dockerfile: Dockerfile.pi, suffix: "-pi", agent: "pi-acp", agent_args: "", build_args: "" }
           - { dockerfile: openshell/Dockerfile, suffix: "-native-sandbox", agent: "openab-agent", agent_args: "", build_args: "" }

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -19,6 +19,7 @@ on:
           - codex
           - copilot
           - cursor
+          - devin
           - gemini
           - grok
           - hermes

--- a/.github/workflows/pre-beta-build.yml
+++ b/.github/workflows/pre-beta-build.yml
@@ -14,7 +14,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  ALL_AGENTS: 'kiro,claude,codex,copilot,cursor,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore'
+  ALL_AGENTS: 'kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore'
 
 jobs:
   gate:

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -21,7 +21,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  ALL_VARIANTS: 'default,agentcore,antigravity,claude,codex,copilot,cursor,gemini,grok,hermes,mimocode,native,opencode,pi'
+  ALL_VARIANTS: 'default,agentcore,antigravity,claude,codex,copilot,cursor,devin,gemini,grok,hermes,mimocode,native,opencode,pi'
 
 jobs:
   matrix:

--- a/Dockerfile.devin
+++ b/Dockerfile.devin
@@ -20,11 +20,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl procps ripgrep tini git unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Devin CLI via official install script
-RUN HOME=/root curl -fsSL https://cli.devin.ai/install.sh | HOME=/root bash && \
-    cp /root/.local/bin/devin /usr/local/bin/devin && \
-    chmod +x /usr/local/bin/devin && \
-    rm -rf /root/.local/share/devin /root/.local/bin/devin
+# Install Devin CLI (pinned version with SHA256 verification)
+ARG DEVIN_VERSION=2026.8.18
+ARG DEVIN_SHA256_AMD64=dd4bba20593086bf708474792c11ab0c9428be5b2419ff5c182ec5f1099a0661
+ARG DEVIN_SHA256_ARM64=127e7a8baf2e09cb0fd23871af989dc9e32e3bfa7f497b1f6560cc52f5bf19c6
+ARG TARGETPLATFORM
+RUN set -eux; \
+    case "${TARGETPLATFORM:-linux/amd64}" in \
+      "linux/amd64") arch=x86_64-unknown-linux; sha="${DEVIN_SHA256_AMD64}" ;; \
+      "linux/arm64") arch=aarch64-unknown-linux; sha="${DEVIN_SHA256_ARM64}" ;; \
+      *) echo "Unsupported platform: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://static.devin.ai/cli/${DEVIN_VERSION}/devin-${DEVIN_VERSION}-${arch}.tar.gz" \
+      -o /tmp/devin.tar.gz && \
+    echo "${sha}  /tmp/devin.tar.gz" | sha256sum -c - && \
+    tar xzf /tmp/devin.tar.gz -C /tmp && \
+    install -m 0755 /tmp/devin /usr/local/bin/devin && \
+    rm -rf /tmp/devin*
 
 # Install gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -40,7 +52,7 @@ WORKDIR /home/agent
 
 COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
 
-RUN mkdir -p /home/agent/.config/devin && chown -R agent:agent /home/agent
+RUN chown -R agent:agent /home/agent
 
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/Dockerfile.devin
+++ b/Dockerfile.devin
@@ -35,8 +35,8 @@ RUN set -eux; \
       -o /tmp/devin.tar.gz && \
     echo "${sha}  /tmp/devin.tar.gz" | sha256sum -c - && \
     tar xzf /tmp/devin.tar.gz -C /tmp && \
-    install -m 0755 /tmp/devin /usr/local/bin/devin && \
-    rm -rf /tmp/devin*
+    install -m 0755 /tmp/bin/devin /usr/local/bin/devin && \
+    rm -rf /tmp/devin* /tmp/bin /tmp/share
 
 # Install gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/Dockerfile.devin
+++ b/Dockerfile.devin
@@ -1,0 +1,52 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY crates/openab-core/Cargo.toml crates/openab-core/Cargo.toml
+COPY crates/openab-gateway/Cargo.toml crates/openab-gateway/Cargo.toml
+RUN mkdir -p src crates/openab-core/src crates/openab-gateway/src \
+    && echo 'fn main() {}' > src/main.rs \
+    && echo '' > crates/openab-core/src/lib.rs \
+    && echo '' > crates/openab-gateway/src/lib.rs \
+    && cargo build --release \
+    && rm -rf src crates/openab-core/src crates/openab-gateway/src
+COPY crates/ crates/
+COPY src/ src/
+RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
+
+# --- Runtime stage ---
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl procps ripgrep tini git unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Devin CLI via official install script
+RUN HOME=/root curl -fsSL https://cli.devin.ai/install.sh | HOME=/root bash && \
+    cp /root/.local/bin/devin /usr/local/bin/devin && \
+    chmod +x /usr/local/bin/devin && \
+    rm -rf /root/.local/share/devin /root/.local/bin/devin
+
+# Install gh CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash -u 1000 agent
+ENV HOME=/home/agent
+WORKDIR /home/agent
+
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
+
+RUN mkdir -p /home/agent/.config/devin && chown -R agent:agent /home/agent
+
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="devin acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="devin auth login --force-manual-token-flow"
+
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -288,6 +288,26 @@ ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 
 # =============================================================================
+# Target: devin
+# =============================================================================
+FROM base-debian AS devin
+RUN curl -fsSL https://cli.devin.ai/install.sh | bash && \
+    mv /root/.devin/bin/devin /usr/local/bin/devin && \
+    chmod +x /usr/local/bin/devin && \
+    rm -rf /root/.devin
+ENV HOME=/home/agent
+WORKDIR /home/agent
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/agent/.config/devin && chown -R agent:agent /home/agent
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="devin acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="devin auth login --force-manual-token-flow"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
 # Target: antigravity
 # =============================================================================
 FROM base-debian AS antigravity

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -291,14 +291,26 @@ CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 # Target: devin
 # =============================================================================
 FROM base-debian AS devin
-RUN HOME=/root curl -fsSL https://cli.devin.ai/install.sh | HOME=/root bash && \
-    cp /root/.local/bin/devin /usr/local/bin/devin && \
-    chmod +x /usr/local/bin/devin && \
-    rm -rf /root/.local/share/devin /root/.local/bin/devin
+ARG DEVIN_VERSION=2026.8.18
+ARG DEVIN_SHA256_AMD64=dd4bba20593086bf708474792c11ab0c9428be5b2419ff5c182ec5f1099a0661
+ARG DEVIN_SHA256_ARM64=127e7a8baf2e09cb0fd23871af989dc9e32e3bfa7f497b1f6560cc52f5bf19c6
+ARG TARGETPLATFORM
+RUN set -eux; \
+    case "${TARGETPLATFORM:-linux/amd64}" in \
+      "linux/amd64") arch=x86_64-unknown-linux; sha="${DEVIN_SHA256_AMD64}" ;; \
+      "linux/arm64") arch=aarch64-unknown-linux; sha="${DEVIN_SHA256_ARM64}" ;; \
+      *) echo "Unsupported platform: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://static.devin.ai/cli/${DEVIN_VERSION}/devin-${DEVIN_VERSION}-${arch}.tar.gz" \
+      -o /tmp/devin.tar.gz && \
+    echo "${sha}  /tmp/devin.tar.gz" | sha256sum -c - && \
+    tar xzf /tmp/devin.tar.gz -C /tmp && \
+    install -m 0755 /tmp/devin /usr/local/bin/devin && \
+    rm -rf /tmp/devin*
 ENV HOME=/home/agent
 WORKDIR /home/agent
 COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
-RUN mkdir -p /home/agent/.config/devin && chown -R agent:agent /home/agent
+RUN chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -291,10 +291,10 @@ CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 # Target: devin
 # =============================================================================
 FROM base-debian AS devin
-RUN curl -fsSL https://cli.devin.ai/install.sh | bash && \
-    mv /root/.devin/bin/devin /usr/local/bin/devin && \
+RUN HOME=/root curl -fsSL https://cli.devin.ai/install.sh | HOME=/root bash && \
+    cp /root/.local/bin/devin /usr/local/bin/devin && \
     chmod +x /usr/local/bin/devin && \
-    rm -rf /root/.devin
+    rm -rf /root/.local/share/devin /root/.local/bin/devin
 ENV HOME=/home/agent
 WORKDIR /home/agent
 COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -305,8 +305,8 @@ RUN set -eux; \
       -o /tmp/devin.tar.gz && \
     echo "${sha}  /tmp/devin.tar.gz" | sha256sum -c - && \
     tar xzf /tmp/devin.tar.gz -C /tmp && \
-    install -m 0755 /tmp/devin /usr/local/bin/devin && \
-    rm -rf /tmp/devin*
+    install -m 0755 /tmp/bin/devin /usr/local/bin/devin && \
+    rm -rf /tmp/devin* /tmp/bin /tmp/share
 ENV HOME=/home/agent
 WORKDIR /home/agent
 COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![OpenAB banner](images/banner.jpg)
 
-A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Copilot CLI, Hermes, Grok Build, Antigravity, Pi, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](crates/openab-gateway/).
+A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Copilot CLI, Hermes, Grok Build, Devin, Antigravity, Pi, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](crates/openab-gateway/).
 
 🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://openab.dev/discord)** 🎉
 
@@ -22,11 +22,10 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 │   LINE       │◄──webhook──┌──────────────────┐              │ opencode acp     │
 │   User       │            │  Custom Gateway  │              │ mimo acp         │
 ├──────────────┤            │  (standalone)    │              │ grok agent stdio │
-├──────────────┤            │  (standalone)    │              │ agy-acp          │
-│  Feishu/Lark │◄───WS──────│                  │              │ pi-acp           │
-│   User       │            │                  │              └──────────────────┘
-├──────────────┤            │                  │
-│ Google Chat  │◄──webhook──│                  │
+│  Feishu/Lark │◄───WS──────│                  │              │ devin acp        │
+│   User       │            │                  │              │ agy-acp          │
+├──────────────┤            │                  │              │ pi-acp           │
+│ Google Chat  │◄──webhook──│                  │              └──────────────────┘
 │   User       │            └──────────────────┘
 └──────────────┘
 ```
@@ -39,7 +38,7 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 
 - **Multi-platform** — supports Discord and Slack, run one or both simultaneously
 - **Custom Gateway** — extend to Telegram, LINE, Feishu/Lark, Google Chat, MS Teams via standalone [gateway](crates/openab-gateway/)
-- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Copilot CLI, Hermes, Grok Build, Antigravity, Pi via config
+- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Copilot CLI, Hermes, Grok Build, Devin, Antigravity, Pi via config
 - **@mention trigger** — mention the bot in an allowed channel to start a conversation
 - **Thread-based multi-turn** — auto-creates threads; no @mention needed for follow-ups
 - **Multi-agent collaboration** — bot-to-bot messaging for coordinated workflows ([docs/multi-agent.md](docs/multi-agent.md))
@@ -173,6 +172,7 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 | Cursor | `cursor-agent acp` | Native | [docs/cursor.md](docs/cursor.md) |
 | Hermes Agent | `hermes-acp` | Native | [docs/hermes.md](docs/hermes.md) |
 | Grok Build | `grok agent stdio` | Native | [docs/grok.md](docs/grok.md) |
+| Devin | `devin acp` | Native | [docs/devin.md](docs/devin.md) |
 | Antigravity | `agy-acp` | [agy-acp](agy-acp/) | [docs/antigravity.md](docs/antigravity.md) |
 | Pi | `pi-acp` | [pi-acp](https://www.npmjs.com/package/pi-acp) | [docs/pi.md](docs/pi.md) |
 | **Native Agent** | `openab-agent` | Built-in (Rust) | [docs/native-agent.md](docs/native-agent.md) |

--- a/config.toml.example
+++ b/config.toml.example
@@ -120,6 +120,15 @@ working_dir = "/home/agent"
 # # Run `opencode auth login` once before starting openab.
 
 # [agent]
+# command = "devin"
+# args = ["acp"]
+# working_dir = "/home/agent"
+# # Devin CLI (formerly Windsurf/Codeium) with native ACP support.
+# # Requires a Devin subscription (Enterprise or individual).
+# # Auth: kubectl exec -it <pod> -- devin auth login --force-manual-token-flow
+# # Also accepts WINDSURF_API_KEY env var for legacy Windsurf credentials.
+
+# [agent]
 # command = "mimo"
 # args = ["acp"]
 # working_dir = "/home/node"

--- a/config.toml.example
+++ b/config.toml.example
@@ -123,10 +123,9 @@ working_dir = "/home/agent"
 # command = "devin"
 # args = ["acp"]
 # working_dir = "/home/agent"
-# # Devin CLI (formerly Windsurf/Codeium) with native ACP support.
+# # Devin CLI (Cognition AI) with native ACP support.
 # # Requires a Devin subscription (Enterprise or individual).
 # # Auth: kubectl exec -it <pod> -- devin auth login --force-manual-token-flow
-# # Also accepts WINDSURF_API_KEY env var for legacy Windsurf credentials.
 
 # [agent]
 # command = "mimo"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,8 +16,8 @@
 group "default" {
   targets = [
     "kiro", "claude", "codex", "copilot", "cursor",
-    "gemini", "grok", "hermes", "mimocode", "opencode",
-    "antigravity", "pi", "gateway",
+    "devin", "gemini", "grok", "hermes", "mimocode",
+    "opencode", "antigravity", "pi", "gateway",
   ]
 }
 
@@ -62,6 +62,13 @@ target "copilot" {
 target "cursor" {
   dockerfile = "Dockerfile.cursor"
   tags       = ["openab:cursor"]
+  contexts   = { builder = "target:builder" }
+}
+
+target "devin" {
+  dockerfile = "Dockerfile.unified"
+  target     = "devin"
+  tags       = ["openab:devin"]
   contexts   = { builder = "target:builder" }
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -66,8 +66,7 @@ target "cursor" {
 }
 
 target "devin" {
-  dockerfile = "Dockerfile.unified"
-  target     = "devin"
+  dockerfile = "Dockerfile.devin"
   tags       = ["openab:devin"]
   contexts   = { builder = "target:builder" }
 }

--- a/docs/devin.md
+++ b/docs/devin.md
@@ -1,0 +1,121 @@
+# Devin CLI — Agent Backend Guide
+
+How to run OpenAB with [Devin CLI](https://docs.devin.ai/cli) as the agent backend.
+
+## Prerequisites
+
+- A [Devin](https://devin.ai/) subscription (Enterprise or individual plan)
+- Devin CLI with native ACP support (`devin acp`)
+
+## Architecture
+
+```
+┌──────────────┐  Gateway WS   ┌──────────────┐  ACP stdio    ┌──────────────┐
+│   Discord    │◄─────────────►│ openab       │──────────────►│ devin acp    │
+│   User       │               │   (Rust)     │◄── JSON-RPC ──│ (Devin CLI)  │
+└──────────────┘               └──────────────┘               └──────────────┘
+```
+
+OpenAB spawns `devin acp` as a child process and communicates via stdio JSON-RPC. No intermediate adapter needed — Devin CLI natively implements the Agent Client Protocol.
+
+## Configuration
+
+```toml
+[agent]
+command = "devin"
+args = ["acp"]
+working_dir = "/home/agent"
+```
+
+## Docker
+
+Build with the unified Dockerfile:
+
+```bash
+docker build --target devin -f Dockerfile.unified -t openab-devin .
+```
+
+Or via docker buildx bake:
+
+```bash
+docker buildx bake devin
+```
+
+The Dockerfile installs Devin CLI via the official install script (`https://cli.devin.ai/install.sh`).
+
+## Authentication
+
+Devin CLI requires authentication via a Devin account. In a headless container:
+
+```bash
+# 1. Exec into the running pod/container
+kubectl exec -it deployment/openab-devin -- bash
+
+# 2. Authenticate via manual token flow (headless-friendly)
+devin auth login --force-manual-token-flow
+
+# 3. Follow the instructions to paste your token
+
+# 4. Restart the pod (credentials persist via PVC)
+kubectl rollout restart deployment/openab-devin
+```
+
+Credentials are stored under `~/.config/devin/` and persist across pod restarts via PVC.
+
+### Alternative: WINDSURF_API_KEY
+
+For legacy Windsurf credentials, set the `WINDSURF_API_KEY` environment variable:
+
+```toml
+[agent]
+command = "devin"
+args = ["acp"]
+working_dir = "/home/agent"
+env = { WINDSURF_API_KEY = "${WINDSURF_API_KEY}" }
+```
+
+## Helm Install
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.devin.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.devin.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.devin.command=devin \
+  --set 'agents.devin.args={acp}' \
+  --set agents.devin.persistence.enabled=true \
+  --set agents.devin.workingDir=/home/agent \
+  --set image.tag=beta
+```
+
+### Image Tag
+
+Use `--set image.tag=<version>` to set the image version globally.
+The chart auto-appends `-<agent>` to produce the final tag (see [image-tags.md](image-tags.md) for full details).
+
+| Tag | Resolves to | Description |
+|-----|-------------|-------------|
+| `beta` | `beta-devin` | Floating beta channel (latest pre-release) |
+| `stable` | `stable-devin` | Floating stable channel |
+
+## Features
+
+Devin CLI provides:
+
+- **Native ACP**: `devin acp` speaks JSON-RPC over stdio directly
+- **AGENTS.md support**: Reads `AGENTS.md` at project root automatically
+- **MCP servers**: Full MCP support (stdio + HTTP transports)
+- **Subagents**: Can spawn foreground/background subagents for parallel work
+- **Session persistence**: Conversation history saved and resumable
+- **Models**: SWE-1.6 series with adaptive routing
+
+## AGENTS.md Compatibility
+
+Devin CLI reads `AGENTS.md` from the project root — the same file OpenAB already uses. It also reads `CLAUDE.md` (for Claude Code compatibility) and rules from `.cursor/rules/` and `.windsurf/rules/`.
+
+## Known Limitations
+
+- Requires a paid Devin subscription; no free tier for CLI access
+- `devin auth login` requires interactive terminal for browser flow; use `--force-manual-token-flow` in headless environments
+- Enterprise features (team settings, controls) require Devin Enterprise plan
+- Devin CLI is the rebranded Windsurf CLI (Codeium); legacy credentials still work via `WINDSURF_API_KEY`

--- a/docs/devin.md
+++ b/docs/devin.md
@@ -4,7 +4,7 @@ How to run OpenAB with [Devin CLI](https://docs.devin.ai/cli) as the agent backe
 
 ## Prerequisites
 
-- A [Devin](https://devin.ai/) subscription (Enterprise or individual plan)
+- A [Devin](https://devin.ai/) subscription (Enterprise or individual plan) from Cognition AI
 - Devin CLI with native ACP support (`devin acp`)
 
 ## Architecture
@@ -60,19 +60,7 @@ devin auth login --force-manual-token-flow
 kubectl rollout restart deployment/openab-devin
 ```
 
-Credentials are stored under `~/.config/devin/` and persist across pod restarts via PVC.
-
-### Alternative: WINDSURF_API_KEY
-
-For legacy Windsurf credentials, set the `WINDSURF_API_KEY` environment variable:
-
-```toml
-[agent]
-command = "devin"
-args = ["acp"]
-working_dir = "/home/agent"
-env = { WINDSURF_API_KEY = "${WINDSURF_API_KEY}" }
-```
+Credentials are stored under `~/.local/share/devin/` and persist across pod restarts via PVC.
 
 ## Helm Install
 
@@ -115,7 +103,7 @@ Devin CLI reads `AGENTS.md` from the project root — the same file OpenAB alrea
 
 ## Known Limitations
 
-- Requires a paid Devin subscription; no free tier for CLI access
+- Requires a paid Devin subscription (Cognition AI); no free tier for CLI access
 - `devin auth login` requires interactive terminal for browser flow; use `--force-manual-token-flow` in headless environments
 - Enterprise features (team settings, controls) require Devin Enterprise plan
-- Devin CLI is the rebranded Windsurf CLI (Codeium); legacy credentials still work via `WINDSURF_API_KEY`
+- Config file must be mounted at `/etc/openab/config.toml` at runtime (not baked into image)

--- a/docs/devin.md
+++ b/docs/devin.md
@@ -41,7 +41,7 @@ Or via docker buildx bake:
 docker buildx bake devin
 ```
 
-The Dockerfile installs Devin CLI via the official install script (`https://cli.devin.ai/install.sh`).
+The Dockerfile installs a pinned version of Devin CLI from `static.devin.ai` with SHA256 checksum verification. The version is controlled by the `DEVIN_VERSION` build arg.
 
 ## Authentication
 

--- a/docs/devin.md
+++ b/docs/devin.md
@@ -97,6 +97,48 @@ Devin CLI provides:
 - **Session persistence**: Conversation history saved and resumable
 - **Models**: SWE-1.6 series with adaptive routing
 
+## Model Selection
+
+Devin CLI uses its own model routing by default (SWE-1.6 series). To specify a model at startup:
+
+```toml
+[agent]
+command = "devin"
+args = ["acp", "--model", "opus"]
+working_dir = "/home/agent"
+```
+
+Available models can be checked via the interactive CLI with `/model`. In ACP mode, the `--model` flag selects the model for the session.
+
+## MCP Usage
+
+Devin CLI supports MCP servers configured via `.devin/config.json` or `devin mcp add`:
+
+```bash
+# Add an MCP server (persists in ~/.config/devin/)
+kubectl exec -it deployment/openab-devin -- devin mcp add github \
+  -- npx -y @modelcontextprotocol/server-github
+
+# List configured servers
+kubectl exec -it deployment/openab-devin -- devin mcp list
+```
+
+MCP configuration can also be placed in the project's `.devin/config.json`:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "ghp_xxx" }
+    }
+  }
+}
+```
+
+Devin CLI supports both stdio and HTTP (Streamable HTTP + SSE fallback) transports.
+
 ## AGENTS.md Compatibility
 
 Devin CLI reads `AGENTS.md` from the project root — the same file OpenAB already uses. It also reads `CLAUDE.md` (for Claude Code compatibility) and rules from `.cursor/rules/` and `.windsurf/rules/`.


### PR DESCRIPTION
## What problem does this solve?

Adds [Devin CLI](https://docs.devin.ai/cli) (formerly Windsurf/Codeium) as a new agent backend for OpenAB.

Devin CLI natively supports ACP via `devin acp` — JSON-RPC over stdio, same protocol as all other OAB backends.

## Prior Art & Industry Research

**OpenClaw:**
N/A — OpenClaw does not support Devin CLI.

**Hermes Agent:**
N/A — Hermes uses its own multi-provider architecture; Devin is not a supported target.

**Other references:**
- Devin CLI ACP docs: https://docs.devin.ai/cli/reference/commands#devin-acp
- Agent Client Protocol: https://agentclientprotocol.com/

## Proposed Solution

Standard OAB agent integration:
- `Dockerfile.unified`: new `devin` target using `base-debian`, installs via official install script
- `docker-bake.hcl`: adds `devin` to default build group
- `config.toml.example`: commented config block showing usage
- `docs/devin.md`: full integration guide (architecture, config, Docker, auth, Helm)

## Why this approach?

Devin CLI has **native ACP support** (`devin acp`) — no adapter needed. Same pattern as Kiro CLI (`kiro-cli acp`). Uses `base-debian` since Devin distributes a standalone binary (no Node.js required).

Auth uses `--force-manual-token-flow` for headless environments (containers/SSH).

## Alternatives Considered

- Writing a custom ACP adapter (like `agy-acp` for Antigravity) — unnecessary since Devin natively speaks ACP
- Using `base-node` — not needed, Devin is a standalone Rust binary

## Test Plan

- [x] Dockerfile syntax verified (target structure matches existing patterns)
- [x] docker-bake.hcl syntax valid
- [x] config.toml.example follows existing pattern
- [x] docs/devin.md follows established doc format (matches cursor.md pattern)