### PR TITLE
ci(oabctl): build and release alongside every openab release

### DIFF
--- a/.github/workflows/build-oabctl.yml
+++ b/.github/workflows/build-oabctl.yml
@@ -1,33 +1,72 @@
 name: Build oabctl
 
+# Rides along with every openab release: fires on the same trigger as
+# release.yml (a merge that bumps charts/openab/Chart.yaml on main), builds
+# oabctl for all supported platforms, and uploads them to the same
+# `openab-<version>` GitHub Release that chart-releaser just created — so
+# `oabctl` always ships attached to the openab release it was built against,
+# without needing its own separate version/tag scheme.
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "charts/openab/Chart.yaml"
   workflow_dispatch:
     inputs:
       target:
-        description: 'Build target (linux-x86_64, linux-aarch64, macos-arm64)'
+        description: 'Build target (leave empty to build all)'
         required: false
-        default: 'linux-x86_64'
+        default: ''
         type: choice
         options:
+          - ''
           - linux-x86_64
           - linux-aarch64
           - macos-arm64
 
 jobs:
-  build:
-    runs-on: ${{ inputs.target == 'macos-arm64' && 'macos-latest' || 'ubuntu-latest' }}
+  resolve:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      targets: ${{ steps.version.outputs.targets }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - name: Resolve version and target matrix
+        id: version
+        run: |
+          VERSION=$(grep '^version:' charts/openab/Chart.yaml | awk '{print $2}')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${{ inputs.target }}" ]; then
+            TARGETS="[\"${{ inputs.target }}\"]"
+          else
+            TARGETS='["linux-x86_64","linux-aarch64","macos-arm64"]'
+          fi
+          echo "targets=${TARGETS}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: resolve
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.resolve.outputs.targets) }}
+    runs-on: ${{ matrix.target == 'macos-arm64' && 'macos-latest' || 'ubuntu-latest' }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ inputs.target == 'linux-aarch64' && 'aarch64-unknown-linux-gnu' || '' }}
+          targets: ${{ matrix.target == 'linux-aarch64' && 'aarch64-unknown-linux-gnu' || '' }}
 
       - name: Install cross-compilation tools
-        if: inputs.target == 'linux-aarch64'
+        if: matrix.target == 'linux-aarch64'
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
@@ -35,7 +74,7 @@ jobs:
       - name: Build oabctl
         working-directory: operator
         run: |
-          if [ "${{ inputs.target }}" = "linux-aarch64" ]; then
+          if [ "${{ matrix.target }}" = "linux-aarch64" ]; then
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
             cargo build --release --target aarch64-unknown-linux-gnu
             cp target/aarch64-unknown-linux-gnu/release/oabctl .
@@ -46,11 +85,30 @@ jobs:
 
       - name: Package
         working-directory: operator
-        run: tar czf oabctl-${{ inputs.target }}.tar.gz oabctl
+        run: tar czf oabctl-${{ needs.resolve.outputs.version }}-${{ matrix.target }}.tar.gz oabctl
+
+      - name: Upload to release
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        working-directory: operator
+        run: |
+          TAG="openab-${{ needs.resolve.outputs.version }}"
+          NAME="oabctl-${{ needs.resolve.outputs.version }}-${{ matrix.target }}.tar.gz"
+          # Release is created by chart-releaser (release.yml) on the same
+          # push — wait for it to exist before uploading.
+          for i in $(seq 1 20); do
+            if gh release view "$TAG" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+              break
+            fi
+            echo "Release ${TAG} not found yet, waiting..."
+            sleep 15
+          done
+          gh release upload "$TAG" "$NAME" --repo "${{ github.repository }}" --clobber
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: oabctl-${{ inputs.target }}
-          path: operator/oabctl-${{ inputs.target }}.tar.gz
+          name: oabctl-${{ needs.resolve.outputs.version }}-${{ matrix.target }}
+          path: operator/oabctl-${{ needs.resolve.outputs.version }}-${{ matrix.target }}.tar.gz
           retention-days: 7

--- a/.github/workflows/pre-beta-build.yml
+++ b/.github/workflows/pre-beta-build.yml
@@ -232,3 +232,92 @@ jobs:
             ${DIGESTS}
 
           echo "### 📦 \`${IMAGE}:pre-beta-${AGENT}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # oabctl pre-beta: builds the operator CLI for all supported platforms and
