### PR TITLE
ci: add unified variant to PR Preview Build

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -13,6 +13,7 @@ on:
         type: choice
         options:
           - default
+          - unified
           - agentcore
           - antigravity
           - claude
@@ -43,6 +44,7 @@ jobs:
       repo: ${{ steps.pr.outputs.repo }}
       dockerfile: ${{ steps.df.outputs.file }}
       suffix: ${{ steps.df.outputs.suffix }}
+      build_args: ${{ steps.df.outputs.build_args }}
     steps:
       - name: Get PR branch
         id: pr
@@ -59,9 +61,22 @@ jobs:
           if [ "${{ inputs.variant }}" = "default" ]; then
             echo "file=Dockerfile" >> "$GITHUB_OUTPUT"
             echo "suffix=" >> "$GITHUB_OUTPUT"
+            echo "build_args=" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.variant }}" = "unified" ]; then
+            # Same base Dockerfile as "default", but built with BUILD_MODE=unified
+            # so the telegram/line/feishu/wecom/googlechat/teams gateway adapters
+            # (Cargo feature `unified`) are actually compiled in. The "default"
+            # variant builds with openab's default Cargo features only
+            # (discord/slack/...), which does NOT include telegram — a PR
+            # touching the unified gateway path needs this variant to test
+            # against a real webhook, not "default".
+            echo "file=Dockerfile" >> "$GITHUB_OUTPUT"
+            echo "suffix=" >> "$GITHUB_OUTPUT"
+            echo "build_args=BUILD_MODE=unified" >> "$GITHUB_OUTPUT"
           else
             echo "file=Dockerfile.${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
             echo "suffix=-${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
+            echo "build_args=" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -96,6 +111,7 @@ jobs:
           context: .
           file: ${{ needs.resolve-pr.outputs.dockerfile }}
           platforms: ${{ matrix.platform.os }}
+          build-args: ${{ needs.resolve-pr.outputs.build_args }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ needs.resolve-pr.outputs.suffix }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=pr-${{ inputs.variant }}-${{ matrix.platform.os }}
           cache-to: type=gha,scope=pr-${{ inputs.variant }}-${{ matrix.platform.os }},mode=max


### PR DESCRIPTION
Adds 'unified' as a variant choice in pr-preview.yml so preview builds can include all platform features (telegram, line, feishu, wecom, googlechat, teams).

Verified by run #139 against PR #1297.