### PR TITLE
fix(operator): strip stage prefix on private API GW integrations

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -247,7 +247,7 @@ On `apply` this reconciles (idempotently, reused by name):
 1. **Cloud Map** private DNS namespace (`<cloudMapNamespace>-<vpc-id>`, shared per-VPC) + a per-service **SRV** record (carries the container port; a plain A record does not work as a VPC-Link integration target)
 2. **ECS service registry** wiring (attached at service creation)
 3. **VPC Link** (`oab-vpc-link-<vpc-id>`, shared per-VPC), waits until `AVAILABLE`
-4. **API Gateway HTTP API** (`oab-webhook-<ns>-<name>`, one per bot) + `HTTP_PROXY` integration over the VPC Link
+4. **API Gateway HTTP API** (`oab-webhook-<ns>-<name>`, one per bot) + `HTTP_PROXY` integration over the VPC Link, with an `overwrite:path` request parameter mapping so the backend receives the raw path (e.g. `/webhook/telegram`) instead of the stage-prefixed one (e.g. `/prod/webhook/telegram`) — see caveat below
 5. One **route** per path + a `prod` auto-deploy **stage**
 6. A self-referencing **security-group** inbound rule on `containerPort`
 
@@ -268,6 +268,19 @@ LINE console:
 > verifies an HMAC-SHA256 signature using `LINE_CHANNEL_SECRET`. Set
 > `TELEGRAM_SECRET_TOKEN` when registering the webhook with BotFather to enable
 > that check.
+>
+> **Stage prefix stripped before it reaches the backend:** for private
+> (VPC_LINK) integrations, API Gateway forwards the *stage-prefixed* request
+> path to the backend by default (e.g. `/prod/webhook/telegram`, not
+> `/webhook/telegram`) — [documented AWS
+> behavior](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-private.html).
+> OpenAB's webhook router matches the exact configured path, so without
+> stripping the prefix every request 404s at the container despite the
+> integration and Cloud Map wiring being otherwise correct. `apply` sets an
+> `overwrite:path=$request.path` request parameter on the integration to strip
+> it, and self-heals existing integrations created before this fix by patching
+> the parameter in on the next `apply` — no manual intervention or recreate
+> needed.
 >
 > **Adding/fixing service discovery never requires recreating the service:**
 > if an existing ECS service has no Cloud Map registry, or has one pointing at a

--- a/operator/src/ingress.rs
+++ b/operator/src/ingress.rs
@@ -28,6 +28,7 @@ use crate::manifest::{Ingress, OABServiceManifest};
 use anyhow::{Context, Result};
 use aws_sdk_apigatewayv2::types::{ConnectionType, IntegrationType, ProtocolType};
 use aws_sdk_servicediscovery::types::{DnsConfig, DnsRecord, RecordType};
+use std::collections::HashMap;
 
 const STAGE_NAME: &str = "prod";
 
@@ -141,6 +142,19 @@ pub async fn ensure_gateway(
 /// API Gateway route key for a webhook path (POST only).
 fn route_key(path: &str) -> String {
     format!("POST {path}")
+}
+
+/// Whether an integration's request parameters already carry the
+/// `overwrite:path` override needed to strip the stage prefix before it
+/// reaches the backend. Without this, private (VPC_LINK) integrations
+/// forward the stage-prefixed path (e.g. `/prod/webhook/telegram`) to the
+/// container, and openab's exact-match router 404s on it. See:
+/// <https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-private.html>
+fn has_stage_path_override(request_parameters: Option<&HashMap<String, String>>) -> bool {
+    request_parameters
+        .and_then(|p| p.get("overwrite:path"))
+        .map(|v| v == "$request.path")
+        .unwrap_or(false)
 }
 
 /// Extract the Cloud Map service ID from its ARN
@@ -733,7 +747,23 @@ async fn ensure_integration(
                     .integration_id()
                     .context("integration missing id")?
                     .to_string();
-                eprintln!("  ✓ Integration exists → {integration_uri}");
+                if has_stage_path_override(i.request_parameters()) {
+                    eprintln!("  ✓ Integration exists → {integration_uri}");
+                } else {
+                    // Self-heal: existing integrations created before this
+                    // fix forward the stage-prefixed path to the backend,
+                    // causing every request to 404. Patch in the override.
+                    eprintln!(
+                        "  ↻ Integration exists but missing path override → {integration_uri}, patching"
+                    );
+                    api.update_integration()
+                        .api_id(api_id)
+                        .integration_id(&id)
+                        .request_parameters("overwrite:path", "$request.path")
+                        .send()
+                        .await
+                        .context("failed to patch integration path override")?;
+                }
                 return Ok(id);
             }
         }
