### PR TITLE
fix(ci): closing-soon must say 'add a new comment'

### DIFF
--- a/.github/workflows/stale-contributor.yml
+++ b/.github/workflows/stale-contributor.yml
@@ -68,8 +68,8 @@ jobs:
                     `(labeled \`${CONTRIBUTOR}\` since ${labeledAt.toISOString().slice(0, 10)}).`,
                   '> It will be **automatically closed in 24 hours** if there is no update.',
                   '',
-                  `@${pr.user.login} — Please push a commit, respond to outstanding review feedback, ` +
-                    'or add a new comment to remove the `closing-soon` label and keep this PR open. ' +
+                  `@${pr.user.login} — You **must add a new comment** on this PR to remove the \`closing-soon\` label ` +
+                    'and keep it open. Pushing commits alone is not sufficient. ' +
                     'Feel free to reopen a new PR later if it gets closed and you want to pick it back up.'
                 ].join('\n');
                 await github.rest.issues.createComment({

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -68,8 +68,8 @@ jobs:
                     `(labeled \`${CONTRIBUTOR}\` since ${labeledAt.toISOString().slice(0, 10)}).`,
                   '> It will be **automatically closed in 24 hours** if there is no update.',
                   '',
-                  `@${issue.user.login} — Please add a new comment to remove the \`closing-soon\` label ` +
-                    'and keep this issue open.'
+                  `@${issue.user.login} — You **must add a new comment** on this issue to remove the \`closing-soon\` label ` +
+                    'and keep it open.'
                 ].join('\n');
                 await github.rest.issues.createComment({
                   ...context.repo,


### PR DESCRIPTION
Pushing commits alone does not remove the `closing-soon` label. The author **must add a new comment** to signal activity. Updated both stale-contributor and stale-issue workflows.