### PR TITLE
feat(pool): add default_config_options for auto-setting mode/model

### DIFF
--- a/crates/openab-core/src/acp/pool.rs
+++ b/crates/openab-core/src/acp/pool.rs
@@ -52,6 +52,7 @@ pub struct SessionPool {
     hung_threshold_secs: u64,
     mapping_path: PathBuf,
     meta_path: PathBuf,
+    default_config_options: HashMap<String, String>,
 }
 
 type CancelHandle = (Arc<tokio::sync::Mutex<tokio::process::ChildStdin>>, String);
@@ -164,7 +165,12 @@ fn apply_hung_eviction(
 }
 
 impl SessionPool {
-    pub fn new(config: AgentConfig, max_sessions: usize, hung_threshold_secs: u64) -> Self {
+    pub fn new(
+        config: AgentConfig,
+        max_sessions: usize,
+        hung_threshold_secs: u64,
+        default_config_options: HashMap<String, String>,
+    ) -> Self {
         let openab_dir = std::env::var("HOME")
             .map(PathBuf::from)
             .unwrap_or_else(|_| PathBuf::from("/tmp"))
@@ -190,6 +196,7 @@ impl SessionPool {
             hung_threshold_secs,
             mapping_path,
             meta_path,
+            default_config_options,
         }
     }
 
@@ -395,6 +402,14 @@ impl SessionPool {
 
         if !resumed {
             new_conn.session_new(&effective_workdir).await?;
+
+            // Apply default config options (e.g. mode=bypass, model=swe-1-6)
+            for (config_id, value) in &self.default_config_options {
+                if let Err(e) = new_conn.set_config_option(config_id, value).await {
+                    warn!(config_id, value, error = %e, "failed to set default config option");
+                }
+            }
+
             // Surface the reset banner both for restored sessions and for stale
             // live entries that died before we could recover a resumable
             // session id. In both cases the caller is continuing after an

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -191,7 +191,9 @@ pub struct ExecSecretsConfig {
 
 impl Default for ExecSecretsConfig {
     fn default() -> Self {
-        Self { timeout_seconds: 10 }
+        Self {
+            timeout_seconds: 10,
+        }
     }
 }
 
@@ -209,7 +211,9 @@ pub struct HooksConfig {
 impl HooksConfig {
     /// Returns true if any lifecycle hook (pre_seed, pre_boot, pre_shutdown) is configured.
     pub fn any_configured(&self) -> bool {
-        self.pre_seed.as_ref().is_some_and(|p| !p.sources.is_empty())
+        self.pre_seed
+            .as_ref()
+            .is_some_and(|p| !p.sources.is_empty())
             || self.pre_boot.is_some()
             || self.pre_shutdown.is_some()
     }
@@ -768,8 +772,8 @@ impl<'de> serde::Deserialize<'de> for AgentConfig {
         // If command was explicitly set but args was not, default args to []
         // to avoid leaking env-var args into a custom command.
         let args = match (cmd_explicit, raw.args) {
-            (_, Some(args)) => args,           // args explicitly set → use them
-            (true, None) => Vec::new(),        // command set, args omitted → empty
+            (_, Some(args)) => args,               // args explicitly set → use them
+            (true, None) => Vec::new(),            // command set, args omitted → empty
             (false, None) => default_agent_args(), // neither set → env var
         };
         Ok(AgentConfig {
@@ -807,6 +811,12 @@ pub struct PoolConfig {
     /// with its connection mutex held is force-evicted from the pool.
     #[serde(default = "default_hung_grace_secs")]
     pub hung_grace_secs: u64,
+    /// Config options to set automatically after session creation.
+    /// Keys are config option IDs (e.g. "mode", "model"), values are the
+    /// desired values (e.g. "bypass", "swe-1-6").
+    /// Sent via `session/set_config_option` after each `session/new`.
+    #[serde(default)]
+    pub default_config_options: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1038,6 +1048,7 @@ impl Default for PoolConfig {
             prompt_hard_timeout_secs: default_prompt_hard_timeout_secs(),
             liveness_check_secs: default_liveness_check_secs(),
             hung_grace_secs: default_hung_grace_secs(),
+            default_config_options: HashMap::new(),
         }
     }
 }
@@ -1161,9 +1172,9 @@ pub fn parse_s3_uri(uri: &str) -> anyhow::Result<(String, String)> {
     let rest = uri
         .strip_prefix("s3://")
         .ok_or_else(|| anyhow::anyhow!("invalid s3:// URI '{uri}' — must start with s3://"))?;
-    let (bucket, key) = rest
-        .split_once('/')
-        .ok_or_else(|| anyhow::anyhow!("invalid s3:// URI '{uri}' — expected s3://<bucket>/<key>"))?;
+    let (bucket, key) = rest.split_once('/').ok_or_else(|| {
+        anyhow::anyhow!("invalid s3:// URI '{uri}' — expected s3://<bucket>/<key>")
+    })?;
     if bucket.is_empty() || key.is_empty() {
         anyhow::bail!("invalid s3:// URI '{uri}' — bucket and key must both be non-empty");
     }
@@ -1642,7 +1653,7 @@ mod tests {
         std::env::remove_var("TELEGRAM_WEBHOOK_PATH");
 
         let cfg = TelegramConfig {
-            bot_token: Some("".into()),       // simulates ${UNSET_VAR} → ""
+            bot_token: Some("".into()), // simulates ${UNSET_VAR} → ""
             secret_token: Some("".into()),
             webhook_path: Some("".into()),
             ..Default::default()
@@ -1688,18 +1699,27 @@ mod tests {
         //     trimmed) when config list is empty ---
         std::env::set_var("TELEGRAM_ALLOWED_USERS", " 111 , 222,333 ");
         let r = TelegramConfig::default().resolve();
-        assert_eq!(r.allowed_users, vec!["111".to_string(), "222".to_string(), "333".to_string()]);
+        assert_eq!(
+            r.allowed_users,
+            vec!["111".to_string(), "222".to_string(), "333".to_string()]
+        );
         assert!(!r.allow_all_users); // default false (deny-all)
         std::env::remove_var("TELEGRAM_ALLOWED_USERS");
 
         // --- Scenario 11: explicit allow_all_users = false matches
         //     the deny-all default (no-op but valid config) ---
-        let cfg = TelegramConfig { allow_all_users: Some(false), ..Default::default() };
+        let cfg = TelegramConfig {
+            allow_all_users: Some(false),
+            ..Default::default()
+        };
         assert!(!cfg.resolve().allow_all_users);
 
         // --- Scenario 12: explicit allow_all_users = true opts in to
         //     allow-all (overrides deny-all default) ---
-        let cfg = TelegramConfig { allow_all_users: Some(true), ..Default::default() };
+        let cfg = TelegramConfig {
+            allow_all_users: Some(true),
+            ..Default::default()
+        };
         assert!(cfg.resolve().allow_all_users);
 
         // --- Scenario 13: explicit empty list (Some([])) overrides
@@ -2231,10 +2251,9 @@ runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent
             assert_eq!(cfg.agent.command, "uv");
         }
         assert!(cfg.agent.args.contains(&"--runtime-arn".to_string()));
-        assert!(cfg
-            .agent
-            .args
-            .contains(&"arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent".to_string()));
+        assert!(cfg.agent.args.contains(
+            &"arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent".to_string()
+        ));
     }
 
     #[test]
@@ -2278,7 +2297,9 @@ bot_token = "t"
 runtime_arn = "not-a-valid-arn"
 "#;
         let err = parse_config(toml, "test").unwrap_err();
-        assert!(err.to_string().contains("not a valid AgentCore Runtime ARN"));
+        assert!(err
+            .to_string()
+            .contains("not a valid AgentCore Runtime ARN"));
     }
 
     #[test]
@@ -2291,7 +2312,9 @@ bot_token = "t"
 runtime_arn = "arn:aws:s3:us-east-1:123456789012:bucket/my-bucket"
 "#;
         let err = parse_config(toml, "test").unwrap_err();
-        assert!(err.to_string().contains("not a valid AgentCore Runtime ARN"));
+        assert!(err
+            .to_string()
+            .contains("not a valid AgentCore Runtime ARN"));
     }
 
     #[test]
@@ -2304,7 +2327,9 @@ bot_token = "t"
 runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:agent/my-agent"
 "#;
         let err = parse_config(toml, "test").unwrap_err();
-        assert!(err.to_string().contains("not a valid AgentCore Runtime ARN"));
+        assert!(err
+            .to_string()
+            .contains("not a valid AgentCore Runtime ARN"));
     }
 
     #[test]

--- a/crates/openab-core/src/dispatch.rs
+++ b/crates/openab-core/src/dispatch.rs
@@ -1202,6 +1202,7 @@ mod tests {
             1,
             crate::config::default_prompt_hard_timeout_secs()
                 .saturating_add(crate::config::default_hung_grace_secs()),
+            HashMap::new(),
         ));
         let router = Arc::new(AdapterRouter::new(
             pool,

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -235,6 +235,16 @@ Session pool settings for managing concurrent agent sessions.
 | `max_sessions` | usize | `10` | Maximum number of concurrent agent sessions. When full, the oldest idle session is suspended (recoverable); if all sessions are busy, new requests are rejected. |
 | `session_ttl_hours` | u64 | `4` | Session time-to-live in hours. Idle sessions are reclaimed after this period. The example config uses `24`. |
 | `hung_grace_secs` | u64 | `120` | Grace period after `prompt_hard_timeout_secs` before a session stuck with its connection mutex held (in-flight prompt) is force-evicted from the pool. Eviction threshold: `prompt_hard_timeout_secs + hung_grace_secs`. |
+| `default_config_options` | map | `{}` | Config options to set automatically after session creation. Keys are config option IDs (e.g. `mode`, `model`), values are the desired values (e.g. `bypass`, `swe-1-6`). Sent via ACP `session/set_config_option` after each `session/new`. |
+
+**Example** — force Devin to bypass mode and use a specific model:
+
+```toml
+[pool]
+max_sessions = 3
+session_ttl_hours = 1
+default_config_options = { mode = "bypass", model = "swe-1-6" }
+```
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,10 @@ fn has_unified_platform_env() -> bool {
         || (cfg!(feature = "feishu") && std::env::var("FEISHU_APP_ID").is_ok())
         || (cfg!(feature = "wecom") && std::env::var("WECOM_CORP_ID").is_ok())
         || (cfg!(feature = "teams") && std::env::var("TEAMS_APP_ID").is_ok())
-        || (cfg!(feature = "googlechat") && std::env::var("GOOGLE_CHAT_ENABLED").map(|v| v == "true" || v == "1").unwrap_or(false))
+        || (cfg!(feature = "googlechat")
+            && std::env::var("GOOGLE_CHAT_ENABLED")
+                .map(|v| v == "true" || v == "1")
+                .unwrap_or(false))
 }
 
 #[tokio::main]
@@ -145,7 +148,11 @@ async fn main() -> anyhow::Result<()> {
             return Ok(());
         }
         #[cfg(feature = "agentcore")]
-        Commands::AgentcoreBridge { runtime_arn, region, command } => {
+        Commands::AgentcoreBridge {
+            runtime_arn,
+            region,
+            command,
+        } => {
             return acp::agentcore::run_bridge(&runtime_arn, &region, &command).await;
         }
         Commands::Set { key, value, thread } => {
@@ -199,7 +206,9 @@ async fn main() -> anyhow::Result<()> {
         "config loaded"
     );
 
-    if cfg.discord.is_none() && cfg.slack.is_none() && cfg.gateway.is_none()
+    if cfg.discord.is_none()
+        && cfg.slack.is_none()
+        && cfg.gateway.is_none()
         && cfg.telegram.is_none()
         && !has_unified_platform_env()
     {
@@ -243,6 +252,7 @@ async fn main() -> anyhow::Result<()> {
         cfg.pool
             .prompt_hard_timeout_secs
             .saturating_add(cfg.pool.hung_grace_secs),
+        cfg.pool.default_config_options,
     ));
     let ttl_secs = cfg.pool.session_ttl_hours * 3600;
 
@@ -317,7 +327,10 @@ async fn main() -> anyhow::Result<()> {
                     Some(true), // L2 open — Discord's own channel/thread/DM logic still applies
                     Vec::<String>::new(),
                     Some(true),
-                    Some(config::resolve_allow_all(d.allow_all_users, &d.allowed_users)),
+                    Some(config::resolve_allow_all(
+                        d.allow_all_users,
+                        &d.allowed_users,
+                    )),
                     d.allowed_users.clone(),
                 ),
             );
@@ -601,11 +614,11 @@ async fn main() -> anyhow::Result<()> {
         feature = "teams",
     ))]
     let _unified_handle = {
-        use openab_core::gateway::{GatewayEventContext, process_gateway_event};
+        use openab_core::gateway::{process_gateway_event, GatewayEventContext};
 
         if has_unified_platform_env() || cfg.telegram.is_some() {
-            let listen_addr = std::env::var("GATEWAY_LISTEN")
-                .unwrap_or_else(|_| "0.0.0.0:8080".into());
+            let listen_addr =
+                std::env::var("GATEWAY_LISTEN").unwrap_or_else(|_| "0.0.0.0:8080".into());
 
             // Create a dedicated dispatcher for unified gateway events
             let unified_dispatcher = Arc::new(dispatch::Dispatcher::with_idle_timeout(
@@ -645,8 +658,8 @@ async fn main() -> anyhow::Result<()> {
             let gw_state = Arc::new(gw_state_inner);
 
             // Build axum router with platform webhook routes
-            let mut app = axum::Router::new()
-                .route("/health", axum::routing::get(|| async { "ok" }));
+            let mut app =
+                axum::Router::new().route("/health", axum::routing::get(|| async { "ok" }));
 
             #[cfg(feature = "telegram")]
             if gw_state.telegram_bot_token.is_some() {
@@ -655,13 +668,19 @@ async fn main() -> anyhow::Result<()> {
                         .unwrap_or_else(|_| "/webhook/telegram".into())
                 });
                 info!(path = %path, "unified: telegram adapter enabled");
-                app = app.route(&path, axum::routing::post(openab_gateway::adapters::telegram::webhook));
+                app = app.route(
+                    &path,
+                    axum::routing::post(openab_gateway::adapters::telegram::webhook),
+                );
             }
 
             #[cfg(feature = "line")]
             {
                 info!("unified: line adapter enabled");
-                app = app.route("/webhook/line", axum::routing::post(openab_gateway::adapters::line::webhook));
+                app = app.route(
+                    "/webhook/line",
+                    axum::routing::post(openab_gateway::adapters::line::webhook),
+                );
             }
 
             #[cfg(feature = "feishu")]
@@ -669,23 +688,35 @@ async fn main() -> anyhow::Result<()> {
                 let path = std::env::var("FEISHU_WEBHOOK_PATH")
                     .unwrap_or_else(|_| "/webhook/feishu".into());
                 info!(path = %path, "unified: feishu adapter enabled");
-                app = app.route(&path, axum::routing::post(openab_gateway::adapters::feishu::webhook));
+                app = app.route(
+                    &path,
+                    axum::routing::post(openab_gateway::adapters::feishu::webhook),
+                );
             }
 
             #[cfg(feature = "wecom")]
             if let Some(ref w) = gw_state.wecom {
                 info!(path = %w.config.webhook_path, "unified: wecom adapter enabled");
                 app = app
-                    .route(&w.config.webhook_path, axum::routing::get(openab_gateway::adapters::wecom::verify))
-                    .route(&w.config.webhook_path, axum::routing::post(openab_gateway::adapters::wecom::webhook));
+                    .route(
+                        &w.config.webhook_path,
+                        axum::routing::get(openab_gateway::adapters::wecom::verify),
+                    )
+                    .route(
+                        &w.config.webhook_path,
+                        axum::routing::post(openab_gateway::adapters::wecom::webhook),
+                    );
             }
 
             #[cfg(feature = "teams")]
             if gw_state.teams.is_some() {
-                let path = std::env::var("TEAMS_WEBHOOK_PATH")
-                    .unwrap_or_else(|_| "/webhook/teams".into());
+                let path =
+                    std::env::var("TEAMS_WEBHOOK_PATH").unwrap_or_else(|_| "/webhook/teams".into());
                 info!(path = %path, "unified: teams adapter enabled");
-                app = app.route(&path, axum::routing::post(openab_gateway::adapters::teams::webhook));
+                app = app.route(
+                    &path,
+                    axum::routing::post(openab_gateway::adapters::teams::webhook),
+                );
             }
 
             #[cfg(feature = "googlechat")]
@@ -693,14 +724,17 @@ async fn main() -> anyhow::Result<()> {
                 let path = std::env::var("GOOGLE_CHAT_WEBHOOK_PATH")
                     .unwrap_or_else(|_| "/webhook/googlechat".into());
                 info!(path = %path, "unified: googlechat adapter enabled");
-                app = app.route(&path, axum::routing::post(openab_gateway::adapters::googlechat::webhook));
+                app = app.route(
+                    &path,
+                    axum::routing::post(openab_gateway::adapters::googlechat::webhook),
+                );
             }
 
             let app = app.with_state(gw_state.clone());
 
             // Bridge task: receive events from adapters via event_tx, dispatch to core
             let unified_adapter: Arc<dyn adapter::ChatAdapter> = Arc::new(
-                unified_adapter::UnifiedGatewayAdapter::new(gw_state.clone())
+                unified_adapter::UnifiedGatewayAdapter::new(gw_state.clone()),
             );
 
             // Read security gating from env (mirrors [gateway] config section)
@@ -901,14 +935,17 @@ async fn main() -> anyhow::Result<()> {
         let reminder_store = remind::ReminderStore::load(reminder_path);
 
         // Construct ambient dispatcher if enabled and channels configured.
-        let ambient_dispatcher = if cfg.ambient.enabled && !cfg.ambient.discord.channels.is_empty() {
+        let ambient_dispatcher = if cfg.ambient.enabled && !cfg.ambient.discord.channels.is_empty()
+        {
             info!(
                 channels = ?cfg.ambient.discord.channels,
                 flush_interval = cfg.ambient.flush_interval_seconds,
                 flush_max_messages = cfg.ambient.flush_max_messages,
                 "ambient mode enabled"
             );
-            Some(Arc::new(openab_core::ambient::AmbientDispatcher::new(cfg.ambient.clone())))
+            Some(Arc::new(openab_core::ambient::AmbientDispatcher::new(
+                cfg.ambient.clone(),
+            )))
         } else {
             None
         };


### PR DESCRIPTION
## Summary

Adds `[pool] default_config_options` — a map of config option IDs to values that are sent via `session/set_config_option` immediately after `session/new`.

## Motivation

Devin CLI in ACP mode:
- Does not support `--permission-mode` flag
- Ignores `DEVIN_PERMISSION_MODE` env var
- Defaults to `accept-edits` mode which prompts for `exec` tool calls

This causes headless deployments to get stuck on permission prompts with no way to auto-approve. The only fix is to switch mode via the ACP config options mechanism after session creation.

## Usage

```toml
[pool]
max_sessions = 3
session_ttl_hours = 1
default_config_options = { mode = "bypass", model = "swe-1-6" }
```

## Changes

- `config.rs`: Added `default_config_options: HashMap<String, String>` to `PoolConfig` with `serde(default)`
- `pool.rs`: Updated `SessionPool::new` to accept and store the map; iterates and calls `set_config_option` after each `session/new`
- `main.rs`: Pass `cfg.pool.default_config_options` to pool constructor
- `dispatch.rs`: Updated test to pass empty HashMap
- `docs/config-reference.md`: Added field docs + TOML example

## Testing

- `cargo fmt` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (15 tests pass)