### PR TITLE
fix(discord): ensure URL separation in /auth output

### DIFF
--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -2054,6 +2054,7 @@ impl Handler {
             // Send the captured output as plain text (no code block) so URLs are
             // clickable in Discord.
             let output = strip_ansi_codes(&collected_lines.join("\n"));
+            let output = ensure_url_separation(&output);
             let prefix = "🔐 **Agent Authentication**\n\n";
             let suffix = "\n\nFollow the instructions above. Waiting for authorization...";
             // Discord enforces the 2000-char limit in UTF-16 code units; budget and
@@ -3014,6 +3015,16 @@ fn strip_ansi_codes(s: &str) -> String {
     ANSI_RE.replace_all(s, "").into_owned()
 }
 
+/// Ensure URLs are not glued to preceding text after ANSI stripping.
+/// Discord's markdown parser collapses list-continuation whitespace when a Link
+/// node is adjacent to a Text node, causing `accounthttps://...` rendering.
+/// This inserts a newline before any URL that immediately follows a non-whitespace char.
+fn ensure_url_separation(s: &str) -> String {
+    static URL_RE: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"(?P<prev>\S)(?P<url>https?://)").unwrap());
+    URL_RE.replace_all(s, "${prev}\n${url}").into_owned()
+}
+
 /// Truncate `body` so that, prefixed by `prefix` and suffixed by `suffix`, the
 /// whole message fits within `limit` measured in **UTF-16 code units** — which
 /// is how Discord enforces its 2000-character message cap. Truncation only ever
@@ -3118,6 +3129,40 @@ mod tests {
     fn strip_ansi_removes_non_sgr_sequences() {
         let input = "\x1b[?25lhello\x1b[?25h \x1b(Bworld";
         assert_eq!(strip_ansi_codes(input), "hello world");
+    }
+
+    // --- ensure_url_separation tests ---
+
+    #[test]
+    fn url_separation_inserts_newline_when_glued() {
+        assert_eq!(
+            ensure_url_separation("accounthttps://auth.openai.com/codex/device"),
+            "account\nhttps://auth.openai.com/codex/device"
+        );
+    }
+
+    #[test]
+    fn url_separation_preserves_existing_space() {
+        assert_eq!(
+            ensure_url_separation("account https://auth.openai.com"),
+            "account https://auth.openai.com"
+        );
+    }
+
+    #[test]
+    fn url_separation_preserves_existing_newline() {
+        assert_eq!(
+            ensure_url_separation("account\nhttps://auth.openai.com"),
+            "account\nhttps://auth.openai.com"
+        );
+    }
+
+    #[test]
+    fn url_separation_handles_http() {
+        assert_eq!(
+            ensure_url_separation("clickhttp://example.com"),
+            "click\nhttp://example.com"
+        );
     }
 
     // --- resolve_mentions tests ---


### PR DESCRIPTION
## Summary

Fix `/auth` slash command output where the device-flow URL gets glued to the preceding text (e.g. `accounthttps://auth.openai.com/codex/device`) instead of appearing on its own line.

## Root Cause

After `strip_ansi_codes()` removes ANSI color escapes from the CLI output, Discord's markdown parser treats the indented URL as a list-item continuation. The Link node gets merged with the preceding Text node, collapsing all whitespace between them.

## Fix

Add `ensure_url_separation()` — a targeted regex post-process applied only to the `/auth` output path:
- Pattern: `(\S)(https?://)` → `$1\n$2`
- Inserts a newline before any URL immediately preceded by a non-whitespace character
- No-op when URL is already preceded by space or newline

## Testing

4 unit tests added covering:
- Glued URL gets newline inserted
- Existing space preserved (no double-separation)
- Existing newline preserved
- Works for both `https://` and `http://`

## Scope

- Only `/auth` normal output path affected
- No changes to global `strip_ansi_codes` or other formatting
- Early-exit path unchanged (uses code block where URLs aren't linkified anyway)