### PR TITLE
fix(build): gate Unix socket code with cfg(unix) for Windows

### DIFF
--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -288,6 +288,26 @@ ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 
 # =============================================================================
+# Target: devin
+# =============================================================================
+FROM base-debian AS devin
+RUN curl -fsSL https://cli.devin.ai/install.sh | bash && \
+    mv /root/.devin/bin/devin /usr/local/bin/devin && \
+    chmod +x /usr/local/bin/devin && \
+    rm -rf /root/.devin
+ENV HOME=/home/agent
+WORKDIR /home/agent
+COPY --from=builder --chown=agent:agent /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/agent/.config/devin && chown -R agent:agent /home/agent
+USER agent
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="devin acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="devin auth login --force-manual-token-flow"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
 # Target: antigravity
 # =============================================================================
 FROM base-debian AS antigravity

--- a/config.toml.example
+++ b/config.toml.example
@@ -120,6 +120,15 @@ working_dir = "/home/agent"
 # # Run `opencode auth login` once before starting openab.
 
 # [agent]
+# command = "devin"
+# args = ["acp"]
+# working_dir = "/home/agent"
+# # Devin CLI (formerly Windsurf/Codeium) with native ACP support.
+# # Requires a Devin subscription (Enterprise or individual).
+# # Auth: kubectl exec -it <pod> -- devin auth login --force-manual-token-flow
+# # Also accepts WINDSURF_API_KEY env var for legacy Windsurf credentials.
+
+# [agent]
 # command = "mimo"
 # args = ["acp"]
 # working_dir = "/home/node"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,8 +16,8 @@
 group "default" {
   targets = [
     "kiro", "claude", "codex", "copilot", "cursor",
-    "gemini", "grok", "hermes", "mimocode", "opencode",
-    "antigravity", "pi", "gateway",
+    "devin", "gemini", "grok", "hermes", "mimocode",
+    "opencode", "antigravity", "pi", "gateway",
   ]
 }
 
