### PR TITLE
fix(line): don't post duplicate messages when streaming to LINE

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -57,6 +57,9 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 #                                       # omitted = auto-detect from list (non-empty → false, empty → true)
 # allowed_users = ["U5678"]             # only checked when allow_all_users = false
 # streaming = true                      # enable streaming (typewriter) mode
+#                                       # note: LINE has no message-edit API, so it is always
+#                                       #       send-once (streaming is forced off to avoid
+#                                       #       posting duplicate, growing messages)
 # streaming_placeholder = false         # set false for draft-based platforms (e.g. Telegram Rich Messages)
 
 # --- Telegram (first-class section; alternative to TELEGRAM_* env vars) ---

--- a/crates/openab-core/src/gateway.rs
+++ b/crates/openab-core/src/gateway.rs
@@ -40,6 +40,31 @@ fn platform_acks_writes(platform: &str) -> bool {
     EDIT_RESPONSE_PLATFORMS.contains(&platform)
 }
 
+/// Gateway platforms whose messaging API cannot edit a message after it is sent.
+///
+/// Cosmetic (typewriter) streaming works by posting a placeholder and then
+/// repeatedly editing it in place with the growing text. On a platform with no
+/// edit endpoint, each of those "edits" is delivered as a brand-new message
+/// instead — so the user sees the same reply posted several times, each copy
+/// longer than the last. Streaming is therefore force-disabled (send-once) for
+/// these platforms regardless of the configured `streaming` flag.
+///
+/// LINE's Messaging API only exposes reply/push (no edit), so it lives here.
+/// (The in-process unified adapter additionally hard-drops stray edit_message
+/// commands in the LINE adapter itself — see `dispatch_line_reply`.)
+///
+/// NOTE: like `EDIT_RESPONSE_PLATFORMS`, this is platform-identity standing in
+/// for a *capability*. The right long-term model is a capability handshake at
+/// gateway-connect time ("can this adapter edit messages?"); until that exists,
+/// any new gateway platform that lacks a message-edit API MUST be added here.
+const NON_EDITABLE_PLATFORMS: &[&str] = &["line"];
+
+/// Whether cosmetic streaming (placeholder + in-place edits) is possible on
+/// `platform`. See `NON_EDITABLE_PLATFORMS`.
+fn platform_supports_streaming(platform: &str) -> bool {
+    !NON_EDITABLE_PLATFORMS.contains(&platform)
+}
+
 /// Shared filter parameters for gateway event gating.
 /// Used by both `run_gateway_adapter` (WebSocket) and `process_gateway_event` (unified).
 struct EventFilterParams<'a> {
