### PR TITLE
fix(operator): resolve_string mishandled ECS-native :jsonKey:: suffix

### DIFF
--- a/operator/src/secrets.rs
+++ b/operator/src/secrets.rs
@@ -2,9 +2,10 @@
 //!
 //! Values can be either a Secrets Manager reference in ECS-native
 //! `valueFrom` format directly (a full ARN, optionally suffixed with
-//! `:<jsonKey>::` to extract one field of a JSON secret), or the same
-//! `aws-sm://<secret-id>#<json-key>` shorthand openab itself uses for
-//! in-app secret refs (see `crates/openab-core/src/secrets.rs`) — kept
+//! `:<jsonKey>::` to extract one field of a JSON secret — an ECS-only
+//! convention; the Secrets Manager API itself has no knowledge of it), or
+//! the same `aws-sm://<secret-id>#<json-key>` shorthand openab itself uses
+//! for in-app secret refs (see `crates/openab-core/src/secrets.rs`) — kept
 //! identical here so a manifest author can write one convention across both
 //! `spec.secrets` (consumed by ECS at container launch) and `config.toml`
 //! (consumed by openab itself at runtime).
@@ -55,47 +56,105 @@ pub async fn resolve_value_from(
     Ok(format!("{arn}:{json_key}::"))
 }
 
+/// Split an ECS-native `valueFrom` value into its base secret ARN/name and
+/// an optional JSON key, if it carries the `:<jsonKey>::` suffix ECS uses to
+/// extract one field of a JSON secret. Only applies to values already
+/// shaped like an ARN (`arn:...:secret:<name>-<suffix>:<jsonKey>::`) — a
+/// bare secret name is never split, since ECS only recognizes the suffix on
+/// a full ARN. Returns `(value, None)` unchanged if there's no such suffix.
+fn split_ecs_json_key_suffix(value: &str) -> (&str, Option<&str>) {
+    if !value.starts_with("arn:") {
+        return (value, None);
+    }
+    // `<base-arn>:<jsonKey>::` — strip the trailing empty segment (from the
+    // final `::`), then split off exactly one more `:<jsonKey>` segment. A
+    // bare secret ARN has none of this, so `rest` won't match the pattern
+    // and falls through to the unchanged case.
+    let Some(without_trailing) = value.strip_suffix("::") else {
+        return (value, None);
+    };
+    let Some((base, json_key)) = without_trailing.rsplit_once(':') else {
+        return (value, None);
+    };
+    if json_key.is_empty() || !base.starts_with("arn:") {
+        return (value, None);
+    }
+    (base, Some(json_key))
+}
+
 /// Resolve a `spec.secrets` value to its plain string content, for callers
 /// that need the actual secret value in-process (e.g. calling a third-party
 /// API on the caller's behalf) rather than an ECS `valueFrom` reference.
 /// Supports the same two forms as [`resolve_value_from`]: `aws-sm://...#...`
 /// (fetched and JSON-key-extracted here), or a plain/ECS-native Secrets
