### PR TITLE
feat(oabctl): support per-service taskRoleArn in manifest

### DIFF
--- a/docs/oabctl.md
+++ b/docs/oabctl.md
@@ -195,6 +195,7 @@ spec:
   runtime:
     type: ecs
     capacityProvider: FARGATE_SPOT
+    taskRoleArn: arn:aws:iam::123456789012:role/oab-task-role-my-bot  # optional
     networking:
       subnets: [subnet-aaa, subnet-bbb]
       securityGroups: [sg-xxx]
@@ -403,6 +404,40 @@ spec:
 - **Agent config is external** — `configFrom` points to config.toml (managed via `--sync`)
 - **Secrets resolved by OpenAB** — `[secrets.refs]` in config.toml, not in manifest
 - **Runtime-agnostic spec** — same top-level fields regardless of ECS or K8S
+
+### Per-Service IAM Task Role (`taskRoleArn`)
+
+By default, all services use the bootstrap shared role (`oab-task-role`) created
+by `oabctl bootstrap`. For production multi-agent fleets where services need
+different IAM permissions (e.g., one bot accesses a specific S3 bucket, another
+needs DynamoDB), you can declare a per-service task role in the manifest:
+
+```yaml
+spec:
+  runtime:
+    type: ecs
+    taskRoleArn: arn:aws:iam::123456789012:role/oab-task-role-my-bot
+    capacityProvider: FARGATE_SPOT
+    networking: { subnets: [...], securityGroups: [...] }
+```
+
+**Resolution order:**
+1. `runtime.taskRoleArn` from manifest → use it
+2. Otherwise → fall back to bootstrap shared role (`oab-task-role`)
+
+**Requirements for the custom role:**
+- Must have a trust policy allowing `ecs-tasks.amazonaws.com` to `sts:AssumeRole`
+- Should include at minimum the permissions the agent needs at runtime
+  (S3 config access, Secrets Manager, ECS Exec if used)
+
+**Recommendation:** Use the bootstrap shared role for quick starts and single-bot
+setups. For production multi-agent fleets, create per-service roles with
+least-privilege policies and declare them in each manifest.
+
+> **Note:** `taskRoleArn` is distinct from `executionRoleArn`. The execution
+> role (always from bootstrap) is used by ECS itself to pull images and inject
+> secrets *before* the container starts. The task role is the identity the
+> *running container* assumes — this is what `taskRoleArn` overrides.
 
 ## Bootstrap
 

--- a/operator/schema/oabservice-v2.json
+++ b/operator/schema/oabservice-v2.json
@@ -143,6 +143,7 @@
         "type": { "const": "ecs" },
         "capacityProvider": { "type": "string", "enum": ["FARGATE", "FARGATE_SPOT"] },
         "architecture": { "type": "string", "enum": ["X86_64", "ARM64"], "default": "X86_64", "description": "CPU architecture for the ECS task. Defaults to X86_64." },
