### PR TITLE
refactor(gateway): decouple adapter tests via AppState::test_default()

### DIFF
--- a/crates/openab-gateway/src/adapters/line.rs
+++ b/crates/openab-gateway/src/adapters/line.rs
@@ -1146,23 +1146,7 @@ mod tests {
     #[tokio::test]
     async fn webhook_acknowledges_before_async_event_forwarding() {
         let (event_tx, mut event_rx) = broadcast::channel::<String>(8);
-        let state = Arc::new(crate::AppState {
-            telegram_bot_token: None,
-            telegram_secret_token: None,
-            telegram_rich_messages: false,
-            line_channel_secret: None,
-            line_access_token: None,
-            teams: None,
-            teams_service_urls: Mutex::new(HashMap::new()),
-            feishu: None,
-            google_chat: None,
-            wecom: None,
-            ws_token: None,
-            event_tx,
-            reply_token_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            line_webhook_semaphore: Arc::new(Semaphore::new(crate::LINE_WEBHOOK_CONCURRENCY_MAX)),
-            client: reqwest::Client::new(),
-        });
+        let state = Arc::new(crate::AppState::test_default(event_tx));
 
         let body = axum::body::Bytes::from(
             serde_json::json!({

--- a/crates/openab-gateway/src/adapters/teams.rs
+++ b/crates/openab-gateway/src/adapters/teams.rs
@@ -652,21 +652,8 @@ mod tests {
         let (event_tx, _rx) = tokio::sync::broadcast::channel(16);
 
         Arc::new(crate::AppState {
-            telegram_bot_token: None,
-            telegram_secret_token: None,
-            telegram_rich_messages: false,
-            line_channel_secret: None,
-            line_access_token: None,
             teams: Some(TeamsAdapter::new(make_config(vec![]))),
-            teams_service_urls: tokio::sync::Mutex::new(std::collections::HashMap::new()),
-            feishu: None,
-            google_chat: None,
-            wecom: None,
-            ws_token: None,
-            event_tx,
-            reply_token_cache: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-            line_webhook_semaphore: Arc::new(tokio::sync::Semaphore::new(crate::LINE_WEBHOOK_CONCURRENCY_MAX)),
-            client: reqwest::Client::new(),
+            ..crate::AppState::test_default(event_tx)
         })
     }
 

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -48,6 +48,36 @@ pub struct AppState {
 
 
 impl AppState {
+    /// Create a minimal AppState for testing. Only requires an `event_tx` sender;
+    /// all adapter fields default to `None`/empty. This decouples adapter tests
+    /// from each other — adding a new adapter no longer forces changes in
+    /// unrelated test files.
+    ///
+    /// See: <https://github.com/openabdev/openab/issues/1239>
+    pub fn test_default(event_tx: broadcast::Sender<String>) -> Self {
+        Self {
+            telegram_bot_token: None,
+            telegram_secret_token: None,
+            telegram_rich_messages: false,
+            line_channel_secret: None,
+            line_access_token: None,
+            #[cfg(feature = "teams")]
+            teams: None,
+            teams_service_urls: Mutex::new(HashMap::new()),
+            #[cfg(feature = "feishu")]
+            feishu: None,
+            #[cfg(feature = "googlechat")]
+            google_chat: None,
+            #[cfg(feature = "wecom")]
+            wecom: None,
+            ws_token: None,
+            event_tx,
+            reply_token_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            line_webhook_semaphore: Arc::new(Semaphore::new(LINE_WEBHOOK_CONCURRENCY_MAX)),
+            client: reqwest::Client::new(),
+        }
+    }
+
     /// Build AppState from environment variables.
     /// Initializes all platform adapters based on available env vars.
     /// `ws_token` is passed separately (only needed for standalone gateway mode).

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -53,6 +53,9 @@ impl AppState {
     /// from each other — adding a new adapter no longer forces changes in
     /// unrelated test files.
     ///
+    /// NOTE: Interim fix — the long-term solution is a full AdapterRegistry
+    /// (trait-object pattern) per the remaining scope of #1239.
+    ///
     /// See: <https://github.com/openabdev/openab/issues/1239>
     pub fn test_default(event_tx: broadcast::Sender<String>) -> Self {
         Self {


### PR DESCRIPTION
## Summary

Adds `AppState::test_default(event_tx)` — a test-only constructor that initializes all adapter fields to `None`/empty defaults. Adapter tests can now use struct update syntax to override only the fields they need:

```rust
// Before: must enumerate ALL fields (breaks when new adapters are added)
let state = Arc::new(crate::AppState {
    telegram_bot_token: None,
    line_channel_secret: None,
    teams: None,
    feishu: None,
    // ... 16 lines
});

// After: only specify what you test
let state = Arc::new(crate::AppState::test_default(event_tx));
// or with overrides:
let state = Arc::new(crate::AppState {
    teams: Some(TeamsAdapter::new(config)),
    ..crate::AppState::test_default(event_tx)
});
```

## Changes

- `lib.rs`: Add `AppState::test_default()` method
- `adapters/line.rs`: Replace 16-line struct literal → 1-line call
- `adapters/teams.rs`: Replace 14-line struct literal → 2-line struct update

## Scope

**Partial fix for #1239** — solves the immediate pain (new adapters don't force test file changes) but does NOT implement the full AdapterRegistry trait-object pattern. Issue #1239 remains open for the long-term architectural refactor.

## What was tested

- Syntax verified via `rustc --edition 2021` (no compilation errors beyond missing external crates)
- Logic review: struct update syntax correctly moves all unspecified fields from base expression
- cfg feature gates in `test_default()` mirror the struct definition exactly

Partially addresses #1239