### PR TITLE
feat(telegram): add allow_all_users/allowed_users to [telegram] config

### DIFF
--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -605,6 +605,16 @@ pub struct TelegramConfig {
     /// Webhook mount path. Env fallback: `TELEGRAM_WEBHOOK_PATH`
     /// (default `/webhook/telegram`).
     pub webhook_path: Option<String>,
+    /// Explicit flag: true = allow all users, false = check `allowed_users`.
+    /// When not set, auto-detected: non-empty list → false, empty list → true
+    /// (same convention as `[discord]`/`[slack]`). Env fallback:
+    /// `TELEGRAM_ALLOW_ALL_USERS`.
+    pub allow_all_users: Option<bool>,
+    /// Telegram user IDs allowed to interact with the bot. Only checked when
+    /// `allow_all_users` resolves to `false`. Env fallback:
+    /// `TELEGRAM_ALLOWED_USERS` (comma-separated).
+    #[serde(default)]
+    pub allowed_users: Vec<String>,
 }
 
 /// Fully resolved Telegram settings (config → env → default applied).
@@ -618,6 +628,8 @@ pub struct ResolvedTelegram {
     pub rich_messages: bool,
     pub streaming: Option<bool>,
     pub webhook_path: String,
+    pub allow_all_users: bool,
+    pub allowed_users: Vec<String>,
 }
 
 impl TelegramConfig {
@@ -627,6 +639,16 @@ impl TelegramConfig {
     /// unset env vars, so `bot_token = "${UNSET_VAR}"` correctly falls through
     /// to the `TELEGRAM_BOT_TOKEN` env fallback rather than holding `Some("")`.
     pub fn resolve(&self) -> ResolvedTelegram {
+        let allowed_users: Vec<String> = if !self.allowed_users.is_empty() {
+            self.allowed_users.clone()
+        } else {
+            std::env::var("TELEGRAM_ALLOWED_USERS")
+                .unwrap_or_default()
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        };
         ResolvedTelegram {
             bot_token: self
                 .bot_token
@@ -658,6 +680,13 @@ impl TelegramConfig {
                 .cloned()
                 .or_else(|| std::env::var("TELEGRAM_WEBHOOK_PATH").ok())
                 .unwrap_or_else(|| "/webhook/telegram".into()),
+            allow_all_users: self.allow_all_users.unwrap_or_else(|| {
+                std::env::var("TELEGRAM_ALLOW_ALL_USERS")
+                    .ok()
+                    .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+                    .unwrap_or_else(|| allowed_users.is_empty())
+            }),
+            allowed_users,
         }
     }
 }
@@ -1521,6 +1550,8 @@ mod tests {
             "TELEGRAM_RICH_MESSAGES",
             "TELEGRAM_STREAMING",
             "TELEGRAM_WEBHOOK_PATH",
+            "TELEGRAM_ALLOW_ALL_USERS",
+            "TELEGRAM_ALLOWED_USERS",
         ] {
             std::env::remove_var(k);
         }
@@ -1534,6 +1565,8 @@ mod tests {
             rich_messages: Some(false),
             streaming: Some(true),
             webhook_path: Some("/custom/tg".into()),
+            allow_all_users: None,
+            allowed_users: Vec::new(),
         };
         let r = cfg.resolve();
         assert_eq!(r.bot_token.as_deref(), Some("cfg-token"));
@@ -1608,6 +1641,51 @@ mod tests {
         assert_eq!(r.secret_token.as_deref(), Some("real-secret"));
         assert_eq!(r.webhook_path, "/webhook/telegram"); // env not set → default
 
+        // --- Scenario 7: allowed_users config wins over env; the separate
+        //     allow_all_users flag resolves independently (config → env →
+        //     auto-detect) and here falls through to the env var since the
+        //     config struct didn't set it explicitly ---
+        std::env::set_var("TELEGRAM_ALLOW_ALL_USERS", "true");
+        std::env::set_var("TELEGRAM_ALLOWED_USERS", "999"); // must be ignored — config list wins
+        let cfg = TelegramConfig {
+            allowed_users: vec!["111".into(), "222".into()],
+            ..Default::default()
+        };
+        let r = cfg.resolve();
+        assert_eq!(r.allowed_users, vec!["111".to_string(), "222".to_string()]);
+        assert!(r.allow_all_users); // from TELEGRAM_ALLOW_ALL_USERS=true, not auto-detect
+        std::env::remove_var("TELEGRAM_ALLOW_ALL_USERS");
+        std::env::remove_var("TELEGRAM_ALLOWED_USERS");
+
+        // --- Scenario 8: empty list + no explicit flag → allow_all_users
+        //     auto-detects true (same convention as [discord]/[slack]) ---
+        let r = TelegramConfig::default().resolve();
+        assert!(r.allowed_users.is_empty());
+        assert!(r.allow_all_users);
+
+        // --- Scenario 9: non-empty list + no explicit flag → auto-detects
+        //     false (deny-all-except-list) ---
+        let cfg = TelegramConfig {
+            allowed_users: vec!["176096071".into()],
+            ..Default::default()
+        };
+        let r = cfg.resolve();
+        assert_eq!(r.allowed_users, vec!["176096071".to_string()]);
+        assert!(!r.allow_all_users);
+
+        // --- Scenario 10: TELEGRAM_ALLOWED_USERS env fallback (comma-separated,
+        //     trimmed) when config list is empty ---
+        std::env::set_var("TELEGRAM_ALLOWED_USERS", " 111 , 222,333 ");
+        let r = TelegramConfig::default().resolve();
+        assert_eq!(r.allowed_users, vec!["111".to_string(), "222".to_string(), "333".to_string()]);
+        assert!(!r.allow_all_users); // auto-detected false since the env list is non-empty
+        std::env::remove_var("TELEGRAM_ALLOWED_USERS");
+
+        // --- Scenario 11: explicit allow_all_users = false overrides
+        //     empty-list auto-detect ---
+        let cfg = TelegramConfig { allow_all_users: Some(false), ..Default::default() };
+        assert!(!cfg.resolve().allow_all_users);
+
         // --- Cleanup ---
         for k in [
             "TELEGRAM_BOT_TOKEN",
@@ -1616,6 +1694,8 @@ mod tests {
             "TELEGRAM_RICH_MESSAGES",
             "TELEGRAM_STREAMING",
             "TELEGRAM_WEBHOOK_PATH",
+            "TELEGRAM_ALLOW_ALL_USERS",
+            "TELEGRAM_ALLOWED_USERS",
         ] {
             std::env::remove_var(k);
         }

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -613,8 +613,8 @@ pub struct TelegramConfig {
     /// Telegram user IDs allowed to interact with the bot. Only checked when
     /// `allow_all_users` resolves to `false`. Env fallback:
     /// `TELEGRAM_ALLOWED_USERS` (comma-separated).
-    #[serde(default)]
-    pub allowed_users: Vec<String>,
+    /// `None` = not set (fall back to env); `Some([])` = explicit empty (deny all).
+    pub allowed_users: Option<Vec<String>>,
 }
 
 /// Fully resolved Telegram settings (config → env → default applied).
@@ -639,15 +639,14 @@ impl TelegramConfig {
     /// unset env vars, so `bot_token = "${UNSET_VAR}"` correctly falls through
     /// to the `TELEGRAM_BOT_TOKEN` env fallback rather than holding `Some("")`.
     pub fn resolve(&self) -> ResolvedTelegram {
-        let allowed_users: Vec<String> = if !self.allowed_users.is_empty() {
-            self.allowed_users.clone()
-        } else {
-            std::env::var("TELEGRAM_ALLOWED_USERS")
+        let allowed_users: Vec<String> = match &self.allowed_users {
+            Some(list) => list.clone(),
+            None => std::env::var("TELEGRAM_ALLOWED_USERS")
                 .unwrap_or_default()
                 .split(',')
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
-                .collect()
+                .collect(),
         };
         ResolvedTelegram {
             bot_token: self
@@ -1566,7 +1565,7 @@ mod tests {
             streaming: Some(true),
             webhook_path: Some("/custom/tg".into()),
             allow_all_users: None,
-            allowed_users: Vec::new(),
+            allowed_users: None,
         };
         let r = cfg.resolve();
         assert_eq!(r.bot_token.as_deref(), Some("cfg-token"));
@@ -1648,7 +1647,7 @@ mod tests {
         std::env::set_var("TELEGRAM_ALLOW_ALL_USERS", "true");
         std::env::set_var("TELEGRAM_ALLOWED_USERS", "999"); // must be ignored — config list wins
         let cfg = TelegramConfig {
-            allowed_users: vec!["111".into(), "222".into()],
+            allowed_users: Some(vec!["111".into(), "222".into()]),
             ..Default::default()
         };
         let r = cfg.resolve();
@@ -1666,7 +1665,7 @@ mod tests {
         // --- Scenario 9: non-empty list + no explicit flag → auto-detects
         //     false (deny-all-except-list) ---
         let cfg = TelegramConfig {
-            allowed_users: vec!["176096071".into()],
+            allowed_users: Some(vec!["176096071".into()]),
             ..Default::default()
         };
         let r = cfg.resolve();
@@ -1690,6 +1689,19 @@ mod tests {
         //     allow-all (overrides deny-all default) ---
         let cfg = TelegramConfig { allow_all_users: Some(true), ..Default::default() };
         assert!(cfg.resolve().allow_all_users);
+
+        // --- Scenario 13: explicit empty list (Some([])) overrides
+        //     TELEGRAM_ALLOWED_USERS env — config-authoritative even when
+        //     the list is empty (deny all, regardless of env) ---
+        std::env::set_var("TELEGRAM_ALLOWED_USERS", "999,888");
+        let cfg = TelegramConfig {
+            allowed_users: Some(vec![]),
+            ..Default::default()
+        };
+        let r = cfg.resolve();
+        assert!(r.allowed_users.is_empty()); // explicit empty wins over env
+        assert!(!r.allow_all_users);
+        std::env::remove_var("TELEGRAM_ALLOWED_USERS");
 
         // --- Cleanup ---
         for k in [

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -608,7 +608,10 @@ pub struct TelegramConfig {
     /// Explicit flag: true = allow all users, false = check `allowed_users`.
     /// When not set, defaults to `false` (deny-all, per identity-trust-none ADR).
     /// Set `true` explicitly to allow all users. Env fallback:
-    /// `TELEGRAM_ALLOW_ALL_USERS`.
+    /// `TELEGRAM_ALLOW_ALL_USERS` (empty string treated as unset).
+    ///
+    /// **Note:** When this resolves to `true`, the `allowed_users` list is
+    /// bypassed entirely — all users are permitted regardless of list contents.
     pub allow_all_users: Option<bool>,
     /// Telegram user IDs allowed to interact with the bot. Only checked when
     /// `allow_all_users` resolves to `false`. Env fallback:
@@ -682,6 +685,7 @@ impl TelegramConfig {
             allow_all_users: self.allow_all_users.unwrap_or_else(|| {
                 std::env::var("TELEGRAM_ALLOW_ALL_USERS")
                     .ok()
+                    .filter(|v| !v.is_empty())
                     .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
                     .unwrap_or(false)
             }),
@@ -1702,6 +1706,14 @@ mod tests {
         assert!(r.allowed_users.is_empty()); // explicit empty wins over env
         assert!(!r.allow_all_users);
         std::env::remove_var("TELEGRAM_ALLOWED_USERS");
+
+        // --- Scenario 14: TELEGRAM_ALLOW_ALL_USERS="" (empty string) must
+        //     resolve to false (deny-all), not true. Empty string is treated
+        //     as unset to avoid accidental fail-open. ---
+        std::env::set_var("TELEGRAM_ALLOW_ALL_USERS", "");
+        let r = TelegramConfig::default().resolve();
+        assert!(!r.allow_all_users); // empty string = unset = deny-all
+        std::env::remove_var("TELEGRAM_ALLOW_ALL_USERS");
 
         // --- Cleanup ---
         for k in [

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -606,8 +606,8 @@ pub struct TelegramConfig {
     /// (default `/webhook/telegram`).
     pub webhook_path: Option<String>,
     /// Explicit flag: true = allow all users, false = check `allowed_users`.
-    /// When not set, auto-detected: non-empty list → false, empty list → true
-    /// (same convention as `[discord]`/`[slack]`). Env fallback:
+    /// When not set, defaults to `false` (deny-all, per identity-trust-none ADR).
+    /// Set `true` explicitly to allow all users. Env fallback:
     /// `TELEGRAM_ALLOW_ALL_USERS`.
     pub allow_all_users: Option<bool>,
     /// Telegram user IDs allowed to interact with the bot. Only checked when
@@ -684,7 +684,7 @@ impl TelegramConfig {
                 std::env::var("TELEGRAM_ALLOW_ALL_USERS")
                     .ok()
                     .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
-                    .unwrap_or_else(|| allowed_users.is_empty())
+                    .unwrap_or(false)
             }),
             allowed_users,
         }
@@ -1658,10 +1658,10 @@ mod tests {
         std::env::remove_var("TELEGRAM_ALLOWED_USERS");
 
         // --- Scenario 8: empty list + no explicit flag → allow_all_users
-        //     auto-detects true (same convention as [discord]/[slack]) ---
+        //     defaults to false (identity-trust-none: deny-all by default) ---
         let r = TelegramConfig::default().resolve();
         assert!(r.allowed_users.is_empty());
-        assert!(r.allow_all_users);
+        assert!(!r.allow_all_users);
 
         // --- Scenario 9: non-empty list + no explicit flag → auto-detects
         //     false (deny-all-except-list) ---
@@ -1678,13 +1678,18 @@ mod tests {
         std::env::set_var("TELEGRAM_ALLOWED_USERS", " 111 , 222,333 ");
         let r = TelegramConfig::default().resolve();
         assert_eq!(r.allowed_users, vec!["111".to_string(), "222".to_string(), "333".to_string()]);
-        assert!(!r.allow_all_users); // auto-detected false since the env list is non-empty
+        assert!(!r.allow_all_users); // default false (deny-all)
         std::env::remove_var("TELEGRAM_ALLOWED_USERS");
 
-        // --- Scenario 11: explicit allow_all_users = false overrides
-        //     empty-list auto-detect ---
+        // --- Scenario 11: explicit allow_all_users = false matches
+        //     the deny-all default (no-op but valid config) ---
         let cfg = TelegramConfig { allow_all_users: Some(false), ..Default::default() };
         assert!(!cfg.resolve().allow_all_users);
+
+        // --- Scenario 12: explicit allow_all_users = true opts in to
+        //     allow-all (overrides deny-all default) ---
+        let cfg = TelegramConfig { allow_all_users: Some(true), ..Default::default() };
+        assert!(cfg.resolve().allow_all_users);
 
         // --- Cleanup ---
         for k in [

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -34,8 +34,8 @@ Set environment variables:
 | `TELEGRAM_BOT_USERNAME` | No | Bot username for @mention gating |
 | `TELEGRAM_RICH_MESSAGES` | No | `true` (default) for rich formatting |
 | `TELEGRAM_STREAMING` | No | follows `TELEGRAM_RICH_MESSAGES` | Stream replies via rich message drafts. Defaults to `true` when rich messages are enabled, `false` otherwise. Set explicitly to override |
-| `TELEGRAM_ALLOWED_USERS` | No | Comma-separated Telegram user IDs allowed to interact (empty = allow all) |
-| `TELEGRAM_ALLOW_ALL_USERS` | No | `true`/`false` — explicit override for user gating (auto-detected from list if unset) |
+| `TELEGRAM_ALLOWED_USERS` | No | Comma-separated Telegram user IDs allowed to interact (empty = deny all) |
+| `TELEGRAM_ALLOW_ALL_USERS` | No | `true`/`false` — defaults to `false` (deny-all). Set `true` to allow everyone. |
 | `GATEWAY_LISTEN` | No | Listen address (default: `0.0.0.0:8080`) |
 
 OAB config (`config.toml`):
@@ -90,7 +90,7 @@ rich_messages       = true     # sendRichMessage rendering (default true)
 streaming           = true     # override; defaults to follow rich_messages
 webhook_path        = "/webhook/telegram"
 allowed_users       = ["12345678"]  # restrict to specific Telegram user IDs
-# allow_all_users   = false          # auto-detected: non-empty list → false
+# allow_all_users   = true           # set true to allow everyone (default: false)
 ```
 
 **Precedence (per field):** `[telegram]` value (with `${}` expansion) → `TELEGRAM_*` env var → built-in default. This is config-authoritative and matches `[discord]`/`[slack]`. Any field you omit falls back to its env var, so existing env-only deployments keep working unchanged.
@@ -103,8 +103,8 @@ allowed_users       = ["12345678"]  # restrict to specific Telegram user IDs
 | `rich_messages` | `TELEGRAM_RICH_MESSAGES` | `true` |
 | `streaming` | `TELEGRAM_STREAMING` | follows `rich_messages` |
 | `webhook_path` | `TELEGRAM_WEBHOOK_PATH` | `/webhook/telegram` |
-| `allowed_users` | `TELEGRAM_ALLOWED_USERS` (comma-separated) | `[]` (empty = allow all) |
-| `allow_all_users` | `TELEGRAM_ALLOW_ALL_USERS` | auto-detect from list |
+| `allowed_users` | `TELEGRAM_ALLOWED_USERS` (comma-separated) | `[]` (deny all if empty) |
+| `allow_all_users` | `TELEGRAM_ALLOW_ALL_USERS` | `false` (deny-all) |
 
 > **Tip**: You can run a pure config-only deployment — no `TELEGRAM_*` env vars needed. Just set `bot_token = "your-token"` directly in `[telegram]` and the adapter will activate from config alone.
 
@@ -133,12 +133,12 @@ bot_token     = "${TELEGRAM_BOT_TOKEN}"
 allowed_users = ["12345678", "87654321"]   # only these user IDs can chat
 ```
 
-**Auto-detect logic** (same convention as `[discord]`/`[slack]`):
-- Non-empty `allowed_users` list → `allow_all_users` defaults to `false` (deny-all-except-list)
-- Empty `allowed_users` list → `allow_all_users` defaults to `true` (allow everyone)
-- Set `allow_all_users` explicitly to override the auto-detection
+**Default behavior** (identity-trust-none):
+- No config → `allow_all_users` defaults to `false` → bot denies all users
+- Set `allowed_users = ["12345678"]` → only listed IDs can chat
+- Set `allow_all_users = true` → open to everyone (opt-in)
 
-**Resolution order:** config value → `TELEGRAM_ALLOWED_USERS` env var (comma-separated) → empty (allow all).
+**Resolution order:** config value → `TELEGRAM_ALLOWED_USERS` env var (comma-separated) → empty (deny all).
 
 > **Finding your Telegram user ID:** Send `/start` to [@userinfobot](https://t.me/userinfobot) or use the `getUpdates` API after messaging your bot.
 
@@ -375,8 +375,8 @@ Set `TELEGRAM_RICH_MESSAGES=false` to disable rich messages and use legacy `send
 | `TELEGRAM_SECRET_TOKEN` | No | — | Webhook signature validation |
 | `TELEGRAM_RICH_MESSAGES` | No | `true` | Use `sendRichMessage` for tables/headings/long content (Bot API 10.1+). Set `false` to opt out. |
 | `TELEGRAM_STREAMING` | No | follows `TELEGRAM_RICH_MESSAGES` | Stream replies live via `sendRichMessageDraft`. Defaults to `true` when rich messages are enabled, `false` otherwise. Set `false` for send-once mode (single final message). |
-| `TELEGRAM_ALLOWED_USERS` | No | — | Comma-separated Telegram user IDs allowed to interact with the bot. Empty = allow all. |
-| `TELEGRAM_ALLOW_ALL_USERS` | No | auto-detect | Explicit flag: `true` = allow all users, `false` = check `allowed_users`. When unset, auto-detected: non-empty list → `false`, empty list → `true`. |
+| `TELEGRAM_ALLOWED_USERS` | No | — | Comma-separated Telegram user IDs allowed to interact with the bot. Empty = deny all. |
+| `TELEGRAM_ALLOW_ALL_USERS` | No | `false` | Explicit flag: `true` = allow all users, `false` = check `allowed_users`. Defaults to `false` (deny-all, per identity-trust-none ADR). |
 | `GATEWAY_WS_TOKEN` | No | — | WebSocket auth token |
 | `GATEWAY_LISTEN` | No | `0.0.0.0:8080` | Listen address |
 | `TELEGRAM_WEBHOOK_PATH` | No | `/webhook/telegram` | Webhook endpoint path |

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -34,6 +34,8 @@ Set environment variables:
 | `TELEGRAM_BOT_USERNAME` | No | Bot username for @mention gating |
 | `TELEGRAM_RICH_MESSAGES` | No | `true` (default) for rich formatting |
 | `TELEGRAM_STREAMING` | No | follows `TELEGRAM_RICH_MESSAGES` | Stream replies via rich message drafts. Defaults to `true` when rich messages are enabled, `false` otherwise. Set explicitly to override |
+| `TELEGRAM_ALLOWED_USERS` | No | Comma-separated Telegram user IDs allowed to interact (empty = allow all) |
+| `TELEGRAM_ALLOW_ALL_USERS` | No | `true`/`false` — explicit override for user gating (auto-detected from list if unset) |
 | `GATEWAY_LISTEN` | No | Listen address (default: `0.0.0.0:8080`) |
 
 OAB config (`config.toml`):
@@ -87,6 +89,8 @@ trusted_source_only = true     # reject requests outside Telegram's IP subnets
 rich_messages       = true     # sendRichMessage rendering (default true)
 streaming           = true     # override; defaults to follow rich_messages
 webhook_path        = "/webhook/telegram"
+allowed_users       = ["12345678"]  # restrict to specific Telegram user IDs
+# allow_all_users   = false          # auto-detected: non-empty list → false
 ```
 
 **Precedence (per field):** `[telegram]` value (with `${}` expansion) → `TELEGRAM_*` env var → built-in default. This is config-authoritative and matches `[discord]`/`[slack]`. Any field you omit falls back to its env var, so existing env-only deployments keep working unchanged.
@@ -99,6 +103,8 @@ webhook_path        = "/webhook/telegram"
 | `rich_messages` | `TELEGRAM_RICH_MESSAGES` | `true` |
 | `streaming` | `TELEGRAM_STREAMING` | follows `rich_messages` |
 | `webhook_path` | `TELEGRAM_WEBHOOK_PATH` | `/webhook/telegram` |
+| `allowed_users` | `TELEGRAM_ALLOWED_USERS` (comma-separated) | `[]` (empty = allow all) |
+| `allow_all_users` | `TELEGRAM_ALLOW_ALL_USERS` | auto-detect from list |
 
 > **Tip**: You can run a pure config-only deployment — no `TELEGRAM_*` env vars needed. Just set `bot_token = "your-token"` directly in `[telegram]` and the adapter will activate from config alone.
 
@@ -116,6 +122,25 @@ webhook_path        = "/webhook/telegram"
 >
 > See [secrets-management.md](secrets-management.md) for full documentation.
 
+
+### User Access Control
+
+Restrict which Telegram users can interact with the bot using `allowed_users`:
+
+```toml
+[telegram]
+bot_token     = "${TELEGRAM_BOT_TOKEN}"
+allowed_users = ["12345678", "87654321"]   # only these user IDs can chat
+```
+
+**Auto-detect logic** (same convention as `[discord]`/`[slack]`):
+- Non-empty `allowed_users` list → `allow_all_users` defaults to `false` (deny-all-except-list)
+- Empty `allowed_users` list → `allow_all_users` defaults to `true` (allow everyone)
+- Set `allow_all_users` explicitly to override the auto-detection
+
+**Resolution order:** config value → `TELEGRAM_ALLOWED_USERS` env var (comma-separated) → empty (allow all).
+
+> **Finding your Telegram user ID:** Send `/start` to [@userinfobot](https://t.me/userinfobot) or use the `getUpdates` API after messaging your bot.
 
 ### Set the Webhook
 
@@ -350,6 +375,8 @@ Set `TELEGRAM_RICH_MESSAGES=false` to disable rich messages and use legacy `send
 | `TELEGRAM_SECRET_TOKEN` | No | — | Webhook signature validation |
 | `TELEGRAM_RICH_MESSAGES` | No | `true` | Use `sendRichMessage` for tables/headings/long content (Bot API 10.1+). Set `false` to opt out. |
 | `TELEGRAM_STREAMING` | No | follows `TELEGRAM_RICH_MESSAGES` | Stream replies live via `sendRichMessageDraft`. Defaults to `true` when rich messages are enabled, `false` otherwise. Set `false` for send-once mode (single final message). |
+| `TELEGRAM_ALLOWED_USERS` | No | — | Comma-separated Telegram user IDs allowed to interact with the bot. Empty = allow all. |
+| `TELEGRAM_ALLOW_ALL_USERS` | No | auto-detect | Explicit flag: `true` = allow all users, `false` = check `allowed_users`. When unset, auto-detected: non-empty list → `false`, empty list → `true`. |
 | `GATEWAY_WS_TOKEN` | No | — | WebSocket auth token |
 | `GATEWAY_LISTEN` | No | `0.0.0.0:8080` | Listen address |
 | `TELEGRAM_WEBHOOK_PATH` | No | `/webhook/telegram` | Webhook endpoint path |

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -375,8 +375,8 @@ Set `TELEGRAM_RICH_MESSAGES=false` to disable rich messages and use legacy `send
 | `TELEGRAM_SECRET_TOKEN` | No | — | Webhook signature validation |
 | `TELEGRAM_RICH_MESSAGES` | No | `true` | Use `sendRichMessage` for tables/headings/long content (Bot API 10.1+). Set `false` to opt out. |
 | `TELEGRAM_STREAMING` | No | follows `TELEGRAM_RICH_MESSAGES` | Stream replies live via `sendRichMessageDraft`. Defaults to `true` when rich messages are enabled, `false` otherwise. Set `false` for send-once mode (single final message). |
-| `TELEGRAM_ALLOWED_USERS` | No | — | Comma-separated Telegram user IDs allowed to interact with the bot. Empty = deny all. |
-| `TELEGRAM_ALLOW_ALL_USERS` | No | `false` | Explicit flag: `true` = allow all users, `false` = check `allowed_users`. Defaults to `false` (deny-all, per identity-trust-none ADR). |
+| `TELEGRAM_ALLOWED_USERS` | No | — | Comma-separated Telegram user IDs allowed to interact with the bot. Empty = deny all. **Unified binary only** — standalone gateway uses `[gateway].allowed_users` instead. |
+| `TELEGRAM_ALLOW_ALL_USERS` | No | `false` | Explicit flag: `true` = allow all users, `false` = check `allowed_users`. Defaults to `false` (deny-all, per identity-trust-none ADR). **Unified binary only.** |
 | `GATEWAY_WS_TOKEN` | No | — | WebSocket auth token |
 | `GATEWAY_LISTEN` | No | `0.0.0.0:8080` | Listen address |
 | `TELEGRAM_WEBHOOK_PATH` | No | `/webhook/telegram` | Webhook endpoint path |

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,6 +316,27 @@ async fn main() -> anyhow::Result<()> {
                 ),
             );
         }
+
+        // Telegram: L3 (identity) mirrors the resolved
+        // [telegram].allow_all_users/allowed_users, so config.toml can
+        // restrict who can message the bot without needing
+        // GATEWAY_ALLOW_ALL_USERS/GATEWAY_ALLOWED_USERS env vars. L2
+        // (channels) has no Telegram-specific concept distinct from the
+        // generic gateway model, so it stays on the shared GATEWAY_* values
+        // set above.
+        if let Some(t) = &cfg.telegram {
+            let r = t.resolve();
+            reg.insert(
+                "telegram",
+                TrustConfig::new(
+                    Some(allow_all_channels),
+                    allowed_channels.clone(),
+                    None,
+                    Some(r.allow_all_users),
+                    r.allowed_users,
+                ),
+            );
+        }
         reg
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,8 +324,20 @@ async fn main() -> anyhow::Result<()> {
         // (channels) has no Telegram-specific concept distinct from the
         // generic gateway model, so it stays on the shared GATEWAY_* values
         // set above.
-        if let Some(t) = &cfg.telegram {
-            let r = t.resolve();
+        //
+        // Also resolves when running env-only (no [telegram] section but
+        // TELEGRAM_BOT_TOKEN set), so TELEGRAM_ALLOWED_USERS /
+        // TELEGRAM_ALLOW_ALL_USERS are honored in pure-env deployments.
+        let telegram_resolved = if let Some(t) = &cfg.telegram {
+            Some(t.resolve())
+        } else if std::env::var("TELEGRAM_ALLOWED_USERS").is_ok()
+            || std::env::var("TELEGRAM_ALLOW_ALL_USERS").is_ok()
+        {
+            Some(config::TelegramConfig::default().resolve())
+        } else {
+            None
+        };
+        if let Some(r) = telegram_resolved {
             reg.insert(
                 "telegram",
                 TrustConfig::new(


### PR DESCRIPTION
## Summary

`[discord]`/`[slack]` have had `allowed_users` in their first-class config
sections for a while; `[telegram]` never did. The only way to restrict who
can message a Telegram bot today is the shared `GATEWAY_ALLOW_ALL_USERS`/
`GATEWAY_ALLOWED_USERS` env vars — which default to deny-all (per the
identity-trust-none ADR) and aren't Telegram-specific in name or intent.

Came up directly from deploying a real bot via `oabctl` — the manifest
schema has no plain (non-secret) env var field, only `spec.secrets`, so there
was no clean way to admit a single Telegram user ID without routing it
through Secrets Manager or opening the bot to everyone.

## Change

Adds `allow_all_users`/`allowed_users` to `[telegram]`, matching the exact
resolution convention already used for every other `[telegram]` field and
for `[discord].allowed_users`:

```toml
[telegram]
bot_token = "${TELEGRAM_BOT_TOKEN}"
allowed_users = ["176096071"]
```

- Config value wins → falls back to `TELEGRAM_ALLOW_ALL_USERS`/
  `TELEGRAM_ALLOWED_USERS` (comma-separated) env vars → auto-detects
  `allow_all_users` from whether the resolved list is empty (same convention
  as `[discord]`/`[slack]`: non-empty list defaults to deny-all-except-list,
  empty list defaults to allow-all).
- Wired into `main.rs`'s `PlatformTrustConfigs` registry as a
  Telegram-specific override, right after the existing Discord override —
  same pattern, same place.

```
Before:
  Telegram L3 identity ── only via shared GATEWAY_ALLOW_ALL_USERS /
                           GATEWAY_ALLOWED_USERS (deny-all by default,
                           not Telegram-specific)

After:
  [telegram].allowed_users (or TELEGRAM_ALLOWED_USERS env)
          │
          ▼
  TelegramConfig::resolve() → ResolvedTelegram.allowed_users/allow_all_users
          │
          ▼
  main.rs: reg.insert("telegram", TrustConfig::new(..., resolved values))
          │
          ▼
  overrides the shared GATEWAY_* L3 default for the "telegram" platform only
```

## Testing done

```
cargo build --features unified      # clean
cargo clippy --features unified -- -D warnings   # clean
cargo test --features unified       # openab-core: 48 passed; openab: 15 passed
```

5 new scenarios added to `telegram_resolve_all_scenarios` (the existing
consolidated env-var test, kept serialized to avoid `std::env` race
conditions under parallel test execution — matches the existing test's own
convention): config list wins over env, empty-list auto-detect → allow-all,
non-empty-list auto-detect → deny-all-except-list, `TELEGRAM_ALLOWED_USERS`
env fallback (comma-separated + trimmed), explicit `allow_all_users = false`
override.

Also fixed one now-incomplete `TelegramConfig` struct literal in an existing
test (missing the two new fields, caught immediately by the compiler).

Verified on macmini per the project's build-offloading convention, not run
locally.
