### PR TITLE
fix: symlink gh to ghp in pre-seed bundle

### DIFF
--- a/.github/workflows/bundle-pre-seed-utils.yml
+++ b/.github/workflows/bundle-pre-seed-utils.yml
@@ -89,12 +89,9 @@ jobs:
           cp /tmp/ghp ./bin/ghp
           chmod +x ./bin/ghp
 
-      - name: Download gh CLI
+      - name: Symlink gh to ghp
         run: |
-          GH_VERSION=$(gh --version | head -1 | awk '{print $3}')
-          # Use the runner's gh binary directly
-          cp $(which gh) ./bin/gh
-          chmod +x ./bin/gh
+          cd bin && ln -sf ghp gh && cd ..
 
       - name: Fix symlinks to be relative
         run: |
@@ -116,7 +113,9 @@ jobs:
           ls -la ./aws-cli/v2/
           echo "=== resolve test ==="
           ./bin/aws --version
-          ./bin/ghp --version || true
+          ./bin/ghp --version
+          # gh should resolve to ghp
+          test "$(readlink ./bin/gh)" = "ghp"
 
       - name: Create tarball
         run: |
@@ -161,7 +160,7 @@ jobs:
           **Contents:**
           - AWS CLI v${{ needs.resolve.outputs.aws_cli_version }}
           - ghp v${{ needs.resolve.outputs.ghpool_version }} (ghpool shim)
-          - gh CLI (from runner)
+          - gh → ghp symlink
 
           **Usage:** Add to \`[hooks.pre_seed].sources\` as S3 URI after uploading." \
             artifacts/utils-x86_64.tar.gz \


### PR DESCRIPTION
## Summary

Replace the bundled `gh` binary with a symlink to `ghp`. When an agent runs `gh`, it resolves to `ghp` which:
- Routes **reads** through ghpool (pooled + cached)
- Falls through to the system `gh` for **writes/mutations**

This cuts ~4.7MB from the tarball and ensures there's only one binary to update.

## bin/ layout

```
aws -> ../aws-cli/v2/current/bin/aws
aws_completer -> ../aws-cli/v2/current/bin/aws_completer
gh -> ghp
ghp (binary)
```

## Changes

- Removed "Download gh CLI" step (was copying runner's `gh` binary)
- Added "Symlink gh to ghp" step (`ln -sf ghp gh`)
- Verify step now asserts symlink target
- Updated release notes to reflect gh is a symlink