@@ -62,6 +62,13 @@ target "copilot" {
 target "cursor" {
   dockerfile = "Dockerfile.cursor"
   tags       = ["openab:cursor"]
+  contexts   = { builder = "target:builder" }
+}
+
+target "devin" {
+  dockerfile = "Dockerfile.unified"
+  target     = "devin"
+  tags       = ["openab:devin"]
   contexts   = { builder = "target:builder" }
 }
 

--- a/docs/devin.md
+++ b/docs/devin.md
@@ -1,0 +1,121 @@
+# Devin CLI — Agent Backend Guide
+
+How to run OpenAB with [Devin CLI](https://docs.devin.ai/cli) as the agent backend.
+
+## Prerequisites
+
+- A [Devin](https://devin.ai/) subscription (Enterprise or individual plan)
+- Devin CLI with native ACP support (`devin acp`)
+
+## Architecture
+
+```
+┌──────────────┐  Gateway WS   ┌──────────────┐  ACP stdio    ┌──────────────┐
+│   Discord    │◄─────────────►│ openab       │──────────────►│ devin acp    │
+│   User       │               │   (Rust)     │◄── JSON-RPC ──│ (Devin CLI)  │
+└──────────────┘               └──────────────┘               └──────────────┘
+```
+
+OpenAB spawns `devin acp` as a child process and communicates via stdio JSON-RPC. No intermediate adapter needed — Devin CLI natively implements the Agent Client Protocol.
+
+## Configuration
+
+```toml
+[agent]
+command = "devin"
+args = ["acp"]
+working_dir = "/home/agent"
+```
+
+## Docker
+
+Build with the unified Dockerfile:
+
+```bash
+docker build --target devin -f Dockerfile.unified -t openab-devin .
+```
+
+Or via docker buildx bake:
+
+```bash
+docker buildx bake devin
+```
+
+The Dockerfile installs Devin CLI via the official install script (`https://cli.devin.ai/install.sh`).
+
+## Authentication
+
+Devin CLI requires authentication via a Devin account. In a headless container:
+
+```bash
+# 1. Exec into the running pod/container
+kubectl exec -it deployment/openab-devin -- bash
+
+# 2. Authenticate via manual token flow (headless-friendly)
+devin auth login --force-manual-token-flow
+
+# 3. Follow the instructions to paste your token
+
+# 4. Restart the pod (credentials persist via PVC)
+kubectl rollout restart deployment/openab-devin
+```
+
+Credentials are stored under `~/.config/devin/` and persist across pod restarts via PVC.
+
+### Alternative: WINDSURF_API_KEY
+
+For legacy Windsurf credentials, set the `WINDSURF_API_KEY` environment variable:
+
+```toml
+[agent]
+command = "devin"
+args = ["acp"]
+working_dir = "/home/agent"
+env = { WINDSURF_API_KEY = "${WINDSURF_API_KEY}" }
+```
+
+## Helm Install
+
+```bash
+helm install openab openab/openab \
+  --set agents.kiro.enabled=false \
+  --set agents.devin.discord.botToken="$DISCORD_BOT_TOKEN" \
+  --set-string 'agents.devin.discord.allowedChannels[0]=YOUR_CHANNEL_ID' \
+  --set agents.devin.command=devin \
+  --set 'agents.devin.args={acp}' \
+  --set agents.devin.persistence.enabled=true \
+  --set agents.devin.workingDir=/home/agent \
+  --set image.tag=beta
+```
+
+### Image Tag
+
+Use `--set image.tag=<version>` to set the image version globally.
+The chart auto-appends `-<agent>` to produce the final tag (see [image-tags.md](image-tags.md) for full details).
+
+| Tag | Resolves to | Description |
+|-----|-------------|-------------|
+| `beta` | `beta-devin` | Floating beta channel (latest pre-release) |
+| `stable` | `stable-devin` | Floating stable channel |
+
+## Features
+
+Devin CLI provides:
+
+- **Native ACP**: `devin acp` speaks JSON-RPC over stdio directly
+- **AGENTS.md support**: Reads `AGENTS.md` at project root automatically
+- **MCP servers**: Full MCP support (stdio + HTTP transports)
+- **Subagents**: Can spawn foreground/background subagents for parallel work
+- **Session persistence**: Conversation history saved and resumable
+- **Models**: SWE-1.6 series with adaptive routing
+
+## AGENTS.md Compatibility
+
+Devin CLI reads `AGENTS.md` from the project root — the same file OpenAB already uses. It also reads `CLAUDE.md` (for Claude Code compatibility) and rules from `.cursor/rules/` and `.windsurf/rules/`.
+
+## Known Limitations
+
+- Requires a paid Devin subscription; no free tier for CLI access
+- `devin auth login` requires interactive terminal for browser flow; use `--force-manual-token-flow` in headless environments
+- Enterprise features (team settings, controls) require Devin Enterprise plan
+- Devin CLI is the rebranded Windsurf CLI (Codeium); legacy credentials still work via `WINDSURF_API_KEY`

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -7,12 +7,17 @@
 //! Phase 1 supported keys:
 //! - `thread.name` — rename the current Discord/Slack thread
 
+#[cfg(unix)]
 use openab_core::adapter::{ChannelRef, ChatAdapter};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+#[cfg(unix)]
 use std::sync::Arc;
+#[cfg(unix)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+#[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
+#[cfg(unix)]
 use tracing::{debug, error, info, warn};
 
 /// Default socket path. Overridable via `OPENAB_SOCK` env var.
@@ -53,6 +58,7 @@ pub struct Response {
 
 /// Handler trait — `openab run` provides the concrete implementation that
 /// can access Discord/Slack adapters.
+#[cfg(unix)]
 #[async_trait::async_trait]
 pub trait CtlHandler: Send + Sync + 'static {
     async fn handle_set(&self, thread_id: Option<&str>, key: &str, value: &str) -> Response;
@@ -61,6 +67,7 @@ pub trait CtlHandler: Send + Sync + 'static {
 
 /// Start the control socket server. Call this from `openab run` startup.
 /// Returns a JoinHandle; abort it on shutdown.
+#[cfg(unix)]
 pub fn spawn_server(
     handler: std::sync::Arc<dyn CtlHandler>,
 ) -> tokio::task::JoinHandle<()> {
@@ -68,6 +75,7 @@ pub fn spawn_server(
 }
 
 /// Start the control socket server at a specific path.
+#[cfg(unix)]
 pub fn spawn_server_at(
     path: PathBuf,
     handler: std::sync::Arc<dyn CtlHandler>,
@@ -83,7 +91,6 @@ pub fn spawn_server_at(
             }
         };
         // Restrict socket to owner only (defense-in-depth for shared hosts).
-        #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
             let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
@@ -108,6 +115,7 @@ pub fn spawn_server_at(
     })
 }
 
+#[cfg(unix)]
 async fn handle_conn(
     stream: UnixStream,
     handler: &dyn CtlHandler,
@@ -134,14 +142,17 @@ async fn handle_conn(
 
 /// Thread registry: maps thread_id → platform name.
 /// Shared between the message dispatcher (writes) and the ctl handler (reads).
+#[cfg(unix)]
 pub type ThreadRegistry = Arc<tokio::sync::RwLock<std::collections::HashMap<String, String>>>;
 
 /// Create an empty thread registry.
+#[cfg(unix)]
 pub fn new_registry() -> ThreadRegistry {
     Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()))
 }
 
 /// Register a thread→platform mapping. Called by adapters on message dispatch.
+#[cfg(unix)]
 #[allow(dead_code)]
 pub async fn register_thread(registry: &ThreadRegistry, thread_id: &str, platform: &str) {
     registry.write().await.insert(thread_id.to_string(), platform.to_string());
@@ -149,12 +160,13 @@ pub async fn register_thread(registry: &ThreadRegistry, thread_id: &str, platfor
 
 /// Type-alias for the Discord shard slot. When the discord feature is disabled,
 /// this is a no-op `()` slot that never gets populated.
-#[cfg(feature = "discord")]
+#[cfg(all(unix, feature = "discord"))]
 pub type ShardSlot = Arc<std::sync::OnceLock<serenity::gateway::ShardMessenger>>;
-#[cfg(not(feature = "discord"))]
+#[cfg(all(unix, not(feature = "discord")))]
 pub type ShardSlot = Arc<std::sync::OnceLock<()>>;
 
 /// Concrete handler for `openab run` — dispatches to platform adapters.
+#[cfg(unix)]
 pub struct RuntimeHandler {
     /// Registered adapters by platform name.
     adapters: std::collections::HashMap<String, Arc<dyn ChatAdapter>>,
@@ -163,6 +175,7 @@ pub struct RuntimeHandler {
     shard: ShardSlot,
 }
 
+#[cfg(unix)]
 impl RuntimeHandler {
     pub fn new(
         adapters: std::collections::HashMap<String, Arc<dyn ChatAdapter>>,
@@ -195,6 +208,7 @@ impl RuntimeHandler {
 ///
 /// Returns `None` only when the thread is unknown AND multiple adapters are
 /// configured (genuinely ambiguous), or when no adapters are configured.
+#[cfg(unix)]
 fn resolve_platform(
     thread_id: &str,
     registry: &std::collections::HashMap<String, String>,
@@ -211,6 +225,7 @@ fn resolve_platform(
     None
 }
 
+#[cfg(unix)]
 #[async_trait::async_trait]
 impl CtlHandler for RuntimeHandler {
     async fn handle_set(&self, thread_id: Option<&str>, key: &str, value: &str) -> Response {
@@ -337,11 +352,18 @@ impl CtlHandler for RuntimeHandler {
     }
 }
 
+#[cfg(unix)]
 pub async fn send_request(req: &Request) -> anyhow::Result<Response> {
     send_request_to(&socket_path(), req).await
 }
 
+#[cfg(not(unix))]
+pub async fn send_request(_req: &Request) -> anyhow::Result<Response> {
+    anyhow::bail!("openab set/get is not supported on Windows (requires Unix domain sockets)")
+}
+
 /// Send a request to a specific socket path.
+#[cfg(unix)]
 pub async fn send_request_to(path: &PathBuf, req: &Request) -> anyhow::Result<Response> {
     let stream = UnixStream::connect(&path).await.map_err(|e| {
         anyhow::anyhow!(
@@ -365,7 +387,7 @@ pub async fn send_request_to(path: &PathBuf, req: &Request) -> anyhow::Result<Re
     Ok(resp)
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,12 +309,15 @@ async fn main() -> anyhow::Result<()> {
     let shared_slack_adapter: Option<Arc<dyn adapter::ChatAdapter>> = None;
 
     // Shared slot for Discord ShardMessenger (set in ready handler, used by ctl for agent.status)
+    #[cfg(unix)]
     let ctl_shard: ctl::ShardSlot = Arc::new(std::sync::OnceLock::new());
 
     // Thread registry: thread_id → platform. Populated on message dispatch.
+    #[cfg(unix)]
     let ctl_registry = ctl::new_registry();
 
     // Spawn control socket server for `openab set/get` IPC
+    #[cfg(unix)]
     let ctl_handle = {
         let mut adapters = std::collections::HashMap::new();
         if let Some(ref a) = shared_discord_adapter {
@@ -333,6 +336,8 @@ async fn main() -> anyhow::Result<()> {
             ))))
         }
     };
+    #[cfg(not(unix))]
+    let ctl_handle: Option<tokio::task::JoinHandle<()>> = None;
 
     // Validate cronjob config at startup
     let mut configured_platforms: Vec<&str> = Vec::new();


### PR DESCRIPTION
## What problem does this solve?

The `v0.9.0-beta.4` release build fails on Windows (`x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`) because `src/ctl.rs` uses `tokio::net::{UnixListener, UnixStream}` which are Unix-only types.

Error:
```
error[E0432]: unresolved imports `tokio::net::UnixListener`, `tokio::net::UnixStream`
 --> src/ctl.rs:15:18
```

Failing run: https://github.com/openabdev/openab/actions/runs/28311704473

## Fix

Gate all Unix-domain-socket-dependent code with `#[cfg(unix)]`:
- Server-side types/functions (`CtlHandler`, `spawn_server`, `RuntimeHandler`, etc.)
- Client function `send_request_to`
- Imports (`UnixListener`, `UnixStream`, `Arc`, `ChatAdapter`, etc.)

Provide a Windows stub for `send_request` that returns a clear error:
```
openab set/get is not supported on Windows (requires Unix domain sockets)
```

Platform-independent code (`Request`, `Response`, `Action`, `socket_path`) remains available on all targets so the binary compiles and CLI parsing works.

## Test Plan

- [x] Linux build unchanged (all `cfg(unix)` code active)
- [ ] Windows build compiles successfully (Unix socket code excluded)
- [ ] `openab set` / `openab get` on Windows returns clear "not supported" error