### PR TITLE
docs: pause OpenSHELL support — not recommended

### DIFF
--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -1,5 +1,23 @@
 # OpenShell
 
+> ⚠️ **NOT RECOMMENDED (June 2026)**
+>
+> OpenSHELL support is **paused** and not recommended for use at this time.
+>
+> **Reason:** Recent OpenSHELL updates enforce mandatory Network Policy Enforcement
+> and require all sandbox traffic to pass through an L7 proxy. This prevents direct
+> outbound connections — including the WebSocket (WSS) connection to Discord Gateway
+> that OpenAB requires for real-time communication.
+>
+> Unless OAB's networking layer is refactored to be fully HTTP/HTTPS proxy-aware
+> (tunneling WSS through OpenSHELL's L7 proxy), the integration cannot function.
+>
+> **Status:** Blocked. We will re-evaluate when:
+> - OpenSHELL provides a relaxed policy option (e.g., outbound WSS allowlist), or
+> - OAB completes a proxy-aware networking refactor.
+>
+> See [PR #1113](https://github.com/openabdev/openab/pull/1113) for full context.
+
 Run OAB inside an [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandbox for isolated, policy-enforced execution.
 
 ## Architecture


### PR DESCRIPTION
## Summary

Mark OpenSHELL integration as **not recommended** due to recent upstream changes that break OpenAB's core functionality.

## What Changed Upstream

OpenSHELL's recent updates enforce:
- **Mandatory Network Policy Enforcement** — strict network access control on all sandboxes
- **Forced L7 Proxy** — all outbound traffic must pass through an L7 proxy; direct connections (including WebSocket) are blocked

## Impact on OpenAB

OpenAB requires a persistent WebSocket connection to Discord Gateway (`wss://gateway.discord.gg`). Under the new policy, the sandbox cannot establish this connection unless OAB's entire networking layer is refactored to be HTTP/HTTPS proxy-aware and can tunnel WSS through OpenSHELL's L7 proxy.

## Changes

- Added a prominent warning banner to `docs/openshell.md` indicating this path is paused and not recommended
- Documented the technical reason and conditions for re-evaluation

## Re-evaluation Conditions

- OpenSHELL provides a relaxed option (e.g., outbound WSS allowlist)
- OAB completes proxy-aware networking refactor

Ref: #1113

https://discord.com/channels/1491295327620169908/1491365150664560881/1521184841192964238