### PR TITLE
feat(cron): support telegram platform for cronjob

### DIFF
--- a/crates/openab-core/src/cron.rs
+++ b/crates/openab-core/src/cron.rs
@@ -1618,7 +1618,7 @@ message = "a"
             schedule: "* * * * *".into(),
             channel: "123".into(),
             message: "hi".into(),
-            platform: "telegram".into(),
+            platform: "matrix".into(),
             sender_name: "test".into(),
             thread_id: None,
             timezone: "UTC".into(),

--- a/crates/openab-core/src/cron.rs
+++ b/crates/openab-core/src/cron.rs
@@ -238,7 +238,7 @@ pub fn should_fire(schedule: &Schedule, tz: Tz) -> bool {
 }
 
 /// Known platforms that have adapter support.
-const VALID_PLATFORMS: &[&str] = &["discord", "slack"];
+const VALID_PLATFORMS: &[&str] = &["discord", "slack", "telegram"];
 
 /// Validate all cronjob configs (fail-fast on bad cron expressions or timezones).
 pub fn validate_cronjobs(

--- a/docs/cronjob.md
+++ b/docs/cronjob.md
@@ -44,9 +44,9 @@ thread_id = ""                               # optional: post to existing thread
 |-------|----------|---------|-------------|
 | `enabled` | | `true` | Set `false` to disable without removing the entry |
 | `schedule` | ✅ | — | 5-field POSIX cron expression |
-| `channel` | ✅ | — | Discord channel/thread ID or Slack channel ID |
+| `channel` | ✅ | — | Discord channel/thread ID, Slack channel ID, or Telegram chat ID |
 | `message` | ✅ | — | Message sent to the agent as a prompt |
-| `platform` | | `"discord"` | `"discord"` or `"slack"` |
+| `platform` | | `"discord"` | `"discord"`, `"slack"`, or `"telegram"` (requires `telegram` feature) |
 | `sender_name` | | `"openab-cron"` | Attribution shown in prompt context |
 | `timezone` | | `"UTC"` | IANA timezone (e.g. `"America/New_York"`, `"Europe/Berlin"`) |
 | `thread_id` | | — | Post into an existing thread instead of the channel |
@@ -113,6 +113,13 @@ channel = "C0123456789"
 message = "check for any critical alerts in the last 8 hours"
 platform = "slack"
 sender_name = "OpsBot"
+
+[[cron.jobs]]
+schedule = "* * * * *"
+channel = "176096071"
+message = "講一個冷笑話"
+platform = "telegram"
+sender_name = "JokeBot"
 ```
 
 ## Helm Deployment
@@ -323,6 +330,16 @@ When a cron job fires, the agent sees a sender context like:
 ```
 
 Use `sender_name` to distinguish different scheduled tasks in logs and thread titles. The agent can use this to tailor its response (e.g. "DailyOps asked for a summary" vs "WeeklyReport asked for a report").
+
+## Platform Prerequisites
+
+| Platform | Feature Flag | Config / Env Required |
+|----------|-------------|----------------------|
+| `discord` | (always enabled) | `[discord]` section in config.toml |
+| `slack` | `--features slack` | `[slack]` section in config.toml |
+| `telegram` | `--features telegram` | `[telegram]` section in config.toml **or** `TELEGRAM_BOT_TOKEN` env var |
+
+> **Note:** The `channel` field for Telegram should be the numeric chat ID (e.g. `"176096071"`). Use [@userinfobot](https://t.me/userinfobot) or the Telegram Bot API `getUpdates` to find your chat ID.
 
 ## When to Use External Schedulers Instead
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -482,9 +482,8 @@ async fn main() -> anyhow::Result<()> {
     if cfg.slack.is_some() {
         configured_platforms.push("slack");
     }
-    if cfg!(feature = "telegram")
-        && (cfg.telegram.is_some() || std::env::var("TELEGRAM_BOT_TOKEN").is_ok())
-    {
+    #[cfg(feature = "telegram")]
+    if cfg.telegram.is_some() || std::env::var("TELEGRAM_BOT_TOKEN").is_ok() {
         configured_platforms.push("telegram");
     }
     cron::validate_cronjobs(&cfg.cron.jobs, &configured_platforms)?;
@@ -870,14 +869,7 @@ async fn main() -> anyhow::Result<()> {
         if let Some(ref a) = shared_slack_adapter {
             cron_adapters.insert("slack".into(), a.clone() as Arc<dyn adapter::ChatAdapter>);
         }
-        #[cfg(any(
-            feature = "telegram",
-            feature = "line",
-            feature = "feishu",
-            feature = "googlechat",
-            feature = "wecom",
-            feature = "teams",
-        ))]
+        #[cfg(feature = "telegram")]
         if let Some(ref a) = shared_unified_adapter {
             cron_adapters.insert("telegram".into(), a.clone());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -482,7 +482,9 @@ async fn main() -> anyhow::Result<()> {
     if cfg.slack.is_some() {
         configured_platforms.push("slack");
     }
-    if cfg.telegram.is_some() || std::env::var("TELEGRAM_BOT_TOKEN").is_ok() {
+    if cfg!(feature = "telegram")
+        && (cfg.telegram.is_some() || std::env::var("TELEGRAM_BOT_TOKEN").is_ok())
+    {
         configured_platforms.push("telegram");
     }
     cron::validate_cronjobs(&cfg.cron.jobs, &configured_platforms)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -482,6 +482,9 @@ async fn main() -> anyhow::Result<()> {
     if cfg.slack.is_some() {
         configured_platforms.push("slack");
     }
+    if cfg.telegram.is_some() || std::env::var("TELEGRAM_BOT_TOKEN").is_ok() {
+        configured_platforms.push("telegram");
+    }
     cron::validate_cronjobs(&cfg.cron.jobs, &configured_platforms)?;
 
     // Spawn Slack adapter (background task)
@@ -613,7 +616,7 @@ async fn main() -> anyhow::Result<()> {
         feature = "wecom",
         feature = "teams",
     ))]
-    let _unified_handle = {
+    let (_unified_handle, shared_unified_adapter) = {
         use openab_core::gateway::{process_gateway_event, GatewayEventContext};
 
         if has_unified_platform_env() || cfg.telegram.is_some() {
@@ -771,6 +774,8 @@ async fn main() -> anyhow::Result<()> {
                     .filter(|s| !s.is_empty())
                     .collect();
 
+            let cron_unified_adapter = unified_adapter.clone();
+
             let event_ctx = Arc::new(GatewayEventContext {
                 adapter: unified_adapter,
                 dispatcher: unified_dispatcher,
@@ -815,7 +820,7 @@ async fn main() -> anyhow::Result<()> {
 
             info!(addr = %listen_addr, "unified webhook server starting");
 
-            Some(tokio::spawn(async move {
+            (Some(tokio::spawn(async move {
                 let listener = match tokio::net::TcpListener::bind(&listen_addr).await {
                     Ok(l) => l,
                     Err(e) => {
@@ -827,9 +832,9 @@ async fn main() -> anyhow::Result<()> {
                 if let Err(e) = axum::serve(listener, app).await {
                     error!(error = %e, "unified webhook server error");
                 }
-            }))
+            })), Some(cron_unified_adapter))
         } else {
-            None
+            (None, None)
         }
     };
 
@@ -862,6 +867,17 @@ async fn main() -> anyhow::Result<()> {
         #[cfg(feature = "slack")]
         if let Some(ref a) = shared_slack_adapter {
             cron_adapters.insert("slack".into(), a.clone() as Arc<dyn adapter::ChatAdapter>);
+        }
+        #[cfg(any(
+            feature = "telegram",
+            feature = "line",
+            feature = "feishu",
+            feature = "googlechat",
+            feature = "wecom",
+            feature = "teams",
+        ))]
+        if let Some(ref a) = shared_unified_adapter {
+            cron_adapters.insert("telegram".into(), a.clone());
         }
         let cron_platforms: Vec<String> =
             configured_platforms.iter().map(|s| s.to_string()).collect();


### PR DESCRIPTION
## Summary

Enables `platform = "telegram"` in cronjob.toml for unified-mode Telegram deployments.

## Before vs After

```
BEFORE:
                                                    
  cronjob.toml                                      
  ┌─────────────────────────┐                       
  │ platform = "telegram"   │                       
  └───────────┬─────────────┘                       
              │                                     
              ▼                                     
  ┌─────────────────────────┐                       
  │   validate_cronjobs()   │                       
  │                         │                       
  │ VALID_PLATFORMS:        │                       
  │   ["discord", "slack"]  │──── ❌ "unknown platform" error
  └─────────────────────────┘                       
                                                    

AFTER:
                                                    
  cronjob.toml                                      
  ┌─────────────────────────┐                       
  │ platform = "telegram"   │                       
  └───────────┬─────────────┘                       
              │                                     
              ▼                                     
  ┌─────────────────────────────────┐               
  │   validate_cronjobs()           │               
  │                                 │               
  │ VALID_PLATFORMS:                │               
  │   ["discord", "slack",          │               
  │    "telegram"]                  │──── ✅ passes  
  └───────────┬─────────────────────┘               
              │                                     
              ▼                                     
  ┌─────────────────────────────────┐               
  │   cron_adapters                 │               
  │                                 │               
  │ #[cfg(feature = "telegram")]    │               
  │ "telegram" → unified_adapter    │               
  └───────────┬─────────────────────┘               
              │                                     
              ▼                                     
  ┌─────────────────────────────────┐               
  │   fire_cronjob()                │               
  │                                 │               
  │ adapter.send_message(channel,   │               
  │   "講一個冷笑話")               │──── ✅ dispatched
  └─────────────────────────────────┘               
              │                                     
              ▼                                     
        Telegram Chat                               
```

## Trust Layer Note

Cron dispatch intentionally bypasses the L2/L3 trust gate. This is by design:

```
Normal inbound:   User → Adapter → Trust Gate (L2+L3) → handle_message → LLM
Cron dispatch:    fire_cronjob → adapter.send_message → router.handle_message → LLM
                                 (no gate_incoming)
```

Rationale: cron jobs are server-side scheduled tasks authored by the server operator
(via `cronjob.toml`), not external untrusted users. Authorization is established at
config time — only the operator can define jobs, and `validate_cronjobs()` ensures
platform/adapter availability at startup.

## Problem

```toml
[[jobs]]
schedule = "* * * * *"
channel = "176096071"
message = "講一個冷笑話"
platform = "telegram"
```

This was rejected at startup with "unknown platform" because `VALID_PLATFORMS` only had `["discord", "slack"]`, and the unified adapter was not registered with the cron scheduler.

## Changes

1. **`crates/openab-core/src/cron.rs`** — added `"telegram"` to `VALID_PLATFORMS`
2. **`src/main.rs`** — register `"telegram"` in `configured_platforms` when `[telegram]` config or `TELEGRAM_BOT_TOKEN` env is present (guarded by `#[cfg(feature = "telegram")]`)
3. **`src/main.rs`** — clone the unified adapter and insert it into `cron_adapters` under `"telegram"` key so `fire_cronjob` can dispatch to Telegram channels

## Testing

- Cronjob with `platform = "telegram"` no longer rejected at startup
- Messages dispatched to the correct Telegram chat via the unified adapter