### PR TITLE
ci: comment when stale-contributor.yml applies closing-soon

### DIFF
--- a/.github/workflows/stale-contributor.yml
+++ b/.github/workflows/stale-contributor.yml
@@ -52,5 +52,32 @@ jobs:
                 issue_number: pr.number,
                 labels: [CLOSING]
               });
+
+              const marker = '<!-- openab-stale-contributor-check -->';
+              const { data: comments } = await github.rest.issues.listComments({
+                ...context.repo,
+                issue_number: pr.number,
+                per_page: 100
+              });
+              const alreadyCommented = comments.some(c => c.body.includes(marker));
+              if (!alreadyCommented) {
+                const msg = [
+                  marker,
+                  '> [!CAUTION]',
+                  `> This PR has been waiting on the author for more than ${STALE_DAYS} days ` +
+                    `(labeled \`${CONTRIBUTOR}\` since ${labeledAt.toISOString().slice(0, 10)}).`,
+                  '> It will be **automatically closed in 24 hours** if there is no update.',
+                  '',
+                  'Please push a commit, respond to outstanding review feedback, or comment here ' +
+                    'to keep this PR open. Feel free to reopen a new PR later if it gets closed and ' +
+                    'you want to pick it back up.'
+                ].join('\n');
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: pr.number,
+                  body: msg
+                });
+              }
+
               console.log(`#${pr.number} — ${CONTRIBUTOR} since ${labeledAt.toISOString()}, added ${CLOSING}`);
             }


### PR DESCRIPTION
## Summary

Found while investigating why PR #1272 had the `closing-soon` label despite
already having a valid Discord Discussion URL in its body. Turned out
`pr-discussion-check.yml` (the Discord URL check) wasn't the cause at all —
it ran once, matched the URL, and cleared the label correctly. The label
kept reappearing because of a **separate, unrelated** workflow:
`stale-contributor.yml`, which adds `closing-soon` to any PR that's held the
`pending-contributor` label for more than 2 days — with **no explanation
posted to the author**, unlike `pr-discussion-check.yml`'s Discord-URL check,
which always posts a `[!CAUTION]` comment.

That silence is the actual problem this PR fixes: an author (or anyone
investigating) sees `closing-soon` appear with zero context about which of
the several `closing-soon`-related workflows applied it or why, since there's
no comment to check.

## Change

Add a caution comment to `stale-contributor.yml`, matching
`pr-discussion-check.yml`'s existing alert style, whenever it adds
`closing-soon`:

```
> [!CAUTION]
> This PR has been waiting on the author for more than 2 days
> (labeled `pending-contributor` since <date>).
> It will be **automatically closed in 24 hours** if there is no update.

Please push a commit, respond to outstanding review feedback, or comment
here to keep this PR open. Feel free to reopen a new PR later if it gets
closed and you want to pick it back up.
```

Uses a `<!-- openab-stale-contributor-check -->` marker (checked against
existing comments) to avoid duplicate comments across runs — belt-and-suspenders
alongside the existing early-`continue` guard for PRs that already carry
`closing-soon`.

## Scope

Only `stale-contributor.yml` (PRs) was changed, per the specific ask.
`stale-issue.yml` has the identical gap on the issue side but wasn't touched
here — happy to open a follow-up for it if wanted.

## Testing done

- Validated the workflow YAML parses correctly.
- Not dry-run against a real stale PR (would require waiting 2 real days or
  manipulating label-event timestamps in a test repo) — the added logic
  mirrors `pr-discussion-check.yml`'s already-working comment-posting pattern
  closely enough that I'm confident in the mechanics, but flagging this as
  the one part that's unverified against a live run.
