### PR TITLE
fix(unified): start feishu websocket + bot identity in unified mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -633,6 +633,39 @@ async fn main() -> anyhow::Result<()> {
                 app = app.route(&path, axum::routing::post(openab_gateway::adapters::feishu::webhook));
             }
 
+            // Feishu bot identity + WebSocket long-connection (unified mode).
+            // Mirrors run_gateway() in openab-gateway/src/lib.rs: identity is
+            // required for @mention gating, and the default connection mode is
+            // websocket — without this spawn the adapter only serves the webhook
+            // route above and never receives events in websocket mode.
+            #[cfg(feature = "feishu")]
+            if let Some(ref f) = gw_state.feishu {
+                use openab_gateway::adapters::feishu;
+                f.resolve_bot_identity().await;
+                if f.config.streaming_mode != feishu::StreamingMode::Post {
+                    let idle_ms = f.config.card_idle_finalize_ms;
+                    tokio::spawn(feishu::run_idle_reaper(
+                        f.stream_sessions.clone(),
+                        f.token_cache.clone(),
+                        f.client.clone(),
+                        f.config.api_base(),
+                        idle_ms,
+                    ));
+                    info!(idle_ms, "unified: feishu card-streaming idle reaper started");
+                }
+                if f.config.connection_mode == feishu::ConnectionMode::Websocket {
+                    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+                    match feishu::start_websocket(f, event_tx.clone(), shutdown_rx).await {
+                        Ok(_handle) => info!("unified: feishu websocket task spawned"),
+                        Err(e) => error!(err = %e, "unified: feishu websocket startup failed"),
+                    }
+                    // Keep the shutdown sender alive for the process lifetime —
+                    // dropping it makes shutdown_rx.changed() fire and ends the
+                    // reconnect loop in start_websocket().
+                    std::mem::forget(shutdown_tx);
+                }
+            }
+
             #[cfg(feature = "wecom")]
             if let Some(ref w) = gw_state.wecom {
                 info!(path = %w.config.webhook_path, "unified: wecom adapter enabled");


### PR DESCRIPTION
## Problem

In unified mode, the feishu adapter is effectively dead in its default configuration. `src/main.rs` only registers the webhook route:

```rust
#[cfg(feature = "feishu")]
if gw_state.feishu.is_some() {
    ...
    app = app.route(&path, axum::routing::post(openab_gateway::adapters::feishu::webhook));
}
```

`resolve_bot_identity()` and `start_websocket()` are only called from the standalone gateway path (`openab-gateway/src/lib.rs::run_gateway`). Since `FEISHU_CONNECTION_MODE` defaults to `websocket` (and the docs recommend it), setting `FEISHU_APP_ID`/`FEISHU_APP_SECRET` in unified mode logs `unified: feishu adapter enabled` but the bot never connects and never receives a single event. `@mention` gating is also broken even in webhook mode, because the bot's own open_id is never resolved.

## Fix

Mirror the gateway startup into the unified block, right after the webhook route registration:

- `resolve_bot_identity().await` — required for @mention gating and self-message filtering
- spawn `run_idle_reaper` when card streaming is enabled (parity with `run_gateway`)
- spawn `start_websocket()` when `connection_mode == Websocket`

The websocket shutdown sender is intentionally leaked (`std::mem::forget`) — dropping it makes `shutdown_rx.changed()` fire inside `start_websocket`'s reconnect loop and permanently stops the connection. In unified mode the adapter should live for the process lifetime, same as the discord/slack adapters.

## Verification

Running live on macOS against Lark (international, `FEISHU_DOMAIN=lark`) with only env vars set (no `[gateway]` config):

```
unified: feishu adapter enabled path=/webhook/feishu
feishu bot identity resolved bot_open_id=ou_xxx
unified: feishu card-streaming idle reaper started idle_ms=3000
unified: feishu websocket task spawned
feishu websocket connected
```

DMs and group @mentions both round-trip to the agent and reply. `cargo check --features unified` passes on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1wSJXGjoZWjarLiDqQFtC