### PR TITLE
feat(chart): add configToml pass-through as alternative to Helm rende…

### DIFF
--- a/charts/openab/README.md
+++ b/charts/openab/README.md
@@ -96,6 +96,22 @@ helm install openab openab/openab \
   --set-file agents.kiro.agentsMd=./AGENTS.md
 ```
 
+### Provide `config.toml` as-is with `--set-file`
+
+`configToml` accepts a raw TOML string, which can be pasted inline into `values.yaml`
+or loaded verbatim from a standalone file. Keeping `config.toml` as a real file gives
+you full IDE syntax highlighting and TOML schema validation, instead of an indented
+YAML block scalar:
+
+```bash
+helm upgrade openab openab/openab \
+  --set-file agents.kiro.configToml=./config.toml
+```
+
+See `docs/migrate-to-configtoml.md` for a full before/after guide, and
+`docs/adr/configurl-over-helm-rendering.md` for when to prefer `configUrl` instead
+(platform-agnostic — works identically on Kubernetes, ECS, Zeabur, and AgentCore).
+
 ### Discord ID precision warning
 
 Discord IDs must be set with `--set-string`, not `--set`. Otherwise Helm may coerce them into numbers and lose precision.

--- a/charts/openab/README.md
+++ b/charts/openab/README.md
@@ -108,8 +108,8 @@ helm upgrade openab openab/openab \
   --set-file agents.kiro.configToml=./config.toml
 ```
 
-See `docs/migrate-to-configtoml.md` for a full before/after guide, and
-`docs/adr/configurl-over-helm-rendering.md` for when to prefer `configUrl` instead
+See [`docs/migrate-to-configtoml.md`](../../docs/migrate-to-configtoml.md) for a full before/after guide, and
+[`docs/adr/configurl-over-helm-rendering.md`](../../docs/adr/configurl-over-helm-rendering.md) for when to prefer `configUrl` instead
 (platform-agnostic — works identically on Kubernetes, ECS, Zeabur, and AgentCore).
 
 ### Discord ID precision warning

--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -71,3 +71,23 @@ Agents deployed:
 ⚠️  SECURITY: The agent subprocess only receives HOME, PATH, and explicitly configured [agent].env vars.
     Any env var passed via [agent].env is accessible to the agent and could be exfiltrated via prompt injection.
     All supported backends use OAuth/file-based auth — avoid passing API keys via env vars when possible.
+
+{{- $legacyAgents := list }}
+{{- range $name, $cfg := .Values.agents }}
+{{- if ne (include "openab.agentEnabled" $cfg) "false" }}
+{{- if and (not $cfg.configToml) (not $cfg.configUrl) }}
+{{- $legacyAgents = append $legacyAgents $name }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $legacyAgents }}
+
+⚠️  DEPRECATION NOTICE:
+    The following agents use Helm-rendered config (slack.*, discord.*, pool.*, etc.):
+{{- range $legacyAgents }}
+      • {{ . }}
+{{- end }}
+    This rendering path will be removed in v0.10.0.
+    Migrate to configToml to write config.toml directly in your values file.
+    See: https://github.com/openabdev/openab/blob/main/docs/migrate-to-configtoml.md
+{{- end }}

--- a/charts/openab/templates/NOTES.txt
+++ b/charts/openab/templates/NOTES.txt
@@ -87,7 +87,9 @@ Agents deployed:
 {{- range $legacyAgents }}
       • {{ . }}
 {{- end }}
-    This rendering path will be removed in v0.10.0.
-    Migrate to configToml to write config.toml directly in your values file.
+    This rendering path is deprecated and will be removed in a future release.
+    Track the removal timeline: https://github.com/openabdev/openab/issues/1278
+    Migrate to configToml (or configUrl for a platform-agnostic setup) to write
+    config.toml directly instead of relying on Helm's rendering.
     See: https://github.com/openabdev/openab/blob/main/docs/migrate-to-configtoml.md
 {{- end }}

