### PR TITLE
ci(bundle-utils): auto-resolve latest versions

### DIFF
--- a/.github/workflows/bundle-pre-seed-utils.yml
+++ b/.github/workflows/bundle-pre-seed-utils.yml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       aws_cli_version:
-        description: 'AWS CLI v2 version (e.g. 2.35.12)'
-        required: true
-        default: '2.35.12'
+        description: 'AWS CLI v2 version (leave empty for latest)'
+        required: false
+        default: ''
       ghpool_version:
-        description: 'ghpool version (e.g. 0.3.2)'
-        required: true
-        default: '0.3.2'
+        description: 'ghpool version (leave empty for latest)'
+        required: false
+        default: ''
       upload_s3:
         description: 'Also upload to S3 (openab-state-pahud/shared/utils.tar.gz)'
         required: false
@@ -24,7 +24,43 @@ env:
   ARTIFACT_NAME: pre-seed-utils
 
 jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      aws_cli_version: ${{ steps.versions.outputs.aws_cli_version }}
+      ghpool_version: ${{ steps.versions.outputs.ghpool_version }}
+    steps:
+      - name: Resolve versions
+        id: versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # AWS CLI version
+          if [ -n "${{ inputs.aws_cli_version }}" ]; then
+            AWS_VER="${{ inputs.aws_cli_version }}"
+          else
+            AWS_VER=$(curl -fsSL https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst | grep -m1 '^[0-9]' | cut -d' ' -f1)
+            echo "Resolved latest AWS CLI: $AWS_VER"
+          fi
+          echo "aws_cli_version=${AWS_VER}" >> "$GITHUB_OUTPUT"
+
+          # ghpool version
+          if [ -n "${{ inputs.ghpool_version }}" ]; then
+            GHP_VER="${{ inputs.ghpool_version }}"
+          else
+            GHP_VER=$(gh release view --repo openabdev/ghpool --json tagName -q '.tagName' | sed 's/^v//')
+            echo "Resolved latest ghpool: $GHP_VER"
+          fi
+          echo "ghpool_version=${GHP_VER}" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        run: |
+          echo "### Resolved Versions" >> "$GITHUB_STEP_SUMMARY"
+          echo "- AWS CLI: ${{ steps.versions.outputs.aws_cli_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ghpool: ${{ steps.versions.outputs.ghpool_version }}" >> "$GITHUB_STEP_SUMMARY"
+
   bundle:
+    needs: resolve
     strategy:
       matrix:
         include:
@@ -34,7 +70,7 @@ jobs:
     steps:
       - name: Install AWS CLI v2
         run: |
-          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${{ matrix.awscli_arch }}-${{ inputs.aws_cli_version }}.zip" -o /tmp/awscli.zip
+          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${{ matrix.awscli_arch }}-${{ needs.resolve.outputs.aws_cli_version }}.zip" -o /tmp/awscli.zip
           unzip -q /tmp/awscli.zip -d /tmp
           /tmp/aws/install --install-dir ./aws-cli --bin-dir ./bin
           rm -rf /tmp/aws /tmp/awscli.zip
@@ -45,11 +81,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release download "v${{ inputs.ghpool_version }}" \
+          GHP_VER="${{ needs.resolve.outputs.ghpool_version }}"
+          gh release download "v${GHP_VER}" \
             --repo openabdev/ghpool \
-            --pattern "ghpool-${{ inputs.ghpool_version }}-${{ matrix.ghpool_arch }}.tar.gz" \
+            --pattern "ghpool-${GHP_VER}-${{ matrix.ghpool_arch }}.tar.gz" \
             --dir /tmp
-          tar -xzf /tmp/ghpool-${{ inputs.ghpool_version }}-${{ matrix.ghpool_arch }}.tar.gz -C /tmp
+          tar -xzf /tmp/ghpool-${GHP_VER}-${{ matrix.ghpool_arch }}.tar.gz -C /tmp
           # ghpool tarball contains 'ghp' binary
           cp /tmp/ghp ./bin/ghp
           chmod +x ./bin/ghp
@@ -100,7 +137,7 @@ jobs:
           retention-days: 30
 
   release:
-    needs: bundle
+    needs: [resolve, bundle]
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
@@ -117,15 +154,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="utils-v${{ inputs.aws_cli_version }}-ghp${{ inputs.ghpool_version }}"
+          TAG="utils-v${{ needs.resolve.outputs.aws_cli_version }}-ghp${{ needs.resolve.outputs.ghpool_version }}"
           gh release create "$TAG" \
             --repo ${{ github.repository }} \
-            --title "pre_seed utils (AWS CLI ${{ inputs.aws_cli_version }} + ghp ${{ inputs.ghpool_version }})" \
+            --title "pre_seed utils (AWS CLI ${{ needs.resolve.outputs.aws_cli_version }} + ghp ${{ needs.resolve.outputs.ghpool_version }})" \
             --notes "Bundled pre_seed utilities for OAB fleet.
 
           **Contents:**
-          - AWS CLI v${{ inputs.aws_cli_version }}
-          - ghp v${{ inputs.ghpool_version }} (ghpool shim)
+          - AWS CLI v${{ needs.resolve.outputs.aws_cli_version }}
+          - ghp v${{ needs.resolve.outputs.ghpool_version }} (ghpool shim)
           - gh CLI (from runner)
 
           **Usage:** Add to \`[hooks.pre_seed].sources\` as S3 URI after uploading." \
@@ -133,7 +170,7 @@ jobs:
             artifacts/utils-aarch64.tar.gz
 
   upload-s3:
-    needs: bundle
+    needs: [resolve, bundle]
     if: inputs.upload_s3
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Inputs now default to empty. A `resolve` job auto-fetches:
- AWS CLI latest version from `aws/aws-cli` CHANGELOG.rst
- ghpool latest release tag from `openabdev/ghpool`

You can still pin specific versions via the workflow_dispatch inputs.