### PR TITLE
revert(chart): restore version to 0.9.0-beta.6

### DIFF
--- a/charts/openab/Chart.yaml
+++ b/charts/openab/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openab
 description: A lightweight, secure, cloud-native ACP harness that bridges Discord and any ACP-compatible coding CLI.
 type: application
-version: 0.10.0
-appVersion: "0.10.0"
+version: 0.9.0-beta.6
+appVersion: "0.9.0-beta.6"


### PR DESCRIPTION
## Summary

PR #1277 accidentally bumped `charts/openab/Chart.yaml` from `0.9.0-beta.6` to `0.10.0`, which triggered the `Release Charts` workflow and created an unintended `openab-0.10.0` release.

**Already done:**
- Deleted the `openab-0.10.0` GitHub release
- Deleted the `openab-0.10.0` git tag

**This PR:**
- Reverts Chart.yaml version back to `0.9.0-beta.6`
- Restores `appVersion` field

> ⚠️ This will trigger the Release Charts workflow again on merge, but `chart-releaser-action` uses `skip_existing: true`, so it will not re-create the `0.9.0-beta.6` release that already exists.