### PR TITLE
fix(ci): mention PR/issue author when adding closing-soon label

### DIFF
--- a/.github/workflows/stale-contributor.yml
+++ b/.github/workflows/stale-contributor.yml
@@ -68,9 +68,9 @@ jobs:
                     `(labeled \`${CONTRIBUTOR}\` since ${labeledAt.toISOString().slice(0, 10)}).`,
                   '> It will be **automatically closed in 24 hours** if there is no update.',
                   '',
-                  'Please push a commit, respond to outstanding review feedback, or comment here ' +
-                    'to keep this PR open. Feel free to reopen a new PR later if it gets closed and ' +
-                    'you want to pick it back up.'
+                  `@${pr.user.login} — Please push a commit, respond to outstanding review feedback, ` +
+                    'or add a new comment to remove the `closing-soon` label and keep this PR open. ' +
+                    'Feel free to reopen a new PR later if it gets closed and you want to pick it back up.'
                 ].join('\n');
                 await github.rest.issues.createComment({
                   ...context.repo,

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -52,5 +52,31 @@ jobs:
                 issue_number: issue.number,
                 labels: [CLOSING]
               });
+
+              const marker = '<!-- openab-stale-issue-check -->';
+              const { data: comments } = await github.rest.issues.listComments({
+                ...context.repo,
+                issue_number: issue.number,
+                per_page: 100
+              });
+              const alreadyCommented = comments.some(c => c.body.includes(marker));
+              if (!alreadyCommented) {
+                const msg = [
+                  marker,
+                  '> [!CAUTION]',
+                  `> This issue has been waiting on the author for more than ${STALE_DAYS} days ` +
+                    `(labeled \`${CONTRIBUTOR}\` since ${labeledAt.toISOString().slice(0, 10)}).`,
+                  '> It will be **automatically closed in 24 hours** if there is no update.',
+                  '',
+                  `@${issue.user.login} — Please add a new comment to remove the \`closing-soon\` label ` +
+                    'and keep this issue open.'
+                ].join('\n');
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: issue.number,
+                  body: msg
+                });
+              }
+
               console.log(`#${issue.number} — ${CONTRIBUTOR} since ${labeledAt.toISOString()}, added ${CLOSING}`);
             }


### PR DESCRIPTION
## Summary

When the `closing-soon` label is added to stale PRs/issues, the author should be notified directly.

## Changes

**`stale-contributor.yml`** (PRs):
- Now tags `@author` in the closing-soon comment
- Updated message to clearly state: add a new comment to remove the label

**`stale-issue.yml`** (Issues):
- Added a comment (was missing entirely — only label was added silently)
- Tags `@author` with instructions to comment to keep the issue open

## Example Comment

> ⚠️ This PR has been waiting on the author for more than 2 days (labeled `pending-contributor` since 2026-07-05).
> It will be **automatically closed in 24 hours** if there is no update.
>
> @contributor — Please push a commit, respond to outstanding review feedback, or add a new comment to remove the `closing-soon` label and keep this PR open.