+        "taskRoleArn": { "type": "string", "description": "Optional IAM task role ARN. Overrides the bootstrap shared role for per-service IAM isolation. Must have ecs-tasks.amazonaws.com trust policy." },
         "networking": {
           "type": "object",
           "required": ["subnets", "securityGroups"],

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -354,9 +354,17 @@ async fn apply_ecs(
     // IMDS, which doesn't exist on Fargate, and fails with a generic
     // "dispatch failure". This was previously never set at all.
     let execution_role_arn = bootstrap_state.as_ref().map(|s| s.resources.execution_role_arn.clone());
-    // Manifest task_role_arn takes precedence over bootstrap shared role
-    let task_role_arn = ecs_rt.task_role_arn.clone()
-        .or_else(|| bootstrap_state.as_ref().map(|s| s.resources.task_role_arn.clone()));
+    // Manifest task_role_arn takes precedence over bootstrap shared role.
+    // Filter empty strings so a blank value falls through to bootstrap.
+    let task_role_arn = resolve_task_role_arn(
+        &ecs_rt.task_role_arn,
+        bootstrap_state.as_ref().map(|s| s.resources.task_role_arn.as_str()),
+    );
+    match (&task_role_arn, ecs_rt.task_role_arn.as_deref().filter(|s| !s.is_empty())) {
+        (Some(arn), Some(_)) => eprintln!("  ℹ taskRoleArn: {arn} (from manifest)"),
+        (Some(arn), None) => eprintln!("  ℹ taskRoleArn: {arn} (from bootstrap)"),
+        (None, _) => eprintln!("  ⚠ no taskRoleArn resolved — task will have no IAM role"),
+    }
 
     let mut register_req = ecs
         .register_task_definition()
@@ -709,4 +717,86 @@ async fn wait_for_stable(ecs: &aws_sdk_ecs::Client, cluster: &str, service: &str
         }
     }
     anyhow::bail!("timed out waiting for service to stabilize (5 min)")
+}
+
+/// Resolve the effective task role ARN.
+///
+/// Resolution order:
+/// 1. Manifest `taskRoleArn` (if present and non-empty) → use it
+/// 2. Bootstrap shared task role → fallback
+/// 3. Neither → `None`
+fn resolve_task_role_arn(
+    manifest_role: &Option<String>,
+    bootstrap_role: Option<&str>,
+) -> Option<String> {
+    manifest_role
+        .clone()
+        .filter(|s| !s.is_empty())
+        .or_else(|| bootstrap_role.map(|s| s.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_role_manifest_wins_over_bootstrap() {
+        let manifest = Some("arn:aws:iam::111:role/manifest-role".to_string());
+        let bootstrap = Some("arn:aws:iam::111:role/bootstrap-role");
+        let result = resolve_task_role_arn(&manifest, bootstrap);
+        assert_eq!(
+            result.as_deref(),
+            Some("arn:aws:iam::111:role/manifest-role")
+        );
+    }
+
+    #[test]
+    fn task_role_falls_back_to_bootstrap() {
+        let manifest: Option<String> = None;
+        let bootstrap = Some("arn:aws:iam::111:role/bootstrap-role");
+        let result = resolve_task_role_arn(&manifest, bootstrap);
+        assert_eq!(
+            result.as_deref(),
+            Some("arn:aws:iam::111:role/bootstrap-role")
+        );
+    }
+
+    #[test]
+    fn task_role_manifest_only_no_bootstrap() {
+        let manifest = Some("arn:aws:iam::111:role/manifest-role".to_string());
+        let bootstrap: Option<&str> = None;
+        let result = resolve_task_role_arn(&manifest, bootstrap);
+        assert_eq!(
+            result.as_deref(),
+            Some("arn:aws:iam::111:role/manifest-role")
+        );
+    }
+
+    #[test]
+    fn task_role_none_when_both_absent() {
+        let manifest: Option<String> = None;
+        let bootstrap: Option<&str> = None;
+        let result = resolve_task_role_arn(&manifest, bootstrap);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn task_role_empty_string_falls_through_to_bootstrap() {
+        let manifest = Some("".to_string());
+        let bootstrap = Some("arn:aws:iam::111:role/bootstrap-role");
+        let result = resolve_task_role_arn(&manifest, bootstrap);
+        assert_eq!(
+            result.as_deref(),
+            Some("arn:aws:iam::111:role/bootstrap-role"),
+            "empty string in manifest should not override bootstrap"
+        );
+    }
+
+    #[test]
+    fn task_role_empty_string_no_bootstrap_returns_none() {
+        let manifest = Some("".to_string());
+        let bootstrap: Option<&str> = None;
+        let result = resolve_task_role_arn(&manifest, bootstrap);
+        assert_eq!(result, None);
+    }
 }

--- a/operator/src/apply.rs
+++ b/operator/src/apply.rs
@@ -354,7 +354,9 @@ async fn apply_ecs(
     // IMDS, which doesn't exist on Fargate, and fails with a generic
     // "dispatch failure". This was previously never set at all.
     let execution_role_arn = bootstrap_state.as_ref().map(|s| s.resources.execution_role_arn.clone());
-    let task_role_arn = bootstrap_state.as_ref().map(|s| s.resources.task_role_arn.clone());
+    // Manifest task_role_arn takes precedence over bootstrap shared role
+    let task_role_arn = ecs_rt.task_role_arn.clone()
+        .or_else(|| bootstrap_state.as_ref().map(|s| s.resources.task_role_arn.clone()));
 
     let mut register_req = ecs
         .register_task_definition()

--- a/operator/src/manifest.rs
+++ b/operator/src/manifest.rs
@@ -251,6 +251,10 @@ pub struct EcsRuntime {
     /// Valid values: `X86_64`, `ARM64`.
     #[serde(default = "default_architecture")]
     pub architecture: String,
+    /// Optional task role ARN. When set, overrides the bootstrap-provided
+    /// shared task role. Use for per-service IAM isolation.
+    #[serde(default)]
+    pub task_role_arn: Option<String>,
     pub networking: EcsNetworking,
 }
 


### PR DESCRIPTION
## Summary

Add optional `taskRoleArn` field to the ECS runtime spec, enabling per-service IAM isolation without manual post-apply fixups.

## Problem

`oabctl apply` always used the bootstrap shared task role (`oab-task-role`). If you manually set a per-service role (e.g. `oab-task-role-emilie` with scoped S3/secrets access), the next `oabctl apply` would revert it to the shared role — breaking the service.

## Solution

```yaml
spec:
  runtime:
    type: ecs
    taskRoleArn: arn:aws:iam::123456789012:role/oab-task-role-emilie
    capacityProvider: FARGATE_SPOT
    networking: ...
```

Resolution order:
1. `runtime.taskRoleArn` from manifest → use it
2. Otherwise → fall back to bootstrap shared role

## Backward Compatible

- Field is optional with no default
- Existing manifests without it behave exactly as before (use bootstrap role)

## Files Changed

- `operator/src/manifest.rs` — added `task_role_arn: Option<String>` to `EcsRuntime`
- `operator/src/apply.rs` — prefer manifest role over bootstrap role