### PR TITLE
fix(pre_seed): allow safe relative symlinks; make lifecycle hooks Unix-only

### DIFF
--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -205,6 +205,33 @@ pub struct HooksConfig {
     pub pre_shutdown: Option<HookConfig>,
 }
 
+impl HooksConfig {
+    /// Returns true if any lifecycle hook (pre_seed, pre_boot, pre_shutdown) is configured.
+    pub fn any_configured(&self) -> bool {
+        self.pre_seed.as_ref().is_some_and(|p| !p.sources.is_empty())
+            || self.pre_boot.is_some()
+            || self.pre_shutdown.is_some()
+    }
+
+    /// Fail fast if hooks are configured on an unsupported platform.
+    ///
+    /// Lifecycle hooks (pre_seed tarball extraction, pre_boot/pre_shutdown shell
+    /// scripts) assume a Unix environment and only ever run inside Linux containers.
+    /// Rather than silently misbehaving on Windows, refuse to start.
+    pub fn ensure_platform_supported(&self) -> anyhow::Result<()> {
+        #[cfg(not(unix))]
+        {
+            if self.any_configured() {
+                anyhow::bail!(
+                    "lifecycle hooks ([hooks.pre_seed], [hooks.pre_boot], [hooks.pre_shutdown]) \
+                     are only supported on Unix platforms; remove them to run on this platform"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Configuration for the pre_seed phase.
 /// Downloads and extracts zip archives from S3 before pre_boot.
 #[derive(Debug, Clone, Deserialize)]
@@ -1378,6 +1405,65 @@ fn default_ambient_context_flushes() -> usize {
 mod tests {
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn hooks_any_configured_false_when_empty() {
+        let h = HooksConfig::default();
+        assert!(!h.any_configured());
+        // Empty pre_seed sources don't count as configured
+        let h2 = HooksConfig {
+            pre_seed: Some(PreSeedConfig {
+                sources: vec![],
+                target: None,
+                region: None,
+                endpoint_url: None,
+                max_bytes: default_max_zip_bytes(),
+                timeout_seconds: default_pre_seed_timeout(),
+                on_failure: OnFailure::default(),
+            }),
+            pre_boot: None,
+            pre_shutdown: None,
+        };
+        assert!(!h2.any_configured());
+    }
+
+    fn sample_hook() -> HookConfig {
+        HookConfig {
+            script: None,
+            inline: Some("echo hi".to_string()),
+            url: None,
+            sha256: None,
+            timeout_seconds: 60,
+            on_failure: OnFailure::default(),
+        }
+    }
+
+    #[test]
+    fn hooks_any_configured_true_with_pre_boot() {
+        let h = HooksConfig {
+            pre_seed: None,
+            pre_boot: Some(sample_hook()),
+            pre_shutdown: None,
+        };
+        assert!(h.any_configured());
+    }
+
+    #[test]
+    fn ensure_platform_supported_ok_when_no_hooks() {
+        // No hooks configured → always Ok regardless of platform
+        assert!(HooksConfig::default().ensure_platform_supported().is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_platform_supported_ok_on_unix_with_hooks() {
+        let h = HooksConfig {
+            pre_seed: None,
+            pre_boot: Some(sample_hook()),
+            pre_shutdown: None,
+        };
+        assert!(h.ensure_platform_supported().is_ok());
+    }
 
     const MINIMAL_TOML: &str = r#"
 [discord]

--- a/crates/openab-core/src/pre_seed.rs
+++ b/crates/openab-core/src/pre_seed.rs
@@ -418,11 +418,29 @@ fn create_symlink_or_copy(link_target: &Path, dst: &Path, src: &Path) -> anyhow:
     }
     #[cfg(not(unix))]
     {
-        // F3/F7: On non-Unix platforms we materialize the link by copying its target.
-        // Directory targets cannot be copied with std::fs::copy, and the target may
-        // not have been moved into place yet during move_recursive. Treat both as
-        // non-fatal: skip the link rather than aborting the whole extraction.
-        let resolved = src.parent().unwrap_or(Path::new(".")).join(link_target);
+        // On non-Unix platforms we materialize the link by copying its target.
+        // During move_recursive, files may already have been moved from the temp (src)
+        // directory to the destination (dst) directory. We check both locations to
+        // handle cross-directory symlinks regardless of processing order.
+        // Directory targets cannot be copied with std::fs::copy — skip with warning.
+        let resolved_src = src.parent().unwrap_or(Path::new(".")).join(link_target);
+        let resolved_dst = dst.parent().unwrap_or(Path::new(".")).join(link_target);
+
+        // Try source first (temp dir), then destination (already moved)
+        let resolved = if resolved_src.exists() {
+            resolved_src
+        } else if resolved_dst.exists() {
+            resolved_dst
+        } else {
+            warn!(
+                "hooks.pre_seed: skipping symlink with unresolved target: {} (checked {} and {})",
+                link_target.display(),
+                resolved_src.display(),
+                resolved_dst.display()
+            );
+            return Ok(());
+        };
+
         match resolved.symlink_metadata() {
             Ok(meta) if meta.is_dir() => {
                 warn!(
@@ -433,10 +451,12 @@ fn create_symlink_or_copy(link_target: &Path, dst: &Path, src: &Path) -> anyhow:
             Ok(_) => {
                 std::fs::copy(&resolved, dst)?;
             }
-            Err(_) => {
+            Err(e) => {
                 warn!(
-                    "hooks.pre_seed: skipping symlink with unresolved target: {}",
-                    resolved.display()
+                    "hooks.pre_seed: skipping symlink copy failed: {} -> {}: {}",
+                    link_target.display(),
+                    resolved.display(),
+                    e
                 );
             }
         }

--- a/crates/openab-core/src/pre_seed.rs
+++ b/crates/openab-core/src/pre_seed.rs
@@ -167,11 +167,7 @@ async fn download_and_extract(
 /// Extract archive to a temp directory with budget enforcement, then move into target.
 /// Supports zip and gzipped tarball formats (detected via magic bytes).
 /// Checks deadline cooperatively before each file operation.
-fn extract_and_apply(
-    data: &[u8],
-    target: &Path,
-    deadline: Instant,
-) -> anyhow::Result<()> {
+fn extract_and_apply(data: &[u8], target: &Path, deadline: Instant) -> anyhow::Result<()> {
     std::fs::create_dir_all(target)?;
     let temp_dir = tempfile::tempdir_in(target)?;
 
@@ -289,7 +285,9 @@ fn extract_tarball_with_limits(data: &[u8], dest: &Path, deadline: Instant) -> a
 
         // Cooperative deadline check every 10 files
         if file_count.is_multiple_of(10) && Instant::now() >= deadline {
-            anyhow::bail!("hooks.pre_seed: timed out during tarball extraction at entry {file_count}");
+            anyhow::bail!(
+                "hooks.pre_seed: timed out during tarball extraction at entry {file_count}"
+            );
         }
 
         // Size budget
@@ -328,12 +326,14 @@ fn extract_tarball_with_limits(data: &[u8], dest: &Path, deadline: Instant) -> a
             use std::os::unix::fs::PermissionsExt;
             if let Ok(path) = entry.path() {
                 let out_path = dest.join(path);
-                if out_path.symlink_metadata().map(|m| m.file_type().is_file()).unwrap_or(false) {
+                if out_path
+                    .symlink_metadata()
+                    .map(|m| m.file_type().is_file())
+                    .unwrap_or(false)
+                {
                     let mode = entry.header().mode().unwrap_or(0o644) & 0o0777;
-                    let _ = std::fs::set_permissions(
-                        &out_path,
-                        std::fs::Permissions::from_mode(mode),
-                    );
+                    let _ =
+                        std::fs::set_permissions(&out_path, std::fs::Permissions::from_mode(mode));
                 }
             }
         }
@@ -380,7 +380,10 @@ fn normalize_path(path: &Path) -> std::path::PathBuf {
             std::path::Component::ParentDir => {
                 // Only pop if there's something to pop and it's not a prefix/root
                 if components.last().is_some_and(|c| {
-                    !matches!(c, std::path::Component::RootDir | std::path::Component::Prefix(_))
+                    !matches!(
+                        c,
+                        std::path::Component::RootDir | std::path::Component::Prefix(_)
+                    )
                 }) {
                     components.pop();
                 }
@@ -443,7 +446,13 @@ fn create_symlink_or_copy(link_target: &Path, dst: &Path, src: &Path) -> anyhow:
 
 /// Recursively move files from src directory into dst directory.
 /// Checks deadline cooperatively.
+/// On non-Unix platforms, symlinks are processed in a second pass after regular
+/// files/directories to ensure symlink targets exist when copied.
 fn move_recursive(src: &Path, dst: &Path, deadline: Instant) -> anyhow::Result<()> {
+    // Collect symlinks for deferred processing (needed on non-Unix where symlinks are
+    // resolved by copying, so targets must already be in place).
+    let mut deferred_symlinks: Vec<(std::path::PathBuf, std::path::PathBuf)> = Vec::new();
+
     for entry in std::fs::read_dir(src)? {
         if Instant::now() >= deadline {
             anyhow::bail!("hooks.pre_seed: timed out during move to target");
@@ -455,17 +464,8 @@ fn move_recursive(src: &Path, dst: &Path, deadline: Instant) -> anyhow::Result<(
 
         let meta = src_path.symlink_metadata()?;
         if meta.is_symlink() {
-            // Preserve symlinks as-is without following
-            let link_target = std::fs::read_link(&src_path)?;
-            // Remove existing dst (file or directory) before creating symlink
-            if let Ok(dst_meta) = dst_path.symlink_metadata() {
-                if dst_meta.is_dir() {
-                    std::fs::remove_dir_all(&dst_path)?;
-                } else {
-                    std::fs::remove_file(&dst_path)?;
-                }
-            }
-            create_symlink_or_copy(&link_target, &dst_path, &src_path)?;
+            // Defer symlinks to second pass on all platforms for consistent behavior
+            deferred_symlinks.push((src_path, dst_path));
         } else if meta.is_dir() {
             std::fs::create_dir_all(&dst_path)?;
             move_recursive(&src_path, &dst_path, deadline)?;
@@ -476,6 +476,26 @@ fn move_recursive(src: &Path, dst: &Path, deadline: Instant) -> anyhow::Result<(
             }
         }
     }
+
+    // Second pass: process symlinks after all regular files are in place
+    for (src_path, dst_path) in deferred_symlinks {
+        if Instant::now() >= deadline {
+            anyhow::bail!("hooks.pre_seed: timed out during move to target");
+        }
+        let link_target = std::fs::read_link(&src_path)?;
+        // Remove existing dst (file or directory) before creating symlink
+        if let Ok(dst_meta) = dst_path.symlink_metadata() {
+            if dst_meta.is_dir() {
+                std::fs::remove_dir_all(&dst_path)?;
+            } else {
+                std::fs::remove_file(&dst_path)?;
+            }
+        }
+        create_symlink_or_copy(&link_target, &dst_path, &src_path)?;
+        // Clean up source symlink
+        let _ = std::fs::remove_file(&src_path);
+    }
+
     Ok(())
 }
 
@@ -802,8 +822,14 @@ mod tests {
         let dst_link = dst.path().join("link.txt");
         let meta = dst_link.symlink_metadata().unwrap();
         assert!(meta.is_symlink(), "destination should be a symlink");
-        assert_eq!(std::fs::read_link(&dst_link).unwrap().to_str().unwrap(), "real.txt");
-        assert_eq!(std::fs::read_to_string(dst.path().join("real.txt")).unwrap(), "content");
+        assert_eq!(
+            std::fs::read_link(&dst_link).unwrap().to_str().unwrap(),
+            "real.txt"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.path().join("real.txt")).unwrap(),
+            "content"
+        );
     }
 
     #[cfg(unix)]
@@ -824,14 +850,17 @@ mod tests {
 
         let dst_item = dst.path().join("item");
         let meta = dst_item.symlink_metadata().unwrap();
-        assert!(meta.is_symlink(), "should have replaced directory with symlink");
+        assert!(
+            meta.is_symlink(),
+            "should have replaced directory with symlink"
+        );
     }
 
     #[cfg(unix)]
     #[test]
     fn extract_and_apply_succeeds_with_non_writable_parent() {
-        use std::os::unix::fs::PermissionsExt;
         use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
 
         // Regression test: target is writable but target.parent() is read-only.
         // Old code used tempdir_in(target.parent()) which would fail here.
@@ -863,7 +892,10 @@ mod tests {
 
         // Should succeed because tempdir_in(target) works even with read-only parent
         result.unwrap();
-        assert_eq!(std::fs::read_to_string(target.join("test.txt")).unwrap(), "data");
+        assert_eq!(
+            std::fs::read_to_string(target.join("test.txt")).unwrap(),
+            "data"
+        );
     }
 
     #[cfg(unix)]
@@ -886,7 +918,10 @@ mod tests {
         let deadline = Instant::now() + std::time::Duration::from_secs(60);
         extract_and_apply(cursor.get_ref(), &target, deadline).unwrap();
 
-        assert_eq!(std::fs::read_to_string(target.join("test.txt")).unwrap(), "hello");
+        assert_eq!(
+            std::fs::read_to_string(target.join("test.txt")).unwrap(),
+            "hello"
+        );
     }
 
     #[test]

--- a/crates/openab-core/src/pre_seed.rs
+++ b/crates/openab-core/src/pre_seed.rs
@@ -308,11 +308,7 @@ fn extract_tarball_with_limits(data: &[u8], dest: &Path, deadline: Instant) -> a
             let out_path = dest.join(&*path);
             if out_path.symlink_metadata().map(|m| m.is_symlink()).unwrap_or(false) {
                 if let Ok(target) = std::fs::read_link(&out_path) {
-                    if target.is_absolute()
-                        || target
-                            .components()
-                            .any(|c| c == std::path::Component::ParentDir)
-                    {
+                    if symlink_escapes(dest, &out_path, &target) {
                         let _ = std::fs::remove_file(&out_path);
                         warn!(
                             "hooks.pre_seed: removed symlink with escaping target: {}",
@@ -343,18 +339,51 @@ fn extract_tarball_with_limits(data: &[u8], dest: &Path, deadline: Instant) -> a
     Ok(())
 }
 
+/// Check whether a symlink at `link_path` with target `link_target` escapes `root`.
+/// Resolves the target relative to the symlink's parent directory and checks
+/// whether the normalized result stays within root. This allows relative symlinks
+/// with `..` components (e.g., `../aws-cli/v2/current/bin/aws`) as long as they
+/// don't escape the extraction root.
+fn symlink_escapes(root: &Path, link_path: &Path, link_target: &Path) -> bool {
+    // Absolute symlinks always escape
+    if link_target.is_absolute() {
+        return true;
+    }
+    // Resolve the symlink target relative to the symlink's parent directory
+    let parent = link_path.parent().unwrap_or(root);
+    let resolved = normalize_path(&parent.join(link_target));
+    let root_normalized = normalize_path(root);
+    !resolved.starts_with(&root_normalized)
+}
+
+/// Normalize a path by resolving `.` and `..` components without touching the filesystem.
+fn normalize_path(path: &Path) -> std::path::PathBuf {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                // Only pop if there's something to pop and it's not a prefix/root
+                if components.last().is_some_and(|c| {
+                    !matches!(c, std::path::Component::RootDir | std::path::Component::Prefix(_))
+                }) {
+                    components.pop();
+                }
+            }
+            std::path::Component::CurDir => {}
+            _ => components.push(component),
+        }
+    }
+    components.iter().collect()
+}
+
 /// Create a symlink on Unix, or copy the resolved target on other platforms.
-/// Rejects symlink targets that escape via absolute path or `..` components.
+/// Rejects symlink targets that escape the extraction root.
 #[allow(unused_variables)]
 fn create_symlink_or_copy(link_target: &Path, dst: &Path, src: &Path) -> anyhow::Result<()> {
-    // Reject symlinks that could escape the target directory
-    if link_target.is_absolute()
-        || link_target
-            .components()
-            .any(|c| c == std::path::Component::ParentDir)
-    {
+    // Reject absolute symlinks unconditionally
+    if link_target.is_absolute() {
         anyhow::bail!(
-            "hooks.pre_seed: rejecting symlink with escaping target: {}",
+            "hooks.pre_seed: rejecting symlink with absolute target: {}",
             link_target.display()
         );
     }
@@ -823,5 +852,160 @@ mod tests {
         extract_and_apply(cursor.get_ref(), &target, deadline).unwrap();
 
         assert_eq!(std::fs::read_to_string(target.join("test.txt")).unwrap(), "hello");
+    }
+
+    #[test]
+    fn normalize_path_resolves_parent_dir() {
+        let p = normalize_path(Path::new("/tmp/extract/bin/../aws-cli/v2"));
+        assert_eq!(p, std::path::PathBuf::from("/tmp/extract/aws-cli/v2"));
+    }
+
+    #[test]
+    fn normalize_path_resolves_multiple_parents() {
+        let p = normalize_path(Path::new("/a/b/c/../../d"));
+        assert_eq!(p, std::path::PathBuf::from("/a/d"));
+    }
+
+    #[test]
+    fn normalize_path_does_not_go_above_root() {
+        let p = normalize_path(Path::new("/a/../../../etc"));
+        // Can't go above /, so stays at /etc
+        assert_eq!(p, std::path::PathBuf::from("/etc"));
+    }
+
+    #[test]
+    fn normalize_path_removes_cur_dir() {
+        let p = normalize_path(Path::new("/a/./b/./c"));
+        assert_eq!(p, std::path::PathBuf::from("/a/b/c"));
+    }
+
+    #[test]
+    fn symlink_escapes_allows_relative_within_root() {
+        let root = Path::new("/tmp/extract");
+        let link_path = Path::new("/tmp/extract/bin/aws");
+        let link_target = Path::new("../aws-cli/v2/current/bin/aws");
+        // ../aws-cli resolves to /tmp/extract/aws-cli — within root
+        assert!(!symlink_escapes(root, link_path, link_target));
+    }
+
+    #[test]
+    fn symlink_escapes_allows_sibling_relative() {
+        let root = Path::new("/tmp/extract");
+        let link_path = Path::new("/tmp/extract/aws-cli/v2/current");
+        let link_target = Path::new("2.35.12");
+        // Resolves to /tmp/extract/aws-cli/v2/2.35.12 — within root
+        assert!(!symlink_escapes(root, link_path, link_target));
+    }
+
+    #[test]
+    fn symlink_escapes_rejects_absolute() {
+        let root = Path::new("/tmp/extract");
+        let link_path = Path::new("/tmp/extract/bin/aws");
+        let link_target = Path::new("/usr/local/bin/aws");
+        assert!(symlink_escapes(root, link_path, link_target));
+    }
+
+    #[test]
+    fn symlink_escapes_rejects_traversal_above_root() {
+        let root = Path::new("/tmp/extract");
+        let link_path = Path::new("/tmp/extract/bin/evil");
+        let link_target = Path::new("../../../etc/passwd");
+        // Resolves to /tmp/etc/passwd — outside root
+        assert!(symlink_escapes(root, link_path, link_target));
+    }
+
+    #[test]
+    fn symlink_escapes_rejects_deep_traversal() {
+        let root = Path::new("/tmp/extract");
+        let link_path = Path::new("/tmp/extract/a/b/c");
+        let link_target = Path::new("../../../../outside");
+        // Resolves to /tmp/outside — outside root
+        assert!(symlink_escapes(root, link_path, link_target));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_tarball_preserves_relative_symlinks_with_parent_dir() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let dir = tempfile::tempdir().unwrap();
+        let deadline = Instant::now() + std::time::Duration::from_secs(60);
+
+        let buf = Vec::new();
+        let enc = GzEncoder::new(buf, Compression::default());
+        let mut builder = tar::Builder::new(enc);
+
+        // Create a real file at aws-cli/bin/aws
+        let mut header = tar::Header::new_gnu();
+        header.set_size(11);
+        header.set_mode(0o755);
+        builder
+            .append_data(&mut header, "aws-cli/bin/aws", &b"#!/bin/bash"[..])
+            .unwrap();
+
+        // Create a relative symlink: bin/aws -> ../aws-cli/bin/aws
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_size(0);
+        header.set_mode(0o777);
+        builder
+            .append_link(&mut header, "bin/aws", "../aws-cli/bin/aws")
+            .unwrap();
+
+        let enc = builder.into_inner().unwrap();
+        let tarball_bytes = enc.finish().unwrap();
+
+        extract_tarball_with_limits(&tarball_bytes, dir.path(), deadline).unwrap();
+
+        // The symlink should exist and be resolvable
+        let symlink_path = dir.path().join("bin/aws");
+        assert!(
+            symlink_path.symlink_metadata().unwrap().is_symlink(),
+            "bin/aws should be a symlink"
+        );
+        assert_eq!(
+            std::fs::read_link(&symlink_path).unwrap(),
+            Path::new("../aws-cli/bin/aws")
+        );
+        // Verify it resolves to the real file
+        assert_eq!(
+            std::fs::read_to_string(&symlink_path).unwrap(),
+            "#!/bin/bash"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_tarball_removes_escaping_symlink() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let dir = tempfile::tempdir().unwrap();
+        let deadline = Instant::now() + std::time::Duration::from_secs(60);
+
+        let buf = Vec::new();
+        let enc = GzEncoder::new(buf, Compression::default());
+        let mut builder = tar::Builder::new(enc);
+
+        // Create an escaping symlink: evil -> ../../../etc/passwd
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_size(0);
+        header.set_mode(0o777);
+        builder
+            .append_link(&mut header, "evil", "../../../etc/passwd")
+            .unwrap();
+
+        let enc = builder.into_inner().unwrap();
+        let tarball_bytes = enc.finish().unwrap();
+
+        extract_tarball_with_limits(&tarball_bytes, dir.path(), deadline).unwrap();
+
+        // The escaping symlink should have been removed
+        assert!(
+            !dir.path().join("evil").exists(),
+            "escaping symlink should be removed"
+        );
     }
 }

--- a/crates/openab-core/src/pre_seed.rs
+++ b/crates/openab-core/src/pre_seed.rs
@@ -299,15 +299,26 @@ fn extract_tarball_with_limits(data: &[u8], dest: &Path, deadline: Instant) -> a
             );
         }
 
-        // F1: Validate symlink targets BEFORE writing them to disk. Skipping
-        // escaping entries at this point eliminates the time-of-check/time-of-use
-        // window that a post-extraction sweep would leave open.
+        // F1: Validate symlink/hardlink targets BEFORE writing them to disk.
+        // Skipping escaping entries eliminates the TOCTOU window.
+        //
+        // F9: Hard link targets in tar are relative to the archive root (dest),
+        // NOT the link's parent directory. Symlink targets are relative to the
+        // symlink's parent. Handle them with different resolution semantics.
         let entry_type = entry.header().entry_type();
         if entry_type.is_symlink() || entry_type.is_hard_link() {
             if let Ok(Some(link_target)) = entry.link_name() {
                 if let Ok(entry_path) = entry.path() {
                     let out_path = dest.join(&*entry_path);
-                    if symlink_escapes(dest, &out_path, &link_target) {
+                    let escapes = if entry_type.is_hard_link() {
+                        // Hard link targets in tar are relative to archive root
+                        let resolved = normalize_path(&dest.join(&*link_target));
+                        let root_normalized = normalize_path(dest);
+                        !resolved.starts_with(&root_normalized)
+                    } else {
+                        symlink_escapes(dest, &out_path, &link_target)
+                    };
+                    if escapes {
                         warn!(
                             "hooks.pre_seed: skipping link with escaping target: {} -> {}",
                             entry_path.display(),
@@ -1072,6 +1083,84 @@ mod tests {
         assert!(
             dir.path().join("evil").symlink_metadata().is_err(),
             "escaping symlink should never be written to disk"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_tarball_allows_valid_hard_link_within_root() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let dir = tempfile::tempdir().unwrap();
+        let deadline = Instant::now() + std::time::Duration::from_secs(60);
+
+        let buf = Vec::new();
+        let enc = GzEncoder::new(buf, Compression::default());
+        let mut builder = tar::Builder::new(enc);
+
+        // Create a real file at lib/core.so
+        let mut header = tar::Header::new_gnu();
+        header.set_size(7);
+        header.set_mode(0o644);
+        builder
+            .append_data(&mut header, "lib/core.so", &b"ELF\x00\x00\x00\x00"[..])
+            .unwrap();
+
+        // F9: Hard link at bin/core.so -> lib/core.so (relative to archive root)
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Link);
+        header.set_size(0);
+        header.set_mode(0o644);
+        builder
+            .append_link(&mut header, "bin/core.so", "lib/core.so")
+            .unwrap();
+
+        let enc = builder.into_inner().unwrap();
+        let tarball_bytes = enc.finish().unwrap();
+
+        extract_tarball_with_limits(&tarball_bytes, dir.path(), deadline).unwrap();
+
+        // Both files should exist and have identical content
+        assert!(dir.path().join("lib/core.so").exists());
+        assert!(dir.path().join("bin/core.so").exists());
+        assert_eq!(
+            std::fs::read(dir.path().join("bin/core.so")).unwrap(),
+            std::fs::read(dir.path().join("lib/core.so")).unwrap(),
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_tarball_skips_escaping_hard_link() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let dir = tempfile::tempdir().unwrap();
+        let deadline = Instant::now() + std::time::Duration::from_secs(60);
+
+        let buf = Vec::new();
+        let enc = GzEncoder::new(buf, Compression::default());
+        let mut builder = tar::Builder::new(enc);
+
+        // F9: Hard link with escaping target -> ../../../etc/passwd (relative to archive root)
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Link);
+        header.set_size(0);
+        header.set_mode(0o644);
+        builder
+            .append_link(&mut header, "evil_link", "../../../etc/passwd")
+            .unwrap();
+
+        let enc = builder.into_inner().unwrap();
+        let tarball_bytes = enc.finish().unwrap();
+
+        extract_tarball_with_limits(&tarball_bytes, dir.path(), deadline).unwrap();
+
+        // Escaping hard link should be skipped — never written to disk
+        assert!(
+            dir.path().join("evil_link").symlink_metadata().is_err(),
+            "escaping hard link should never be written to disk"
         );
     }
 }

--- a/crates/openab-core/src/pre_seed.rs
+++ b/crates/openab-core/src/pre_seed.rs
@@ -300,24 +300,27 @@ fn extract_tarball_with_limits(data: &[u8], dest: &Path, deadline: Instant) -> a
             );
         }
 
-        entry.unpack_in(dest)?;
-
-        // Skip symlinks with escaping targets created by unpack_in
-        #[cfg(unix)]
-        if let Ok(path) = entry.path() {
-            let out_path = dest.join(&*path);
-            if out_path.symlink_metadata().map(|m| m.is_symlink()).unwrap_or(false) {
-                if let Ok(target) = std::fs::read_link(&out_path) {
-                    if symlink_escapes(dest, &out_path, &target) {
-                        let _ = std::fs::remove_file(&out_path);
+        // F1: Validate symlink targets BEFORE writing them to disk. Skipping
+        // escaping entries at this point eliminates the time-of-check/time-of-use
+        // window that a post-extraction sweep would leave open.
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_symlink() || entry_type.is_hard_link() {
+            if let Ok(Some(link_target)) = entry.link_name() {
+                if let Ok(entry_path) = entry.path() {
+                    let out_path = dest.join(&*entry_path);
+                    if symlink_escapes(dest, &out_path, &link_target) {
                         warn!(
-                            "hooks.pre_seed: removed symlink with escaping target: {}",
-                            target.display()
+                            "hooks.pre_seed: skipping link with escaping target: {} -> {}",
+                            entry_path.display(),
+                            link_target.display()
                         );
+                        continue;
                     }
                 }
             }
         }
+
+        entry.unpack_in(dest)?;
 
         // Manually set permissions (strip suid/sgid/sticky, like zip path)
         #[cfg(unix)]
@@ -344,6 +347,11 @@ fn extract_tarball_with_limits(data: &[u8], dest: &Path, deadline: Instant) -> a
 /// whether the normalized result stays within root. This allows relative symlinks
 /// with `..` components (e.g., `../aws-cli/v2/current/bin/aws`) as long as they
 /// don't escape the extraction root.
+///
+/// F6: `normalize_path` resolves `..` across the *entire* joined path, including any
+/// `..` components in `link_path.parent()` itself (e.g., a tar entry like
+/// `a/../b/link`). This makes the containment check robust regardless of how the
+/// entry path is structured. (In practice `tar::Entry::path` is already sanitized.)
 fn symlink_escapes(root: &Path, link_path: &Path, link_target: &Path) -> bool {
     // Absolute symlinks always escape
     if link_target.is_absolute() {
@@ -356,7 +364,15 @@ fn symlink_escapes(root: &Path, link_path: &Path, link_target: &Path) -> bool {
     !resolved.starts_with(&root_normalized)
 }
 
-/// Normalize a path by resolving `.` and `..` components without touching the filesystem.
+/// Normalize a path by resolving `.` and `..` components lexically (no filesystem
+/// access, avoiding canonicalize TOCTOU).
+///
+/// F5: Leading `..` components that would traverse above the path root are dropped
+/// rather than preserved. For a pure-relative input like `../../etc`, this yields
+/// `etc` (the leading `..` have nothing to pop). Callers in this module always pass
+/// absolute paths (the extraction root and entries joined onto it), so a dropped
+/// leading `..` cannot produce a false "contained" result — see `symlink_escapes`,
+/// where both sides are absolute and compared via component-wise `starts_with`.
 fn normalize_path(path: &Path) -> std::path::PathBuf {
     let mut components = Vec::new();
     for component in path.components() {
@@ -377,10 +393,16 @@ fn normalize_path(path: &Path) -> std::path::PathBuf {
 }
 
 /// Create a symlink on Unix, or copy the resolved target on other platforms.
-/// Rejects symlink targets that escape the extraction root.
+///
+/// SAFETY PRECONDITION (F2): This function only rejects *absolute* symlink targets.
+/// It has no `root` parameter and therefore CANNOT validate whether a relative
+/// target escapes the extraction root. Callers MUST pre-validate relative targets
+/// with [`symlink_escapes`] before calling this. The sole caller, `move_recursive`,
+/// receives entries that were already validated during `extract_tarball_with_limits`.
 #[allow(unused_variables)]
 fn create_symlink_or_copy(link_target: &Path, dst: &Path, src: &Path) -> anyhow::Result<()> {
-    // Reject absolute symlinks unconditionally
+    // Reject absolute symlinks unconditionally. Relative-target containment is the
+    // caller's responsibility (see SAFETY PRECONDITION above).
     if link_target.is_absolute() {
         anyhow::bail!(
             "hooks.pre_seed: rejecting symlink with absolute target: {}",
@@ -393,14 +415,27 @@ fn create_symlink_or_copy(link_target: &Path, dst: &Path, src: &Path) -> anyhow:
     }
     #[cfg(not(unix))]
     {
+        // F3/F7: On non-Unix platforms we materialize the link by copying its target.
+        // Directory targets cannot be copied with std::fs::copy, and the target may
+        // not have been moved into place yet during move_recursive. Treat both as
+        // non-fatal: skip the link rather than aborting the whole extraction.
         let resolved = src.parent().unwrap_or(Path::new(".")).join(link_target);
-        if resolved.exists() {
-            std::fs::copy(&resolved, dst)?;
-        } else {
-            anyhow::bail!(
-                "hooks.pre_seed: symlink target does not exist: {}",
-                resolved.display()
-            );
+        match resolved.symlink_metadata() {
+            Ok(meta) if meta.is_dir() => {
+                warn!(
+                    "hooks.pre_seed: skipping directory symlink on non-unix platform: {}",
+                    resolved.display()
+                );
+            }
+            Ok(_) => {
+                std::fs::copy(&resolved, dst)?;
+            }
+            Err(_) => {
+                warn!(
+                    "hooks.pre_seed: skipping symlink with unresolved target: {}",
+                    resolved.display()
+                );
+            }
         }
     }
     Ok(())
@@ -880,6 +915,33 @@ mod tests {
     }
 
     #[test]
+    fn normalize_path_drops_leading_parent_dir_on_relative() {
+        // F5: leading `..` on a pure-relative path have nothing to pop and are dropped.
+        let p = normalize_path(Path::new("../../etc/passwd"));
+        assert_eq!(p, std::path::PathBuf::from("etc/passwd"));
+    }
+
+    #[test]
+    fn symlink_escapes_handles_parent_with_dotdot() {
+        // F6: link_path itself contains `..` — normalization resolves it across the
+        // whole joined path. dest/a/../b/link -> target ../x resolves to dest/x.
+        let root = Path::new("/tmp/extract");
+        let link_path = Path::new("/tmp/extract/a/../b/link");
+        let link_target = Path::new("../x");
+        // parent = /tmp/extract/a/../b ; join ../x ; normalize -> /tmp/extract/x : within root
+        assert!(!symlink_escapes(root, link_path, link_target));
+    }
+
+    #[test]
+    fn symlink_escapes_parent_with_dotdot_still_blocks_escape() {
+        // F6: even with `..` in the entry path, a real escape is still caught.
+        let root = Path::new("/tmp/extract");
+        let link_path = Path::new("/tmp/extract/a/../b/link");
+        let link_target = Path::new("../../../../etc/passwd");
+        assert!(symlink_escapes(root, link_path, link_target));
+    }
+
+    #[test]
     fn symlink_escapes_allows_relative_within_root() {
         let root = Path::new("/tmp/extract");
         let link_path = Path::new("/tmp/extract/bin/aws");
@@ -977,7 +1039,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn extract_tarball_removes_escaping_symlink() {
+    fn extract_tarball_skips_escaping_symlink_without_writing() {
         use flate2::write::GzEncoder;
         use flate2::Compression;
 
@@ -1002,10 +1064,10 @@ mod tests {
 
         extract_tarball_with_limits(&tarball_bytes, dir.path(), deadline).unwrap();
 
-        // The escaping symlink should have been removed
+        // F1: the escaping symlink is skipped before unpacking — it never touches disk
         assert!(
-            !dir.path().join("evil").exists(),
-            "escaping symlink should be removed"
+            dir.path().join("evil").symlink_metadata().is_err(),
+            "escaping symlink should never be written to disk"
         );
     }
 }

--- a/crates/openab-core/src/pre_seed.rs
+++ b/crates/openab-core/src/pre_seed.rs
@@ -18,6 +18,7 @@ pub async fn run(cfg: &PreSeedConfig) -> anyhow::Result<()> {
     if cfg.sources.is_empty() {
         return Ok(());
     }
+
     if cfg.sources.len() > MAX_SOURCES {
         anyhow::bail!(
             "hooks.pre_seed: too many sources ({}, max {})",
@@ -395,7 +396,10 @@ fn normalize_path(path: &Path) -> std::path::PathBuf {
     components.iter().collect()
 }
 
-/// Create a symlink on Unix, or copy the resolved target on other platforms.
+/// Create a relative symlink at `dst` pointing to `link_target`.
+///
+/// pre_seed refuses to run on non-Unix platforms (see [`run`]), so symlink creation
+/// is Unix-only. On non-Unix the call is unreachable, but we keep a defensive bail.
 ///
 /// SAFETY PRECONDITION (F2): This function only rejects *absolute* symlink targets.
 /// It has no `root` parameter and therefore CANNOT validate whether a relative
@@ -403,7 +407,7 @@ fn normalize_path(path: &Path) -> std::path::PathBuf {
 /// with [`symlink_escapes`] before calling this. The sole caller, `move_recursive`,
 /// receives entries that were already validated during `extract_tarball_with_limits`.
 #[allow(unused_variables)]
-fn create_symlink_or_copy(link_target: &Path, dst: &Path, src: &Path) -> anyhow::Result<()> {
+fn create_symlink(link_target: &Path, dst: &Path) -> anyhow::Result<()> {
     // Reject absolute symlinks unconditionally. Relative-target containment is the
     // caller's responsibility (see SAFETY PRECONDITION above).
     if link_target.is_absolute() {
@@ -415,64 +419,19 @@ fn create_symlink_or_copy(link_target: &Path, dst: &Path, src: &Path) -> anyhow:
     #[cfg(unix)]
     {
         std::os::unix::fs::symlink(link_target, dst)?;
+        Ok(())
     }
     #[cfg(not(unix))]
     {
-        // On non-Unix platforms we materialize the link by copying its target.
-        // During move_recursive, files may already have been moved from the temp (src)
-        // directory to the destination (dst) directory. We check both locations to
-        // handle cross-directory symlinks regardless of processing order.
-        // Directory targets cannot be copied with std::fs::copy — skip with warning.
-        let resolved_src = src.parent().unwrap_or(Path::new(".")).join(link_target);
-        let resolved_dst = dst.parent().unwrap_or(Path::new(".")).join(link_target);
-
-        // Try source first (temp dir), then destination (already moved)
-        let resolved = if resolved_src.exists() {
-            resolved_src
-        } else if resolved_dst.exists() {
-            resolved_dst
-        } else {
-            warn!(
-                "hooks.pre_seed: skipping symlink with unresolved target: {} (checked {} and {})",
-                link_target.display(),
-                resolved_src.display(),
-                resolved_dst.display()
-            );
-            return Ok(());
-        };
-
-        match resolved.symlink_metadata() {
-            Ok(meta) if meta.is_dir() => {
-                warn!(
-                    "hooks.pre_seed: skipping directory symlink on non-unix platform: {}",
-                    resolved.display()
-                );
-            }
-            Ok(_) => {
-                std::fs::copy(&resolved, dst)?;
-            }
-            Err(e) => {
-                warn!(
-                    "hooks.pre_seed: skipping symlink copy failed: {} -> {}: {}",
-                    link_target.display(),
-                    resolved.display(),
-                    e
-                );
-            }
-        }
+        // Unreachable: run() bails on non-Unix before any extraction happens.
+        anyhow::bail!("hooks.pre_seed: symlinks are unsupported on non-unix platforms")
     }
-    Ok(())
 }
 
 /// Recursively move files from src directory into dst directory.
-/// Checks deadline cooperatively.
-/// On non-Unix platforms, symlinks are processed in a second pass after regular
-/// files/directories to ensure symlink targets exist when copied.
+/// Checks deadline cooperatively. Unix symlinks are created as-is (target string
+/// preserved), so processing order does not matter — no deferred pass needed.
 fn move_recursive(src: &Path, dst: &Path, deadline: Instant) -> anyhow::Result<()> {
-    // Collect symlinks for deferred processing (needed on non-Unix where symlinks are
-    // resolved by copying, so targets must already be in place).
-    let mut deferred_symlinks: Vec<(std::path::PathBuf, std::path::PathBuf)> = Vec::new();
-
     for entry in std::fs::read_dir(src)? {
         if Instant::now() >= deadline {
             anyhow::bail!("hooks.pre_seed: timed out during move to target");
@@ -484,8 +443,17 @@ fn move_recursive(src: &Path, dst: &Path, deadline: Instant) -> anyhow::Result<(
 
         let meta = src_path.symlink_metadata()?;
         if meta.is_symlink() {
-            // Defer symlinks to second pass on all platforms for consistent behavior
-            deferred_symlinks.push((src_path, dst_path));
+            // Preserve symlinks as-is without following
+            let link_target = std::fs::read_link(&src_path)?;
+            // Remove existing dst (file or directory) before creating symlink
+            if let Ok(dst_meta) = dst_path.symlink_metadata() {
+                if dst_meta.is_dir() {
+                    std::fs::remove_dir_all(&dst_path)?;
+                } else {
+                    std::fs::remove_file(&dst_path)?;
+                }
+            }
+            create_symlink(&link_target, &dst_path)?;
         } else if meta.is_dir() {
             std::fs::create_dir_all(&dst_path)?;
             move_recursive(&src_path, &dst_path, deadline)?;
@@ -495,25 +463,6 @@ fn move_recursive(src: &Path, dst: &Path, deadline: Instant) -> anyhow::Result<(
                 std::fs::remove_file(&src_path)?;
             }
         }
-    }
-
-    // Second pass: process symlinks after all regular files are in place
-    for (src_path, dst_path) in deferred_symlinks {
-        if Instant::now() >= deadline {
-            anyhow::bail!("hooks.pre_seed: timed out during move to target");
-        }
-        let link_target = std::fs::read_link(&src_path)?;
-        // Remove existing dst (file or directory) before creating symlink
-        if let Ok(dst_meta) = dst_path.symlink_metadata() {
-            if dst_meta.is_dir() {
-                std::fs::remove_dir_all(&dst_path)?;
-            } else {
-                std::fs::remove_file(&dst_path)?;
-            }
-        }
-        create_symlink_or_copy(&link_target, &dst_path, &src_path)?;
-        // Clean up source symlink
-        let _ = std::fs::remove_file(&src_path);
     }
 
     Ok(())

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -2,6 +2,8 @@
 
 OpenAB supports lifecycle hooks that run at specific points during the container lifecycle. All lifecycle phases are configured in `config.toml` under the `[hooks]` table.
 
+> **Platform support:** Lifecycle hooks are **Unix-only** (Linux/macOS). They rely on Unix symlinks (`pre_seed` tarball extraction) and POSIX shell scripts (`pre_boot`/`pre_shutdown`), and are only ever exercised inside Linux containers. If any hook (`pre_seed`, `pre_boot`, or `pre_shutdown`) is configured while running on **Windows**, OpenAB **fails fast at startup** rather than misbehaving silently. Remove the `[hooks.*]` config to run on Windows.
+
 ## Lifecycle Order
 
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,6 +207,9 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
+    // --- Lifecycle hooks: Unix-only. Fail fast on unsupported platforms. ---
+    cfg.hooks.ensure_platform_supported()?;
+
     // --- pre_seed: download & extract S3 zips before pre_boot ---
     #[cfg(feature = "pre-seed")]
     if let Some(ref pre_seed) = cfg.hooks.pre_seed {


### PR DESCRIPTION
## Summary

Two related changes to lifecycle hooks:

### 1. Allow safe relative symlinks in pre_seed extraction
`pre_seed` tarball extraction rejected **all** symlinks containing `..`, breaking valid layouts like `./bin/aws -> ../aws-cli/v2/current/bin/aws`. Replaced the naive `ParentDir` check with proper path normalization (`symlink_escapes` + `normalize_path`) that only rejects symlinks actually escaping the extraction root. Validation now happens **before** writing (no TOCTOU window).

### 2. Fail fast on Windows for all lifecycle hooks
Lifecycle hooks (`pre_seed`, `pre_boot`, `pre_shutdown`) are inherently Unix-only — they rely on Unix symlinks and POSIX shell scripts and only ever run in Linux containers. Instead of silently misbehaving on Windows:
- `HooksConfig::ensure_platform_supported()` bails at startup if any hook is configured on a non-unix platform
- `pre_seed` symlink handling simplified to Unix-only (dropped the fragile Windows copy-fallback and deferred second-pass — now unreachable)
- Documented the limitation in `docs/hooks.md`

## Review findings addressed
All 8 findings from the review resolved: F1 (TOCTOU — validate before write), F2 (safety-contract doc), F3/F7 (Windows symlink handling — now moot, hooks fail fast on Windows), F4 (unit tests), F5/F6 (normalize_path edge cases documented + tested), F8 (temp cleanup — TempDir handles it).

## Testing
- 35 pre_seed + hooks-platform unit tests pass
- clippy clean with `--features pre-seed`
- Windows fail-fast path is `#[cfg(not(unix))]` gated