### PR TITLE
feat(oabctl): add architecture field for ARM64/X86_64 task scheduling

### DIFF
--- a/operator/schema/oabservice-v2.json
+++ b/operator/schema/oabservice-v2.json
@@ -142,6 +142,7 @@
       "properties": {
         "type": { "const": "ecs" },
         "capacityProvider": { "type": "string", "enum": ["FARGATE", "FARGATE_SPOT"] },
+        "architecture": { "type": "string", "enum": ["X86_64", "ARM64"], "default": "X86_64", "description": "CPU architecture for the ECS task. Defaults to X86_64." },
         "networking": {
           "type": "object",
           "required": ["subnets", "securityGroups"],

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -3,7 +3,7 @@ use crate::manifest::{OABFleetManifest, OABServiceManifest, RawManifest, Runtime
 use anyhow::{Context, Result};
 use aws_sdk_ecs::types::{
     AssignPublicIp, AwsVpcConfiguration, CapacityProviderStrategyItem, ContainerDefinition,
-    KeyValuePair, NetworkConfiguration, Secret,
+    KeyValuePair, NetworkConfiguration, RuntimePlatform, Secret,
 };
 use aws_sdk_s3::primitives::ByteStream;
 use std::path::Path;
@@ -378,6 +378,19 @@ async fn apply_ecs(
             "no bootstrap task role was found — run `oabctl bootstrap` first, or the running container will have no AWS credentials"
         );
     }
+
+    // Set runtime platform (OS + CPU architecture) — required for Fargate to
+    // schedule on Graviton (ARM64) vs Intel/AMD (X86_64).
+    let cpu_arch = match ecs_rt.architecture.as_str() {
+        "ARM64" => aws_sdk_ecs::types::CpuArchitecture::Arm64,
+        _ => aws_sdk_ecs::types::CpuArchitecture::X8664,
+    };
+    register_req = register_req.runtime_platform(
+        RuntimePlatform::builder()
+            .operating_system_family(aws_sdk_ecs::types::OsFamily::Linux)
+            .cpu_architecture(cpu_arch)
+            .build(),
+    );
 
     let task_def = register_req
         .send()

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -383,7 +383,8 @@ async fn apply_ecs(
     // schedule on Graviton (ARM64) vs Intel/AMD (X86_64).
     let cpu_arch = match ecs_rt.architecture.as_str() {
         "ARM64" => aws_sdk_ecs::types::CpuArchitecture::Arm64,
-        _ => aws_sdk_ecs::types::CpuArchitecture::X8664,
+        "X86_64" => aws_sdk_ecs::types::CpuArchitecture::X8664,
+        other => anyhow::bail!("unsupported architecture '{other}' — should be caught by manifest validation"),
     };
     register_req = register_req.runtime_platform(
         RuntimePlatform::builder()

--- a/operator/src/manifest.rs
+++ b/operator/src/manifest.rs
@@ -467,6 +467,141 @@ spec:
     }
 
     #[test]
+    fn accepts_arm64_architecture() {
+        let yaml = r#"
+apiVersion: oab.dev/v2
+kind: OABService
+metadata:
+  name: mybot
+  namespace: prod
+spec:
+  image: img:tag
+  resources:
+    cpu: "256"
+    memory: "512"
+  configFrom: s3://bucket/config.toml
+  runtime:
+    type: ecs
+    architecture: ARM64
+    capacityProvider: FARGATE_SPOT
+    networking:
+      subnets: ["subnet-a"]
+      securityGroups: ["sg-1"]
+"#;
+        let m = parse(yaml);
+        m.validate().expect("ARM64 should be valid");
+    }
+
+    #[test]
+    fn accepts_x86_64_architecture() {
+        let yaml = r#"
+apiVersion: oab.dev/v2
+kind: OABService
+metadata:
+  name: mybot
+  namespace: prod
+spec:
+  image: img:tag
+  resources:
+    cpu: "256"
+    memory: "512"
+  configFrom: s3://bucket/config.toml
+  runtime:
+    type: ecs
+    architecture: X86_64
+    capacityProvider: FARGATE_SPOT
+    networking:
+      subnets: ["subnet-a"]
+      securityGroups: ["sg-1"]
+"#;
+        let m = parse(yaml);
+        m.validate().expect("X86_64 should be valid");
+    }
+
+    #[test]
+    fn defaults_to_x86_64_when_architecture_omitted() {
+        let yaml = r#"
+apiVersion: oab.dev/v2
+kind: OABService
+metadata:
+  name: mybot
+  namespace: prod
+spec:
+  image: img:tag
+  resources:
+    cpu: "256"
+    memory: "512"
+  configFrom: s3://bucket/config.toml
+  runtime:
+    type: ecs
+    capacityProvider: FARGATE_SPOT
+    networking:
+      subnets: ["subnet-a"]
+      securityGroups: ["sg-1"]
+"#;
+        let m = parse(yaml);
+        m.validate().expect("should be valid with default architecture");
+        match &m.spec.runtime {
+            Runtime::Ecs(ecs) => assert_eq!(ecs.architecture, "X86_64"),
+            _ => panic!("expected ECS runtime"),
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_architecture() {
+        let yaml = r#"
+apiVersion: oab.dev/v2
+kind: OABService
+metadata:
+  name: mybot
+  namespace: prod
+spec:
+  image: img:tag
+  resources:
+    cpu: "256"
+    memory: "512"
+  configFrom: s3://bucket/config.toml
+  runtime:
+    type: ecs
+    architecture: MIPS
+    capacityProvider: FARGATE_SPOT
+    networking:
+      subnets: ["subnet-a"]
+      securityGroups: ["sg-1"]
+"#;
+        let m = parse(yaml);
+        let err = m.validate().unwrap_err();
+        assert!(err.to_string().contains("runtime.architecture must be one of"));
+    }
+
+    #[test]
+    fn rejects_lowercase_architecture() {
+        let yaml = r#"
+apiVersion: oab.dev/v2
+kind: OABService
+metadata:
+  name: mybot
+  namespace: prod
+spec:
+  image: img:tag
+  resources:
+    cpu: "256"
+    memory: "512"
+  configFrom: s3://bucket/config.toml
+  runtime:
+    type: ecs
+    architecture: arm64
+    capacityProvider: FARGATE_SPOT
+    networking:
+      subnets: ["subnet-a"]
+      securityGroups: ["sg-1"]
+"#;
+        let m = parse(yaml);
+        let err = m.validate().unwrap_err();
+        assert!(err.to_string().contains("runtime.architecture must be one of"));
+    }
+
+    #[test]
     fn fleet_passes_ingress_from_template_and_override_wins() {
         let yaml = r#"
 apiVersion: oab.dev/v2

--- a/operator/src/manifest.rs
+++ b/operator/src/manifest.rs
@@ -247,6 +247,10 @@ pub enum Runtime {
 pub struct EcsRuntime {
     #[serde(default = "default_capacity_provider")]
     pub capacity_provider: String,
+    /// CPU architecture for the ECS task. Defaults to `X86_64`.
+    /// Valid values: `X86_64`, `ARM64`.
+    #[serde(default = "default_architecture")]
+    pub architecture: String,
     pub networking: EcsNetworking,
 }
 
@@ -272,6 +276,10 @@ pub struct KubernetesRuntime {
 
 fn default_capacity_provider() -> String {
     "FARGATE".to_string()
+}
+
+fn default_architecture() -> String {
+    "X86_64".to_string()
 }
 
 /// Valid ECS Fargate CPU/memory combinations
@@ -302,6 +310,14 @@ impl OABServiceManifest {
                 let valid_cp = ["FARGATE", "FARGATE_SPOT"];
                 if !valid_cp.contains(&ecs.capacity_provider.as_str()) {
                     anyhow::bail!("runtime.capacityProvider must be FARGATE or FARGATE_SPOT");
+                }
+                let valid_arch = ["X86_64", "ARM64"];
+                if !valid_arch.contains(&ecs.architecture.as_str()) {
+                    anyhow::bail!(
+                        "runtime.architecture must be one of {:?} (got '{}')",
+                        valid_arch,
+                        ecs.architecture
+                    );
                 }
                 if ecs.networking.subnets.is_empty() {
                     anyhow::bail!("runtime.networking.subnets must not be empty");


### PR DESCRIPTION
## Summary

Add optional `architecture` field to the ECS runtime spec so oabctl can schedule tasks on Graviton (ARM64) for ~20% Fargate cost savings.

**Default:** `X86_64` — existing manifests work unchanged (backward-compatible).

## Changes

- `operator/src/manifest.rs`: Add `architecture` field to `EcsRuntime` struct with serde default + validation
- `operator/src/apply.rs`: Set `RuntimePlatform` (OS: Linux, CPU: from manifest) on `register_task_definition`
- `operator/schema/oabservice-v2.json`: Add `architecture` enum to `ecsRuntime` definition

## Usage

```yaml
runtime:
  type: ecs
  architecture: ARM64  # or X86_64 (default)
  capacityProvider: FARGATE_SPOT
  networking:
    subnets: [subnet-aaa]
    securityGroups: [sg-1]
```

## Tested

- `cargo build --release` ✅ (macmini M4)