### PR TITLE
chore(gateway): remove unused imports from #1241

### DIFF
--- a/crates/openab-gateway/src/adapters/line.rs
+++ b/crates/openab-gateway/src/adapters/line.rs
@@ -733,9 +733,8 @@ pub async fn dispatch_line_reply(
 mod tests {
     use super::*;
     use axum::extract::State;
-    use std::collections::HashMap;
     use std::sync::Arc;
-    use tokio::sync::{broadcast, Mutex, Semaphore};
+    use tokio::sync::broadcast;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 


### PR DESCRIPTION
Removes `HashMap`, `Mutex`, and `Semaphore` imports in `line.rs` tests that became unused after #1241 replaced inline `AppState` construction with `AppState::test_default()`.

Missed in the squash merge of #1241.