### PR TITLE
fix(docker): upgrade runtime base to Debian Trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/li
     fi
 
 # --- Runtime stage ---
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install kiro-cli (auto-detect arch, copy binary directly)

--- a/Dockerfile.agentcore
+++ b/Dockerfile.agentcore
@@ -19,7 +19,7 @@ COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release --features agentcore
 
 # --- Runtime stage ---
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates tini \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,33 +1,9 @@
 # --- Build openab ---
-FROM rust:1-bookworm AS builder
-WORKDIR /build
-COPY Cargo.toml Cargo.lock ./
-COPY crates/openab-core/Cargo.toml crates/openab-core/Cargo.toml
-COPY crates/openab-gateway/Cargo.toml crates/openab-gateway/Cargo.toml
-RUN mkdir -p src crates/openab-core/src crates/openab-gateway/src \
-    && echo 'fn main() {}' > src/main.rs \
-    && echo '' > crates/openab-core/src/lib.rs \
-    && echo '' > crates/openab-gateway/src/lib.rs \
-    && cargo build --release \
-    && rm -rf src crates/openab-core/src crates/openab-gateway/src
-COPY crates/ crates/
-COPY src/ src/
-RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
-
-# --- Build agy-acp adapter ---
-FROM rust:1-bookworm AS adapter-builder
-WORKDIR /build
-COPY agy-acp/Cargo.toml ./
-RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
-COPY agy-acp/src/ src/
-RUN touch src/main.rs && cargo build --release
-
-# --- Runtime stage ---
 FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps tini unzip && rm -rf /var/lib/apt/lists/*
 
-# Install agy (Google Antigravity CLI) — pinned version
-ENV AGY_VERSION=1.0.10
+# Install agy (Google Antigravity CLI) — pinned to v1.0.4
+ENV AGY_VERSION=1.0.4
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) ASSET="agy_cli_linux_x64.tar.gz" ;; \
@@ -59,8 +35,5 @@ RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND="agy-acp"
-ENV OPENAB_AGENT_AUTH_COMMAND="agy auth"
-
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -15,7 +15,7 @@ COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
 
 # --- Runtime stage ---
-FROM node:22-bookworm-slim
+FROM node:22-trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini bubblewrap socat unzip && rm -rf /var/lib/apt/lists/*
 
 # Install claude-agent-acp adapter and Claude Code CLI.

--- a/Dockerfile.codex
+++ b/Dockerfile.codex
@@ -15,7 +15,7 @@ COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
 
 # --- Runtime stage ---
-FROM node:22-bookworm-slim
+FROM node:22-trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini bubblewrap unzip && rm -rf /var/lib/apt/lists/*
 
 # Pre-install codex-acp and codex CLI globally

--- a/Dockerfile.copilot
+++ b/Dockerfile.copilot
@@ -15,7 +15,7 @@ COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
 
 # --- Runtime stage ---
-FROM node:22-bookworm-slim
+FROM node:22-trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub Copilot CLI via npm (pinned version)

--- a/Dockerfile.cursor
+++ b/Dockerfile.cursor
@@ -15,7 +15,7 @@ COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
 
 # --- Runtime stage ---
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install Cursor Agent CLI (pinned version)

--- a/Dockerfile.devin
+++ b/Dockerfile.devin
@@ -15,7 +15,7 @@ COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
 
 # --- Runtime stage ---
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl procps ripgrep tini git unzip \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.final
+++ b/Dockerfile.final
@@ -1,33 +1,12 @@
+FROM debian:trixie-slim AS builder
+RUN mkdir -p /build/target/release
+COPY .pre-built/* /build/target/release/
 # --- Build openab ---
-FROM rust:1-bookworm AS builder
-WORKDIR /build
-COPY Cargo.toml Cargo.lock ./
-COPY crates/openab-core/Cargo.toml crates/openab-core/Cargo.toml
-COPY crates/openab-gateway/Cargo.toml crates/openab-gateway/Cargo.toml
-RUN mkdir -p src crates/openab-core/src crates/openab-gateway/src \
-    && echo 'fn main() {}' > src/main.rs \
-    && echo '' > crates/openab-core/src/lib.rs \
-    && echo '' > crates/openab-gateway/src/lib.rs \
-    && cargo build --release \
-    && rm -rf src crates/openab-core/src crates/openab-gateway/src
-COPY crates/ crates/
-COPY src/ src/
-RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
-
-# --- Build agy-acp adapter ---
-FROM rust:1-bookworm AS adapter-builder
-WORKDIR /build
-COPY agy-acp/Cargo.toml ./
-RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
-COPY agy-acp/src/ src/
-RUN touch src/main.rs && cargo build --release
-
-# --- Runtime stage ---
 FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps tini unzip && rm -rf /var/lib/apt/lists/*
 
-# Install agy (Google Antigravity CLI) — pinned version
-ENV AGY_VERSION=1.0.10
+# Install agy (Google Antigravity CLI) — pinned to v1.0.4
+ENV AGY_VERSION=1.0.4
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) ASSET="agy_cli_linux_x64.tar.gz" ;; \
@@ -59,8 +38,5 @@ RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent
 USER agent
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD pgrep -x openab || exit 1
-ENV OPENAB_AGENT_COMMAND="agy-acp"
-ENV OPENAB_AGENT_AUTH_COMMAND="agy auth"
-
 ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -33,7 +33,7 @@ RUN touch crates/openab-gateway/src/main.rs crates/openab-gateway/src/lib.rs && 
     fi
 
 # --- Runtime stage ---
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tini && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash -u 1000 gateway

--- a/Dockerfile.gemini
+++ b/Dockerfile.gemini
@@ -15,7 +15,7 @@ COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
 
 # --- Runtime stage ---
-FROM node:22-bookworm-slim
+FROM node:22-trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI (native ACP support via --acp)

--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -15,7 +15,7 @@ COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
 
 # --- Runtime stage ---
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 # Create agent user first so WORKDIR gets correct ownership
 RUN useradd -m -u 1000 agent

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -15,7 +15,7 @@ COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
 
 # --- Runtime stage ---
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-trixie
 
 # Create agent user first so WORKDIR gets correct ownership
 RUN useradd -m -u 1000 agent

--- a/Dockerfile.mimocode
+++ b/Dockerfile.mimocode
@@ -23,7 +23,7 @@ RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/li
 # ACP is supported via `mimo acp` (same JSON-RPC/stdio protocol as OpenCode).
 #
 # Version is pinned for reproducible builds.
-FROM node:22-bookworm-slim
+FROM node:22-trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install MiMo-Code

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -17,7 +17,7 @@ RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/li
 RUN cd openab-agent && cargo build --release
 
 # --- Runtime stage ---
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install gh CLI

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -15,7 +15,7 @@ COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
 
 # --- Runtime stage ---
-# node:22-bookworm-slim mirrors the base image used by Dockerfile.claude,
+# node:22-trixie-slim mirrors the base image used by Dockerfile.claude,
 # Dockerfile.codex, and Dockerfile.gemini, keeping the project on a single
 # consistent runtime base.
 #
@@ -40,7 +40,7 @@ RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/li
 # The upstream fix landed in 1.17.0 (sst/opencode#30332,
 # "fix(opencode): generate reasoning variants for all OpenRouter models").
 # 1.17.3 is the latest 1.17.x verified by users to recover correctly.
-FROM node:22-bookworm-slim
+FROM node:22-trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps ripgrep tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install opencode

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -15,7 +15,7 @@ COPY openab openab-agent* agy-acp* /
 # =============================================================================
 # Stage: base-debian — shared runtime base for debian-based agents
 # =============================================================================
-FROM debian:bookworm-slim AS base-debian
+FROM debian:trixie-slim AS base-debian
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl procps ripgrep tini git unzip \
     && rm -rf /var/lib/apt/lists/*
@@ -30,7 +30,7 @@ RUN useradd -m -s /bin/bash -u 1000 agent
 # =============================================================================
 # Stage: base-node — shared runtime base for node-based agents
 # =============================================================================
-FROM node:22-bookworm-slim AS base-node
+FROM node:22-trixie-slim AS base-node
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl procps ripgrep tini bubblewrap socat unzip git \
     && rm -rf /var/lib/apt/lists/*
@@ -201,7 +201,7 @@ CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 # =============================================================================
 # Target: hermes
 # =============================================================================
-FROM python:3.12-slim-bookworm AS hermes
+FROM python:3.12-slim-trixie AS hermes
 RUN useradd -m -u 1000 agent
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl procps ripgrep tini git ffmpeg unzip xz-utils \
@@ -368,7 +368,7 @@ CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 # =============================================================================
 # Target: agentcore (minimal — no agent CLI bundled)
 # =============================================================================
-FROM debian:bookworm-slim AS agentcore
+FROM debian:trixie-slim AS agentcore
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates tini \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.pi
+++ b/Dockerfile.pi
@@ -15,7 +15,7 @@ COPY src/ src/
 RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs && cargo build --release
 
 # --- Runtime stage ---
-FROM node:22-bookworm-slim
+FROM node:22-trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git procps ripgrep tini bubblewrap socat unzip && rm -rf /var/lib/apt/lists/*
 
 # Install pi-acp adapter and Pi coding agent CLI.

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -60,7 +60,7 @@ RUN for bin in /build/target/release/openab \
 # =============================================================================
 # Stage: base-debian — shared runtime base for debian-based agents
 # =============================================================================
-FROM debian:bookworm-slim AS base-debian
+FROM debian:trixie-slim AS base-debian
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl procps ripgrep tini git unzip \
     && rm -rf /var/lib/apt/lists/*
@@ -75,7 +75,7 @@ RUN useradd -m -s /bin/bash -u 1000 agent
 # =============================================================================
 # Stage: base-node — shared runtime base for node-based agents
 # =============================================================================
-FROM node:22-bookworm-slim AS base-node
+FROM node:22-trixie-slim AS base-node
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl procps ripgrep tini bubblewrap socat unzip git \
     && rm -rf /var/lib/apt/lists/*
@@ -246,7 +246,7 @@ CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 # =============================================================================
 # Target: hermes
 # =============================================================================
-FROM python:3.12-slim-bookworm AS hermes
+FROM python:3.12-slim-trixie AS hermes
 RUN useradd -m -u 1000 agent
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl procps ripgrep tini git ffmpeg unzip xz-utils \
@@ -413,7 +413,7 @@ CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 # =============================================================================
 # Target: agentcore (minimal — no agent CLI bundled)
 # =============================================================================
-FROM debian:bookworm-slim AS agentcore
+FROM debian:trixie-slim AS agentcore
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates tini \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem

All bots crash immediately with:
```
/usr/local/bin/openab: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
/usr/local/bin/openab: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

The `compile` job in `pre-beta-build.yml` runs on `ubuntu-latest` (24.04, GLIBC 2.39) but runtime images used `debian:bookworm-slim` (GLIBC 2.36).

## Fix

Upgrade all runtime bases from Bookworm (Debian 12) to Trixie (Debian 13 stable, GLIBC 2.40):
- `debian:bookworm-slim` → `debian:trixie-slim`
- `node:22-bookworm-slim` → `node:22-trixie-slim`
- `python:3.12-slim-bookworm` → `python:3.12-slim-trixie`

## Testing

Trigger pre-beta build after merge, verify bots start cleanly.