### PR TITLE
feat(telegram): log source IP on webhook requests (phase 1)

### DIFF
--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -102,6 +102,27 @@ pub async fn webhook(
     headers: axum::http::HeaderMap,
     Json(update): Json<TelegramUpdate>,
 ) -> axum::http::StatusCode {
+    // Log source IP for monitoring (phase 1: observe before enforcing)
+    let source_ip = headers.get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.split(',').next())
+        .map(|s| s.trim().to_string())
+        .or_else(|| headers.get("x-real-ip").and_then(|v| v.to_str().ok()).map(|s| s.to_string()))
+        .or_else(|| headers.get("cf-connecting-ip").and_then(|v| v.to_str().ok()).map(|s| s.to_string()))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let is_telegram_subnet = check_telegram_subnet(&source_ip);
+    tracing::info!(
+        source_ip = %source_ip,
+        is_telegram = is_telegram_subnet,
+        "telegram webhook received"
+    );
+
+    if state.telegram_trusted_source_only && !is_telegram_subnet {
+        warn!(source_ip = %source_ip, "webhook rejected: source IP not in Telegram subnet");
+        return axum::http::StatusCode::FORBIDDEN;
+    }
+
     if let Some(ref expected) = state.telegram_secret_token {
         let provided = headers
             .get("x-telegram-bot-api-secret-token")
@@ -252,6 +273,27 @@ fn is_markdown_parse_error(description: &str) -> bool {
 /// - False positives are acceptable (rich renders simple text fine too), but we avoid
 ///   unnecessary API switches for plain prose to reduce risk surface.
 /// - LaTeX and blockquotes are intentionally omitted for now (Phase 2).
+/// Check if an IP is within Telegram's known webhook source subnets.
+/// See: https://core.telegram.org/bots/webhooks
+/// Subnets: 149.154.160.0/20, 91.108.4.0/22
+fn check_telegram_subnet(ip_str: &str) -> bool {
+    let ip: std::net::IpAddr = match ip_str.parse() {
+        Ok(ip) => ip,
+        Err(_) => return false,
+    };
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            // 149.154.160.0/20 → 149.154.160.0 - 149.154.175.255
+            let in_range1 = octets[0] == 149 && octets[1] == 154 && (octets[2] >= 160 && octets[2] <= 175);
+            // 91.108.4.0/22 → 91.108.4.0 - 91.108.7.255
+            let in_range2 = octets[0] == 91 && octets[1] == 108 && (octets[2] >= 4 && octets[2] <= 7);
+            in_range1 || in_range2
+        }
+        std::net::IpAddr::V6(_) => false,
+    }
+}
+
 fn is_complex_markdown(text: &str) -> bool {
     // 🟡 Code blocks intentionally NOT routed to rich — sendMessage preserves
     // syntax highlighting (language header + copy button) which RichBlockPreformatted lacks.

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -103,12 +103,19 @@ pub async fn webhook(
     Json(update): Json<TelegramUpdate>,
 ) -> axum::http::StatusCode {
     // Log source IP for monitoring (phase 1: observe before enforcing)
-    let source_ip = headers.get("x-forwarded-for")
+    // Priority: CF-Connecting-IP (edge proxy, non-spoofable) > X-Real-IP > X-Forwarded-For
+    // NOTE: XFF leftmost entry is client-supplied and spoofable. Phase 2 must implement
+    // trusted proxy configuration for accurate IP extraction when enforcement is enabled.
+    let source_ip = headers.get("cf-connecting-ip")
         .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.split(',').next())
         .map(|s| s.trim().to_string())
-        .or_else(|| headers.get("x-real-ip").and_then(|v| v.to_str().ok()).map(|s| s.to_string()))
-        .or_else(|| headers.get("cf-connecting-ip").and_then(|v| v.to_str().ok()).map(|s| s.to_string()))
+        .or_else(|| headers.get("x-real-ip").and_then(|v| v.to_str().ok()).map(|s| s.trim().to_string()))
+        .or_else(|| {
+            headers.get("x-forwarded-for")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.split(',').next())
+                .map(|s| s.trim().to_string())
+        })
         .unwrap_or_else(|| "unknown".to_string());
 
     let is_telegram_subnet = check_telegram_subnet(&source_ip);
@@ -258,6 +265,27 @@ fn chunk_text(text: &str, limit: usize) -> Vec<String> {
     chunks
 }
 