--- a/charts/openab/templates/configmap.yaml
+++ b/charts/openab/templates/configmap.yaml
@@ -10,6 +10,10 @@ metadata:
   labels:
     {{- include "openab.labels" $d | nindent 4 }}
 data:
+  {{- if $cfg.configToml }}
+  config.toml: |
+{{ $cfg.configToml | indent 4 }}
+  {{- else }}
   config.toml: |
     {{- if ($cfg.discord).enabled }}
     [discord]
@@ -342,6 +346,7 @@ data:
     {{ $alias | toJson }} = {{ $path | toJson }}
     {{- end }}
     {{- end }}
+  {{- end }}
   {{- if $cfg.agentsMd }}
   AGENTS.md: |
     {{- $cfg.agentsMd | nindent 4 }}

--- a/charts/openab/tests/configtoml-passthrough_test.yaml
+++ b/charts/openab/tests/configtoml-passthrough_test.yaml
@@ -1,0 +1,56 @@
+suite: configToml pass-through
+templates:
+  - templates/configmap.yaml
+
+tests:
+  - it: renders configToml verbatim when set
+    set:
+      agents.kiro.configToml: |
+        [slack]
+        bot_token = "${SLACK_BOT_TOKEN}"
+        allowed_channels = ["C01234567"]
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[slack\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'allowed_channels = \["C01234567"\]'
+
+  - it: does not render Helm-templated fields when configToml is set
+    set:
+      agents.kiro.configToml: |
+        [slack]
+        bot_token = "${SLACK_BOT_TOKEN}"
+      agents.kiro.slack.enabled: true
+      agents.kiro.pool.maxSessions: 5
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: '\[pool\]'
+
+  - it: still renders agentsMd alongside configToml
+    set:
+      agents.kiro.configToml: |
+        [slack]
+        bot_token = "${SLACK_BOT_TOKEN}"
+      agents.kiro.agentsMd: "# My Agent\nDo things."
+    asserts:
+      - isNotNull:
+          path: data["AGENTS.md"]
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[slack\]'
+
+  - it: skips ConfigMap entirely when configUrl is set
+    set:
+      agents.kiro.configUrl: "s3://my-bucket/config.toml"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: falls back to Helm rendering when configToml is absent
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[agent\]'

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -88,6 +88,25 @@ agents:
     #     existingClaim: ""  # set to reuse an existing PVC (skips PVC creation)
     #     storageClass: ""
     #     size: 1Gi
+    #   # configToml: provide a raw config.toml string instead of using the Helm-rendered template.
+    #   # The content is mounted verbatim — no field mapping, no validation. Secrets must still be
+    #   # injected via secretEnv (they render as env vars and are referenced as ${VAR} in the TOML).
+    #   # When set, all adapter fields (slack.*, discord.*, pool.*, etc.) are ignored for rendering.
+    #   # Example:
+    #   # configToml: |
+    #   #   [slack]
+    #   #   bot_token = "${SLACK_BOT_TOKEN}"
+    #   #   allowed_channels = ["C01234567"]
+    #   #   allow_user_messages = "mentions"
+    #   #
+    #   #   [agent]
+    #   #   command = "claude-agent-acp"
+    #   #   inherit_env = ["ANTHROPIC_API_KEY"]
+    #   #
+    #   #   [pool]
+    #   #   max_sessions = 10
+    #   #   session_ttl_hours = 24
+    #   configToml: ""
     #   # ⚠️ When set, this ConfigMap mount shadows any file at the same path on the PVC.
     #   # The PVC file is NOT deleted but becomes invisible to the agent. Remove agentsMd to restore.
     #   agentsMd: ""

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -92,6 +92,9 @@ agents:
     #   # The content is mounted verbatim — no field mapping, no validation. Secrets must still be
     #   # injected via secretEnv (they render as env vars and are referenced as ${VAR} in the TOML).
     #   # When set, all adapter fields (slack.*, discord.*, pool.*, etc.) are ignored for rendering.
+    #   # Can be set inline (below) or loaded as-is from a standalone file (WYSIWYG editing, full
+    #   # TOML syntax highlighting/schema validation in your editor) via:
+    #   #   helm upgrade ... --set-file agents.<name>.configToml=./config.toml
     #   # Example:
     #   # configToml: |
     #   #   [slack]

--- a/docs/migrate-to-configtoml.md
+++ b/docs/migrate-to-configtoml.md
@@ -7,7 +7,7 @@ issue for its removal timeline: https://github.com/openabdev/openab/issues/1278
 
 For the platform-agnostic option (works identically on Kubernetes, ECS,
 Zeabur, and AgentCore Runtime — no chart required), see `configUrl` instead:
-`docs/adr/configurl-over-helm-rendering.md`. `configToml` is the
+[`docs/adr/configurl-over-helm-rendering.md`](adr/configurl-over-helm-rendering.md). `configToml` is the
 Kubernetes/Helm-only convenience for users not yet on external config storage.
 
 ## Why

--- a/docs/migrate-to-configtoml.md
+++ b/docs/migrate-to-configtoml.md
@@ -1,0 +1,160 @@
+# Migrating to `configToml`
+
+`configToml` lets you write `config.toml` directly instead of relying on the
+Helm-rendered path (`slack.*`, `discord.*`, `pool.*`, etc. in `values.yaml`).
+The Helm-rendered path is deprecated and unmaintained — see the tracking
+issue for its removal timeline: https://github.com/openabdev/openab/issues/1278
+
+For the platform-agnostic option (works identically on Kubernetes, ECS,
+Zeabur, and AgentCore Runtime — no chart required), see `configUrl` instead:
+`docs/adr/configurl-over-helm-rendering.md`. `configToml` is the
+Kubernetes/Helm-only convenience for users not yet on external config storage.
+
+## Why
+
+The old path was a ~350-line TOML serializer written in Helm template language.
+Every new config field required a chart release. The rendered output was invisible
+to users without running `helm template`. `configToml` is a direct pass-through —
+what you write is what gets deployed.
+
+## Two ways to set `configToml`
+
+**Inline** — paste TOML directly into `values.yaml`:
+
+```yaml
+agents:
+  kiro:
+    configToml: |
+      [discord]
+      bot_token = "${DISCORD_BOT_TOKEN}"
+```
+
+**As-is from a standalone file** — keep `config.toml` as a real file (full IDE
+syntax highlighting / TOML schema validation) and load it verbatim with Helm's
+built-in `--set-file`:
+
+```bash
+helm upgrade openab openab/openab \
+  --set-file agents.kiro.configToml=./config.toml
+```
+
+`--set-file` reads the file's raw content and assigns it as a string to
+`agents.kiro.configToml`, merging the same way `--set` does. No chart changes
+needed — this is the recommended way to keep `config.toml` WYSIWYG-editable.
+
+## Before → After
+
+### Slack
+
+**Before:**
+```yaml
+agents:
+  claude:
+    slack:
+      enabled: true
+      existingSecret: openab
+      assistantMode: true
+      allowUserMessages: "mentions"
+      allowedChannels:
+        - "C01234567"
+      allowedUsers:
+        - "U01234567"
+    pool:
+      maxSessions: 10
+      sessionTtlHours: 24
+    reactions:
+      enabled: true
+      removeAfterReply: false
+    command: claude-agent-acp
+    workingDir: /home/node
+    secretEnv:
+      - name: ANTHROPIC_API_KEY
+        secretName: openab
+        secretKey: ANTHROPIC_API_KEY
+```
+
+**After:**
+```yaml
+agents:
+  claude:
+    secretEnv:
+      - name: ANTHROPIC_API_KEY
+        secretName: openab
+        secretKey: ANTHROPIC_API_KEY
+      - name: SLACK_BOT_TOKEN
+        secretName: openab
+        secretKey: slack-bot-token
+      - name: SLACK_APP_TOKEN
+        secretName: openab
+        secretKey: slack-app-token
+    configToml: |
+      [slack]
+      bot_token = "${SLACK_BOT_TOKEN}"
+      app_token = "${SLACK_APP_TOKEN}"
+      allowed_channels = ["C01234567"]
+      allowed_users = ["U01234567"]
+      allow_user_messages = "mentions"
+      assistant_mode = true
+
+      [agent]
+      command = "claude-agent-acp"
+      working_dir = "/home/node"
+      inherit_env = ["ANTHROPIC_API_KEY"]
+
+      [pool]
+      max_sessions = 10
+      session_ttl_hours = 24
+
+      [reactions]
+      enabled = true
+      remove_after_reply = false
+```
+
+### Discord
+
+**Before:**
+```yaml
+agents:
+  kiro:
+    discord:
+      botToken: "${DISCORD_BOT_TOKEN}"
+      allowedChannels:
+        - "123456789012345678"
+      allowedUsers:
+        - "987654321098765432"
+    command: kiro-cli
+```
+
+**After:**
+```yaml
+agents:
+  kiro:
+    secretEnv:
+      - name: DISCORD_BOT_TOKEN
+        secretName: my-secret
+        secretKey: discord-bot-token
+    configToml: |
+      [discord]
+      bot_token = "${DISCORD_BOT_TOKEN}"
+      allowed_channels = ["123456789012345678"]
+      allowed_users = ["987654321098765432"]
+
+      [agent]
+      command = "kiro-cli"
+```
+
+## Secrets
+
+Secrets must still be injected via `secretEnv` — they render as `valueFrom.secretKeyRef`
+in the Deployment and are available as environment variables. Reference them in
+`configToml` as `${VAR_NAME}` placeholders exactly as before.
+
+## Tip: see your current rendered config
+
+Before migrating, check what your current `config.toml` looks like:
+
+```bash
+kubectl exec -it deployment/<your-agent> -- cat /etc/openab/config.toml
+```
+
+Use that output as the starting point for your `configToml` value.


### PR DESCRIPTION
## Problem

`configmap.yaml` is a 352-line TOML serializer written in Helm template language.
Every new config.toml field requires a chart PR. Users cannot read their rendered
config without running `helm template`. As discussed in the community:

> "I just want a 20-line config.toml, not 1000 lines of .tpl + .yaml" — @pahud

Related: #1271 (ADR merged separately)

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1521929061511991449/1522153901816549397 

## At a Glance

Current path (unchanged):
values.yaml (YAML)
└── configmap.yaml (352-line Helm→TOML serializer)
└── ConfigMap config.toml (rendered)

New path (configToml):
values.yaml (raw TOML string)
└── configmap.yaml (5-line pass-through)
└── ConfigMap config.toml (verbatim)

configUrl path (unchanged):
values.yaml (configUrl: s3://...)
└── No ConfigMap — pod fetches at boot


## Prior Art & Industry Research

**OpenClaw:**
OpenClaw stores its configuration as a raw JSON file (`~/.openclaw/openclaw.json`) that users write directly — there is no Helm-to-JSON rendering layer. The deploy tooling mounts the file as-is. Source: https://github.com/openclaw/openclaw

**Hermes Agent:**
Hermes Agent has no official Helm chart of its own. The openab project defines how to deploy Hermes via its chart (`docs/hermes.md`), and the `config.toml` example there (`[agent]` block only) is notably minimal — suggesting that users are expected to write TOML directly rather than derive it through values mappings.

**Other references:**
The pass-through pattern is well-established in the Helm ecosystem for application-specific config formats:
- `bitnami/redis` accepts raw `redis.conf` content via `configmap.redis` rather than templating individual Redis options
- `grafana/grafana` supports both structured values and a raw `grafana.ini` override
The principle: Helm renders K8s resources; the application owns its config format.

## Proposed Solution

Add a `configToml` field to agent config. When set, the content is mounted verbatim into the ConfigMap as `config.toml` using a 5-line pass-through template — no field mapping, no format conversion.

The `configmap.yaml` change is a minimal if/else wrapper around the existing template:

```yaml
{{- if $cfg.configToml }}
config.toml: |
{{ $cfg.configToml | indent 4 }}
{{- else }}
config.toml: |
  ... existing 352-line template unchanged ...
{{- end }}
