### PR TITLE
build: pin rust builder image digest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,17 @@ Never leak `DISCORD_BOT_TOKEN` or other OAB credentials to the agent.
 
 ### 4. Dockerfile Discipline
 
-There are 11 Dockerfiles: `Dockerfile`, `Dockerfile.antigravity`, `Dockerfile.claude`, `Dockerfile.codex`, `Dockerfile.copilot`, `Dockerfile.cursor`, `Dockerfile.gemini`, `Dockerfile.grok`, `Dockerfile.hermes`, `Dockerfile.opencode`, `Dockerfile.pi`.
+The primary Dockerfile is `Dockerfile.unified` (multi-target, all variants). Legacy per-agent Dockerfiles exist but are deprecated.
 
-A change to one MUST be evaluated against ALL. Common layers (base image, openab binary, tini) are shared — update all or explain why not.
+A change to common layers (base image, openab binary, tini) affects ALL variants — test broadly.
+
+**Builder image is pinned by digest** in `Dockerfile.unified`. Do NOT change `rust:1-bookworm` to an unpinned rolling tag. The digest prevents silent glibc upgrades that break runtime compatibility. Update it only when intentionally upgrading the Rust toolchain:
+
+```bash
+docker pull rust:1-bookworm
+docker inspect rust:1-bookworm --format '{{index .RepoDigests 0}}'
+# Update the @sha256:... in Dockerfile.unified
+```
 
 ### 5. Cross-Platform
 

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -19,7 +19,13 @@ ARG BUILDER_IMAGE=local_builder
 # Only executed during build-core or local dev. When BUILDER_IMAGE is overridden
 # (CI build-agents), BuildKit prunes this stage entirely via dependency analysis.
 # =============================================================================
-FROM rust:1-bookworm AS local_builder
+# Pinned to prevent silent glibc upgrades that break runtime compatibility.
+# Update this digest when:
+#   - A crate requires a newer Rust compiler version
+#   - A Rust security advisory is published
+#   - Routine maintenance (every few months)
+# To get new digest: docker pull rust:1-bookworm && docker inspect rust:1-bookworm --format '{{index .RepoDigests 0}}'
+FROM rust:1-bookworm@sha256:5e2214abe154fe26e39f64488952e5c991eeed1d6d6da7cc8381ae83927f0cfc AS local_builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/openab-core/Cargo.toml crates/openab-core/Cargo.toml


### PR DESCRIPTION
## Problem

After building `pre-beta` images (run #28324260545), all containers failed at startup:

```
openab: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by openab)
openab: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by openab)
```

The runtime base is `debian:bookworm-slim` (glibc 2.36), but the binary was linked against glibc 2.38/2.39.

## Root Cause

```
rust:1-bookworm (rolling tag)
       │
       │  silently advanced to newer glibc
       ▼
GHA build cache (cache-from: type=gha)
       │
       │  cached cargo artifacts compiled against newer glibc
       ▼
build-core produces binary requiring GLIBC_2.38/2.39
       │
       ▼
debian:bookworm-slim (glibc 2.36) → CRASH
```

The `rust:1-bookworm` tag is rolling — Docker Hub can update it at any time. When combined with GHA layer caching, stale build artifacts compiled against a newer base can persist across builds, producing binaries incompatible with the runtime.

## Impact

- Entire ECS fleet (16 services) went down after upgrading to `pre-beta`
- Rolled back to `0.9.0-beta.4-*` images
- Purged GHA cache and triggered clean rebuild

## Fix

Pin `rust:1-bookworm` to a specific `@sha256:` digest. This ensures:
1. The builder image never silently upgrades
2. GHA cache layers are always compatible with the pinned base
3. Rust toolchain upgrades are intentional (update digest in a PR)

## Upgrade Process

When bumping Rust version:
```bash
docker pull rust:1-bookworm
docker inspect rust:1-bookworm --format "{{index .RepoDigests 0}}"
# Update the digest in Dockerfile.unified
```