### PR TITLE
docs: add AWS Secrets Manager path for GitHub token setup

### DIFF
--- a/docs/github-token-setup.md
+++ b/docs/github-token-setup.md
@@ -4,7 +4,23 @@ Step-by-step guide to give your agent secure access to GitHub via `gh` CLI.
 
 ## Overview
 
-Agents sometimes need to interact with GitHub — push branches, open PRs, comment on issues. The recommended approach is to store a GitHub fine-grained personal access token in a Kubernetes secret and inject it via the Helm chart's `envFrom`.
+Agents sometimes need to interact with GitHub — push branches, open PRs, comment on issues. The recommended approach is to store a GitHub fine-grained personal access token centrally (AWS Secrets Manager for ECS, or a Kubernetes secret for k8s) and inject it into the agent's environment.
+
+### OAuth device flow vs. PAT stored in Secrets Manager
+
+Some backends (`gh auth login` device flow, `codex login --device-auth`, etc.) authenticate interactively and store a session token on disk inside the container. This works but has tradeoffs versus a PAT resolved from Secrets Manager at boot:
+
+| | OAuth device flow | PAT in Secrets Manager (`aws-sm://`) |
+|---|---|---|
+| **Setup** | Manual — exec into each container, run `gh auth login`, complete browser flow | One-time secret creation; every new/restarted task picks it up automatically |
+| **Survives restart** | No — lost unless persisted to a volume (EFS/PVC); container restart on ephemeral storage requires re-auth | Yes — resolved fresh from Secrets Manager on every boot, no persistent volume needed |
+| **Centralized rotation** | No — each container's token is independent; rotating means re-authenticating every instance | Yes — rotate once in Secrets Manager, all consumers get the new value on next restart |
+| **Access control** | Tied to the OAuth app's scopes granted at login time; revocation happens on GitHub's side per-token | IAM-based — grant/revoke `secretsmanager:GetSecretValue` on the task role; no GitHub-side action needed |
+| **Multi-bot sharing** | Each bot needs its own interactive login | One secret + one IAM grant can be shared read-only across many bots (e.g. `OAB_BX_GITHUB_PAT_RO`) |
+| **Audit trail** | GitHub's OAuth app authorization log only | CloudTrail logs every `GetSecretValue` call — who/what/when |
+| **Best for** | The single "lead" bot that needs write access under its own GitHub identity | Fleets of read-only bots, or any ECS/Fargate deployment without persistent storage |
+
+In practice: use OAuth device flow for the one bot that needs to push/comment as itself (see [gh-auth-device-flow.md](gh-auth-device-flow.md)), and a shared read-only PAT via Secrets Manager for the rest of the fleet.
 
 ## 1. Create a Fine-Grained Personal Access Token
 
@@ -21,7 +37,96 @@ Agents sometimes need to interact with GitHub — push branches, open PRs, comme
      - Workflows: Read and write (if the agent needs to modify workflows)
 4. Click **Generate token** and copy it immediately
 
-## 2. Store the Token in a Kubernetes Secret
+## 2. Store the Token
+
+Choose the approach that matches your deployment target.
+
+### Option A: AWS Secrets Manager (`aws-sm://`) — recommended for ECS
+
+If you're running on ECS (or any AWS deployment), this is the recommended pattern. It has three parts:
+
+1. **Centralized PAT storage** — the GitHub PAT lives in AWS Secrets Manager, not scattered across task definitions, Helm values, or shell history. One secret can be shared across multiple agents/bots that need read-only GitHub access, with rotation handled in one place.
+2. **IAM role for access control** — only task roles explicitly granted `secretsmanager:GetSecretValue` on that secret ARN can read it. This is your access boundary: revoke the IAM permission and every agent using that role loses access immediately, no need to rotate the token itself.
+3. **Secret ref → agent env inheritance** — `config.toml`'s `[secrets.refs]` resolves the secret in-memory at boot and injects it into `[agent].env` as `GITHUB_TOKEN`. Because the agent process inherits its parent's environment, `gh` (and any other tool that reads `GITHUB_TOKEN`) picks it up automatically when the agent runs `gh` commands — no separate auth step.
+
+```
+┌───────────────────────────┐
+│  AWS Secrets Manager      │
+│  openab/github            │
+│  { "github_pat": "..." }  │
+└─────────────┬─────────────┘
+              │ secretsmanager:GetSecretValue
+              │ (only allowed for roles granted below)
+              ▼
+┌───────────────────────────┐
+│  ECS Task Role            │  ← IAM access control boundary
+│  openab-ecs-task-role     │    (grant/revoke here, not the token)
+└─────────────┬─────────────┘
+              │ resolved in-memory at boot
+              ▼
+┌───────────────────────────┐
+│  config.toml               │
+│  [secrets.refs]             │
+│  github_token = "aws-sm://openab/github#github_pat"
+└─────────────┬─────────────┘
+              │ ${secrets.github_token}
+              ▼
+┌───────────────────────────┐
+│  [agent].env                │
+│  GITHUB_TOKEN = "${secrets.github_token}"
+└─────────────┬─────────────┘
+              │ inherited by child process
+              ▼
+┌───────────────────────────┐
+│  Agent process (kiro-cli,  │
+│  codex, etc.)               │
+│    └─ gh pr create          │  ← gh CLI reads GITHUB_TOKEN
+│         (auto-authenticated,│    from its own env, no
+│          no gh auth login)  │    separate login step
+└───────────────────────────┘
+```
+
+**Step 1 — store the token** (as a JSON key in a secret; can share a secret with other keys):
+
+```bash
+aws secretsmanager create-secret \
+  --name openab/github \
+  --secret-string '{"github_pat":"<YOUR_GITHUB_TOKEN>"}'
+```
+
+**Step 2 — grant IAM access.** Add `secretsmanager:GetSecretValue` on that secret's ARN to the ECS task role (this is the access control boundary — only roles with this permission can resolve the secret):
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["secretsmanager:GetSecretValue"],
+  "Resource": "arn:aws:secretsmanager:<region>:<account-id>:secret:openab/github-*"
+}
+```
+
+**Step 3 — reference it in `config.toml`** via `[secrets.refs]`, then wire it into `[agent].env` as `GITHUB_TOKEN` so the agent process (and any `gh` invocation inside it) inherits it:
+
+```toml
+[secrets.refs]
+github_token = "aws-sm://openab/github#github_pat"
+
+[agent]
+env = { GITHUB_TOKEN = "${secrets.github_token}" }
+```
+
+See [secrets-management.md](secrets-management.md) for the full `aws-sm://` reference format, including how to point at a shared secret with multiple keys (e.g. a fleet-wide read-only PAT reused across several bots):
+
+```toml
+[secrets.refs]
+github_token = "aws-sm://oab#OAB_BX_GITHUB_PAT_RO"
+
+[agent]
+env = { GITHUB_TOKEN = "${secrets.github_token}" }
+```
+
+This keeps the token out of the task definition, container environment dumps, and shell history — it's resolved in-memory at boot from Secrets Manager and only reachable by roles you've explicitly granted access to.
+
+### Option B: Kubernetes Secret — for k8s deployments
 
 Create a dedicated secret for the GitHub token:
 