@@ -743,6 +773,13 @@ async fn ensure_integration(
         }
     }
     eprintln!("  ⊕ Creating integration → {integration_uri}");
+    // For private (VPC_LINK) integrations, API Gateway forwards the stage
+    // portion of the request path to the backend by default (e.g.
+    // `/prod/webhook/telegram` instead of `/webhook/telegram`), per AWS docs:
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-private.html
+    // openab's router matches the exact configured path, so without this
+    // override every request 404s at the backend. Overwrite the forwarded
+    // path with $request.path (stage-stripped) to match.
     let out = api
         .create_integration()
         .api_id(api_id)
@@ -752,6 +789,7 @@ async fn ensure_integration(
         .connection_type(ConnectionType::VpcLink)
         .connection_id(vpc_link_id)
         .payload_format_version("1.0")
+        .request_parameters("overwrite:path", "$request.path")
         .send()
         .await
         .context("failed to create integration")?;
@@ -880,6 +918,31 @@ mod tests {
     fn route_key_is_post_prefixed() {
         assert_eq!(route_key("/webhook/telegram"), "POST /webhook/telegram");
         assert_eq!(route_key("/webhook/line"), "POST /webhook/line");
+    }
+
+    #[test]
+    fn stage_path_override_absent_when_no_request_parameters() {
+        // Integrations created before this fix have no RequestParameters at
+        // all, so they must be detected as needing the self-heal patch.
+        assert!(!has_stage_path_override(None));
+    }
+
+    #[test]
+    fn stage_path_override_absent_when_other_params_present() {
+        let params = HashMap::from([("someOtherKey".to_string(), "value".to_string())]);
+        assert!(!has_stage_path_override(Some(&params)));
+    }
+
+    #[test]
+    fn stage_path_override_absent_when_value_wrong() {
+        let params = HashMap::from([("overwrite:path".to_string(), "/literal/path".to_string())]);
+        assert!(!has_stage_path_override(Some(&params)));
+    }
+
+    #[test]
+    fn stage_path_override_present_when_correctly_set() {
+        let params = HashMap::from([("overwrite:path".to_string(), "$request.path".to_string())]);
+        assert!(has_stage_path_override(Some(&params)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a real 404 bug in `oabctl`'s API Gateway ingress (#1275) found via live
E2E testing against a real deployed Telegram bot.

Private (`VPC_LINK`) HTTP API integrations forward the **stage-prefixed**
request path to the backend by default (e.g. `/prod/webhook/telegram` instead
of `/webhook/telegram`) — this is [documented AWS
behavior](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-private.html)
for private integrations. OpenAB's webhook router (`axum`) matches the exact
configured path, so every request 404s at the container even though the VPC
Link, Cloud Map instance, route, and integration are all wired correctly.

Fix: set `overwrite:path=$request.path` on the integration's request
parameters when creating it, so the backend receives the stage-stripped path.
Existing integrations created before this fix self-heal on the next
`oabctl apply` — the code detects the missing parameter and patches it in via
`UpdateIntegration`, no manual intervention or service recreate needed.

## The bug, visually

```
BEFORE FIX
──────────
┌────────┐  POST /prod/webhook/telegram   ┌───────────────┐
│ Client │───────────────────────────────►│ API Gateway   │
└────────┘                                │ route matches:│
                                           │ "/webhook/    │
                                           │  telegram" ✓  │
                                           └──────┬────────┘
                                                  │ forwards RAW path
                                                  │ "/prod/webhook/telegram"
                                                  │ (stage NOT stripped)
                                                  ▼
                                           ┌───────────────┐
                                           │  VPC Link     │  AVAILABLE ✓
                                           └──────┬────────┘
                                                  ▼
                                           ┌───────────────┐
                                           │  Cloud Map    │  SRV resolved,
                                           │  (SRV lookup) │  instance HEALTHY ✓
                                           └──────┬────────┘
                                                  ▼
                                           ┌───────────────┐
                                           │ openab (axum) │  router only knows
                                           │  container    │  "/webhook/telegram"
                                           └──────┬────────┘  exact-match — MISS
                                                  ▼
┌────────┐        404 (integrationStatus=404)    │
│ Client │◄───────────────────────────────────────┘
└────────┘

AFTER FIX
─────────
┌────────┐  POST /prod/webhook/telegram   ┌───────────────┐
│ Client │───────────────────────────────►│ API Gateway   │
└────────┘                                │ route matches ✓│
                                           │ + integration  │
                                           │ request param: │
                                           │ overwrite:path │
                                           │ =$request.path │
                                           └──────┬────────┘
                                                  │ forwards STRIPPED path
                                                  │ "/webhook/telegram"
                                                  ▼
                                           ┌───────────────┐
                                           │  VPC Link     │──►┌───────────────┐
                                           └───────────────┘   │  Cloud Map    │
                                                                └──────┬────────┘
                                                                       ▼
                                                                ┌───────────────┐
                                                                │ openab (axum) │
                                                                │  MATCH ✓      │
                                                                └──────┬────────┘
┌────────┐              200 OK                                        │
│ Client │◄──────────────────────────────────────────────────────────┘
└────────┘
```

Everything except the final hop — VPC Link status, Cloud Map SRV resolution,
route/integration config — was already correct and reported healthy by every
`aws apigatewayv2`/`servicediscovery get-*` call. Only the one request
parameter mapping on the integration was missing.

## How this was found

Ran a full from-scratch `oabctl apply` against a real Telegram bot deployment.
The webhook URL returned a persistent `404` for 20+ minutes — not a brief
warm-up delay like previously-observed `503`s. Isolated the cause by:

1. Confirming the VPC Link was genuinely `AVAILABLE`, the Cloud Map instance
   was `HEALTHY`/discoverable, the route/integration/stage were all configured
   exactly as expected via `aws apigatewayv2 get-*` — everything checked out.
2. Confirming the container itself was healthy and listening on `/webhook/telegram`
   via CloudWatch logs — no crash, no error.
3. Temporarily enabling API Gateway access logs on the stage. The log line
   showed `routeKey=POST /webhook/telegram status=404 integrationStatus=404`
   — proving API Gateway matched the route and invoked the integration, but
   the **backend** returned 404.
4. Cross-referencing openab's router code (`src/main.rs`) confirmed exact-path
   `axum` routing, and AWS's private-integration docs confirmed the
   stage-prefix forwarding behavior.
5. Manually applying `overwrite:path=$request.path` via the AWS CLI fixed it
   immediately (`200 OK`).

An earlier round of scratch testing with an echo-image backend
(`mendhak/http-https-echo`) never caught this, because that image echoes back
whatever path it receives — it doesn't do path-based routing, so it can't
expose a path-mismatch bug.

## Verification

- `cargo build --release`, `cargo clippy --all-targets -- -D warnings`,
  `cargo test --release` — all clean on macmini (19/19 tests pass, 4 new
  regression tests for the extracted `has_stage_path_override` helper).
- Live E2E: ran 2 full `oabctl apply` → test webhook → `oabctl delete` cycles
  with the fixed binary against a real deployed bot
  (`ghcr.io/openabdev/openab:pre-beta-kiro` + real Telegram config/secret).
  Both cycles created the integration with the path override baked in
  automatically (no manual patching) and both returned `200 OK` end-to-end
  (curl → API Gateway → VPC Link → Cloud Map → Fargate → openab), after the
  expected brief `503` VPC Link warm-up window.
- All test AWS resources (APIs, VPC Links, ECS services, SG rules) were
  cleaned up after each cycle; confirmed via a final sweep.

## Testing done

```
cargo build --release   # clean
cargo clippy --all-targets -- -D warnings   # clean
cargo test --release    # 19 passed; 0 failed
```

Plus live E2E against real AWS resources in a scratch account/VPC (see
commit message for the reproduction sequence).

