### PR TITLE
fix(oabctl): wait for service drain on delete, retry on create

### DIFF
--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -526,6 +526,9 @@ async fn apply_ecs(
 
         // Retry with backoff if ECS reports "still Draining" (race with a
         // recent delete that hasn't fully completed yet).
+        // Match on the typed error code (InvalidParameterException) rather than
+        // raw message text to be resilient to SDK/API wording changes.
+        use aws_sdk_ecs::error::ProvideErrorMetadata;
         let mut last_err = None;
         for attempt in 0..12 {
             match create_req.clone().send().await {
@@ -537,10 +540,16 @@ async fn apply_ecs(
                     break;
                 }
                 Err(e) => {
-                    let msg = format!("{e}");
-                    if msg.contains("still Draining") {
+                    let is_draining = e.code() == Some("InvalidParameterException")
+                        && e.message()
+                            .unwrap_or_default()
+                            .to_lowercase()
+                            .contains("draining");
+                    if is_draining {
                         if attempt == 0 {
                             eprint!("  ⏳ Service still draining, retrying...");
+                        } else {
+                            eprint!(".");
                         }
                         last_err = Some(e);
                         if attempt < 11 {

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -524,10 +524,39 @@ async fn apply_ecs(
             create_req = create_req.service_registries(registry.build());
         }
 
-        create_req
-            .send()
-            .await
-            .context("failed to create ECS service")?;
+        // Retry with backoff if ECS reports "still Draining" (race with a
+        // recent delete that hasn't fully completed yet).
+        let mut last_err = None;
+        for attempt in 0..12 {
+            match create_req.clone().send().await {
+                Ok(_) => {
+                    if attempt > 0 {
+                        println!(" ok");
+                    }
+                    last_err = None;
+                    break;
+                }
+                Err(e) => {
+                    let msg = format!("{e}");
+                    if msg.contains("still Draining") && attempt < 11 {
+                        if attempt == 0 {
+                            eprint!("  ⏳ Service still draining, retrying...");
+                        }
+                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                        last_err = Some(e);
+                    } else {
+                        if attempt > 0 {
+                            eprintln!(" failed");
+                        }
+                        return Err(e).context("failed to create ECS service");
+                    }
+                }
+            }
+        }
+        if let Some(e) = last_err {
+            eprintln!(" timed out");
+            return Err(anyhow::anyhow!(e)).context("failed to create ECS service after retries");
+        }
         println!(
             "  ✓ {} created ({}, {}cpu/{}mem{})",
             m.metadata.name,

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -531,19 +531,21 @@ async fn apply_ecs(
             match create_req.clone().send().await {
                 Ok(_) => {
                     if attempt > 0 {
-                        println!(" ok");
+                        eprintln!(" ok");
                     }
                     last_err = None;
                     break;
                 }
                 Err(e) => {
                     let msg = format!("{e}");
-                    if msg.contains("still Draining") && attempt < 11 {
+                    if msg.contains("still Draining") {
                         if attempt == 0 {
                             eprint!("  ⏳ Service still draining, retrying...");
                         }
-                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                         last_err = Some(e);
+                        if attempt < 11 {
+                            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                        }
                     } else {
                         if attempt > 0 {
                             eprintln!(" failed");

--- a/operator/src/delete.rs
+++ b/operator/src/delete.rs
@@ -93,7 +93,8 @@ pub async fn run(
     // is still Draining".
     eprint!("  ⏳ Waiting for drain to complete...");
     for i in 0..12 {
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        // Check status first, then sleep — avoids an unnecessary initial delay
+        // when the service transitions quickly.
         let resp = ecs
             .describe_services()
             .cluster(cluster)
@@ -112,12 +113,19 @@ pub async fn run(
             }
         };
         if is_gone {
-            let elapsed = (i + 1) * 5;
-            eprintln!(" done ({elapsed}s)");
+            if i == 0 {
+                eprintln!(" done (immediate)");
+            } else {
+                let elapsed = i * 5;
+                eprintln!(" done ({elapsed}s)");
+            }
             break;
         }
         if i == 11 {
             eprintln!(" timed out (service may still be draining)");
+        } else {
+            eprint!(".");
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         }
     }
 

--- a/operator/src/delete.rs
+++ b/operator/src/delete.rs
@@ -91,8 +91,9 @@ pub async fn run(
     // 2a. Wait for the service to fully drain (INACTIVE status) so that
     // a subsequent `apply` doesn't hit "Unable to Start a service that
     // is still Draining".
-    print!("  ⏳ Waiting for drain to complete...");
-    for i in 0..60 {
+    eprint!("  ⏳ Waiting for drain to complete...");
+    for i in 0..12 {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         let resp = ecs
             .describe_services()
             .cluster(cluster)
@@ -105,16 +106,19 @@ pub async fn run(
                 .first()
                 .map(|s| s.status() == Some("INACTIVE"))
                 .unwrap_or(true),
-            Err(_) => true,
+            Err(e) => {
+                eprintln!("\n  ⚠ describe_services error (retrying): {e}");
+                false
+            }
         };
         if is_gone {
-            println!(" done ({i}s)");
+            let elapsed = (i + 1) * 5;
+            eprintln!(" done ({elapsed}s)");
             break;
         }
-        if i == 59 {
-            println!(" timed out (service may still be draining)");
+        if i == 11 {
+            eprintln!(" timed out (service may still be draining)");
         }
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
 
     // 2b. Best-effort ingress teardown: Cloud Map service + this API's

--- a/operator/src/delete.rs
+++ b/operator/src/delete.rs
@@ -88,6 +88,35 @@ pub async fn run(
         .context("failed to delete ECS service")?;
     println!("  ✓ ECS service deleted");
 
+    // 2a. Wait for the service to fully drain (INACTIVE status) so that
+    // a subsequent `apply` doesn't hit "Unable to Start a service that
+    // is still Draining".
+    print!("  ⏳ Waiting for drain to complete...");
+    for i in 0..60 {
+        let resp = ecs
+            .describe_services()
+            .cluster(cluster)
+            .services(&service_name)
+            .send()
+            .await;
+        let is_gone = match resp {
+            Ok(r) => r
+                .services()
+                .first()
+                .map(|s| s.status() == Some("INACTIVE"))
+                .unwrap_or(true),
+            Err(_) => true,
+        };
+        if is_gone {
+            println!(" done ({i}s)");
+            break;
+        }
+        if i == 59 {
+            println!(" timed out (service may still be draining)");
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+
     // 2b. Best-effort ingress teardown: Cloud Map service + this API's
     // routes/integration/stage. No-op for bots that never had ingress. Never
     // blocks deletion — failures are logged only.


### PR DESCRIPTION
## Problem

`oabctl delete` returns immediately after `DeleteService(force=true)`, but ECS keeps the service in DRAINING state for a while. A subsequent `oabctl apply` hits:

```
InvalidParameterException: Unable to Start a service that is still Draining.
```

## Fix

**delete.rs**: After deleting the ECS service, poll `DescribeServices` every 5s (up to 60s) until status becomes INACTIVE. This ensures the service is fully gone before returning. Transient API errors are logged and retried (not treated as "service gone").

**apply.rs**: As a safety net, if `CreateService` fails with "still Draining", retry with 5s backoff (up to 12 attempts / 60s) instead of failing immediately. Handles cases where a service was deleted outside of oabctl.

## Testing

Manual E2E: `oabctl delete -f manifest.yaml && oabctl apply -f manifest.yaml` — previously failed, now works in one shot.