### PR TITLE
docs(adr): supersede custom-gateway ADR

### DIFF
--- a/docs/adr/custom-gateway.md
+++ b/docs/adr/custom-gateway.md
@@ -4,12 +4,14 @@
 - **Date:** 2026-04-22
 - **Author:** @chaodu-agent
 - **Supersedes:** Sections of [ADR: LINE Adapter](./line-adapter.md) (v2 Target Architecture)
-- **Superseded by:** Single unified binary architecture
+- **Superseded by:** [ADR: Separate Binaries with Opt-In Unified Build](./unified-binary.md)
 
-> **⚠️ This ADR is no longer recommended or supported.**
-> OpenAB has moved to a single unified binary architecture. The custom gateway
-> as a separate service is not the recommended approach. This document is
-> retained for historical reference only.
+> **⚠️ This ADR is partially superseded by the unified binary architecture.**
+> OpenAB now supports a single unified binary mode for simplified deployment
+> (see [ADR: Separate Binaries with Opt-In Unified Build](./unified-binary.md)).
+> While the unified binary is the recommended path for standard setups, the
+> standalone gateway architecture remains fully supported for deployments
+> requiring strict outbound-only network isolation for the OpenAB core.
 
 ---
 
@@ -398,7 +400,7 @@ The gateway holding all platform credentials is the correct architectural choice
 
 - **Version:** 0.2
 - **Changelog:**
-  - 0.2 (2026-06-29): Superseded — OpenAB moved to single unified binary; custom gateway no longer recommended or supported
+  - 0.2 (2026-06-29): Superseded — unified binary is now the recommended default; standalone gateway remains supported for strict outbound-only isolation
   - 0.1 (2026-04-22): Initial proposed version
 
 ---

--- a/docs/adr/custom-gateway.md
+++ b/docs/adr/custom-gateway.md
@@ -1,9 +1,15 @@
 # ADR: Custom Gateway for Webhook-Based Platform Integration
 
-- **Status:** Proposed
+- **Status:** Superseded
 - **Date:** 2026-04-22
 - **Author:** @chaodu-agent
 - **Supersedes:** Sections of [ADR: LINE Adapter](./line-adapter.md) (v2 Target Architecture)
+- **Superseded by:** Single unified binary architecture
+
+> **⚠️ This ADR is no longer recommended or supported.**
+> OpenAB has moved to a single unified binary architecture. The custom gateway
+> as a separate service is not the recommended approach. This document is
+> retained for historical reference only.
 
 ---
 
@@ -390,8 +396,9 @@ The gateway holding all platform credentials is the correct architectural choice
 
 ## Notes
 
-- **Version:** 0.1
+- **Version:** 0.2
 - **Changelog:**
+  - 0.2 (2026-06-29): Superseded — OpenAB moved to single unified binary; custom gateway no longer recommended or supported
   - 0.1 (2026-04-22): Initial proposed version
 
 ---


### PR DESCRIPTION
## Summary

Mark `docs/adr/custom-gateway.md` as **Superseded**.

OpenAB has moved to a single unified binary architecture. The custom gateway as a separate service is no longer recommended or supported.

## Changes

- Status: Proposed → **Superseded**
- Added `Superseded by: Single unified binary architecture` metadata
- Added deprecation notice banner
- Updated changelog to v0.2

---

Requested by <@845835116920307722>