### PR TITLE
fix(slack): bound reconnect-path network calls with a 30s timeout

### DIFF
--- a/crates/openab-core/Cargo.toml
+++ b/crates/openab-core/Cargo.toml
@@ -51,6 +51,9 @@ http = { version = "1", optional = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }
+
 [features]
 default = ["discord", "slack", "secrets-aws", "agentcore", "config-s3"]
 discord = ["dep:serenity"]

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -699,14 +699,36 @@ const MAX_CONSECUTIVE_BOT_TURNS: usize = 1000;
 const PING_INTERVAL_SECS: u64 = 30;
 const IDLE_TIMEOUT_SECS: u64 = 75;
 const MAX_BACKOFF_SECS: u64 = 30;
-/// Bounds `get_socket_mode_url` and `connect_async` in the reconnect path so a
-/// stalled TCP/TLS handshake surfaces as a retry instead of parking the
-/// reconnect task forever with no logs (see #1279).
+/// Bounds `connect_async` (the WebSocket handshake) in the reconnect path.
+/// `tokio_tungstenite` carries no timeout of its own, so this is the sole
+/// bound against a stalled TLS/WS handshake parking the reconnect task
+/// forever with no logs (see #1279).
 const RECONNECT_TIMEOUT_SECS: u64 = 30;
+/// Bounds `get_socket_mode_url` (the `apps.connections.open` Web API call) in
+/// the reconnect path. Set strictly above the adapter client's own 30s
+/// timeout (see `SlackAdapter::new`) so that timeout — which carries a
+/// diagnosable cause — fires first in the normal case; this constant is a
+/// backstop for the rare case the client builder failed and fell back to an
+/// unbounded `reqwest::Client::new()` (see #1279).
+const RECONNECT_HTTP_TIMEOUT_SECS: u64 = 35;
 
 /// Next reconnect delay: double, capped. Reset to 1 on a successful connect.
 fn next_backoff(cur: u64) -> u64 {
     (cur * 2).min(MAX_BACKOFF_SECS)
+}
+
+/// Sleep for `backoff_secs`, honoring shutdown. Returns the next backoff
+/// value, or `None` if a shutdown signal arrived during the sleep (caller
+/// should return immediately). Shared by every retry point in the reconnect
+/// loop so backoff/shutdown handling only needs to change in one place.
+async fn wait_backoff_or_shutdown(
+    backoff_secs: u64,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) -> Option<u64> {
+    tokio::select! {
+        _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => Some(next_backoff(backoff_secs)),
+        _ = shutdown_rx.changed() => None,
+    }
 }
 
 /// The socket is considered dead (half-open) when no inbound frame has arrived
@@ -749,7 +771,7 @@ pub async fn run_slack_adapter(
         }
 
         let ws_url = match tokio::time::timeout(
-            std::time::Duration::from_secs(RECONNECT_TIMEOUT_SECS),
+            std::time::Duration::from_secs(RECONNECT_HTTP_TIMEOUT_SECS),
             get_socket_mode_url(&adapter.client, &app_token),
         )
         .await
