### PR TITLE
fix(acp): use integer protocolVersion in agentcore bridge per latest ACP spec

### DIFF
--- a/crates/openab-core/src/acp/agentcore.rs
+++ b/crates/openab-core/src/acp/agentcore.rs
@@ -529,7 +529,7 @@ where
             "id": 0,
             "method": "initialize",
             "params": {
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": 1,
                 "capabilities": {},
                 "clientInfo": {"name": "openab-agentcore-bridge", "version": env!("CARGO_PKG_VERSION")}
             }


### PR DESCRIPTION
## Summary

Change `protocolVersion` from string `"2024-11-05"` to integer `1` in `agentcore.rs`, matching:
- The latest `@agentclientprotocol/sdk@1.2.0` spec (ProtocolVersion = uint16)
- The existing `connection.rs:533` which already uses integer `1`

## Problem

Agents using the latest ACP SDK (e.g. OpenCode 1.17.11) reject the initialize request with:
```
Invalid input: expected number, received string
```

## Fix

One-line change in `crates/openab-core/src/acp/agentcore.rs`:
```diff
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": 1,
```

Fixes #1318

Discord Discussion URL: https://discord.com/channels/1519878950669647945/1521149141999161386