### PR TITLE
fix(telegram): dismiss thinking indicator on remove_reaction

### DIFF
--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -288,6 +288,13 @@ fn is_complex_markdown(text: &str) -> bool {
 
 /// Send a rich message via Bot API 10.1 sendRichMessage.
 ///
+/// Compute a stable draft_id from channel + thread to avoid collisions in forum topics.
+fn compute_draft_id(chat_id: &str, thread_id: &Option<String>) -> i64 {
+    let chan: i64 = chat_id.parse::<i64>().unwrap_or(1).abs();
+    let tid: i64 = thread_id.as_deref().and_then(|t| t.parse::<i64>().ok()).unwrap_or(0).abs();
+    (chan.wrapping_add(tid)) % 1_000_000 + 1
+}
+
 /// Design: we pass agent markdown directly via InputRichMessage.markdown.
 /// Rich Markdown is GFM-compatible, so no conversion layer is needed.
 /// The API handles rendering (tables, syntax highlighting, headings, etc.)
@@ -424,9 +431,7 @@ pub async fn handle_reply(
                     &reply.content.text
                 };
                 // Combine channel + thread to avoid draft_id collision in forum topics
-                let chan: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs();
-                let tid: i64 = reply.channel.thread_id.as_deref().and_then(|t| t.parse::<i64>().ok()).unwrap_or(0).abs();
-                let draft_id: i64 = (chan.wrapping_add(tid)) % 1_000_000 + 1;
+                let draft_id = compute_draft_id(&reply.channel.id, &reply.channel.thread_id);
                 let _ = send_rich_message_draft(client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id, text).await;
             }
             // else: rich_messages=false with dummy ref — silently drop (no real msg to edit)
@@ -462,9 +467,7 @@ pub async fn handle_reply(
                 _ => None,
             };
             if let Some(text) = thinking_text {
-                let chan: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs();
-                let tid: i64 = reply.channel.thread_id.as_deref().and_then(|t| t.parse::<i64>().ok()).unwrap_or(0).abs();
-                let draft_id: i64 = (chan.wrapping_add(tid)) % 1_000_000 + 1;
+                let draft_id = compute_draft_id(&reply.channel.id, &reply.channel.thread_id);
                 let _ = send_rich_message_draft(
                     client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id, text,
                 ).await;
@@ -474,12 +477,12 @@ pub async fn handle_reply(
         if rich_messages && reply.command.as_deref() == Some("remove_reaction") {
             let is_thinking_emoji = matches!(reply.content.text.as_str(), "👀" | "🤔" | "👨\u{200d}💻" | "🔥" | "⚡");
             if is_thinking_emoji {
-                let chan: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs();
-                let tid: i64 = reply.channel.thread_id.as_deref().and_then(|t| t.parse::<i64>().ok()).unwrap_or(0).abs();
-                let draft_id: i64 = (chan.wrapping_add(tid)) % 1_000_000 + 1;
-                let _ = send_rich_message_draft(
+                let draft_id = compute_draft_id(&reply.channel.id, &reply.channel.thread_id);
+                if let Err(e) = send_rich_message_draft(
                     client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id, "",
-                ).await;
+                ).await {
+                    warn!("failed to dismiss thinking draft: {e}");
+                }
             }
         }
 

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -470,6 +470,18 @@ pub async fn handle_reply(
                 ).await;
             }
         }
+        // Dismiss thinking draft immediately on remove_reaction
+        if rich_messages && reply.command.as_deref() == Some("remove_reaction") {
+            let is_thinking_emoji = matches!(reply.content.text.as_str(), "👀" | "🤔" | "👨\u{200d}💻" | "🔥" | "⚡");
+            if is_thinking_emoji {
+                let chan: i64 = reply.channel.id.parse::<i64>().unwrap_or(1).abs();
+                let tid: i64 = reply.channel.thread_id.as_deref().and_then(|t| t.parse::<i64>().ok()).unwrap_or(0).abs();
+                let draft_id: i64 = (chan.wrapping_add(tid)) % 1_000_000 + 1;
+                let _ = send_rich_message_draft(
+                    client, bot_token, &reply.channel.id, &reply.channel.thread_id, draft_id, "",
+                ).await;
+            }
+        }
 
         let msg_key = format!("{}:{}", reply.channel.id, reply.reply_to);
         let emoji = &reply.content.text;

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -286,8 +286,6 @@ fn is_complex_markdown(text: &str) -> bool {
     })
 }
 
-/// Send a rich message via Bot API 10.1 sendRichMessage.
-///
 /// Compute a stable draft_id from channel + thread to avoid collisions in forum topics.
 fn compute_draft_id(chat_id: &str, thread_id: &Option<String>) -> i64 {
     let chan: i64 = chat_id.parse::<i64>().unwrap_or(1).abs();
@@ -295,6 +293,8 @@ fn compute_draft_id(chat_id: &str, thread_id: &Option<String>) -> i64 {
     (chan.wrapping_add(tid)) % 1_000_000 + 1
 }
 
+/// Send a rich message via Bot API 10.1 sendRichMessage.
+///
 /// Design: we pass agent markdown directly via InputRichMessage.markdown.
 /// Rich Markdown is GFM-compatible, so no conversion layer is needed.
 /// The API handles rendering (tables, syntax highlighting, headings, etc.)


### PR DESCRIPTION
## Summary

Fixes the issue where the Telegram "Thinking..." indicator lingers for several seconds after the bot has already responded.

## Root Cause

When `add_reaction` is received (e.g. 🤔), a `sendRichMessageDraft` is sent to show the thinking animation. However, when `remove_reaction` is received (agent done), no corresponding dismiss was being sent — the draft just relied on its 30-second auto-expiry.

## Fix

Send an empty draft with the same `draft_id` on `remove_reaction` for any thinking emoji, which immediately clears the indicator.

## Testing

- Send a message to the Telegram bot
- Verify "Thinking..." appears and disappears as soon as the response is sent (not seconds later)