@@ -757,24 +779,22 @@ pub async fn run_slack_adapter(
             Ok(Ok(url)) => url,
             Ok(Err(e)) => {
                 error!(err = %e, backoff = backoff_secs, "failed to get Socket Mode URL, retrying");
-                tokio::select! {
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
-                    _ = shutdown_rx.changed() => { return Ok(()); }
+                match wait_backoff_or_shutdown(backoff_secs, &mut shutdown_rx).await {
+                    Some(next) => backoff_secs = next,
+                    None => return Ok(()),
                 }
-                backoff_secs = next_backoff(backoff_secs);
                 continue;
             }
             Err(_) => {
                 error!(
                     backoff = backoff_secs,
-                    timeout = RECONNECT_TIMEOUT_SECS,
+                    timeout = RECONNECT_HTTP_TIMEOUT_SECS,
                     "get Socket Mode URL timed out, retrying"
                 );
-                tokio::select! {
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
-                    _ = shutdown_rx.changed() => { return Ok(()); }
+                match wait_backoff_or_shutdown(backoff_secs, &mut shutdown_rx).await {
+                    Some(next) => backoff_secs = next,
+                    None => return Ok(()),
                 }
-                backoff_secs = next_backoff(backoff_secs);
                 continue;
             }
         };
@@ -1187,18 +1207,19 @@ pub async fn run_slack_adapter(
         }
 
         warn!(backoff = backoff_secs, "reconnecting to Slack Socket Mode");
-        tokio::select! {
-            _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
-            _ = shutdown_rx.changed() => { return Ok(()); }
+        match wait_backoff_or_shutdown(backoff_secs, &mut shutdown_rx).await {
+            Some(next) => backoff_secs = next,
+            None => return Ok(()),
         }
-        backoff_secs = next_backoff(backoff_secs);
     }
 }
 
 /// Call apps.connections.open to get a WebSocket URL for Socket Mode.
-/// Reuses the adapter's `reqwest::Client` (already bounded by a 30s timeout,
-/// see `SlackAdapter::new`) instead of building a fresh unbounded one per call
-/// (#386), and relies on that timeout to bound the reconnect path (#1279).
+/// Reuses the adapter's `reqwest::Client` instead of building a fresh
+/// unbounded one per call (#386). The reconnect path is bounded by the
+/// caller's explicit `tokio::time::timeout(RECONNECT_HTTP_TIMEOUT_SECS, ...)`
+/// (see #1279); the client's own 30s timeout (see `SlackAdapter::new`) is a
+/// secondary bound that fires first in the normal case, since it's shorter.
 async fn get_socket_mode_url(client: &reqwest::Client, app_token: &str) -> Result<String> {
     let resp = client
         .post(format!("{SLACK_API}/apps.connections.open"))
@@ -2349,7 +2370,7 @@ mod tests {
 
 #[cfg(test)]
 mod socket_keepalive_tests {
-    use super::{next_backoff, socket_idle, IDLE_TIMEOUT_SECS, MAX_BACKOFF_SECS};
+    use super::{next_backoff, socket_idle, IDLE_TIMEOUT_SECS, MAX_BACKOFF_SECS, RECONNECT_TIMEOUT_SECS};
     use std::time::Duration;
 
     /// Backoff doubles and caps, matching the gateway adapter (1,2,4,8,16,30,30…).
@@ -2376,5 +2397,37 @@ mod socket_keepalive_tests {
         assert!(!socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS - 1), timeout));
         assert!(socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS), timeout));
         assert!(socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS + 10), timeout));
+    }
+
+    /// Regression test for #1279: a stalled WebSocket handshake during reconnect
+    /// must surface as a timeout instead of parking the reconnect task forever.
+    /// `start_paused` lets the 30s timeout resolve instantly under Tokio's
+    /// virtual clock instead of a real wall-clock wait.
+    #[tokio::test(start_paused = true)]
+    async fn connect_async_timeout_fires_on_stalled_handshake() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind local listener");
+        let addr = listener.local_addr().expect("local addr");
+
+        // Accept the TCP connection but never send any WS handshake bytes, so
+        // `connect_async` blocks forever waiting for the server's HTTP
+        // upgrade response — the exact stall this timeout is meant to catch.
+        tokio::spawn(async move {
+            let _socket = listener.accept().await.expect("accept");
+            std::future::pending::<()>().await;
+        });
+
+        let ws_url = format!("ws://{addr}");
+        let result = tokio::time::timeout(
+            Duration::from_secs(RECONNECT_TIMEOUT_SECS),
+            tokio_tungstenite::connect_async(&ws_url),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "connect_async on a stalled handshake must time out, not hang"
+        );
     }
 }

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -699,6 +699,10 @@ const MAX_CONSECUTIVE_BOT_TURNS: usize = 1000;
 const PING_INTERVAL_SECS: u64 = 30;
 const IDLE_TIMEOUT_SECS: u64 = 75;
 const MAX_BACKOFF_SECS: u64 = 30;
