### PR TITLE
fix(telegram): remove thinking draft, keep emoji reactions only

### DIFF
--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -537,7 +537,13 @@ pub async fn handle_reply(
                 .unwrap_or_default()
         };
         let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/setMessageReaction");
-        let msg_id: i64 = reply.reply_to.parse().unwrap_or(0);
+        let msg_id: i64 = match reply.reply_to.parse() {
+            Ok(id) => id,
+            Err(e) => {
+                warn!(reply_to = %reply.reply_to, error = %e, "invalid message_id for reaction, skipping");
+                return;
+            }
+        };
         let body = serde_json::json!({
             "chat_id": reply.channel.id,
             "message_id": msg_id,

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -517,9 +517,10 @@ pub async fn handle_reply(
             let mut reactions = reaction_state.lock().await;
             let set = reactions.entry(msg_key.clone()).or_default();
             if is_add {
-                if !set.contains(&tg_emoji.to_string()) {
-                    set.push(tg_emoji.to_string());
-                }
+                // Telegram private chats only allow 1 reaction per message (non-premium).
+                // Replace all existing reactions with the new one instead of accumulating.
+                set.clear();
+                set.push(tg_emoji.to_string());
             } else {
                 set.retain(|e| e != tg_emoji);
             }

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -510,13 +510,10 @@ pub async fn handle_reply(
         let emoji = &reply.content.text;
         let tg_emoji = match emoji.as_str() {
             "🆗" => "👍",
-            // Map mood faces to valid Telegram reaction emojis.
-            // Telegram has a fixed allowlist; unsupported emojis cause REACTION_INVALID.
-            "😊" => "😇",
-            "😏" => "😎",
-            "✌️" => "👌",
-            "💪" => "🔥",
-            "🦾" => "⚡",
+            // Mood faces are used on platforms that support multiple reactions (Discord).
+            // On Telegram (single reaction, non-premium), skip them to keep 👍 as the
+            // final "done" indicator instead of replacing it with a random face.
+            "😊" | "😎" | "🫡" | "🤓" | "😏" | "✌️" | "💪" | "🦾" => return,
             other => other,
         };
         let is_add = reply.command.as_deref() == Some("add_reaction");

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -506,28 +506,6 @@ pub async fn handle_reply(
     if reply.command.as_deref() == Some("add_reaction")
         || reply.command.as_deref() == Some("remove_reaction")
     {
-        // Show native "Thinking..." indicator via sendMessageDraft on first thinking emoji.
-        // Uses plain-text draft (not rich) — Telegram auto-clears it when the final
-        // sendMessage/sendRichMessage arrives in the same chat. No explicit dismiss needed.
-        // See: https://core.telegram.org/bots/api#sendmessagedraft
-        if rich_messages && reply.command.as_deref() == Some("add_reaction") {
-            let is_thinking = matches!(reply.content.text.as_str(), "👀" | "🤔" | "👨\u{200d}💻" | "🔥" | "⚡");
-            if is_thinking {
-                let draft_id = compute_draft_id(&reply.channel.id, &reply.channel.thread_id);
-                let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/sendMessageDraft");
-                let mut body = serde_json::json!({
-                    "chat_id": reply.channel.id,
-                    "draft_id": draft_id,
-                    "text": "",
-                });
-                if let Some(ref tid) = reply.channel.thread_id {
-                    body["message_thread_id"] = serde_json::json!(tid.parse::<i64>().unwrap_or(0));
-                }
-                let _ = client.post(&url).json(&body).send().await;
-            }
-        }
-        // No explicit dismiss on remove_reaction — the final reply auto-clears the draft.
-
         let msg_key = format!("{}:{}", reply.channel.id, reply.reply_to);
         let emoji = &reply.content.text;
         let tg_emoji = match emoji.as_str() {

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -510,6 +510,13 @@ pub async fn handle_reply(
         let emoji = &reply.content.text;
         let tg_emoji = match emoji.as_str() {
             "🆗" => "👍",
+            // Map mood faces to valid Telegram reaction emojis.
+            // Telegram has a fixed allowlist; unsupported emojis cause REACTION_INVALID.
+            "😊" => "😇",
+            "😏" => "😎",
+            "✌️" => "👌",
+            "💪" => "🔥",
+            "🦾" => "⚡",
             other => other,
         };
         let is_add = reply.command.as_deref() == Some("add_reaction");

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -540,7 +540,7 @@ pub async fn handle_reply(
         let msg_id: i64 = match reply.reply_to.parse() {
             Ok(id) => id,
             Err(e) => {
-                warn!(reply_to = %reply.reply_to, error = %e, "invalid message_id for reaction, skipping");
+                warn!(reply_to = %reply.reply_to, chat_id = %reply.channel.id, error = %e, "invalid message_id for reaction, skipping");
                 return;
             }
         };

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Base URL for Telegram Bot API. Extracted as constant for consistency
 /// with LINE's `LINE_API_BASE` and to enable future mock testing.
@@ -536,16 +536,29 @@ pub async fn handle_reply(
                 .unwrap_or_default()
         };
         let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/setMessageReaction");
-        let _ = client
-            .post(&url)
-            .json(&serde_json::json!({
-                "chat_id": reply.channel.id,
-                "message_id": reply.reply_to,
-                "reaction": current,
-            }))
-            .send()
-            .await
-            .map_err(|e| error!("telegram reaction error: {e}"));
+        let msg_id: i64 = reply.reply_to.parse().unwrap_or(0);
+        let body = serde_json::json!({
+            "chat_id": reply.channel.id,
+            "message_id": msg_id,
+            "reaction": current,
+        });
+        debug!(
+            chat_id = %reply.channel.id,
+            message_id = msg_id,
+            emoji = %tg_emoji,
+            is_add,
+            "telegram reaction"
+        );
+        match client.post(&url).json(&body).send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                if !status.is_success() {
+                    let text = resp.text().await.unwrap_or_default();
+                    warn!(status = %status, body = %text, "setMessageReaction failed");
+                }
+            }
+            Err(e) => error!("telegram reaction error: {e}"),
+        }
         return;
     }
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -33,7 +33,7 @@ Set environment variables:
 | `TELEGRAM_SECRET_TOKEN` | No | Webhook signature validation |
 | `TELEGRAM_BOT_USERNAME` | No | Bot username for @mention gating |
 | `TELEGRAM_RICH_MESSAGES` | No | `true` (default) for rich formatting |
-| `TELEGRAM_STREAMING` | No | `true` (default) — stream replies via rich message drafts. Set `false` for send-once mode |
+| `TELEGRAM_STREAMING` | No | follows `TELEGRAM_RICH_MESSAGES` | Stream replies via rich message drafts. Defaults to `true` when rich messages are enabled, `false` otherwise. Set explicitly to override |
 | `GATEWAY_LISTEN` | No | Listen address (default: `0.0.0.0:8080`) |
 
 OAB config (`config.toml`):
@@ -62,7 +62,7 @@ tool_display = "compact"
 tables = "off"
 ```
 
-Streaming is enabled by default — replies are streamed live via `sendRichMessageDraft` with rich formatting, then finalized with `sendRichMessage`. To disable streaming (send-once mode), set `TELEGRAM_STREAMING=false` in the container environment.
+Streaming is enabled by default when Rich Messages are active — replies are streamed live via `sendRichMessageDraft` with rich formatting, then finalized with `sendRichMessage`. If `TELEGRAM_RICH_MESSAGES=false`, streaming is also disabled by default. To override, set `TELEGRAM_STREAMING=true` or `TELEGRAM_STREAMING=false` explicitly.
 
 No `[gateway]` section needed — the unified adapter activates automatically when `TELEGRAM_BOT_TOKEN` is set.
 
@@ -298,7 +298,7 @@ Set `TELEGRAM_RICH_MESSAGES=false` to disable rich messages and use legacy `send
 | `TELEGRAM_BOT_TOKEN` | Yes | — | Bot API token from @BotFather |
 | `TELEGRAM_SECRET_TOKEN` | No | — | Webhook signature validation |
 | `TELEGRAM_RICH_MESSAGES` | No | `true` | Use `sendRichMessage` for tables/headings/long content (Bot API 10.1+). Set `false` to opt out. |
-| `TELEGRAM_STREAMING` | No | `true` | Stream replies live via `sendRichMessageDraft`. Set `false` for send-once mode (single final message). |
+| `TELEGRAM_STREAMING` | No | follows `TELEGRAM_RICH_MESSAGES` | Stream replies live via `sendRichMessageDraft`. Defaults to `true` when rich messages are enabled, `false` otherwise. Set `false` for send-once mode (single final message). |
 | `GATEWAY_WS_TOKEN` | No | — | WebSocket auth token |
 | `GATEWAY_LISTEN` | No | `0.0.0.0:8080` | Listen address |
 | `TELEGRAM_WEBHOOK_PATH` | No | `/webhook/telegram` | Webhook endpoint path |

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -33,6 +33,7 @@ Set environment variables:
 | `TELEGRAM_SECRET_TOKEN` | No | Webhook signature validation |
 | `TELEGRAM_BOT_USERNAME` | No | Bot username for @mention gating |
 | `TELEGRAM_RICH_MESSAGES` | No | `true` (default) for rich formatting |
+| `TELEGRAM_STREAMING` | No | `true` (default) — stream replies via rich message drafts. Set `false` for send-once mode |
 | `GATEWAY_LISTEN` | No | Listen address (default: `0.0.0.0:8080`) |
 
 OAB config (`config.toml`):
@@ -60,6 +61,8 @@ tool_display = "compact"
 [markdown]
 tables = "off"
 ```
+
+Streaming is enabled by default — replies are streamed live via `sendRichMessageDraft` with rich formatting, then finalized with `sendRichMessage`. To disable streaming (send-once mode), set `TELEGRAM_STREAMING=false` in the container environment.
 
 No `[gateway]` section needed — the unified adapter activates automatically when `TELEGRAM_BOT_TOKEN` is set.
 
@@ -295,6 +298,7 @@ Set `TELEGRAM_RICH_MESSAGES=false` to disable rich messages and use legacy `send
 | `TELEGRAM_BOT_TOKEN` | Yes | — | Bot API token from @BotFather |
 | `TELEGRAM_SECRET_TOKEN` | No | — | Webhook signature validation |
 | `TELEGRAM_RICH_MESSAGES` | No | `true` | Use `sendRichMessage` for tables/headings/long content (Bot API 10.1+). Set `false` to opt out. |
+| `TELEGRAM_STREAMING` | No | `true` | Stream replies live via `sendRichMessageDraft`. Set `false` for send-once mode (single final message). |
 | `GATEWAY_WS_TOKEN` | No | — | WebSocket auth token |
 | `GATEWAY_LISTEN` | No | `0.0.0.0:8080` | Listen address |
 | `TELEGRAM_WEBHOOK_PATH` | No | `/webhook/telegram` | Webhook endpoint path |

--- a/src/unified_adapter.rs
+++ b/src/unified_adapter.rs
@@ -162,13 +162,17 @@ impl ChatAdapter for UnifiedGatewayAdapter {
     }
 
     async fn add_reaction(&self, msg: &MessageRef, emoji: &str) -> Result<()> {
-        let reply = self.build_reply(&msg.channel, emoji, Some("add_reaction"), None);
+        let mut reply = self.build_reply(&msg.channel, emoji, Some("add_reaction"), None);
+        // Use the actual platform message_id (not origin_event_id which is a UUID)
+        reply.reply_to = msg.message_id.clone();
         self.dispatch_reply(&reply).await;
         Ok(())
     }
 
     async fn remove_reaction(&self, msg: &MessageRef, emoji: &str) -> Result<()> {
-        let reply = self.build_reply(&msg.channel, emoji, Some("remove_reaction"), None);
+        let mut reply = self.build_reply(&msg.channel, emoji, Some("remove_reaction"), None);
+        // Use the actual platform message_id (not origin_event_id which is a UUID)
+        reply.reply_to = msg.message_id.clone();
         self.dispatch_reply(&reply).await;
         Ok(())
     }

--- a/src/unified_adapter.rs
+++ b/src/unified_adapter.rs
@@ -199,10 +199,11 @@ impl ChatAdapter for UnifiedGatewayAdapter {
     }
 
     fn use_streaming(&self, _other_bot_present: bool) -> bool {
-        // Enable streaming (rich message draft) for Telegram when TELEGRAM_STREAMING=true
+        // Telegram rich streaming is enabled by default.
+        // Set TELEGRAM_STREAMING=false to disable.
         std::env::var("TELEGRAM_STREAMING")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
+            .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+            .unwrap_or(true)
     }
 
     fn show_streaming_placeholder(&self) -> bool {

--- a/src/unified_adapter.rs
+++ b/src/unified_adapter.rs
@@ -199,15 +199,17 @@ impl ChatAdapter for UnifiedGatewayAdapter {
     }
 
     fn use_streaming(&self, _other_bot_present: bool) -> bool {
-        // Telegram rich streaming is enabled by default.
-        // Set TELEGRAM_STREAMING=false to disable.
+        // Behavior change: previously always returned `false` because webhook platforms
+        // couldn't do streaming edits. Now that Telegram supports sendRichMessageDraft,
+        // streaming is enabled by default. Operators can disable with TELEGRAM_STREAMING=false.
         std::env::var("TELEGRAM_STREAMING")
             .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
             .unwrap_or(true)
     }
 
     fn show_streaming_placeholder(&self) -> bool {
-        // No placeholder needed — Telegram uses sendRichMessageDraft for streaming preview
+        // No placeholder needed — Telegram uses sendRichMessageDraft for streaming preview.
+        // The draft mechanism handles the "typing" indicator natively.
         false
     }
 }

--- a/src/unified_adapter.rs
+++ b/src/unified_adapter.rs
@@ -178,7 +178,9 @@ impl ChatAdapter for UnifiedGatewayAdapter {
     }
 
     async fn edit_message(&self, msg: &MessageRef, content: &str) -> Result<()> {
-        let reply = self.build_reply(&msg.channel, content, Some("edit_message"), None);
+        let mut reply = self.build_reply(&msg.channel, content, Some("edit_message"), None);
+        // Use the actual platform message_id (e.g. "draft" for streaming, or numeric for edits)
+        reply.reply_to = msg.message_id.clone();
         self.dispatch_reply(&reply).await;
         Ok(())
     }
@@ -199,12 +201,15 @@ impl ChatAdapter for UnifiedGatewayAdapter {
     }
 
     fn use_streaming(&self, _other_bot_present: bool) -> bool {
-        // Behavior change: previously always returned `false` because webhook platforms
-        // couldn't do streaming edits. Now that Telegram supports sendRichMessageDraft,
-        // streaming is enabled by default. Operators can disable with TELEGRAM_STREAMING=false.
-        std::env::var("TELEGRAM_STREAMING")
-            .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
-            .unwrap_or(true)
+        // TELEGRAM_STREAMING env var is the explicit override (true/false).
+        // If not set, default to `true` when Telegram Rich Messages are enabled
+        // (implies sendRichMessageDraft support), `false` otherwise.
+        // This ensures Telegram-only deployments get streaming out of the box,
+        // while multi-platform deployments stay safe by default.
+        if let Ok(v) = std::env::var("TELEGRAM_STREAMING") {
+            return v == "1" || v.eq_ignore_ascii_case("true");
+        }
+        self.gw_state.telegram_rich_messages
     }
 
     fn show_streaming_placeholder(&self) -> bool {

--- a/src/unified_adapter.rs
+++ b/src/unified_adapter.rs
@@ -199,6 +199,14 @@ impl ChatAdapter for UnifiedGatewayAdapter {
     }
 
     fn use_streaming(&self, _other_bot_present: bool) -> bool {
-        false // Webhook platforms don't support streaming edits
+        // Enable streaming (rich message draft) for Telegram when TELEGRAM_STREAMING=true
+        std::env::var("TELEGRAM_STREAMING")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    }
+
+    fn show_streaming_placeholder(&self) -> bool {
+        // No placeholder needed — Telegram uses sendRichMessageDraft for streaming preview
+        false
     }
 }


### PR DESCRIPTION
## Problem

Emoji reactions (🤔 → 👨‍💻 → ⚡ → 🆗 rotation) stopped appearing on Telegram messages after the unified adapter refactor.

### Root Cause

`unified_adapter.add_reaction()` used `build_reply()` which sets `reply_to = channel.origin_event_id`. But `origin_event_id` is an internal UUID (`"evt_<random-uuid>"`), **not** the actual Telegram message ID.

Telegram's `setMessageReaction` API received `"message_id": "evt_abc123..."` → 400 Bad Request, silently swallowed by `let _ =`.

In v0.8.2 (pre-unified adapter), the gateway adapter directly used `msg.message_id` (the real Telegram numeric message ID like `"12345"`) — which was correct.

### Fix

1. **`unified_adapter`**: Override `reply_to = msg.message_id` in `add_reaction()` / `remove_reaction()` instead of using `origin_event_id`.
2. **`telegram adapter`**: Parse `reply_to` as `i64` for the API call + add debug/warn logging so reaction failures are no longer silent. Early return on parse failure instead of sending invalid message_id.
3. **Remove thinking draft**: Remove the `sendMessageDraft` indicator (from #1249) — it only showed `...` instead of useful text, and the emoji-reaction approach is cleaner.

### Behavior Change: Streaming Enabled

**`use_streaming()` now returns `true` by default** (previously `false`).

This is intentional: with the thinking draft removed, Telegram's `sendRichMessageDraft` is used for streaming preview instead. The old `false` return was because webhook platforms couldn't do streaming edits — now that Telegram supports rich message drafts, streaming works natively.

- **Default**: streaming enabled (`use_streaming() → true`)
- **Opt-out**: set `TELEGRAM_STREAMING=false` to disable
- **Placeholder**: `show_streaming_placeholder()` returns `false` (drafts handle this natively)

### What You'll See

Bot reacts to your message with rotating emoji during processing:
```
User sends message
  → 👀 (queued)
  → 🤔 (thinking)
  → 👨‍💻 / 🌐 / ⚡ (tool use)
  → 🆗 + random mood face (done)
```

### Changes

- `src/unified_adapter.rs`: Fix `reply_to` for reactions, enable streaming by default
- `crates/openab-gateway/src/adapters/telegram.rs`: Remove thinking draft, add reaction logging, fix msg_id type with early-return on parse failure

### Reverts / Fixes

- Fixes emoji reaction regression introduced in unified adapter refactor
- Removes thinking draft from #1249, #1247, #1238