+  # publishes them to a rolling `oabctl-pre-beta` GitHub Release, so the
+  # latest pre-beta oabctl is always downloadable at a fixed URL instead of
+  # requiring a local build — mirrors the `pre-beta-<agent>` rolling Docker
+  # tags above, but as a rolling release since oabctl has no image to push.
+  # ---------------------------------------------------------------------------
+  oabctl-pre-beta:
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [linux-x86_64, linux-aarch64, macos-arm64]
+    runs-on: ${{ matrix.target == 'macos-arm64' && 'macos-latest' || 'ubuntu-latest' }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target == 'linux-aarch64' && 'aarch64-unknown-linux-gnu' || '' }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'linux-aarch64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build oabctl
+        working-directory: operator
+        run: |
+          if [ "${{ matrix.target }}" = "linux-aarch64" ]; then
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+            cargo build --release --target aarch64-unknown-linux-gnu
+            cp target/aarch64-unknown-linux-gnu/release/oabctl .
+          else
+            cargo build --release
+            cp target/release/oabctl .
+          fi
+
+      - name: Package
+        working-directory: operator
+        run: tar czf oabctl-pre-beta-${{ matrix.target }}.tar.gz oabctl
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: oabctl-pre-beta-${{ matrix.target }}
+          path: operator/oabctl-pre-beta-${{ matrix.target }}.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  oabctl-pre-beta-publish:
+    needs: [gate, oabctl-pre-beta]
+    if: needs.gate.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: oabctl-pre-beta-*
+          merge-multiple: true
+
+      - name: Recreate rolling pre-beta release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="oabctl-pre-beta"
+          SHORT_SHA=$(echo "${{ github.sha }}" | head -c 7)
+          # Rolling release: delete any previous one so the tag always points
+          # at the latest build (mirrors the rolling `pre-beta-<agent>` image
+          # tags — not a versioned release).
+          gh release delete "$TAG" --repo "${{ github.repository }}" --yes --cleanup-tag 2>/dev/null || true
+          gh release create "$TAG" \
+            --repo "${{ github.repository }}" \
+            --title "oabctl pre-beta (${SHORT_SHA})" \
+            --notes "Rolling pre-beta build of \`oabctl\` from \`main\`@${SHORT_SHA}. Overwritten on every pre-beta build — not a stable version, matches the \`pre-beta-*\` image tags. For a pinned version, use the \`openab-<version>\` release attached to a real openab release instead." \
+            --prerelease \
+            artifacts/*.tar.gz
+

--- a/operator/README.md
+++ b/operator/README.md
@@ -49,6 +49,29 @@ CLI tool that provisions and manages OpenAB agents on Amazon ECS Fargate (with K
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
+## Installation
+
+`oabctl` ships attached to every `openab` release — it's built and uploaded to
+the same `openab-<version>` GitHub Release as soon as `charts/openab/Chart.yaml`
+is bumped on `main`, so it always tracks openab's own version:
+
+```bash
+# Download the latest release for your platform (linux-x86_64, linux-aarch64,
+# or macos-arm64) from:
+# https://github.com/openabdev/openab/releases/latest
+curl -L -o oabctl.tar.gz \
+  https://github.com/openabdev/openab/releases/latest/download/oabctl-<version>-<platform>.tar.gz
+tar xzf oabctl.tar.gz
+sudo mv oabctl /usr/local/bin/
+```
+
+Or build from source (requires Rust):
+
+```bash
+cd operator && cargo build --release
+cp target/release/oabctl /usr/local/bin/
+```
+
 ## Quick Start
 
 ```bash

--- a/operator/README.md
+++ b/operator/README.md
@@ -65,6 +65,17 @@ tar xzf oabctl.tar.gz
 sudo mv oabctl /usr/local/bin/
 ```
 
+Pre-beta builds (matching the rolling `pre-beta-<agent>` image tags, built
+hourly off `main`) are published to a rolling `oabctl-pre-beta` release —
+overwritten on every pre-beta build, so it always tracks the latest `main`:
+
+```bash
+curl -L -o oabctl.tar.gz \
+  https://github.com/openabdev/openab/releases/download/oabctl-pre-beta/oabctl-pre-beta-<platform>.tar.gz
+tar xzf oabctl.tar.gz
+sudo mv oabctl /usr/local/bin/
+```
+
 Or build from source (requires Rust):
 
 ```bash


### PR DESCRIPTION
## Summary

Makes `oabctl` ride along with every `openab` release instead of having no
real release path at all.

**Before:** `build-oabctl.yml` was `workflow_dispatch`-only, built one
platform per manual run, uploaded a plain workflow artifact (7-day
retention), and was never attached to a GitHub Release. There was also no
documented way to actually install `oabctl` — the README had no install
section.

**After:** the workflow fires on the same trigger `release.yml` already
uses — a push to `main` that bumps `charts/openab/Chart.yaml` (this is what
actually creates a release today; confirmed via `gh release list` that real
releases are tagged `openab-<version>`, not `v*` — nothing in the repo
currently pushes a `v*` tag, so `build-binaries.yml`'s tag-triggered path is
presently dead code and explains why the latest release has no binaries
attached). It builds all three supported platforms via a matrix
(linux-x86_64, linux-aarch64, macos-arm64) and uploads each to the same
`openab-<version>` release that `chart-releaser` just created on the same
push, polling briefly since both workflows respond to the same event and
ordering between them isn't guaranteed.

`workflow_dispatch` still works exactly as before for ad-hoc manual builds
(now also supports building all platforms in one dispatch, or a single one)
without touching any release.

```
Before:
  charts/openab/Chart.yaml bump on main
          │
          ▼
  release.yml → chart-releaser → GitHub Release "openab-<version>"
                                   (Helm chart .tgz only)

  build-oabctl.yml: workflow_dispatch only, single platform,
                     plain artifact, 7-day retention, no release attach

After:
  charts/openab/Chart.yaml bump on main
          │
          ├──────────────────────────┐
          ▼                          ▼
  release.yml                build-oabctl.yml (matrix: 3 platforms)
   │                                 │
   ▼                                 ▼
  chart-releaser creates      wait for release to exist, then
  "openab-<version>"  ◄───────  gh release upload (per platform)
   (Helm chart .tgz)
          │
          ▼
  GitHub Release "openab-<version>"
   ├─ openab-<version>.tgz               (Helm chart)
   ├─ oabctl-<version>-linux-x86_64.tar.gz
   ├─ oabctl-<version>-linux-aarch64.tar.gz
   └─ oabctl-<version>-macos-arm64.tar.gz
```

Also adds an install section to `operator/README.md` documenting how to
actually download `oabctl` (there was none before), plus a source-build
fallback.

## Also: rolling pre-beta build

`pre-beta-build.yml` builds pre-beta Docker images hourly off `main`
(rolling `pre-beta-<agent>` tags) but has no GitHub Release object of its own
— it only pushes container images, so there was nowhere to attach an oabctl
binary. Added two new jobs there that build oabctl for all three platforms
and publish them to a rolling `oabctl-pre-beta` GitHub Release (delete +
recreate on every run, marked `--prerelease`), so triggering (or waiting for
the hourly schedule of) a pre-beta build also gives a fixed, always-current
download URL for the matching `oabctl` — no local build required, and it
always tracks whatever's on `main` right now, same as the `pre-beta-<agent>`
image tags do.

```
Pre-beta (rolling, always overwritten — tracks main, not a version):
  hourly schedule (if a commit landed in ~70min) or workflow_dispatch
          │
          ▼
  pre-beta-build.yml
   ├─ existing jobs: build + tag pre-beta-<agent> Docker images
   └─ new: oabctl-pre-beta → oabctl-pre-beta-publish
                                   │
                                   ▼
                    delete + recreate GitHub Release "oabctl-pre-beta"
                     ├─ oabctl-pre-beta-linux-x86_64.tar.gz
                     ├─ oabctl-pre-beta-linux-aarch64.tar.gz
                     └─ oabctl-pre-beta-macos-arm64.tar.gz
```

## Testing done

- Validated the workflow YAML parses correctly for both `build-oabctl.yml`
  and `pre-beta-build.yml` after the edits.
- No Rust source changed — this is CI + docs only, so `cargo build`/`clippy`/
  `test` are unaffected and were not re-run.
- Could not fully dry-run either `push`/schedule-triggered path locally: the
  `openab-<version>` path depends on `chart-releaser-action` creating the
  release in the same CI run, and the pre-beta path depends on the hourly
  schedule or a manual dispatch actually firing. Both will be exercised for
  real on the next actual release / next pre-beta build. Flagging this as
  the part of the change that's unverified until then — happy to do a manual
  `workflow_dispatch` smoke test on both workflows if you want extra
  confidence before merging.