+/// Bounds `get_socket_mode_url` and `connect_async` in the reconnect path so a
+/// stalled TCP/TLS handshake surfaces as a retry instead of parking the
+/// reconnect task forever with no logs (see #1279).
+const RECONNECT_TIMEOUT_SECS: u64 = 30;
 
 /// Next reconnect delay: double, capped. Reset to 1 on a successful connect.
 fn next_backoff(cur: u64) -> u64 {
@@ -744,10 +748,28 @@ pub async fn run_slack_adapter(
             return Ok(());
         }
 
-        let ws_url = match get_socket_mode_url(&app_token).await {
-            Ok(url) => url,
-            Err(e) => {
+        let ws_url = match tokio::time::timeout(
+            std::time::Duration::from_secs(RECONNECT_TIMEOUT_SECS),
+            get_socket_mode_url(&adapter.client, &app_token),
+        )
+        .await
+        {
+            Ok(Ok(url)) => url,
+            Ok(Err(e)) => {
                 error!(err = %e, backoff = backoff_secs, "failed to get Socket Mode URL, retrying");
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
+                    _ = shutdown_rx.changed() => { return Ok(()); }
+                }
+                backoff_secs = next_backoff(backoff_secs);
+                continue;
+            }
+            Err(_) => {
+                error!(
+                    backoff = backoff_secs,
+                    timeout = RECONNECT_TIMEOUT_SECS,
+                    "get Socket Mode URL timed out, retrying"
+                );
                 tokio::select! {
                     _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
                     _ = shutdown_rx.changed() => { return Ok(()); }
@@ -758,8 +780,13 @@ pub async fn run_slack_adapter(
         };
         info!(url = %ws_url, "connecting to Slack Socket Mode");
 
-        match tokio_tungstenite::connect_async(&ws_url).await {
-            Ok((ws_stream, _)) => {
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(RECONNECT_TIMEOUT_SECS),
+            tokio_tungstenite::connect_async(&ws_url),
+        )
+        .await
+        {
+            Ok(Ok((ws_stream, _))) => {
                 info!("Slack Socket Mode connected");
                 backoff_secs = 1; // reset on success
                 let (mut write, mut read) = ws_stream.split();
@@ -1147,8 +1174,15 @@ pub async fn run_slack_adapter(
                     }
                 }
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 error!(err = %e, backoff = backoff_secs, "failed to connect to Slack Socket Mode, retrying");
+            }
+            Err(_) => {
+                error!(
+                    backoff = backoff_secs,
+                    timeout = RECONNECT_TIMEOUT_SECS,
+                    "Slack Socket Mode connect timed out, retrying"
+                );
             }
         }
 
@@ -1162,8 +1196,10 @@ pub async fn run_slack_adapter(
 }
 
 /// Call apps.connections.open to get a WebSocket URL for Socket Mode.
-async fn get_socket_mode_url(app_token: &str) -> Result<String> {
-    let client = reqwest::Client::new();
+/// Reuses the adapter's `reqwest::Client` (already bounded by a 30s timeout,
+/// see `SlackAdapter::new`) instead of building a fresh unbounded one per call
+/// (#386), and relies on that timeout to bound the reconnect path (#1279).
+async fn get_socket_mode_url(client: &reqwest::Client, app_token: &str) -> Result<String> {
     let resp = client
         .post(format!("{SLACK_API}/apps.connections.open"))
         .header("Authorization", format!("Bearer {app_token}"))

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -717,6 +717,28 @@ fn next_backoff(cur: u64) -> u64 {
     (cur * 2).min(MAX_BACKOFF_SECS)
 }
 
+/// Wraps `connect_async` in the reconnect-path timeout. Extracted so the
+/// regression test exercises the exact same code path `run_slack_adapter`
+/// uses, instead of duplicating the timeout expression (#1279).
+async fn connect_with_reconnect_timeout(
+    ws_url: &str,
+) -> std::result::Result<
+    std::result::Result<
+        (
+            tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+            tungstenite::handshake::client::Response,
+        ),
+        tungstenite::Error,
+    >,
+    tokio::time::error::Elapsed,
+> {
+    tokio::time::timeout(
+        std::time::Duration::from_secs(RECONNECT_TIMEOUT_SECS),
+        tokio_tungstenite::connect_async(ws_url),
+    )
+    .await
+}
+
 /// Sleep for `backoff_secs`, honoring shutdown. Returns the next backoff
 /// value, or `None` if a shutdown signal arrived during the sleep (caller
 /// should return immediately). Shared by every retry point in the reconnect
@@ -800,12 +822,7 @@ pub async fn run_slack_adapter(
         };
         info!(url = %ws_url, "connecting to Slack Socket Mode");
 
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(RECONNECT_TIMEOUT_SECS),
-            tokio_tungstenite::connect_async(&ws_url),
-        )
-        .await
-        {
+        match connect_with_reconnect_timeout(&ws_url).await {
             Ok(Ok((ws_stream, _))) => {
                 info!("Slack Socket Mode connected");
                 backoff_secs = 1; // reset on success
@@ -2370,7 +2387,10 @@ mod tests {
 
 #[cfg(test)]
 mod socket_keepalive_tests {
-    use super::{next_backoff, socket_idle, IDLE_TIMEOUT_SECS, MAX_BACKOFF_SECS, RECONNECT_TIMEOUT_SECS};
+    use super::{
+        connect_with_reconnect_timeout, next_backoff, socket_idle, wait_backoff_or_shutdown,
+        IDLE_TIMEOUT_SECS, MAX_BACKOFF_SECS,
+    };
     use std::time::Duration;
 
     /// Backoff doubles and caps, matching the gateway adapter (1,2,4,8,16,30,30…).
@@ -2401,8 +2421,11 @@ mod socket_keepalive_tests {
 
     /// Regression test for #1279: a stalled WebSocket handshake during reconnect
     /// must surface as a timeout instead of parking the reconnect task forever.
-    /// `start_paused` lets the 30s timeout resolve instantly under Tokio's
-    /// virtual clock instead of a real wall-clock wait.
+    /// Calls `connect_with_reconnect_timeout` directly (the same helper
+    /// `run_slack_adapter` calls) so this pins the actual production code
+    /// path, not just a copy of the timeout expression. `start_paused` lets
+    /// the 30s timeout resolve instantly under Tokio's virtual clock instead
+    /// of a real wall-clock wait.
     #[tokio::test(start_paused = true)]
     async fn connect_async_timeout_fires_on_stalled_handshake() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -2419,15 +2442,32 @@ mod socket_keepalive_tests {
         });
 
         let ws_url = format!("ws://{addr}");
-        let result = tokio::time::timeout(
-            Duration::from_secs(RECONNECT_TIMEOUT_SECS),
-            tokio_tungstenite::connect_async(&ws_url),
-        )
-        .await;
+        let result = connect_with_reconnect_timeout(&ws_url).await;
 
         assert!(
             result.is_err(),
             "connect_async on a stalled handshake must time out, not hang"
         );
+    }
+
+    /// With no shutdown signal, `wait_backoff_or_shutdown` sleeps out the
+    /// backoff and returns the next (doubled) value. `start_paused` resolves
+    /// the sleep instantly under Tokio's virtual clock.
+    #[tokio::test(start_paused = true)]
+    async fn wait_backoff_or_shutdown_returns_next_backoff_when_no_shutdown() {
+        let (_tx, mut rx) = tokio::sync::watch::channel(false);
+        let result = wait_backoff_or_shutdown(2, &mut rx).await;
+        assert_eq!(result, Some(next_backoff(2)));
+    }
+
+    /// A shutdown signal wins the race against an arbitrarily long backoff,
+    /// returning `None` so the caller returns immediately instead of parking
+    /// until the backoff elapses.
+    #[tokio::test(start_paused = true)]
+    async fn wait_backoff_or_shutdown_returns_none_on_shutdown() {
+        let (tx, mut rx) = tokio::sync::watch::channel(false);
+        tx.send(true).expect("receiver still open");
+        let result = wait_backoff_or_shutdown(3600, &mut rx).await;
+        assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
## What problem does this solve?

`get_socket_mode_url` and `tokio_tungstenite::connect_async` in the Slack Socket Mode reconnect loop (`crates/openab-core/src/slack.rs`) had no timeout, unlike the post-connect idle watchdog (`IDLE_TIMEOUT_SECS`) and `SlackAdapter::new`'s Web API client (`.timeout(Duration::from_secs(30))`). If the same flaky network path that triggers a disconnect also stalls (not resets) a subsequent `apps.connections.open` POST or the WS handshake during reconnect, the reconnect task parks in `.await` forever - no error, no log, process alive but the bot permanently dark on Slack until manually restarted. This is exactly what happened to openab-viola in production: a normal reconnect cycle ran for ~6 minutes, then total silence for 11+ hours.

Closes #1279

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491969620754567270/1522434117642223616

## At a Glance

```
run_slack_adapter reconnect loop:
  get_socket_mode_url(app_token)  --[NO TIMEOUT]--> could hang forever
        |
  connect_async(ws_url)           --[NO TIMEOUT]--> could hang forever
        |
  (only once connected: IDLE_TIMEOUT_SECS watchdog protects the read loop)

After this fix, both calls above are wrapped in tokio::time::timeout(30s),
matching the existing pattern.
```

## Prior Art & Industry Research

Not applicable - trivial bug fix. This mirrors an existing, already-established pattern in the same file (`SlackAdapter::new`'s bounded `reqwest::Client` and the `IDLE_TIMEOUT_SECS` idle watchdog), rather than introducing new architecture.

## Proposed Solution

1. Wrap `get_socket_mode_url(...)` in `tokio::time::timeout(Duration::from_secs(30), ...)`. On timeout, log a warning and fall through to the existing backoff/retry path.
2. Wrap `tokio_tungstenite::connect_async(&ws_url)` in the same 30s timeout, with the same fallback-to-retry behavior.
3. Change `get_socket_mode_url` to accept `&reqwest::Client` instead of constructing `reqwest::Client::new()` per call, and pass in `SlackAdapter`'s existing client (already configured with a 30s timeout). This folds in #386 (client-reuse nit) as a side effect of threading a client through anyway.

`RECONNECT_TIMEOUT_SECS = 30` matches the existing Web API client timeout for consistency.

## Why this approach?

`tokio::time::timeout` is the standard, already-used-in-this-codebase idiom for bounding a future (see `gateway.rs`, `discord.rs`, `hooks.rs`, `secrets.rs`, `cron.rs`, `ambient.rs`). No new dependency, no new abstraction - it directly fixes the exact two unbounded `.await` points named in the issue.

## Alternatives Considered

- **Only add `.timeout()` to a `reqwest::Client` and leave `connect_async` unbounded:** rejected - the issue's root cause analysis shows the WS handshake itself (not just the HTTP POST) can stall, so both must be bounded.
- **Add a liveness/readiness probe to the Helm chart instead:** the issue explicitly flags this as a *secondary, separate* gap (no probe would mask this exact failure mode as "healthy"), but fixing the underlying unbounded `.await` is the direct fix; the probe gap is worth tracking as its own follow-up issue.

## Validation

Rust changes:
- [x] `cargo check` passes (`cargo build -p openab-core`)
- [x] `cargo test` passes (including new tests) - 62/62 tests pass in the `slack` module (`cargo test -p openab-core slack`)
- [x] `cargo clippy` clean (`cargo clippy -p openab-core --all-targets` - no new warnings; 4 pre-existing warnings in `discord.rs` are unrelated)

All PRs:
- [x] Manual testing - read through the full reconnect loop control flow after the change to confirm both new timeout branches (a) log a distinguishable message, (b) respect the shutdown signal via the same `tokio::select!` pattern as the existing error branches, and (c) fall through to the existing exponential backoff instead of retrying immediately.
