### PR TITLE
fix(oabctl): always enable execute command on ECS services

### DIFF
--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -468,6 +468,7 @@ async fn apply_ecs(
             .cluster("oab")
             .service(&service_name)
             .task_definition(&task_def_arn)
+            .enable_execute_command(true)
             .network_configuration(network_config);
 
         if let Some(cm) = &cloud_map {
@@ -522,6 +523,7 @@ async fn apply_ecs(
             .service_name(&service_name)
             .task_definition(&task_def_arn)
             .desired_count(1)
+            .enable_execute_command(true)
             .capacity_provider_strategy(cap_strategy)
             .network_configuration(network_config);
 


### PR DESCRIPTION
oabctl apply was creating/updating services without `enableExecuteCommand`, requiring a manual `aws ecs update-service --enable-execute-command` before `oabctl exec` or `ecsh` would work.

Now both `create_service` and `update_service` always set `enable_execute_command(true)`. All OAB services need it for debugging — no manifest field needed, it's unconditionally on.