@@ -30,7 +135,7 @@ kubectl create secret generic gh-token-secret \
   --from-literal=gh-token="<YOUR_GITHUB_TOKEN>"
 ```
 
-## 3. Inject via Helm Chart
+## 3. Inject via Helm Chart (k8s only)
 
 Use `envFrom` in your Helm values to inject the token as `GH_TOKEN`:
 
@@ -50,7 +155,7 @@ helm install openab openab/openab \
   --set env.GH_TOKEN="<YOUR_GITHUB_TOKEN>"
 ```
 
-The `gh` CLI automatically picks up `GH_TOKEN` — no additional auth setup needed.
+The `gh` CLI automatically picks up `GH_TOKEN` (or `GITHUB_TOKEN`, used by the AWS Secrets Manager path in Option A above) — no additional auth setup needed.
 
 ## 4. Install `gh` CLI in the Agent Container
 
@@ -93,7 +198,7 @@ The agent can now run `gh` commands: `gh pr create`, `gh issue comment`, `gh rep
 
 ## Troubleshooting
 
-- **`gh auth status` fails** — check that `GH_TOKEN` env var is set: `echo ${GH_TOKEN:+exists}`
+- **`gh auth status` fails** — check that `GH_TOKEN` or `GITHUB_TOKEN` is set: `echo ${GH_TOKEN:+exists}${GITHUB_TOKEN:+exists}`
 - **Permission denied on push** — the token's repo access doesn't include the target repo, or write permission is missing
 - **403 on PR create** — the token needs Pull requests: Read and write permission
 - **Token expired** — generate a new one and update the k8s secret

--- a/docs/github-token-setup.md
+++ b/docs/github-token-setup.md
@@ -8,7 +8,9 @@ Agents sometimes need to interact with GitHub — push branches, open PRs, comme
 
 ### OAuth device flow vs. PAT stored in Secrets Manager
 
-Some backends (`gh auth login` device flow, `codex login --device-auth`, etc.) authenticate interactively and store a session token on disk inside the container. This works but has tradeoffs versus a PAT resolved from Secrets Manager at boot:
+**OAuth device flow** is ad-hoc authentication/authorization — you run `gh auth login` (or `codex login --device-auth`, etc.) interactively, complete a browser flow, and the resulting token is generated and persisted under `$HOME/` inside the container.
+
+**PAT in Secrets Manager** is the opposite: the token is pre-generated once from the GitHub console (Step 1 below), then stored and protected in AWS Secrets Manager with IAM access control — no interactive step, no per-container state.
 
 | | OAuth device flow | PAT in Secrets Manager (`aws-sm://`) |
 |---|---|---|


### PR DESCRIPTION
## Summary

Adds an AWS Secrets Manager (`aws-sm://`) path to `docs/github-token-setup.md`, alongside the existing Kubernetes secret + Helm `envFrom` approach (now Option B).

## What's new

1. **Overview comparison table** — OAuth device flow vs. PAT stored in Secrets Manager, covering setup, restart survival, rotation, access control, multi-bot sharing, and audit trail. Guidance: OAuth device flow for the one "lead" bot that pushes/comments as itself, shared read-only PAT via Secrets Manager for the rest of the fleet.

2. **Option A: AWS Secrets Manager** — three-part model:
   - **Centralized PAT storage** in Secrets Manager (shareable across bots)
   - **IAM role as the access control boundary** (`secretsmanager:GetSecretValue` scoped to the secret ARN — grant/revoke here, not the token)
   - **`[secrets.refs]` → `[agent].env` inheritance** — resolved in-memory at boot, injected as `GITHUB_TOKEN`, inherited by the agent's child process so `gh` CLI works with no separate `gh auth login` step

3. **ASCII diagram** showing the flow: Secrets Manager → IAM task role → `config.toml` → `[agent].env` → agent process → `gh` CLI.

4. Real example from the OAB fleet (`aws-sm://oab#OAB_BX_GITHUB_PAT_RO`) showing a shared read-only PAT reused across multiple bots via one `[secrets.refs]` entry.

## Verified

- Cross-referenced against `docs/secrets-management.md` for the `aws-sm://` syntax (matches existing convention)
- Confirmed `docs/gh-auth-device-flow.md` exists before linking to it
- No changes to existing Kubernetes/Helm instructions — purely additive