@@ -743,7 +768,19 @@ pub async fn run_gateway_adapter(
     let allowed_users: HashSet<String> = params.allowed_users.into_iter().collect();
     let allow_bot_messages = params.allow_bot_messages;
     let trusted_bot_ids: HashSet<String> = params.trusted_bot_ids.into_iter().collect();
-    let streaming = params.streaming;
+    // Cosmetic streaming edits a placeholder in place. On platforms without an
+    // edit API (e.g. LINE) every edit lands as a new message — growing
+    // duplicates — so force send-once mode there regardless of config.
+    let streaming = if params.streaming && !platform_supports_streaming(platform) {
+        warn!(
+            platform,
+            "streaming is enabled but this platform cannot edit messages; \
+             forcing send-once mode to avoid duplicate messages"
+        );
+        false
+    } else {
+        params.streaming
+    };
     let streaming_placeholder = params.streaming_placeholder;
     let stt_config = params.stt;
 
@@ -1472,6 +1509,30 @@ fn format_size(n: u64) -> String {
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    #[test]
+    fn line_cannot_stream_and_is_forced_send_once() {
+        // LINE has no message-edit API, so cosmetic streaming is impossible.
+        assert!(!platform_supports_streaming("line"));
+    }
+
+    #[test]
+    fn editable_platforms_still_allow_streaming() {
+        for platform in [
+            "telegram",
+            "slack",
+            "discord",
+            "feishu",
+            "teams",
+            "googlechat",
+            "wecom",
+        ] {
+            assert!(
+                platform_supports_streaming(platform),
+                "{platform} should still support streaming",
+            );
+        }
+    }
 
     #[test]
     fn echo_allowed_throttles_repeat_within_window() {

--- a/crates/openab-gateway/src/adapters/line.rs
+++ b/crates/openab-gateway/src/adapters/line.rs
@@ -658,6 +658,22 @@ pub async fn dispatch_line_reply(
         return false;
     }
 
+    // LINE's Messaging API cannot edit or delete a message once it is sent.
+    // In streaming mode the core posts a placeholder then repeatedly calls
+    // edit_message with the growing text; on an editable platform this updates in
+    // place, but on LINE every edit_message would be delivered as a *new* message
+    // — the reply gets reposted several times, each copy longer than the last.
+    // Because the unified adapter uses a "draft" placeholder (no real message), the
+    // final content is delivered separately via send_message, so dropping these
+    // cosmetic edit/delete commands removes the duplicates without losing content.
+    if matches!(
+        reply.command.as_deref(),
+        Some("edit_message") | Some("delete_message")
+    ) {
+        info!(command = ?reply.command.as_deref(), "line: ignoring edit/delete command (LINE cannot edit messages)");
+        return false;
+    }
+
     // Extract token from cache (drop lock before HTTP call)
     let cached_token = {
         let mut cache = reply_cache.lock().unwrap_or_else(|e| e.into_inner());
@@ -1265,5 +1281,53 @@ mod tests {
         )
         .await;
         assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn edit_message_command_is_ignored_not_forwarded() {
+        // LINE cannot edit messages. A streaming `edit_message` reply must be
+        // dropped, never forwarded as a new Reply/Push message — otherwise each
+        // edit posts the growing text as a separate message (duplicate replies).
+        let server = MockServer::start().await;
+        // If the guard fails and the command falls through, the empty reply-token
+        // cache forces the Push API. This expectation forbids that call.
+        let _push = Mock::given(method("POST"))
+            .and(path("/v2/bot/message/push"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount_as_scoped(&server)
+            .await;
+
+        let cache: crate::ReplyTokenCache =
+            Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let reply = GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: "evt1".into(),
+            platform: "line".into(),
+            channel: ReplyChannel {
+                id: "U123".into(),
+                thread_id: None,
+            },
+            content: Content {
+                content_type: "text".into(),
+                text: "partial streamed text".into(),
+                attachments: vec![],
+            },
+            command: Some("edit_message".into()),
+            request_id: None,
+            quote_message_id: None,
+        };
+
+        let used_reply = dispatch_line_reply(
+            &reqwest::Client::new(),
+            "line_token",
+            &cache,
+            &reply,
+            &server.uri(),
+        )
+        .await;
+
+        assert!(!used_reply, "edit_message must not use the Reply API");
+        // `_push` expect(0) is verified on drop: no push request was sent.
     }
 }


### PR DESCRIPTION
## What problem does this solve?

When a deployment has streaming enabled, replies sent to **LINE** are posted as
several separate messages, each copy longer than the last — instead of one
message that fills in. The reported symptom is the same reply bubble appearing
3+ times, growing each time.

Root cause: LINE's Messaging API has **no message-edit endpoint** (reply/push
only). Cosmetic ("typewriter") streaming posts a placeholder and then repeatedly
calls `edit_message` with the growing text. On LINE, each `edit_message` is
delivered as a brand-new message → duplicate, growing replies.

In the 0.9.x unified webhook server this is worse than a simple misconfig: the
`UnifiedGatewayAdapter` decides streaming **globally** (from the Telegram
streaming flag) and is not platform-aware, so LINE turns stream too whenever any
Telegram streaming is on in the same process.

No linked GitHub issue — reported and discussed in Discord (URL below).

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404/1522936692183662642

## At a Glance

```
LINE user ──webhook──► openab (unified webhook server, :8080)
                              │
                              ▼
                 core streaming loop (openab-core/adapter.rs)
                 use_streaming() == true   (global, Telegram-driven)
                   1) placeholder = "draft"  (show_streaming_placeholder=false)
                   2) edit_message(growing text) × N   ← cosmetic updates
                   3) send_message(final chunks)        ← draft path = final content
                              │
                              ▼
                 UnifiedGatewayAdapter::dispatch_reply  (src/unified_adapter.rs)
                              │
                              ▼
                 dispatch_line_reply (openab-gateway/adapters/line.rs)

  BEFORE: each edit_message → a new LINE Reply/Push  ⇒ 3 growing duplicate bubbles
  AFTER : edit_message dropped (LINE can't edit)     ⇒ 1 final bubble via send_message
```

## Prior Art & Industry Research

This is a message-**delivery** change, so per CONTRIBUTING I researched how
comparable projects handle streaming on platforms that cannot edit messages.

**Hermes Agent (NousResearch)** — handles LINE exactly the way this PR does.
Its docs state: *"LINE has no edit-message API — streaming responses always send
fresh bubbles, never edit prior ones,"* and streaming/progressive editing is
only offered on Telegram, Discord, Slack and the CLI. Long replies are
smart-chunked into fresh bubbles rather than edited in place.
(https://hermes-agent.nousresearch.com/docs/user-guide/messaging/line)

**OpenClaw** — models edit/stream as **per-adapter capabilities**:
`Capabilities: { live?: { edit: boolean; delete: boolean; nativeStream?: boolean } }`.
Adapters without live/edit support omit the `live` property and fall back to
fresh-send / cancel / draft-to-final strategies instead of in-place edits.
(https://docs.openclaw.ai/concepts/message-lifecycle-refactor)

Takeaway: the industry consensus is "don't edit where you can't edit — send a
single final message." This PR implements that for LINE, and the hardcoded
`NON_EDITABLE_PLATFORMS` list is the pragmatic stand-in for OpenClaw's
`capabilities.live.edit` flag until OAB grows a real capability handshake (called
out as tech debt in the code).

## Proposed Solution

Two layers, matching the two code paths LINE can flow through:

1. **Unified/in-process path (primary fix)** —
   `crates/openab-gateway/src/adapters/line.rs`: `dispatch_line_reply` now drops
   `edit_message` / `delete_message` commands (mirroring the existing
   reaction-command ignore). Because the unified adapter uses a `"draft"`
   placeholder, the **final content is delivered separately via `send_message`**,
   so dropping the cosmetic edits removes the duplicates **without losing
   content**.

2. **Split WebSocket-gateway path (completeness)** —
   `crates/openab-core/src/gateway.rs`: platforms that cannot edit
   (`NON_EDITABLE_PLATFORMS`, incl. `"line"`) force send-once regardless of the
   configured `streaming` flag. This keeps layer 1 safe in the split topology,
   where a *real* placeholder would otherwise finalize via an `edit_message` that
   the adapter now drops.

Plus a note in `config.toml.example` and unit tests for both layers.

## Why this approach?

- **Correct where the knowledge lives.** In unified mode the core streaming loop
  is platform-blind, so the LINE adapter — the only place that knows the reply is
  going to LINE — is the right layer to refuse edits. This mirrors OpenClaw's
  per-adapter capability model and Hermes' LINE behavior.
- **No content loss.** Relies on the unified adapter's draft→`send_message`
  finalize path, so users still get the complete reply as a single message.
- **Minimal & focused.** No trait-signature changes; one guard + one platform
  gate.

Known limitations / future work:
- `UnifiedGatewayAdapter::use_streaming()` remains globally Telegram-driven; a
  proper fix would make it platform-aware (or introduce a capability handshake so
  `NON_EDITABLE_PLATFORMS` can be retired). Left out to keep this PR small.
- LINE users get no live typewriter effect (impossible without an edit API) — the
  reply arrives as one final message, which is the intended UX.

## Alternatives Considered

- **Make `use_streaming` platform-aware in the unified adapter** — cleanest
  conceptually, but `use_streaming(&self, other_bot_present)` has no channel/
  platform argument and one adapter serves all platforms; doing it right means a
  trait-signature change across every adapter. Deferred as future work.
- **Only gate streaming off in the core (no adapter guard)** — does not help the
  unified path, where streaming is decided globally and independently of the WS
  `run_gateway_adapter`.
- **Only drop `edit_message` in the adapter (no core gate)** — unsafe for the
  split WS path with a *real* placeholder: the final content arrives via
  `edit_message` there and would be dropped. Hence both layers.

## Validation

Rust changes:
- [x] `cargo build --release --features unified` succeeds — the test image was
  built from this branch via `Dockerfile.unified --target claude` (a successful
  release build implies `cargo check` passes).
- [x] `cargo fmt --check` clean on the changed hunks.
- [x] Unit tests added — `edit_message_command_is_ignored_not_forwarded`
  (openab-gateway) and `line_cannot_stream_and_is_forced_send_once` /
  `editable_platforms_still_allow_streaming` (openab-core). Full `cargo test` and
  `cargo clippy` will run in CI (I could not run the full suite in my local
  environment).

All PRs:
- [x] **Manual testing** — Built the unified + claude image from this branch and
  deployed it to a live 0.9.0 LINE bot via `kubectl set image`, then sent a
  message that triggers a long reply. **Before:** the reply was posted as 3
  separate, progressively-growing messages (screenshot in the Discord
  discussion). **After:** a single complete message is posted; Discord delivery
  unaffected.
