### PR TITLE
fix(auth): remove code block so URLs are clickable

### DIFF
--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -2051,10 +2051,11 @@ impl Handler {
                 return;
             }
 
-            // Send the captured output (truncated to Discord's 2000-char limit).
+            // Send the captured output as plain text (no code block) so URLs are
+            // clickable in Discord.
             let output = strip_ansi_codes(&collected_lines.join("\n"));
-            let prefix = "🔐 **Agent Authentication**\n```\n";
-            let suffix = "\n```\nFollow the instructions above. Waiting for authorization...";
+            let prefix = "🔐 **Agent Authentication**\n\n";
+            let suffix = "\n\nFollow the instructions above. Waiting for authorization...";
             // Discord enforces the 2000-char limit in UTF-16 code units; budget and
             // truncate by UTF-16 units rather than Unicode scalar values. See
             // `truncate_to_utf16_budget` for the testable implementation.


### PR DESCRIPTION
## Summary
The `/auth` slash command wrapped the device-flow output in a markdown code block (\`\`\`), which prevents Discord from rendering URLs as clickable links. Users had to manually copy-paste the device auth URL.

## Change
Remove the code block wrapper and emit plain text instead. Discord auto-links URLs in plain text messages, making them clickable.

**Before:** output in code block → URL not clickable
**After:** plain text → URL clickable

## Testing
- Verified the change is a minimal 2-line prefix/suffix swap
- No logic change to truncation or auth flow