### PR TITLE
feat(trust): gateway echo-on-deny (Phase 2) + trust-none default (Phase 3)

### DIFF
--- a/crates/openab-core/src/gateway.rs
+++ b/crates/openab-core/src/gateway.rs
@@ -1473,6 +1473,15 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
+    #[test]
+    fn echo_allowed_throttles_repeat_within_window() {
+        // Unique key so we don't collide with other tests touching the global map.
+        let key = "test-platform:test-sender-echo-throttle";
+        assert!(echo_allowed(key), "first echo should be allowed");
+        assert!(!echo_allowed(key), "immediate repeat should be throttled");
+        assert!(!echo_allowed(key), "still throttled within the window");
+    }
+
     fn make_event(is_bot: bool, sender_id: &str, channel_id: &str, channel_type: &str, thread_id: Option<&str>, mentions: Vec<&str>) -> GatewayEvent {
         serde_json::from_value(serde_json::json!({
             "schema": "openab.gateway.event.v1",

--- a/crates/openab-core/src/gateway.rs
+++ b/crates/openab-core/src/gateway.rs
@@ -1140,6 +1140,28 @@ pub struct GatewayEventContext {
 ///
 /// This is the core event-handling logic extracted from the WebSocket handler,
 /// made available for the unified binary to call directly from axum webhook handlers.
+/// Throttle for request-access echoes: at most one echo per (platform, sender)
+/// per [`ECHO_WINDOW`], to prevent an untrusted spammer from being amplified by
+/// the bot's replies.
+static ECHO_THROTTLE: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, std::time::Instant>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+const ECHO_WINDOW: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Returns true if an echo to `key` is allowed now (and records the timestamp).
+fn echo_allowed(key: &str) -> bool {
+    let now = std::time::Instant::now();
+    let mut map = ECHO_THROTTLE.lock().unwrap();
+    match map.get(key) {
+        Some(prev) if now.duration_since(*prev) < ECHO_WINDOW => false,
+        _ => {
+            map.insert(key.to_string(), now);
+            true
+        }
+    }
+}
+
 pub async fn process_gateway_event(
     event_json: &str,
     ctx: &GatewayEventContext,
@@ -1174,16 +1196,47 @@ pub async fn process_gateway_event(
     let decision =
         ctx.router
             .gate_incoming(&event.platform, &event.channel.id, false, &event.sender.id);
-    if !decision.is_allowed() {
-        tracing::info!(
-            platform = %event.platform,
-            sender = %event.sender.id,
-            channel = %event.channel.id,
-            ?decision,
-            "gateway event denied by trust gate"
-        );
-        // Phase 2 will echo the sender their ID on Decision::DenyIdentity.
-        return Ok(false);
+    match decision {
+        crate::trust::Decision::Allow => {}
+        crate::trust::Decision::DenyIdentity => {
+            // L3 identity deny → echo the sender their ID so they can request
+            // access (throttled to avoid amplification). Bots never reach here
+            // (should_skip_event handles bot admission; L3 is human-only).
+            tracing::info!(
+                platform = %event.platform,
+                sender = %event.sender.id,
+                channel = %event.channel.id,
+                "gateway event denied (identity); echoing request-access"
+            );
+            let throttle_key = format!("{}:{}", event.platform, event.sender.id);
+            if echo_allowed(&throttle_key) {
+                let echo_channel = ChannelRef {
+                    platform: event.platform.clone(),
+                    channel_id: event.channel.id.clone(),
+                    thread_id: event.channel.thread_id.clone(),
+                    parent_id: None,
+                    origin_event_id: Some(event.event_id.clone()),
+                };
+                let echo = format!(
+                    "⚠️ You are not on this bot's trusted list.\nYour ID: {}\nAsk the admin to add it to allowed_users.",
+                    event.sender.id
+                );
+                let _ = ctx.adapter.send_message(&echo_channel, &echo).await;
+            }
+            return Ok(false);
+        }
+        // DenyScope (and any future variant) → silent drop (scope is not a
+        // security boundary; no request-access echo).
+        _ => {
+            tracing::info!(
+                platform = %event.platform,
+                sender = %event.sender.id,
+                channel = %event.channel.id,
+                ?decision,
+                "gateway event denied (scope); silent"
+            );
+            return Ok(false);
+        }
     }
 
     tracing::info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,7 +278,10 @@ async fn main() -> anyhow::Result<()> {
         };
         let allow_all_channels = env_bool("GATEWAY_ALLOW_ALL_CHANNELS", true);
         let allowed_channels = env_set("GATEWAY_ALLOWED_CHANNELS");
-        let allow_all_users = env_bool("GATEWAY_ALLOW_ALL_USERS", true);
+        // L3 identity: trust-none by default (Phase 3). Was `true` in #1267
+        // (behavior-preserving); now defaults deny-all — set GATEWAY_ALLOW_ALL_USERS=true
+        // or list GATEWAY_ALLOWED_USERS to admit senders. L2 (channels) stays open.
+        let allow_all_users = env_bool("GATEWAY_ALLOW_ALL_USERS", false);
         let allowed_users = env_set("GATEWAY_ALLOWED_USERS");
         let mut reg = PlatformTrustConfigs::new();
         for platform in ["telegram", "line", "feishu", "wecom", "googlechat", "teams"] {


### PR DESCRIPTION
Enables **trust-none** for the gateway path (Telegram/LINE/…) with the **request-access echo**, so you can see the deny + echo UX end-to-end. Scoped intent: only pre-beta (self-use) runs this; **emilie is unaffected** (its own image + WS path, which doesn't use this registry/echo).

## Changes
- **Phase 2 — echo on deny**: when the gate returns `DenyIdentity`, reply to the sender with their ID + how to request access (`adapter.send_message`). Throttled to **1 echo per (platform, sender) / 5 min** (LazyLock map) to prevent amplification. `DenyScope` stays **silent** (scope isn't a security boundary).
- **Phase 3 (gateway) — trust-none default**: flip `GATEWAY_ALLOW_ALL_USERS` default `true → false`. Gateway L3 is now deny-all unless `GATEWAY_ALLOWED_USERS` lists the sender (or `GATEWAY_ALLOW_ALL_USERS=true`). **L2 (channels) stays open.**

## ⚠️ Behavior change (intended)
Gateway deployments on this image now **deny unknown users by default**. To keep a bot working:
- set `GATEWAY_ALLOWED_USERS=<uid,…>`, or
- set `GATEWAY_ALLOW_ALL_USERS=true` (old behavior).

Discord/Slack registry entries are **unchanged** (still behavior-preserving allow-all). Deviates from the strict #1269 phase order (deny-flip before privatization) — accepted because it ships only to pre-beta (self-use) for validation.

## How to test (Telegram)
1. On the pre-beta Telegram bot, set `GATEWAY_ALLOWED_USERS=<your uid>` → you're admitted.
2. Message from a **non-listed** account → no agent action + you get: `⚠️ You are not on this bot's trusted list. Your ID: <id> …` (once per 5 min).

## Testing
- clippy `--features unified -D warnings` clean; 10/10 gateway tests (incl. new `echo_allowed_throttles_repeat_within_window`).

Refs #1264 #1269