### PR TITLE
fix(ci): pr-preview agent variants use correct image tag

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -47,6 +47,7 @@ jobs:
       suffix: ${{ steps.df.outputs.suffix }}
       build_args: ${{ steps.df.outputs.build_args }}
       tag_suffix: ${{ steps.df.outputs.tag_suffix }}
+      target: ${{ steps.df.outputs.target }}
     steps:
       - name: Get PR branch
         id: pr
@@ -65,12 +66,14 @@ jobs:
             echo "suffix=" >> "$GITHUB_OUTPUT"
             echo "build_args=" >> "$GITHUB_OUTPUT"
             echo "tag_suffix=" >> "$GITHUB_OUTPUT"
+            echo "target=" >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.variant }}" = "kiro" ]; then
             # Unified build (all platforms) tagged as :pr<N>-kiro
             echo "file=Dockerfile" >> "$GITHUB_OUTPUT"
             echo "suffix=" >> "$GITHUB_OUTPUT"
             echo "build_args=BUILD_MODE=unified" >> "$GITHUB_OUTPUT"
             echo "tag_suffix=-kiro" >> "$GITHUB_OUTPUT"
+            echo "target=" >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.variant }}" = "unified" ]; then
             # Same base Dockerfile as "default", but built with BUILD_MODE=unified
             # so the telegram/line/feishu/wecom/googlechat/teams gateway adapters
@@ -83,11 +86,15 @@ jobs:
             echo "suffix=" >> "$GITHUB_OUTPUT"
             echo "build_args=BUILD_MODE=unified" >> "$GITHUB_OUTPUT"
             echo "tag_suffix=" >> "$GITHUB_OUTPUT"
+            echo "target=" >> "$GITHUB_OUTPUT"
           else
-            echo "file=Dockerfile.${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
-            echo "suffix=-${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
+            # Unified Dockerfile with --target for agent-specific variants.
+            # Image: ghcr.io/openabdev/openab:pr<N>-<variant>
+            echo "file=Dockerfile.unified" >> "$GITHUB_OUTPUT"
+            echo "suffix=" >> "$GITHUB_OUTPUT"
             echo "build_args=" >> "$GITHUB_OUTPUT"
-            echo "tag_suffix=" >> "$GITHUB_OUTPUT"
+            echo "tag_suffix=-${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
+            echo "target=${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -121,6 +128,7 @@ jobs:
         with:
           context: .
           file: ${{ needs.resolve-pr.outputs.dockerfile }}
+          target: ${{ needs.resolve-pr.outputs.target || '' }}
           platforms: ${{ matrix.platform.os }}
           build-args: ${{ needs.resolve-pr.outputs.build_args }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ needs.resolve-pr.outputs.suffix }},push-by-digest=true,name-canonical=true,push=true


### PR DESCRIPTION
## Summary

Fix pr-preview workflow so agent variants (devin, claude, codex, etc.) produce `ghcr.io/openabdev/openab:pr<N>-<variant>` instead of `ghcr.io/openabdev/openab-<variant>:pr<N>`.

## Problem

The `else` branch used legacy `Dockerfile.<variant>` with `suffix=-<variant>` which pushed to a separate image repo. ECS task definitions expect the image at `openab:tag-variant`, causing `CannotPullContainerError: not found` on deploy.

## Fix

- Use `Dockerfile.unified` with `--target <variant>` for all agent variants
- Set `suffix=""` (same base repo) and `tag_suffix=-<variant>` (appended to tag)
- Add `target` output to resolve-pr job, consumed by build-push-action

## Result

| Before | After |
|--------|-------|
| `ghcr.io/openabdev/openab-devin:pr1307` | `ghcr.io/openabdev/openab:pr1307-devin` |