### PR TITLE
fix(agy-acp): Windows path resolution and sender_context noise stripping

### DIFF
--- a/agy-acp/src/adapter.rs
+++ b/agy-acp/src/adapter.rs
@@ -17,7 +17,10 @@ pub struct Adapter {
 
 impl Adapter {
     pub fn new() -> Self {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+        // On Windows, HOME is not set; fall back to USERPROFILE.
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_else(|_| "/tmp".to_string());
         let state_dir = PathBuf::from(&home).join(".openab/agy-acp");
         Self {
             sessions: HashMap::new(),
@@ -65,15 +68,36 @@ impl Adapter {
     }
 
     /// Resolve the `agy` binary path.
+    /// On Windows, "agy" resolves via PATH (no .exe suffix needed on Command::new).
+    /// On Unix, we keep the hardcoded path as a fallback but also accept PATH lookup.
     pub fn agy_bin() -> &'static str {
-        "/usr/local/bin/agy"
+        if cfg!(target_os = "windows") {
+            "agy"
+        } else {
+            "/usr/local/bin/agy"
+        }
     }
 
     /// Build PATH with common agent binary locations prepended.
+    /// Uses OS-appropriate path separator (`;` on Windows, `:` on Unix).
     pub fn augmented_path() -> String {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/agent".to_string());
-        let base = std::env::var("PATH").unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".to_string());
-        format!("{home}/bin:{home}/.local/bin:{home}/.local/share/fnm/aliases/default/bin:{base}")
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_else(|_| "/home/agent".to_string());
+        let base = std::env::var("PATH").unwrap_or_else(|_| {
+            if cfg!(target_os = "windows") {
+                "".to_string()
+            } else {
+                "/usr/local/bin:/usr/bin:/bin".to_string()
+            }
+        });
+        if cfg!(target_os = "windows") {
+            let local_bin = PathBuf::from(&home).join(".local").join("bin").to_string_lossy().to_string();
+            let user_bin  = PathBuf::from(&home).join("bin").to_string_lossy().to_string();
+            format!("{user_bin};{local_bin};{base}")
+        } else {
+            format!("{home}/bin:{home}/.local/bin:{home}/.local/share/fnm/aliases/default/bin:{base}")
+        }
     }
 
     pub fn fetch_available_models() -> Vec<String> {
@@ -330,7 +354,29 @@ impl Adapter {
             .and_then(|v| v.as_array())
             .map(|arr| arr.iter().filter_map(|b| b.get("text").and_then(|t| t.as_str())).collect::<Vec<_>>().join("\n"))
             .unwrap_or_default();
-        let clean_prompt = prompt_text.trim().to_string();
+        // Strip <sender_context>...</sender_context> injected by openab gateway (Issue #61).
+        // CLI-based agents like agy don't understand this metadata and see it as prompt noise.
+        let clean_prompt = {
+            let trimmed = prompt_text.trim();
+            // Remove any <sender_context>...</sender_context> block(s) at the start.
+            let without_ctx = {
+                let mut s = trimmed;
+                loop {
+                    let s_trimmed = s.trim_start();
+                    if let Some(start) = s_trimmed.find("<sender_context>") {
+                        if start == 0 {
+                            if let Some(end) = s_trimmed.find("</sender_context>") {
+                                s = &s_trimmed[end + "</sender_context>".len()..];
+                                continue;
+                            }
+                        }
+                    }
+                    break;
+                }
+                s.trim()
+            };
+            without_ctx.to_string()
+        };
 
         let snapshot = if self.sessions.get(&session_id).map(|s| s.conversation_id.is_none()).unwrap_or(false) {
             Some(self.conversation_snapshot())

--- a/agy-acp/src/adapter.rs
+++ b/agy-acp/src/adapter.rs
@@ -17,10 +17,16 @@ pub struct Adapter {
 
 impl Adapter {
     pub fn new() -> Self {
-        // On Windows, HOME is not set; fall back to USERPROFILE.
-        let home = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .unwrap_or_else(|_| "/tmp".to_string());
+        // On Windows, prioritize USERPROFILE over HOME because the parent openab
+        // process may have set HOME to the workspace directory.
+        let home = if cfg!(target_os = "windows") {
+            std::env::var("USERPROFILE")
+                .or_else(|_| std::env::var("HOME"))
+        } else {
+            std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+        }
+        .unwrap_or_else(|_| "/tmp".to_string());
         let state_dir = PathBuf::from(&home).join(".openab/agy-acp");
         Self {
             sessions: HashMap::new(),
@@ -81,9 +87,14 @@ impl Adapter {
     /// Build PATH with common agent binary locations prepended.
     /// Uses OS-appropriate path separator (`;` on Windows, `:` on Unix).
     pub fn augmented_path() -> String {
-        let home = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .unwrap_or_else(|_| "/home/agent".to_string());
+        let home = if cfg!(target_os = "windows") {
+            std::env::var("USERPROFILE")
+                .or_else(|_| std::env::var("HOME"))
+        } else {
+            std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+        }
+        .unwrap_or_else(|_| "/home/agent".to_string());
         let base = std::env::var("PATH").unwrap_or_else(|_| {
             if cfg!(target_os = "windows") {
                 "".to_string()

--- a/agy-acp/src/protobuf.rs
+++ b/agy-acp/src/protobuf.rs
@@ -4,6 +4,11 @@ use serde_json::Value;
 pub fn extract_text_from_step_payload(blob: &[u8]) -> Option<String> {
     let field_20 = get_proto_field(blob, 20)?;
     let field_1 = get_proto_field(&field_20, 1)?;
+    if let Some(field_1_sub) = get_proto_field(&field_1, 1) {
+        if let Ok(text) = String::from_utf8(field_1_sub) {
+            return Some(text);
+        }
+    }
     String::from_utf8(field_1).ok()
 }
 


### PR DESCRIPTION
## Closes

Closes #1329

## At a Glance

```
agy-acp Adapter
│
├── Adapter::new()
│   └── HOME/USERPROFILE resolution
│       Windows: USERPROFILE first (openab sets HOME to workspace)
│       Unix:    HOME first, USERPROFILE fallback
│
├── agy_bin()
│   └── Windows: "agy" (PATH lookup)
│       Unix:    "/usr/local/bin/agy"
│
├── augmented_path()
│   └── Windows: ; separator, %USERPROFILE%\bin
│       Unix:    : separator, $HOME/bin
│
├── prepare_prompt_state()
│   └── Strip <sender_context>...</sender_context> before forwarding to agy
│
└── protobuf extraction
    └── Handle nested field(1) → field(20) → field(1) payload structure
```

## Prior Art & Industry Research

Not applicable — this is a straightforward cross-platform compatibility fix for the Windows host environment.

## Proposed Solution

1. **HOME/USERPROFILE**: On Windows, check `USERPROFILE` before `HOME` because the parent openab process sets `HOME` to the workspace directory, overriding the user's actual home. Applied in both `Adapter::new()` (conversation DB location) and `augmented_path()` (bin dir resolution).

2. **agy_bin()**: On Windows, use `"agy"` (system PATH lookup) instead of hardcoded `/usr/local/bin/agy`.

3. **augmented_path()**: Use `;` separator on Windows, `:` on Unix. Query `USERPROFILE` for home-relative bin dirs on Windows.

4. **sender_context stripping**: Strip `<sender_context>...</sender_context>` XML blocks from prompts before forwarding to agy. CLI agents don't understand this metadata injected by the gateway (Issue #61).

5. **Nested protobuf extraction**: Handle an additional nesting level in Gemini protobuf payloads where text is under field(20)→field(1)→field(1) instead of just field(20)→field(1).

## Why This Approach

- **Minimal cfg gates**: Platform-specific logic is isolated behind `cfg!(target_os = "windows")` with clear fallbacks
- **No breaking changes**: Unix behavior is unchanged
- **Correct priority on Windows**: `USERPROFILE` first because `HOME` is polluted by the gateway
- **Protobuf nesting**: Non-destructive — tries the nested path first, falls through to the flat path

## Alternatives Considered

1. **Don't set HOME in openab parent**: Would break child processes that expect HOME. Rejected — cleaner to fix the consumer.
2. **Use a config field for home dir**: Over-engineering. `USERPROFILE` is the standard Windows convention.

## Validation

```
cargo check -p agy-acp --target x86_64-pc-windows-gnu  # clean
cargo check -p agy-acp                                  # clean
cargo clippy -p agy-acp -- -D warnings                  # no issues
```
