### PR TITLE
feat(operator): support 'oabctl delete -f <manifest>', mirroring apply -f

### DIFF
--- a/docs/oabctl.md
+++ b/docs/oabctl.md
@@ -345,7 +345,8 @@ must still be registered manually in the LINE Developers console.
 > loudly on a mismatch (subnets aren't exposed by the API, so those can only be
 > reminded, not verified).
 >
-> **Teardown:** `oabctl delete oabservice <name>` permanently removes the bot's
+> **Teardown:** `oabctl delete oabservice <name>` (or `oabctl delete -f <manifest>`,
+> using the same file `apply -f` deployed it from) permanently removes the bot's
 > per-bot ingress resources — its exact Cloud Map service (resolved by the ECS
 > service's own registry ARN, not a name search, so same-named bots in different
 > VPCs/environments can't collide) and its HTTP API (`oab-webhook-<ns>-<name>`,
@@ -525,6 +526,7 @@ s3://oab-control-plane-{account}/
 | `oabctl apply -f <file> --no-sync` | Deploy without syncing config |
 | `oabctl get oabservice [name]` | List agents and status |
 | `oabctl delete oabservice <name>` | Teardown agent |
+| `oabctl delete -f <file\|dir>` | Teardown every agent defined in a manifest (mirrors `apply -f`) |
 | `oabctl exec <agent> -- <cmd>` | Execute command in container |
 | `oabctl cp <src> <dst>` | Copy files to/from container |
 | `oabctl sync <src> <dst>` | Sync directories (bidirectional) |

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -98,7 +98,7 @@ pub async fn run(aws_config: &aws_config::SdkConfig, file_path: &str, sync_confi
     Ok(())
 }
 
-fn load_manifests(path: &Path) -> Result<Vec<OABServiceManifest>> {
+pub(crate) fn load_manifests(path: &Path) -> Result<Vec<OABServiceManifest>> {
     let mut manifests = Vec::new();
     if path.is_dir() {
         for entry in std::fs::read_dir(path)? {

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -89,6 +89,8 @@ pub async fn run(aws_config: &aws_config::SdkConfig, file_path: &str, sync_confi
         }
     }
 
+    print_plan(&manifests);
+
     for m in &manifests {
         println!("  Applying {} (ECS)...", m.metadata.name);
         apply_ecs(&ecs, &s3, aws_config, m, wait).await?;
@@ -96,6 +98,41 @@ pub async fn run(aws_config: &aws_config::SdkConfig, file_path: &str, sync_confi
 
     println!("\n{} service(s) applied.", manifests.len());
     Ok(())
+}
+
+/// Print the upfront plan: every resource `apply` may touch for each
+/// manifest, as an unchecked `[ ]` list, before any AWS calls are made.
+/// Purely informational — derived straight from manifest fields, so it
+/// never blocks execution and never needs to stay in sync with exactly what
+/// each step decides to do at runtime (create vs. update, skip vs. act);
+/// the existing `✓`/`⚠` lines printed by `apply_ecs`/`ensure_gateway` as
+/// each step actually completes remain the source of truth for real detail
+/// (resource IDs, ARNs, URLs) — this is just the "what's coming" preview.
+fn print_plan(manifests: &[OABServiceManifest]) {
+    println!("Plan:");
+    for m in manifests {
+        println!("  {}:", m.metadata.name);
+        println!("    [ ] S3 manifest");
+        println!("    [ ] ECS task definition");
+        println!("    [ ] ECS service");
+        if let Some(ingress) = &m.spec.ingress {
+            println!("    [ ] Cloud Map namespace + service");
+            println!("    [ ] VPC Link");
+            println!("    [ ] API Gateway HTTP API");
+            println!("    [ ] API Gateway integration");
+            for path in &ingress.paths {
+                println!("    [ ] API Gateway route: {path}");
+            }
+            println!("    [ ] API Gateway stage");
+            println!("    [ ] Security group inbound rule");
+            if ingress.paths.iter().any(|p| p == "/webhook/telegram")
+                && m.spec.secrets.contains_key("TELEGRAM_BOT_TOKEN")
+            {
+                println!("    [ ] Telegram webhook registration");
+            }
+        }
+    }
+    println!();
 }
 
 pub(crate) fn load_manifests(path: &Path) -> Result<Vec<OABServiceManifest>> {

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -125,11 +125,6 @@ fn print_plan(manifests: &[OABServiceManifest]) {
             }
             println!("    [ ] API Gateway stage");
             println!("    [ ] Security group inbound rule");
-            if ingress.paths.iter().any(|p| p == "/webhook/telegram")
-                && m.spec.secrets.contains_key("TELEGRAM_BOT_TOKEN")
-            {
-                println!("    [ ] Telegram webhook registration");
-            }
         }
     }
     println!();

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -89,8 +89,6 @@ pub async fn run(aws_config: &aws_config::SdkConfig, file_path: &str, sync_confi
         }
     }
 
-    print_plan(&manifests);
-
     for m in &manifests {
         println!("  Applying {} (ECS)...", m.metadata.name);
         apply_ecs(&ecs, &s3, aws_config, m, wait).await?;
@@ -98,36 +96,6 @@ pub async fn run(aws_config: &aws_config::SdkConfig, file_path: &str, sync_confi
 
     println!("\n{} service(s) applied.", manifests.len());
     Ok(())
-}
-
-/// Print the upfront plan: every resource `apply` may touch for each
-/// manifest, as an unchecked `[ ]` list, before any AWS calls are made.
-/// Purely informational — derived straight from manifest fields, so it
-/// never blocks execution and never needs to stay in sync with exactly what
-/// each step decides to do at runtime (create vs. update, skip vs. act);
-/// the existing `✓`/`⚠` lines printed by `apply_ecs`/`ensure_gateway` as
-/// each step actually completes remain the source of truth for real detail
-/// (resource IDs, ARNs, URLs) — this is just the "what's coming" preview.
-fn print_plan(manifests: &[OABServiceManifest]) {
-    println!("Plan:");
-    for m in manifests {
-        println!("  {}:", m.metadata.name);
-        println!("    [ ] S3 manifest");
-        println!("    [ ] ECS task definition");
-        println!("    [ ] ECS service");
-        if let Some(ingress) = &m.spec.ingress {
-            println!("    [ ] Cloud Map namespace + service");
-            println!("    [ ] VPC Link");
-            println!("    [ ] API Gateway HTTP API");
-            println!("    [ ] API Gateway integration");
-            for path in &ingress.paths {
-                println!("    [ ] API Gateway route: {path}");
-            }
-            println!("    [ ] API Gateway stage");
-            println!("    [ ] Security group inbound rule");
-        }
-    }
-    println!();
 }
 
 pub(crate) fn load_manifests(path: &Path) -> Result<Vec<OABServiceManifest>> {
@@ -446,7 +414,8 @@ async fn apply_ecs(
     // existing service since March 2022; no delete-and-recreate is needed).
     let cloud_map = if let Some(ingress) = &m.spec.ingress {
         eprintln!("  🌐 Reconciling ingress (Cloud Map)...");
-        Some(crate::ingress::ensure_cloud_map(config, m, ingress).await?)
+        let cm = crate::ingress::ensure_cloud_map(config, m, ingress).await?;
+        Some(cm)
     } else {
         None
     };
@@ -616,22 +585,71 @@ async fn apply_ecs(
     Ok(())
 }
 
+/// Poll until the ECS service's deployment stabilizes, printing each
+/// transition as a composite status string — same vocabulary `ecsctl`
+/// itself uses for `get`/`alias ls` (github.com/oablab/ecsctl,
+/// src/alias.rs): `RUNNING`, `REPLACING(n→m)` (new deployment's tasks still
+/// coming up), `DRAINING(n+m)` (new deployment up, old one's tasks still
+/// stopping), `PENDING(n)`, `PARTIAL(n/m)`, or the raw ECS service status as
+/// a fallback — reused here for a consistent status vocabulary across both
+/// tools instead of raw `running_count`/`rollout_state` fields.
 async fn wait_for_stable(ecs: &aws_sdk_ecs::Client, cluster: &str, service: &str) -> Result<()> {
-    for _ in 0..60 {
+    for i in 0..60 {
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         let resp = ecs.describe_services()
             .cluster(cluster)
             .services(service)
             .send().await?;
-        if let Some(svc) = resp.services().first() {
-            let deployments = svc.deployments();
-            if deployments.len() == 1 {
-                if let Some(d) = deployments.first() {
-                    if d.running_count() == d.desired_count() && d.rollout_state() == Some(&aws_sdk_ecs::types::DeploymentRolloutState::Completed) {
-                        return Ok(());
-                    }
+        let elapsed = (i + 1) * 5;
+
+        let Some(svc) = resp.services().first() else {
+            eprintln!("    [{elapsed}s] service not found in describe-services response yet");
+            continue;
+        };
+
+        let running = svc.running_count() as usize;
+        let desired = svc.desired_count() as usize;
+        let pending = svc.pending_count() as usize;
+        let deployments = svc.deployments();
+        let num_deployments = deployments.len();
+        let primary = deployments
+            .iter()
+            .find(|d| d.status().unwrap_or_default() == "PRIMARY")
+            .or_else(|| deployments.first());
+
+        let status = if desired == 0 {
+            "STOPPED".to_string()
+        } else if running == desired && pending == 0 && num_deployments <= 1 {
+            "RUNNING".to_string()
+        } else if num_deployments > 1 {
+            if let Some(p) = primary {
+                let p_running = p.running_count() as usize;
+                let p_desired = p.desired_count() as usize;
+                if p_running < p_desired {
+                    format!("REPLACING({p_running}→{p_desired})")
+                } else {
+                    let old_running: usize = deployments
+                        .iter()
+                        .filter(|d| d.status().unwrap_or_default() != "PRIMARY")
+                        .map(|d| d.running_count() as usize)
+                        .sum();
+                    format!("DRAINING({p_running}+{old_running})")
                 }
+            } else {
+                svc.status().unwrap_or("UNKNOWN").to_string()
             }
+        } else if pending > 0 {
+            format!("PENDING({pending})")
+        } else if running < desired {
+            format!("PARTIAL({running}/{desired})")
+        } else {
+            svc.status().unwrap_or("UNKNOWN").to_string()
+        };
+
+        eprintln!("    [{elapsed}s] {status}");
+
+        if status == "RUNNING" {
+            return Ok(());
         }
     }
     anyhow::bail!("timed out waiting for service to stabilize (5 min)")

--- a/operator/src/delete.rs
+++ b/operator/src/delete.rs
@@ -20,6 +20,8 @@ pub async fn run_from_file(aws_config: &aws_config::SdkConfig, file_path: &str) 
         anyhow::bail!("no manifests found at {}", file_path);
     }
 
+    print_plan(&manifests);
+
     let mut failures = Vec::new();
     for m in &manifests {
         println!("Deleting {} (from {})...", m.metadata.name, file_path);
@@ -33,6 +35,32 @@ pub async fn run_from_file(aws_config: &aws_config::SdkConfig, file_path: &str) 
         anyhow::bail!("failed to delete {} of {} service(s): {}", failures.len(), manifests.len(), failures.join(", "));
     }
     Ok(())
+}
+
+/// Print the upfront plan: every resource `delete -f` may remove for each
+/// manifest, as an unchecked `[ ]` list, before any AWS calls are made.
+/// Purely informational — see [`crate::apply::print_plan`] for the same
+/// rationale on the apply side; the existing `✓`/`⚠` lines printed by
+/// `run`/`ingress::teardown` as each step actually completes remain the
+/// source of truth for real detail.
+fn print_plan(manifests: &[crate::manifest::OABServiceManifest]) {
+    println!("Plan:");
+    for m in manifests {
+        println!("  {}:", m.metadata.name);
+        println!("    [ ] Scale ECS service to 0");
+        println!("    [ ] ECS service");
+        if let Some(ingress) = &m.spec.ingress {
+            println!("    [ ] Cloud Map service (namespace kept — shared per-VPC)");
+            for path in &ingress.paths {
+                println!("    [ ] API Gateway route: {path}");
+            }
+            println!("    [ ] API Gateway integration");
+            println!("    [ ] API Gateway HTTP API");
+        }
+        println!("    [ ] S3 manifest");
+        println!("    [ ] S3 config artifacts");
+    }
+    println!();
 }
 
 pub async fn run(

--- a/operator/src/delete.rs
+++ b/operator/src/delete.rs
@@ -20,8 +20,6 @@ pub async fn run_from_file(aws_config: &aws_config::SdkConfig, file_path: &str) 
         anyhow::bail!("no manifests found at {}", file_path);
     }
 
-    print_plan(&manifests);
-
     let mut failures = Vec::new();
     for m in &manifests {
         println!("Deleting {} (from {})...", m.metadata.name, file_path);
@@ -37,31 +35,6 @@ pub async fn run_from_file(aws_config: &aws_config::SdkConfig, file_path: &str) 
     Ok(())
 }
 
-/// Print the upfront plan: every resource `delete -f` may remove for each
-/// manifest, as an unchecked `[ ]` list, before any AWS calls are made.
-/// Purely informational — see [`crate::apply::print_plan`] for the same
-/// rationale on the apply side; the existing `✓`/`⚠` lines printed by
-/// `run`/`ingress::teardown` as each step actually completes remain the
-/// source of truth for real detail.
-fn print_plan(manifests: &[crate::manifest::OABServiceManifest]) {
-    println!("Plan:");
-    for m in manifests {
-        println!("  {}:", m.metadata.name);
-        println!("    [ ] Scale ECS service to 0");
-        println!("    [ ] ECS service");
-        if let Some(ingress) = &m.spec.ingress {
-            println!("    [ ] Cloud Map service (namespace kept — shared per-VPC)");
-            for path in &ingress.paths {
-                println!("    [ ] API Gateway route: {path}");
-            }
-            println!("    [ ] API Gateway integration");
-            println!("    [ ] API Gateway HTTP API");
-        }
-        println!("    [ ] S3 manifest");
-        println!("    [ ] S3 config artifacts");
-    }
-    println!();
-}
 
 pub async fn run(
     aws_config: &aws_config::SdkConfig,

--- a/operator/src/delete.rs
+++ b/operator/src/delete.rs
@@ -1,4 +1,39 @@
 use anyhow::{Context, Result};
+use std::path::Path;
+
+/// Delete every OABService defined in a manifest file or directory (mirrors
+/// `apply -f`). Each manifest's `metadata.name`/`metadata.namespace` are used
+/// directly — there's no `--cluster` override here because `apply` itself
+/// only ever deploys to the hardcoded `"oab"` cluster (manifests don't carry
+/// a cluster field), so deletion targets the same cluster unconditionally.
+/// An `OABFleet` manifest expands to multiple services, all deleted in turn.
+///
+/// Continues past a failed delete instead of stopping at the first one, so
+/// one broken/already-gone service in a fleet doesn't block cleanup of the
+/// rest — but still returns an error at the end if anything failed.
+pub async fn run_from_file(aws_config: &aws_config::SdkConfig, file_path: &str) -> Result<()> {
+    let path = Path::new(file_path);
+    let manifests = crate::apply::load_manifests(path)
+        .with_context(|| format!("failed to load manifest(s) from {file_path}"))?;
+
+    if manifests.is_empty() {
+        anyhow::bail!("no manifests found at {}", file_path);
+    }
+
+    let mut failures = Vec::new();
+    for m in &manifests {
+        println!("Deleting {} (from {})...", m.metadata.name, file_path);
+        if let Err(e) = run(aws_config, "oabservice", &m.metadata.name, "oab", &m.metadata.namespace).await {
+            eprintln!("  ⚠ failed to delete {}: {e}", m.metadata.name);
+            failures.push(m.metadata.name.clone());
+        }
+    }
+
+    if !failures.is_empty() {
+        anyhow::bail!("failed to delete {} of {} service(s): {}", failures.len(), manifests.len(), failures.join(", "));
+    }
+    Ok(())
+}
 
 pub async fn run(
     aws_config: &aws_config::SdkConfig,

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -9,6 +9,7 @@ mod ingress;
 mod secrets;
 
 use clap::{Parser, Subcommand};
+use anyhow::Context;
 
 #[derive(Parser)]
 #[command(name = "oabctl", about = "OAB agent provisioner for ECS")]
@@ -54,14 +55,19 @@ enum Commands {
     },
     /// Delete an OAB service
     Delete {
-        /// Resource type
-        resource: String,
-        /// Resource name
-        name: String,
-        /// ECS cluster name
+        /// Resource type (omit when using -f)
+        resource: Option<String>,
+        /// Resource name (omit when using -f)
+        name: Option<String>,
+        /// Delete all services defined in a manifest file or directory,
+        /// instead of specifying <resource> <name> directly (mirrors `apply -f`)
+        #[arg(short, long, conflicts_with_all = ["resource", "name"])]
+        file: Option<String>,
+        /// ECS cluster name (ignored when using -f — manifests are always
+        /// deployed to the "oab" cluster, same as `apply`)
         #[arg(long, default_value = "default")]
         cluster: String,
-        /// Namespace
+        /// Namespace (ignored when using -f — read from each manifest instead)
         #[arg(long, default_value = "prod")]
         namespace: String,
     },
@@ -128,8 +134,14 @@ async fn main() -> anyhow::Result<()> {
         Commands::Apply { file, no_sync, wait } => apply::run(&config, &file, !no_sync, wait).await,
         Commands::Create { name, namespace, auto_apply } => create::run(&config, &name, &namespace, auto_apply).await,
         Commands::Get { resource, name, cluster } => get::run(&config, &resource, name.as_deref(), &cluster).await,
-        Commands::Delete { resource, name, cluster, namespace } => {
-            delete::run(&config, &resource, &name, &cluster, &namespace).await
+        Commands::Delete { resource, name, file, cluster, namespace } => {
+            if let Some(file) = file {
+                delete::run_from_file(&config, &file).await
+            } else {
+                let resource = resource.context("<RESOURCE> is required when not using -f")?;
+                let name = name.context("<NAME> is required when not using -f")?;
+                delete::run(&config, &resource, &name, &cluster, &namespace).await
+            }
         }
         Commands::Exec { agent, command } => {
             let resolved = ecsctl::alias::resolve(&config, &agent).await?;


### PR DESCRIPTION
## Summary

`kubectl` has a well-established convention: `kubectl apply -f <file>` and
`kubectl delete -f <file>` both accept the exact same manifest, so tearing
down what you deployed doesn't require separately remembering/typing the
resource type and name. `oabctl apply` already followed this pattern
(`apply -f <file>`), but `oabctl delete` only supported the imperative
`<resource> <name>` form — no file-based option at all, which is what
prompted this PR (came up while walking through manual teardown of a test
deployment).

## Change

Adds `-f`/`--file` to `oabctl delete`, mirroring `apply -f` exactly:

```bash
oabctl delete -f /tmp/oab-telegram-ingress/manifest.yaml
# equivalent to:
oabctl delete oabservice telegram-ingress-demo --cluster oab --namespace prod
```

- Mutually exclusive with `<resource>/<name>` (clap's `conflicts_with_all`) —
  clear error if both are given, or if neither is given.
- Accepts a file *or a directory* (same as `apply -f`), and correctly expands
  an `OABFleet` manifest into multiple services, deleting each in turn.
- `--cluster`/`--namespace` are ignored when using `-f` — consistent with
  `apply`, which never reads a cluster from the manifest either (hardcoded to
  `"oab"`); namespace comes from each manifest's `metadata.namespace`.
- Continues past an individual service's delete failure (e.g. one already
  gone) instead of aborting the whole batch, but still reports an overall
  error at the end listing which ones failed.
- No duplicated delete logic — reuses the existing `load_manifests`/
  `parse_manifest_file` parsing (now `pub(crate)`, previously private to
  `apply.rs`) and the existing per-service `delete::run()`.

```
Before:
  oabctl delete oabservice telegram-ingress-demo --cluster oab --namespace prod
  (must know/type the resource type, exact name, cluster, and namespace)

After:
  oabctl delete -f /tmp/oab-telegram-ingress/manifest.yaml
  (same file used for `apply -f` — name/namespace read straight from it,
   cluster is oab same as apply)
```

## Testing done

```
cargo build --release                        # clean
cargo clippy --all-targets -- -D warnings    # clean
cargo test --release                         # 33 passed; 0 failed (no regressions)
```

No new pure logic to unit test here — this is CLI wiring plus reuse of
already-tested parsing/delete paths, matching the pattern of `apply::run`/
`delete::run` themselves (neither has direct unit tests either; only their
pure helper functions do).

**Live E2E**: ran `oabctl delete -f /tmp/oab-telegram-ingress/manifest.yaml`
against a real running service. Output was identical to the equivalent
`oabctl delete oabservice <name> --cluster oab --namespace <ns>` invocation
— scaled to 0, deleted the ECS service, tore down ingress wiring (Cloud Map
service, HTTP API route/integration), cleaned up S3 manifest/config
artifacts. Confirmed via `aws ecs describe-services` that the service
transitioned to `DRAINING` afterward. Also verified: the traditional
`<resource> <name>` form still works unchanged, and both new validation
error paths (missing args, `-f` combined with `<resource>/<name>`) produce
clear error messages.

Also updates `docs/oabctl.md`'s commands table and the ingress teardown note
to mention the new flag.


## Update: upfront resource plan before apply/delete -f

Added a second commit: both `apply -f` and this PR's new `delete -f` now
print an upfront `Plan:` listing every resource that manifest may touch, as
an unchecked `[ ]` list, before any AWS calls happen — then each step's
existing `✓`/`⚠` confirmation line follows with the real detail (resource
ID, ARN, URL) as it actually completes:

```
Plan:
  telegram-ingress-demo:
    [ ] S3 manifest
    [ ] ECS task definition
    [ ] ECS service
    [ ] Cloud Map namespace + service
    [ ] VPC Link
    [ ] API Gateway HTTP API
    [ ] API Gateway integration
    [ ] API Gateway route: /webhook/telegram
    [ ] API Gateway stage
    [ ] Security group inbound rule
    [ ] Telegram webhook registration

  Applying telegram-ingress-demo (ECS)...
  ✓ Cloud Map namespace exists: oab-vpc-1f5b7e78
  ✓ Cloud Map service exists: oab-prod-telegram-ingress-demo.oab-vpc-1f5b7e78
  ...
```

This is the terraform-style "plan, then confirm as it happens" pattern —
deliberately not a true in-place terminal checklist redraw (which needs ANSI
cursor control and breaks when output is piped, redirected, or viewed in CI
logs). Stays plain sequential `println!`, safe everywhere.

The plan is derived purely from each manifest's own fields (`spec.ingress`
presence/paths, `spec.secrets` keys) — read-only, informational, never
blocks execution, and doesn't try to predict create-vs-update or
skip-vs-act decisions made at runtime by the existing logic. The already
existing `✓`/`⚠` lines remain the single source of truth for real detail;
this only adds the upfront preview on top.

The imperative `delete oabservice <name>` form has no manifest to derive a
plan from, so it's unaffected — only the `-f` paths get a plan.

Re-verified live: ran both `apply -f` and `delete -f` again against the
real manifest with this change — plan prints correctly, followed by the
same detailed confirmations as before.
