### PR TITLE
fix(oabctl): restrict scale to oabctl-managed services only

### DIFF
--- a/docs/oabctl.md
+++ b/docs/oabctl.md
@@ -621,6 +621,11 @@ oabctl scale my-bot 1 --with-schedule 'rate(6 hours)'
 - `rate(value unit)` — e.g. `rate(1 hour)`, `rate(5 minutes)`
 - `at(yyyy-mm-ddThh:mm:ss)` — one-time execution
 
+### Restrictions
+
+- **Size: 0 or 1 only.** OAB services are single-instance (one bot token per service). Scaling above 1 would cause duplicate responses.
+- **oabctl-managed services only.** The `<name>` argument resolves as `oab-{namespace}-{name}` in the oab cluster. Use `oabctl get oabservice` to list available services. ecsctl aliases are not supported.
+
 ### Managing Schedules
 
 ```bash
@@ -636,15 +641,9 @@ oabctl schedule delete oab-scale-my-bot-to-0
 Uses **EventBridge Scheduler** with universal target (`arn:aws:scheduler:::aws-sdk:ecs:updateService`). No Lambda required. Auto-creates:
 
 - `oab-schedules` schedule group (idempotent)
-- `oab-scheduler-role` IAM role with `ecs:UpdateService` scoped to `service/*/oab-*` (wildcard cluster for multi-cluster support)
+- `oab-scheduler-role` IAM role with `ecs:UpdateService` scoped to `service/*/oab-*`
 
 The scheduler role includes confused-deputy protection (`aws:SourceAccount` + `aws:SourceArn` conditions).
-
-### Alias Resolution
-
-The `<alias>` argument supports:
-1. **ecsctl alias** — if the name matches an alias in `~/.ecsctl/config.toml`, uses that cluster/service
-2. **Bare agent name** — resolves as `oab-{namespace}-{name}` in the configured cluster
 
 ## JSON Schema
 

--- a/operator/src/scale.rs
+++ b/operator/src/scale.rs
@@ -48,6 +48,7 @@ async fn resolve_service(
 
 /// Immediate scale: delegates to ecsctl's scale_service for the core ECS call.
 pub async fn run(aws_config: &aws_config::SdkConfig, alias: &str, size: i32) -> Result<()> {
+    validate_size(size)?;
     let (cluster, service_name) = resolve_service(aws_config, alias).await?;
     let ecs = aws_sdk_ecs::Client::new(aws_config);
 
@@ -75,6 +76,19 @@ fn build_flexible_time_window() -> Result<aws_sdk_scheduler::types::FlexibleTime
         .mode(aws_sdk_scheduler::types::FlexibleTimeWindowMode::Off)
         .build()
         .context("failed to build flexible time window")
+}
+
+/// Validate scale size — OAB services are single-instance (one bot token per service).
+/// Only 0 (off) or 1 (on) is valid.
+fn validate_size(size: i32) -> Result<()> {
+    if size != 0 && size != 1 {
+        anyhow::bail!(
+            "invalid size: {}. OAB services can only scale to 0 (off) or 1 (on) — \
+             each service runs a single bot token and scaling above 1 would cause duplicate responses.",
+            size
+        );
+    }
+    Ok(())
 }
 
 /// Validate schedule expression format.
@@ -155,6 +169,7 @@ pub async fn run_with_schedule(
     schedule_expression: &str,
     timezone: Option<&str>,
 ) -> Result<()> {
+    validate_size(size)?;
     // Basic input validation for schedule expression
     validate_schedule_expression(schedule_expression)?;
 
@@ -659,5 +674,38 @@ mod tests {
     fn test_build_flexible_time_window() {
         let ftw = build_flexible_time_window();
         assert!(ftw.is_ok());
+    }
+
+    #[test]
+    fn test_validate_size_zero() {
+        assert!(validate_size(0).is_ok());
+    }
+
+    #[test]
+    fn test_validate_size_one() {
+        assert!(validate_size(1).is_ok());
+    }
+
+    #[test]
+    fn test_validate_size_rejects_two() {
+        let result = validate_size(2);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("invalid size: 2"));
+        assert!(err.contains("0 (off) or 1 (on)"));
+    }
+
+    #[test]
+    fn test_validate_size_rejects_negative() {
+        let result = validate_size(-1);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("invalid size: -1"));
+    }
+
+    #[test]
+    fn test_validate_size_rejects_large() {
+        let result = validate_size(100);
+        assert!(result.is_err());
     }
 }

--- a/operator/src/scale.rs
+++ b/operator/src/scale.rs
@@ -1,81 +1,49 @@
 use anyhow::{Context, Result};
 use aws_sdk_scheduler::error::ProvideErrorMetadata;
 
-/// Resolve an alias (or bare name) to (cluster, service_name).
-/// Supports:
-///   - ecsctl alias format: "cluster/service[/container[/task_id]]"
-///   - bare agent name: resolved as "oab-{namespace}-{name}" in the config cluster
+/// Resolve a service name to (cluster, service_name).
+/// Only resolves against oabctl-managed services (oab cluster, oab-* prefix).
+/// Does NOT use ecsctl aliases — scheduled scaling is for oabctl services only.
 async fn resolve_service(
     aws_config: &aws_config::SdkConfig,
-    alias_or_name: &str,
+    name: &str,
 ) -> Result<(String, String)> {
-    let ecsctl_cfg = match ecsctl::config::Config::load() {
-        Ok(cfg) => cfg,
-        Err(e) => {
-            eprintln!("  warning: failed to load ecsctl config: {e} — alias lookup disabled");
-            ecsctl::config::Config::default()
-        }
-    };
-
-    // Check if it's an ecsctl alias
-    if let Some(target) = ecsctl_cfg.aliases.get(alias_or_name) {
-        let parts: Vec<&str> = target.splitn(4, '/').collect();
-        if parts.len() >= 2 {
-            let cluster = parts[0].to_string();
-            let service_name = parts[1].to_string();
-            // Validate service exists and is scalable (same check as bare-name path)
-            validate_service_status(aws_config, &cluster, &service_name).await?;
-            return Ok((cluster, service_name));
-        }
-    }
-
-    // Not an alias — treat as bare agent name
-    eprintln!(
-        "  note: '{}' not found in ecsctl aliases, resolving as bare agent name",
-        alias_or_name
-    );
     let oab_cfg =
         crate::config::OabConfig::load().context("failed to load ~/.oabctl/config.toml")?;
     let cluster = oab_cfg.defaults.cluster;
     let namespace = oab_cfg.defaults.namespace;
-    let service_name = format!("oab-{}-{}", namespace, alias_or_name);
+    let service_name = format!("oab-{}-{}", namespace, name);
 
-    // Verify the service exists and is scalable
-    validate_service_status(aws_config, &cluster, &service_name).await?;
-
-    Ok((cluster, service_name))
-}
-
-/// Validate that a service exists and is in a scalable state (ACTIVE).
-async fn validate_service_status(
-    aws_config: &aws_config::SdkConfig,
-    cluster: &str,
-    service_name: &str,
-) -> Result<()> {
+    // Verify the service exists in the oab cluster
     let ecs = aws_sdk_ecs::Client::new(aws_config);
     let resp = ecs
         .describe_services()
-        .cluster(cluster)
-        .services(service_name)
+        .cluster(&cluster)
+        .services(&service_name)
         .send()
         .await
         .context("failed to describe ECS service")?;
 
-    let svc = resp.services().first().context(format!(
-        "service '{}' not found in cluster '{}'. Use 'oabctl get services' to list available services.",
-        service_name, cluster
-    ))?;
-
-    let status = svc.status().unwrap_or("UNKNOWN");
-    if status == "INACTIVE" || status == "DRAINING" {
-        anyhow::bail!(
-            "service '{}' is {} — cannot scale. Check service status with 'oabctl get services'.",
-            service_name,
-            status
-        );
+    let svc = resp.services().first();
+    match svc {
+        Some(s) if s.status() == Some("ACTIVE") => {}
+        Some(s) => {
+            let status = s.status().unwrap_or("UNKNOWN");
+            anyhow::bail!(
+                "service '{}' is {} — cannot scale. Use 'oabctl get oabservice' to list available services.",
+                name, status
+            );
+        }
+        None => {
+            anyhow::bail!(
+                "service '{}' not found. Use 'oabctl get oabservice' to list available services.\n\
+                 Note: oabctl scale only works with oabctl-managed services, not ecsctl aliases.",
+                name
+            );
+        }
     }
 
-    Ok(())
+    Ok((cluster, service_name))
 }
 
 /// Immediate scale: delegates to ecsctl's scale_service for the core ECS call.


### PR DESCRIPTION
## Summary

`oabctl scale` should only target oabctl-managed services (on the `oab` cluster), not arbitrary ecsctl aliases.

## Problem

Previously `oabctl scale b11 0` resolved via ecsctl aliases to `openab/openab-b11` (on the `openab` cluster). This:
1. Is outside oabctl's management scope
2. Breaks the scheduler IAM policy which is scoped to `oab-*` services
3. Violates separation of concerns between ecsctl (fleet ops) and oabctl (provisioner)

## Fix

- Removed ecsctl alias resolution from the scale command
- Only resolves as `oab-{namespace}-{name}` in the configured oab cluster
- Throws a clear error if service not found: `Use 'oabctl get oabservice' to list available services`
- Error also notes: `oabctl scale only works with oabctl-managed services, not ecsctl aliases`

## Behavior

```bash
# Works — oabctl-managed service
oabctl scale telegram-ingress-demo 0

# Fails with clear error — not an oabctl service
oabctl scale b11 0
# Error: service 'b11' not found. Use 'oabctl get oabservice' to list available services.
```