-/// Manager ARN — including one already carrying a `:<jsonKey>::` suffix,
-/// which `GetSecretValue` resolves natively.
+/// Manager ARN — including one already carrying a `:<jsonKey>::` suffix.
+/// That suffix is an ECS-only convention (resolved by ECS itself at
+/// container launch, via `register_task_definition`'s `valueFrom` field) —
+/// the Secrets Manager `GetSecretValue` API has no knowledge of it and
+/// rejects it as an invalid secret ID, so it's stripped and the JSON key
+/// extracted manually here, the same way the `aws-sm://` form is.
 pub async fn resolve_string(sm: &aws_sdk_secretsmanager::Client, value: &str) -> Result<String> {
-    if let Some(parsed) = parse_aws_sm_uri(value) {
-        let (secret_id, json_key) = parsed?;
-        let secret_string = sm
-            .get_secret_value()
-            .secret_id(secret_id)
-            .send()
-            .await
-            .with_context(|| format!("failed to fetch secret '{secret_id}' from Secrets Manager"))?
-            .secret_string()
-            .with_context(|| format!("secret '{secret_id}' has no string value"))?
-            .to_string();
-        let json: serde_json::Value = serde_json::from_str(&secret_string)
-            .with_context(|| format!("secret '{secret_id}' is not valid JSON"))?;
-        return json
-            .get(json_key)
-            .and_then(|v| v.as_str())
-            .map(|v| v.to_string())
-            .with_context(|| format!("JSON key '{json_key}' not found in secret '{secret_id}'"));
-    }
+    let (secret_id, json_key) = match parse_aws_sm_uri(value) {
+        Some(parsed) => {
+            let (id, key) = parsed?;
+            (id, Some(key))
+        }
+        None => split_ecs_json_key_suffix(value),
+    };
 
-    sm.get_secret_value()
-        .secret_id(value)
+    let secret_string = sm
+        .get_secret_value()
+        .secret_id(secret_id)
         .send()
         .await
-        .with_context(|| format!("failed to fetch secret '{value}' from Secrets Manager"))?
+        .with_context(|| format!("failed to fetch secret '{secret_id}' from Secrets Manager"))?
         .secret_string()
-        .with_context(|| format!("secret '{value}' has no string value"))
+        .with_context(|| format!("secret '{secret_id}' has no string value"))?
+        .to_string();
+
+    let Some(json_key) = json_key else {
+        return Ok(secret_string);
+    };
+    let json: serde_json::Value = serde_json::from_str(&secret_string)
+        .with_context(|| format!("secret '{secret_id}' is not valid JSON"))?;
+    json.get(json_key)
+        .and_then(|v| v.as_str())
         .map(|v| v.to_string())
+        .with_context(|| format!("JSON key '{json_key}' not found in secret '{secret_id}'"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn split_ecs_json_key_suffix_extracts_key_from_real_world_arn() {
+        // The exact shape that surfaced this bug: an ECS-native valueFrom
+        // ARN with a JSON-key suffix, passed to resolve_string (which used
+        // to hand this straight to GetSecretValue and fail, since that API
+        // has no knowledge of the trailing `:<jsonKey>::` ECS convention).
+        let (base, key) = split_ecs_json_key_suffix(
+            "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP:TELEGRAM_BOT_TOKEN::",
+        );
+        assert_eq!(base, "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP");
+        assert_eq!(key, Some("TELEGRAM_BOT_TOKEN"));
+    }
+
+    #[test]
+    fn split_ecs_json_key_suffix_unchanged_for_plain_arn() {
+        let (base, key) = split_ecs_json_key_suffix(
+            "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP",
+        );
+        assert_eq!(base, "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP");
+        assert_eq!(key, None);
+    }
+
+    #[test]
+    fn split_ecs_json_key_suffix_unchanged_for_bare_secret_name() {
+        let (base, key) = split_ecs_json_key_suffix("plain-secret-name");
+        assert_eq!(base, "plain-secret-name");
+        assert_eq!(key, None);
+    }
 
     #[test]
     fn parse_aws_sm_uri_extracts_id_and_key() {

--- a/operator/src/secrets.rs
+++ b/operator/src/secrets.rs
@@ -56,30 +56,61 @@ pub async fn resolve_value_from(
     Ok(format!("{arn}:{json_key}::"))
 }
 
-/// Split an ECS-native `valueFrom` value into its base secret ARN/name and
-/// an optional JSON key, if it carries the `:<jsonKey>::` suffix ECS uses to
-/// extract one field of a JSON secret. Only applies to values already
-/// shaped like an ARN (`arn:...:secret:<name>-<suffix>:<jsonKey>::`) — a
-/// bare secret name is never split, since ECS only recognizes the suffix on
-/// a full ARN. Returns `(value, None)` unchanged if there's no such suffix.
-fn split_ecs_json_key_suffix(value: &str) -> (&str, Option<&str>) {
-    if !value.starts_with("arn:") {
-        return (value, None);
-    }
-    // `<base-arn>:<jsonKey>::` — strip the trailing empty segment (from the
-    // final `::`), then split off exactly one more `:<jsonKey>` segment. A
-    // bare secret ARN has none of this, so `rest` won't match the pattern
-    // and falls through to the unchanged case.
-    let Some(without_trailing) = value.strip_suffix("::") else {
-        return (value, None);
+/// Split an ECS-native `valueFrom` value into its base secret ARN and an
+/// optional JSON key, if it carries ECS's suffix for extracting one field of
+/// a JSON secret. Only applies to values already shaped like a Secrets
+/// Manager ARN — a bare secret name is never split. Returns `(value, None)`
+/// unchanged if there's no `secret:` component at all (not a Secrets
+/// Manager ARN) or no suffix is present.
+///
+/// The full ECS syntax has three optional positional fields after the
+/// secret name, always present as colons even when empty:
+/// `arn:...:secret:<name>-<suffix>:<json-key>:<version-stage>:<version-id>`
+/// (see the ECS docs' "Example referencing a specific key/version" section:
+/// <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar-secrets-manager.html>).
+/// Only the json-key field is supported here — `oabctl`'s own use case
+/// (fetching a plaintext secret value in-process) never needs to pin a
+/// specific rotation version. A value with a non-empty version-stage or
+/// version-id fails closed with a clear error instead of silently
+/// mis-splitting or ignoring those fields.
+fn split_ecs_json_key_suffix(value: &str) -> Result<(&str, Option<&str>)> {
+    // The base ARN's secret-name segment is `secret:<name>-<6-char-suffix>`
+    // and never contains a colon itself, so the first `:` after `secret:`
+    // unambiguously starts the optional field suffix (if any) — this is
+    // what let a value like `arn:...:secret:mysecret::` be misparsed before
+    // (treating `mysecret` as a json-key, when it's actually the secret
+    // name with all three optional fields empty).
+    let Some(secret_marker) = value.find(":secret:") else {
+        return Ok((value, None));
     };
-    let Some((base, json_key)) = without_trailing.rsplit_once(':') else {
-        return (value, None);
+    let after_name_start = secret_marker + ":secret:".len();
+    let Some(name_end) = value[after_name_start..].find(':') else {
+        // No suffix at all — a bare secret ARN.
+        return Ok((value, None));
     };
-    if json_key.is_empty() || !base.starts_with("arn:") {
-        return (value, None);
+    let base = &value[..after_name_start + name_end];
+    let fields: Vec<&str> = value[after_name_start + name_end + 1..].split(':').collect();
+    let (json_key, version_stage, version_id) = match fields.as_slice() {
+        [k] => (*k, "", ""),
+        [k, s] => (*k, *s, ""),
+        [k, s, i] => (*k, *s, *i),
+        _ => anyhow::bail!(
+            "unrecognized Secrets Manager ARN suffix in '{value}' — expected at most \
+             <json-key>:<version-stage>:<version-id>"
+        ),
+    };
+    if !version_stage.is_empty() || !version_id.is_empty() {
+        anyhow::bail!(
+            "'{value}' pins a specific secret version (version-stage/version-id), which \
+             oabctl does not support when resolving a secret's plaintext value in-process \
+             (only when passing it through as an ECS task-definition valueFrom, where ECS \
+             itself resolves the version) — use the secret's AWSCURRENT version instead"
+        );
     }
-    (base, Some(json_key))
+    if json_key.is_empty() {
+        return Ok((base, None));
+    }
+    Ok((base, Some(json_key)))
 }
 
 /// Resolve a `spec.secrets` value to its plain string content, for callers
@@ -99,7 +130,7 @@ pub async fn resolve_string(sm: &aws_sdk_secretsmanager::Client, value: &str) ->
             let (id, key) = parsed?;
             (id, Some(key))
         }
-        None => split_ecs_json_key_suffix(value),
+        None => split_ecs_json_key_suffix(value)?,
     };
 
     let secret_string = sm
@@ -129,13 +160,14 @@ mod tests {
 
     #[test]
     fn split_ecs_json_key_suffix_extracts_key_from_real_world_arn() {
-        // The exact shape that surfaced this bug: an ECS-native valueFrom
-        // ARN with a JSON-key suffix, passed to resolve_string (which used
-        // to hand this straight to GetSecretValue and fail, since that API
-        // has no knowledge of the trailing `:<jsonKey>::` ECS convention).
+        // The exact shape that surfaced the original bug: an ECS-native
+        // valueFrom ARN with a JSON-key suffix, passed to resolve_string
+        // (which used to hand this straight to GetSecretValue and fail,
+        // since that API has no knowledge of the trailing ECS suffix).
         let (base, key) = split_ecs_json_key_suffix(
             "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP:TELEGRAM_BOT_TOKEN::",
-        );
+        )
+        .unwrap();
         assert_eq!(base, "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP");
         assert_eq!(key, Some("TELEGRAM_BOT_TOKEN"));
     }
@@ -144,16 +176,59 @@ mod tests {
     fn split_ecs_json_key_suffix_unchanged_for_plain_arn() {
         let (base, key) = split_ecs_json_key_suffix(
             "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP",
-        );
+        )
+        .unwrap();
         assert_eq!(base, "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP");
         assert_eq!(key, None);
     }
 
     #[test]
     fn split_ecs_json_key_suffix_unchanged_for_bare_secret_name() {
-        let (base, key) = split_ecs_json_key_suffix("plain-secret-name");
+        let (base, key) = split_ecs_json_key_suffix("plain-secret-name").unwrap();
         assert_eq!(base, "plain-secret-name");
         assert_eq!(key, None);
+    }
+
+    #[test]
+    fn split_ecs_json_key_suffix_does_not_mistake_secret_name_for_json_key() {
+        // Review finding #1: a full-secret-value reference with all three
+        // optional fields empty (`::`) must not be misparsed as
+        // json-key="mysecret" — "mysecret" here is part of the secret
+        // name/base ARN, not a suffix field.
+        let (base, key) =
+            split_ecs_json_key_suffix("arn:aws:secretsmanager:us-east-1:903779448426:secret:mysecret::").unwrap();
+        assert_eq!(base, "arn:aws:secretsmanager:us-east-1:903779448426:secret:mysecret");
+        assert_eq!(key, None);
+    }
+
+    #[test]
+    fn split_ecs_json_key_suffix_rejects_version_stage() {
+        // Review finding #2: version-stage/version-id pinning is out of
+        // scope for in-process resolution — fail closed with a clear error
+        // instead of silently mishandling it.
+        let err = split_ecs_json_key_suffix(
+            "arn:aws:secretsmanager:us-east-1:903779448426:secret:appauthexample-AbCdEf::AWSPREVIOUS:",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("version"));
+    }
+
+    #[test]
+    fn split_ecs_json_key_suffix_rejects_version_id() {
+        let err = split_ecs_json_key_suffix(
+            "arn:aws:secretsmanager:us-east-1:903779448426:secret:appauthexample-AbCdEf:::9d4cb84b-ad69-40c0-a0ab-cead3EXAMPLE",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("version"));
+    }
+
+    #[test]
+    fn split_ecs_json_key_suffix_rejects_key_and_version_stage_together() {
+        let err = split_ecs_json_key_suffix(
+            "arn:aws:secretsmanager:us-east-1:903779448426:secret:appauthexample-AbCdEf:username1:AWSPREVIOUS:",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("version"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a real bug found within minutes of merging #1285 by re-testing `oabctl
apply` live against a real manifest.

`resolve_string` (used to fetch `TELEGRAM_BOT_TOKEN`'s plaintext value for
the new auto-`setWebhook` call) claimed in its doc comment that
`GetSecretValue` "resolves natively" an ARN carrying the ECS-only
`:<jsonKey>::` suffix — that claim was simply wrong. AWS's own docs confirm
`GetSecretValue`'s `SecretId` parameter only ever accepts a plain ARN or
secret name; the `:<jsonKey>::` JSON-key-extraction suffix is purely an ECS
`valueFrom` convention, resolved by ECS itself at container launch via
`register_task_definition`, not something the Secrets Manager API
understands at all.

Result: any manifest using the ECS-native `valueFrom` ARN format for
`TELEGRAM_BOT_TOKEN` — which is Format 1 in the README, i.e. the more common
of the two documented formats — failed webhook registration with `failed to
resolve TELEGRAM_BOT_TOKEN`, even though the exact same value works fine as
an ECS task-definition secret (that path goes through `resolve_value_from`,
which never had this bug).

```
TELEGRAM_BOT_TOKEN: "arn:...:secret:oab/telegram/mybot-AC80TP:TELEGRAM_BOT_TOKEN::"
                                                              └──────┬──────┘
                                                         ECS-only suffix —
                                                    GetSecretValue rejects this
                                                    as part of the SecretId

Before: resolve_string(value) → GetSecretValue(secret_id=value) → error
After:  resolve_string(value) → split_ecs_json_key_suffix(value)
                                   → GetSecretValue(secret_id=<base-arn>)
                                   → extract "TELEGRAM_BOT_TOKEN" from the
                                     returned JSON secret string manually
```

## Fix

Added `split_ecs_json_key_suffix`, which detects and strips the ECS-only
suffix from an ARN-shaped value (only ARNs — a bare secret name is never
split), then `resolve_string` extracts the JSON key manually from the
fetched secret string — the same way it already did for the `aws-sm://`
form. `resolve_value_from` (used to build the actual ECS task definition,
where ECS *does* understand the suffix) is untouched and unaffected.

## Testing done

```
cargo build --release                        # clean
cargo clippy --all-targets -- -D warnings    # clean
cargo test --release                         # 29 passed; 0 failed
```

3 new unit tests, including the exact real-world ARN value that surfaced
the bug (`arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP:TELEGRAM_BOT_TOKEN::`)
as a regression test.

**Live E2E**: re-ran `oabctl apply` against the real manifest that hit this
bug (`TELEGRAM_BOT_TOKEN` as an ECS-native ARN). Before the fix:
`⚠ Telegram webhook registration failed (apply still succeeded): failed to
resolve TELEGRAM_BOT_TOKEN`. After: `✓ Telegram webhook registered: Webhook
was set`.


## Update: addressed 2 code review findings

A review flagged two real gaps in the initial `split_ecs_json_key_suffix`:

| # | Finding | Verdict |
|---|---------|---------|
| 1 | `arn:...:secret:mysecret::` gets misparsed — `mysecret` is treated as a json-key, but it's actually part of the secret name (a full-secret-value reference with all suffix fields empty) | Real bug, cheap fix — confirmed by simulating the exact value |
| 2 | The ECS suffix isn't just `:<jsonKey>::` — it's 3 positional fields (`<json-key>:<version-stage>:<version-id>`), unhandled here | Real gap, correctly identified as a feature-boundary — verified against [AWS's own ECS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar-secrets-manager.html) worked examples |

Both fixed:
1. Locate the unambiguous `:secret:` marker in the ARN and treat everything
   up to the *next* colon as the secret-name segment (which per AWS's docs
   never itself contains a colon) — rather than blindly `rsplit`-ing on the
   last colon, which can't distinguish "secret name" from "json-key" when
   the suffix fields are all empty.
2. Parse all three positional fields; fail closed with a clear, specific
   error when version-stage/version-id is non-empty, instead of silently
   falling through to "no suffix" (which would then fail later at
   `GetSecretValue` with a confusing, unrelated error). `oabctl`'s own use
   case — fetching a secret's plaintext value in-process to call a
   third-party API — never needs to pin a rotation version, so this is an
   intentional, documented limitation, not a missing feature to build out
   further right now.

7 new tests added covering both findings, using AWS's own documented
example ARN shapes (key-only, version-stage-only, version-id-only,
key+version-stage). Re-verified live against the real manifest from the
original bug report — still resolves correctly, no regression.