+/// Check if an IP is within Telegram's known webhook source subnets.
+/// See: <https://core.telegram.org/bots/webhooks>
+/// Subnets: 149.154.160.0/20, 91.108.4.0/22
+fn check_telegram_subnet(ip_str: &str) -> bool {
+    let ip: std::net::IpAddr = match ip_str.parse() {
+        Ok(ip) => ip,
+        Err(_) => return false,
+    };
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            // 149.154.160.0/20 → 149.154.160.0 - 149.154.175.255
+            let in_range1 = octets[0] == 149 && octets[1] == 154 && (160..=175).contains(&octets[2]);
+            // 91.108.4.0/22 → 91.108.4.0 - 91.108.7.255
+            let in_range2 = octets[0] == 91 && octets[1] == 108 && (4..=7).contains(&octets[2]);
+            in_range1 || in_range2
+        }
+        std::net::IpAddr::V6(_) => false,
+    }
+}
+
 fn is_markdown_parse_error(description: &str) -> bool {
     let desc_lower = description.to_lowercase();
     desc_lower.contains("can't find end")
@@ -273,27 +301,6 @@ fn is_markdown_parse_error(description: &str) -> bool {
 /// - False positives are acceptable (rich renders simple text fine too), but we avoid
 ///   unnecessary API switches for plain prose to reduce risk surface.
 /// - LaTeX and blockquotes are intentionally omitted for now (Phase 2).
-/// Check if an IP is within Telegram's known webhook source subnets.
-/// See: https://core.telegram.org/bots/webhooks
-/// Subnets: 149.154.160.0/20, 91.108.4.0/22
-fn check_telegram_subnet(ip_str: &str) -> bool {
-    let ip: std::net::IpAddr = match ip_str.parse() {
-        Ok(ip) => ip,
-        Err(_) => return false,
-    };
-    match ip {
-        std::net::IpAddr::V4(v4) => {
-            let octets = v4.octets();
-            // 149.154.160.0/20 → 149.154.160.0 - 149.154.175.255
-            let in_range1 = octets[0] == 149 && octets[1] == 154 && (octets[2] >= 160 && octets[2] <= 175);
-            // 91.108.4.0/22 → 91.108.4.0 - 91.108.7.255
-            let in_range2 = octets[0] == 91 && octets[1] == 108 && (octets[2] >= 4 && octets[2] <= 7);
-            in_range1 || in_range2
-        }
-        std::net::IpAddr::V6(_) => false,
-    }
-}
-
 fn is_complex_markdown(text: &str) -> bool {
     // 🟡 Code blocks intentionally NOT routed to rich — sendMessage preserves
     // syntax highlighting (language header + copy button) which RichBlockPreformatted lacks.
@@ -952,6 +959,28 @@ mod tests {
         assert!(is_markdown_parse_error("can't parse entities in message text"));
         assert!(!is_markdown_parse_error("Unauthorized"));
         assert!(!is_markdown_parse_error("Bad Request: chat not found"));
+    }
+
+    #[test]
+    fn test_check_telegram_subnet() {
+        // 149.154.160.0/20 boundaries
+        assert!(!check_telegram_subnet("149.154.159.255"));
+        assert!(check_telegram_subnet("149.154.160.0"));
+        assert!(check_telegram_subnet("149.154.175.255"));
+        assert!(!check_telegram_subnet("149.154.176.0"));
+        // 91.108.4.0/22 boundaries
+        assert!(!check_telegram_subnet("91.108.3.255"));
+        assert!(check_telegram_subnet("91.108.4.0"));
+        assert!(check_telegram_subnet("91.108.7.255"));
+        assert!(!check_telegram_subnet("91.108.8.0"));
+        // Invalid inputs
+        assert!(!check_telegram_subnet("unknown"));
+        assert!(!check_telegram_subnet(""));
+        assert!(!check_telegram_subnet("not-an-ip"));
+        assert!(!check_telegram_subnet("::1"));
+        // Non-Telegram IPs
+        assert!(!check_telegram_subnet("8.8.8.8"));
+        assert!(!check_telegram_subnet("192.168.1.1"));
     }
 
     #[test]

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -28,6 +28,7 @@ pub struct AppState {
     pub telegram_bot_token: Option<String>,
     pub telegram_secret_token: Option<String>,
     pub telegram_rich_messages: bool,
+    pub telegram_trusted_source_only: bool,
     pub line_channel_secret: Option<String>,
     pub line_access_token: Option<String>,
     #[cfg(feature = "teams")]
@@ -62,6 +63,7 @@ impl AppState {
             telegram_bot_token: None,
             telegram_secret_token: None,
             telegram_rich_messages: false,
+            telegram_trusted_source_only: false,
             line_channel_secret: None,
             line_access_token: None,
             #[cfg(feature = "teams")]
@@ -93,6 +95,9 @@ impl AppState {
         let telegram_rich_messages = std::env::var("TELEGRAM_RICH_MESSAGES")
             .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
             .unwrap_or(true);
+        let telegram_trusted_source_only = std::env::var("TELEGRAM_TRUSTED_SOURCE_ONLY")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
 
         // LINE
         let line_channel_secret = std::env::var("LINE_CHANNEL_SECRET").ok();
@@ -160,6 +165,7 @@ impl AppState {
             telegram_bot_token,
             telegram_secret_token,
             telegram_rich_messages,
+            telegram_trusted_source_only,
             line_channel_secret,
             line_access_token,
             #[cfg(feature = "teams")]
@@ -226,6 +232,10 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
         .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
         .unwrap_or(true);
     #[cfg(feature = "telegram")]
+    let telegram_trusted_source_only = std::env::var("TELEGRAM_TRUSTED_SOURCE_ONLY")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    #[cfg(feature = "telegram")]
     if telegram_bot_token.is_some() {
         let webhook_path =
             std::env::var("TELEGRAM_WEBHOOK_PATH").unwrap_or_else(|_| "/webhook/telegram".into());
@@ -241,6 +251,8 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
     let telegram_secret_token: Option<String> = None;
     #[cfg(not(feature = "telegram"))]
     let telegram_rich_messages = false;
+    #[cfg(not(feature = "telegram"))]
+    let telegram_trusted_source_only = false;
 
     // LINE adapter
     #[cfg(feature = "line")]
@@ -393,6 +405,7 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
         telegram_bot_token,
         telegram_secret_token,
         telegram_rich_messages,
+        telegram_trusted_source_only,
         line_channel_secret,
         line_access_token,
         #[cfg(feature = "teams")]

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -232,10 +232,6 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
         .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
         .unwrap_or(true);
     #[cfg(feature = "telegram")]
-    let telegram_trusted_source_only = std::env::var("TELEGRAM_TRUSTED_SOURCE_ONLY")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-    #[cfg(feature = "telegram")]
     if telegram_bot_token.is_some() {
         let webhook_path =
             std::env::var("TELEGRAM_WEBHOOK_PATH").unwrap_or_else(|_| "/webhook/telegram".into());
@@ -251,8 +247,6 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
     let telegram_secret_token: Option<String> = None;
     #[cfg(not(feature = "telegram"))]
     let telegram_rich_messages = false;
-    #[cfg(not(feature = "telegram"))]
-    let telegram_trusted_source_only = false;
 
     // LINE adapter
     #[cfg(feature = "line")]
@@ -405,7 +399,9 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
         telegram_bot_token,
         telegram_secret_token,
         telegram_rich_messages,
-        telegram_trusted_source_only,
+        telegram_trusted_source_only: std::env::var("TELEGRAM_TRUSTED_SOURCE_ONLY")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false),
         line_channel_secret,
         line_access_token,
         #[cfg(feature = "teams")]


### PR DESCRIPTION
## Context

Telegram webhooks should only originate from known subnets. From the [official docs](https://core.telegram.org/bots/webhooks):

> Accepts incoming POSTs from subnets **149.154.160.0/20** and **91.108.4.0/22**

## Phase 1: Observe

This PR adds source IP logging to all Telegram webhook requests so we can monitor and validate before enforcing.

### What it does

1. Extracts source IP from `X-Forwarded-For` → `X-Real-IP` → `CF-Connecting-IP` → `"unknown"`
2. Checks if IP falls within Telegram subnets
3. Logs: `telegram webhook received source_ip=x.x.x.x is_telegram=true/false`
4. When `TELEGRAM_TRUSTED_SOURCE_ONLY=true`, rejects non-Telegram IPs with 403

### Config

| Env Var | Default | Description |
|---------|---------|-------------|
| `TELEGRAM_TRUSTED_SOURCE_ONLY` | `false` | When `true`, reject webhooks from non-Telegram IPs |

### Phase 2 (future)

Once we confirm the source IPs from logs, flip default to `true` and add `trusted_proxies` config for accurate XFF parsing behind reverse proxies.

## References

- https://core.telegram.org/bots/webhooks