### PR TITLE
fix(slack): bound reconnect-path and socket-write network calls with timeouts

### DIFF
--- a/crates/openab-core/Cargo.toml
+++ b/crates/openab-core/Cargo.toml
@@ -51,6 +51,9 @@ http = { version = "1", optional = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }
+
 [features]
 default = ["discord", "slack", "secrets-aws", "agentcore", "config-s3"]
 discord = ["dep:serenity"]

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -711,6 +711,40 @@ const RECONNECT_TIMEOUT_SECS: u64 = 30;
 /// backstop for the rare case the client builder failed and fell back to an
 /// unbounded `reqwest::Client::new()` (see #1279).
 const RECONNECT_HTTP_TIMEOUT_SECS: u64 = 35;
+/// Bounds outbound `write.send(...)` calls in the live socket loop. The
+/// inbound half-open case is guarded by `IDLE_TIMEOUT_SECS`, but a stalled
+/// *outbound* send parks the loop inside that `select!` branch forever too —
+/// and since it can never reach `ping_interval.tick()`, the idle watchdog
+/// itself becomes unreachable. Same bug class as #1279, on the write side.
+const WRITE_TIMEOUT_SECS: u64 = 10;
+
+/// The Socket Mode WebSocket write half, as produced by splitting the stream
+/// returned from `connect_with_reconnect_timeout`. Named so the nested
+/// generic doesn't have to be repeated at every `send_with_timeout` call
+/// site.
+type SlackWsSink = futures_util::stream::SplitSink<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+    tungstenite::Message,
+>;
+
+/// Result of `connect_with_reconnect_timeout`: the outer `Result` is the
+/// timeout, the inner `Result` is `connect_async`'s own outcome.
+type ConnectResult = std::result::Result<
+    std::result::Result<
+        (
+            tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+            >,
+            tungstenite::handshake::client::Response,
+        ),
+        tungstenite::Error,
+    >,
+    tokio::time::error::Elapsed,
+>;
+
+/// Result of `get_socket_mode_url_with_timeout`: `Err` is the outer timeout;
+/// `Ok` carries `get_socket_mode_url`'s own `anyhow::Result`.
+type SocketModeUrlResult = std::result::Result<Result<String>, tokio::time::error::Elapsed>;
 
 /// Next reconnect delay: double, capped. Reset to 1 on a successful connect.
 fn next_backoff(cur: u64) -> u64 {
@@ -720,21 +754,25 @@ fn next_backoff(cur: u64) -> u64 {
 /// Wraps `connect_async` in the reconnect-path timeout. Extracted so the
 /// regression test exercises the exact same code path `run_slack_adapter`
 /// uses, instead of duplicating the timeout expression (#1279).
-async fn connect_with_reconnect_timeout(
-    ws_url: &str,
-) -> std::result::Result<
-    std::result::Result<
-        (
-            tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
-            tungstenite::handshake::client::Response,
-        ),
-        tungstenite::Error,
-    >,
-    tokio::time::error::Elapsed,
-> {
+async fn connect_with_reconnect_timeout(ws_url: &str) -> ConnectResult {
     tokio::time::timeout(
         std::time::Duration::from_secs(RECONNECT_TIMEOUT_SECS),
         tokio_tungstenite::connect_async(ws_url),
+    )
+    .await
+}
+
+/// Send `msg` on `write`, bounded by `WRITE_TIMEOUT_SECS`. Mirrors
+/// `connect_with_reconnect_timeout`: extracted so every write in the live
+/// socket loop shares one bounded-send implementation instead of each call
+/// site duplicating (or omitting) the timeout.
+async fn send_with_timeout(
+    write: &mut SlackWsSink,
+    msg: tungstenite::Message,
+) -> std::result::Result<std::result::Result<(), tungstenite::Error>, tokio::time::error::Elapsed> {
+    tokio::time::timeout(
+        std::time::Duration::from_secs(WRITE_TIMEOUT_SECS),
+        write.send(msg),
     )
     .await
 }
@@ -792,12 +830,7 @@ pub async fn run_slack_adapter(
             return Ok(());
         }
 
-        let ws_url = match tokio::time::timeout(
-            std::time::Duration::from_secs(RECONNECT_HTTP_TIMEOUT_SECS),
-            get_socket_mode_url(&adapter.client, &app_token),
-        )
-        .await
-        {
+        let ws_url = match get_socket_mode_url_with_timeout(&adapter.client, &app_token).await {
             Ok(Ok(url)) => url,
             Ok(Err(e)) => {
                 error!(err = %e, backoff = backoff_secs, "failed to get Socket Mode URL, retrying");
@@ -848,9 +881,19 @@ pub async fn run_slack_adapter(
                                     // Acknowledge the envelope immediately
                                     if let Some(envelope_id) = envelope["envelope_id"].as_str() {
                                         let ack = serde_json::json!({"envelope_id": envelope_id});
-                                        let _ = write
-                                            .send(tungstenite::Message::Text(ack.to_string()))
-                                            .await;
+                                        if send_with_timeout(
+                                            &mut write,
+                                            tungstenite::Message::Text(ack.to_string()),
+                                        )
+                                        .await
+                                        .is_err()
+                                        {
+                                            warn!(
+                                                timeout = WRITE_TIMEOUT_SECS,
+                                                "Slack Socket Mode envelope ack timed out, reconnecting"
+                                            );
+                                            break;
+                                        }
                                     }
 
                                     // Slash commands and interactive block_actions aren't
@@ -1174,7 +1217,16 @@ pub async fn run_slack_adapter(
                                     }
                                 }
                                 Ok(tungstenite::Message::Ping(data)) => {
-                                    let _ = write.send(tungstenite::Message::Pong(data)).await;
+                                    if send_with_timeout(&mut write, tungstenite::Message::Pong(data))
+                                        .await
+                                        .is_err()
+                                    {
+                                        warn!(
+                                            timeout = WRITE_TIMEOUT_SECS,
+                                            "Slack Socket Mode pong send timed out, reconnecting"
+                                        );
+                                        break;
+                                    }
                                 }
                                 Ok(tungstenite::Message::Close(_)) => {
                                     warn!("Slack Socket Mode connection closed by server");
@@ -1198,14 +1250,24 @@ pub async fn run_slack_adapter(
                                 );
                                 break;
                             }
-                            if let Err(e) = write.send(tungstenite::Message::Ping(Vec::new())).await {
-                                warn!(error = %e, "Slack Socket Mode ping failed, reconnecting");
-                                break;
+                            match send_with_timeout(&mut write, tungstenite::Message::Ping(Vec::new())).await {
+                                Ok(Err(e)) => {
+                                    warn!(error = %e, "Slack Socket Mode ping failed, reconnecting");
+                                    break;
+                                }
+                                Err(_) => {
+                                    warn!(
+                                        timeout = WRITE_TIMEOUT_SECS,
+                                        "Slack Socket Mode ping timed out, reconnecting"
+                                    );
+                                    break;
+                                }
+                                Ok(Ok(())) => {}
                             }
                         }
                         _ = shutdown_rx.changed() => {
                             info!("Slack adapter received shutdown signal");
-                            let _ = write.send(tungstenite::Message::Close(None)).await;
+                            let _ = send_with_timeout(&mut write, tungstenite::Message::Close(None)).await;
                             return Ok(());
                         }
                     }
@@ -1253,6 +1315,21 @@ async fn get_socket_mode_url(client: &reqwest::Client, app_token: &str) -> Resul
         .as_str()
         .map(|s| s.to_string())
         .ok_or_else(|| anyhow!("no url in apps.connections.open response"))
+}
+
+/// Wraps `get_socket_mode_url` in the reconnect-path HTTP timeout. Extracted
+/// (mirroring `connect_with_reconnect_timeout`) so the regression test calls
+/// the same production code path `run_slack_adapter` uses, instead of
+/// duplicating the timeout expression.
+async fn get_socket_mode_url_with_timeout(
+    client: &reqwest::Client,
+    app_token: &str,
+) -> SocketModeUrlResult {
+    tokio::time::timeout(
+        std::time::Duration::from_secs(RECONNECT_HTTP_TIMEOUT_SECS),
+        get_socket_mode_url(client, app_token),
+    )
+    .await
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2388,8 +2465,8 @@ mod tests {
 #[cfg(test)]
 mod socket_keepalive_tests {
     use super::{
-        connect_with_reconnect_timeout, next_backoff, socket_idle, wait_backoff_or_shutdown,
-        IDLE_TIMEOUT_SECS, MAX_BACKOFF_SECS,
+        connect_with_reconnect_timeout, get_socket_mode_url_with_timeout, next_backoff,
+        socket_idle, wait_backoff_or_shutdown, IDLE_TIMEOUT_SECS, MAX_BACKOFF_SECS,
     };
     use std::time::Duration;
 
@@ -2447,6 +2524,40 @@ mod socket_keepalive_tests {
         assert!(
             result.is_err(),
             "connect_async on a stalled handshake must time out, not hang"
+        );
+    }
+
+    /// Regression test for #1279 (the HTTP leg): a stalled `apps.connections.open`
+    /// call during reconnect must surface as a timeout instead of parking the
+    /// reconnect task forever. Overrides DNS resolution for `slack.com` to a
+    /// local listener that accepts the TCP connection and never responds, so
+    /// the client's TLS handshake stalls exactly like a silently-dropped peer
+    /// would. Calls `get_socket_mode_url_with_timeout` directly (the same
+    /// helper `run_slack_adapter` calls) so this pins the actual production
+    /// code path, mirroring `connect_async_timeout_fires_on_stalled_handshake`
+    /// above.
+    #[tokio::test(start_paused = true)]
+    async fn get_socket_mode_url_timeout_fires_on_stalled_http_call() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind local listener");
+        let addr = listener.local_addr().expect("local addr");
+
+        tokio::spawn(async move {
+            let _socket = listener.accept().await.expect("accept");
+            std::future::pending::<()>().await;
+        });
+
+        let client = reqwest::Client::builder()
+            .resolve("slack.com", addr)
+            .build()
+            .expect("build client");
+
+        let result = get_socket_mode_url_with_timeout(&client, "xapp-test-token").await;
+
+        assert!(
+            result.is_err(),
+            "get_socket_mode_url on a stalled HTTP call must time out, not hang"
         );
     }
 

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -881,18 +881,30 @@ pub async fn run_slack_adapter(
                                     // Acknowledge the envelope immediately
                                     if let Some(envelope_id) = envelope["envelope_id"].as_str() {
                                         let ack = serde_json::json!({"envelope_id": envelope_id});
-                                        if send_with_timeout(
+                                        // Reconnect before dispatch if the ack cannot be written;
+                                        // Slack redelivers unacked envelopes, avoiding work it
+                                        // still considers pending.
+                                        match send_with_timeout(
                                             &mut write,
                                             tungstenite::Message::Text(ack.to_string()),
                                         )
                                         .await
-                                        .is_err()
                                         {
-                                            warn!(
-                                                timeout = WRITE_TIMEOUT_SECS,
-                                                "Slack Socket Mode envelope ack timed out, reconnecting"
-                                            );
-                                            break;
+                                            Ok(Err(e)) => {
+                                                warn!(
+                                                    error = %e,
+                                                    "Slack Socket Mode envelope ack failed, reconnecting"
+                                                );
+                                                break;
+                                            }
+                                            Err(_) => {
+                                                warn!(
+                                                    timeout = WRITE_TIMEOUT_SECS,
+                                                    "Slack Socket Mode envelope ack timed out, reconnecting"
+                                                );
+                                                break;
+                                            }
+                                            Ok(Ok(())) => {}
                                         }
                                     }
 
@@ -1217,15 +1229,27 @@ pub async fn run_slack_adapter(
                                     }
                                 }
                                 Ok(tungstenite::Message::Ping(data)) => {
-                                    if send_with_timeout(&mut write, tungstenite::Message::Pong(data))
-                                        .await
-                                        .is_err()
+                                    match send_with_timeout(
+                                        &mut write,
+                                        tungstenite::Message::Pong(data),
+                                    )
+                                    .await
                                     {
-                                        warn!(
-                                            timeout = WRITE_TIMEOUT_SECS,
-                                            "Slack Socket Mode pong send timed out, reconnecting"
-                                        );
-                                        break;
+                                        Ok(Err(e)) => {
+                                            warn!(
+                                                error = %e,
+                                                "Slack Socket Mode pong send failed, reconnecting"
+                                            );
+                                            break;
+                                        }
+                                        Err(_) => {
+                                            warn!(
+                                                timeout = WRITE_TIMEOUT_SECS,
+                                                "Slack Socket Mode pong send timed out, reconnecting"
+                                            );
+                                            break;
+                                        }
+                                        Ok(Ok(())) => {}
                                     }
                                 }
                                 Ok(tungstenite::Message::Close(_)) => {

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -699,14 +699,36 @@ const MAX_CONSECUTIVE_BOT_TURNS: usize = 1000;
 const PING_INTERVAL_SECS: u64 = 30;
 const IDLE_TIMEOUT_SECS: u64 = 75;
 const MAX_BACKOFF_SECS: u64 = 30;
-/// Bounds `get_socket_mode_url` and `connect_async` in the reconnect path so a
-/// stalled TCP/TLS handshake surfaces as a retry instead of parking the
-/// reconnect task forever with no logs (see #1279).
+/// Bounds `connect_async` (the WebSocket handshake) in the reconnect path.
+/// `tokio_tungstenite` carries no timeout of its own, so this is the sole
+/// bound against a stalled TLS/WS handshake parking the reconnect task
+/// forever with no logs (see #1279).
 const RECONNECT_TIMEOUT_SECS: u64 = 30;
+/// Bounds `get_socket_mode_url` (the `apps.connections.open` Web API call) in
+/// the reconnect path. Set strictly above the adapter client's own 30s
+/// timeout (see `SlackAdapter::new`) so that timeout — which carries a
+/// diagnosable cause — fires first in the normal case; this constant is a
+/// backstop for the rare case the client builder failed and fell back to an
+/// unbounded `reqwest::Client::new()` (see #1279).
+const RECONNECT_HTTP_TIMEOUT_SECS: u64 = 35;
 
 /// Next reconnect delay: double, capped. Reset to 1 on a successful connect.
 fn next_backoff(cur: u64) -> u64 {
     (cur * 2).min(MAX_BACKOFF_SECS)
+}
+
+/// Sleep for `backoff_secs`, honoring shutdown. Returns the next backoff
+/// value, or `None` if a shutdown signal arrived during the sleep (caller
+/// should return immediately). Shared by every retry point in the reconnect
+/// loop so backoff/shutdown handling only needs to change in one place.
+async fn wait_backoff_or_shutdown(
+    backoff_secs: u64,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) -> Option<u64> {
+    tokio::select! {
+        _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => Some(next_backoff(backoff_secs)),
+        _ = shutdown_rx.changed() => None,
+    }
 }
 
 /// The socket is considered dead (half-open) when no inbound frame has arrived
@@ -749,7 +771,7 @@ pub async fn run_slack_adapter(
         }
 
         let ws_url = match tokio::time::timeout(
-            std::time::Duration::from_secs(RECONNECT_TIMEOUT_SECS),
+            std::time::Duration::from_secs(RECONNECT_HTTP_TIMEOUT_SECS),
             get_socket_mode_url(&adapter.client, &app_token),
         )
         .await
@@ -757,24 +779,22 @@ pub async fn run_slack_adapter(
             Ok(Ok(url)) => url,
             Ok(Err(e)) => {
                 error!(err = %e, backoff = backoff_secs, "failed to get Socket Mode URL, retrying");
-                tokio::select! {
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
-                    _ = shutdown_rx.changed() => { return Ok(()); }
+                match wait_backoff_or_shutdown(backoff_secs, &mut shutdown_rx).await {
+                    Some(next) => backoff_secs = next,
+                    None => return Ok(()),
                 }
-                backoff_secs = next_backoff(backoff_secs);
                 continue;
             }
             Err(_) => {
                 error!(
                     backoff = backoff_secs,
-                    timeout = RECONNECT_TIMEOUT_SECS,
+                    timeout = RECONNECT_HTTP_TIMEOUT_SECS,
                     "get Socket Mode URL timed out, retrying"
                 );
-                tokio::select! {
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
-                    _ = shutdown_rx.changed() => { return Ok(()); }
+                match wait_backoff_or_shutdown(backoff_secs, &mut shutdown_rx).await {
+                    Some(next) => backoff_secs = next,
+                    None => return Ok(()),
                 }
-                backoff_secs = next_backoff(backoff_secs);
                 continue;
             }
         };
@@ -1187,18 +1207,19 @@ pub async fn run_slack_adapter(
         }
 
         warn!(backoff = backoff_secs, "reconnecting to Slack Socket Mode");
-        tokio::select! {
-            _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
-            _ = shutdown_rx.changed() => { return Ok(()); }
+        match wait_backoff_or_shutdown(backoff_secs, &mut shutdown_rx).await {
+            Some(next) => backoff_secs = next,
+            None => return Ok(()),
         }
-        backoff_secs = next_backoff(backoff_secs);
     }
 }
 
 /// Call apps.connections.open to get a WebSocket URL for Socket Mode.
-/// Reuses the adapter's `reqwest::Client` (already bounded by a 30s timeout,
-/// see `SlackAdapter::new`) instead of building a fresh unbounded one per call
-/// (#386), and relies on that timeout to bound the reconnect path (#1279).
+/// Reuses the adapter's `reqwest::Client` instead of building a fresh
+/// unbounded one per call (#386). The reconnect path is bounded by the
+/// caller's explicit `tokio::time::timeout(RECONNECT_HTTP_TIMEOUT_SECS, ...)`
+/// (see #1279); the client's own 30s timeout (see `SlackAdapter::new`) is a
+/// secondary bound that fires first in the normal case, since it's shorter.
 async fn get_socket_mode_url(client: &reqwest::Client, app_token: &str) -> Result<String> {
     let resp = client
         .post(format!("{SLACK_API}/apps.connections.open"))
@@ -2349,7 +2370,7 @@ mod tests {
 
 #[cfg(test)]
 mod socket_keepalive_tests {
-    use super::{next_backoff, socket_idle, IDLE_TIMEOUT_SECS, MAX_BACKOFF_SECS};
+    use super::{next_backoff, socket_idle, IDLE_TIMEOUT_SECS, MAX_BACKOFF_SECS, RECONNECT_TIMEOUT_SECS};
     use std::time::Duration;
 
     /// Backoff doubles and caps, matching the gateway adapter (1,2,4,8,16,30,30…).
@@ -2376,5 +2397,37 @@ mod socket_keepalive_tests {
         assert!(!socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS - 1), timeout));
         assert!(socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS), timeout));
         assert!(socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS + 10), timeout));
+    }
+
+    /// Regression test for #1279: a stalled WebSocket handshake during reconnect
+    /// must surface as a timeout instead of parking the reconnect task forever.
+    /// `start_paused` lets the 30s timeout resolve instantly under Tokio's
+    /// virtual clock instead of a real wall-clock wait.
+    #[tokio::test(start_paused = true)]
+    async fn connect_async_timeout_fires_on_stalled_handshake() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind local listener");
+        let addr = listener.local_addr().expect("local addr");
+
+        // Accept the TCP connection but never send any WS handshake bytes, so
+        // `connect_async` blocks forever waiting for the server's HTTP
+        // upgrade response — the exact stall this timeout is meant to catch.
+        tokio::spawn(async move {
+            let _socket = listener.accept().await.expect("accept");
+            std::future::pending::<()>().await;
+        });
+
+        let ws_url = format!("ws://{addr}");
+        let result = tokio::time::timeout(
+            Duration::from_secs(RECONNECT_TIMEOUT_SECS),
+            tokio_tungstenite::connect_async(&ws_url),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "connect_async on a stalled handshake must time out, not hang"
+        );
     }
 }

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -699,6 +699,10 @@ const MAX_CONSECUTIVE_BOT_TURNS: usize = 1000;
 const PING_INTERVAL_SECS: u64 = 30;
 const IDLE_TIMEOUT_SECS: u64 = 75;
 const MAX_BACKOFF_SECS: u64 = 30;
+/// Bounds `get_socket_mode_url` and `connect_async` in the reconnect path so a
+/// stalled TCP/TLS handshake surfaces as a retry instead of parking the
+/// reconnect task forever with no logs (see #1279).
+const RECONNECT_TIMEOUT_SECS: u64 = 30;
 
 /// Next reconnect delay: double, capped. Reset to 1 on a successful connect.
 fn next_backoff(cur: u64) -> u64 {
@@ -744,10 +748,28 @@ pub async fn run_slack_adapter(
             return Ok(());
         }
 
-        let ws_url = match get_socket_mode_url(&app_token).await {
-            Ok(url) => url,
-            Err(e) => {
+        let ws_url = match tokio::time::timeout(
+            std::time::Duration::from_secs(RECONNECT_TIMEOUT_SECS),
+            get_socket_mode_url(&adapter.client, &app_token),
+        )
+        .await
+        {
+            Ok(Ok(url)) => url,
+            Ok(Err(e)) => {
                 error!(err = %e, backoff = backoff_secs, "failed to get Socket Mode URL, retrying");
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
+                    _ = shutdown_rx.changed() => { return Ok(()); }
+                }
+                backoff_secs = next_backoff(backoff_secs);
+                continue;
+            }
+            Err(_) => {
+                error!(
+                    backoff = backoff_secs,
+                    timeout = RECONNECT_TIMEOUT_SECS,
+                    "get Socket Mode URL timed out, retrying"
+                );
                 tokio::select! {
                     _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
                     _ = shutdown_rx.changed() => { return Ok(()); }
@@ -758,8 +780,13 @@ pub async fn run_slack_adapter(
         };
         info!(url = %ws_url, "connecting to Slack Socket Mode");
 
-        match tokio_tungstenite::connect_async(&ws_url).await {
-            Ok((ws_stream, _)) => {
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(RECONNECT_TIMEOUT_SECS),
+            tokio_tungstenite::connect_async(&ws_url),
+        )
+        .await
+        {
+            Ok(Ok((ws_stream, _))) => {
                 info!("Slack Socket Mode connected");
                 backoff_secs = 1; // reset on success
                 let (mut write, mut read) = ws_stream.split();
@@ -1147,8 +1174,15 @@ pub async fn run_slack_adapter(
                     }
                 }
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 error!(err = %e, backoff = backoff_secs, "failed to connect to Slack Socket Mode, retrying");
+            }
+            Err(_) => {
+                error!(
+                    backoff = backoff_secs,
+                    timeout = RECONNECT_TIMEOUT_SECS,
+                    "Slack Socket Mode connect timed out, retrying"
+                );
             }
         }
 
@@ -1162,8 +1196,10 @@ pub async fn run_slack_adapter(
 }
 
 /// Call apps.connections.open to get a WebSocket URL for Socket Mode.
-async fn get_socket_mode_url(app_token: &str) -> Result<String> {
-    let client = reqwest::Client::new();
+/// Reuses the adapter's `reqwest::Client` (already bounded by a 30s timeout,
+/// see `SlackAdapter::new`) instead of building a fresh unbounded one per call
+/// (#386), and relies on that timeout to bound the reconnect path (#1279).
+async fn get_socket_mode_url(client: &reqwest::Client, app_token: &str) -> Result<String> {
     let resp = client
         .post(format!("{SLACK_API}/apps.connections.open"))
         .header("Authorization", format!("Bearer {app_token}"))

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -717,6 +717,28 @@ fn next_backoff(cur: u64) -> u64 {
     (cur * 2).min(MAX_BACKOFF_SECS)
 }
 
+/// Wraps `connect_async` in the reconnect-path timeout. Extracted so the
+/// regression test exercises the exact same code path `run_slack_adapter`
+/// uses, instead of duplicating the timeout expression (#1279).
+async fn connect_with_reconnect_timeout(
+    ws_url: &str,
+) -> std::result::Result<
+    std::result::Result<
+        (
+            tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+            tungstenite::handshake::client::Response,
+        ),
+        tungstenite::Error,
+    >,
+    tokio::time::error::Elapsed,
+> {
+    tokio::time::timeout(
+        std::time::Duration::from_secs(RECONNECT_TIMEOUT_SECS),
+        tokio_tungstenite::connect_async(ws_url),
+    )
+    .await
+}
+
 /// Sleep for `backoff_secs`, honoring shutdown. Returns the next backoff
 /// value, or `None` if a shutdown signal arrived during the sleep (caller
 /// should return immediately). Shared by every retry point in the reconnect
@@ -800,12 +822,7 @@ pub async fn run_slack_adapter(
         };
         info!(url = %ws_url, "connecting to Slack Socket Mode");
 
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(RECONNECT_TIMEOUT_SECS),
-            tokio_tungstenite::connect_async(&ws_url),
-        )
-        .await
-        {
+        match connect_with_reconnect_timeout(&ws_url).await {
             Ok(Ok((ws_stream, _))) => {
                 info!("Slack Socket Mode connected");
                 backoff_secs = 1; // reset on success
@@ -2370,7 +2387,10 @@ mod tests {
 
 #[cfg(test)]
 mod socket_keepalive_tests {
-    use super::{next_backoff, socket_idle, IDLE_TIMEOUT_SECS, MAX_BACKOFF_SECS, RECONNECT_TIMEOUT_SECS};
+    use super::{
+        connect_with_reconnect_timeout, next_backoff, socket_idle, wait_backoff_or_shutdown,
+        IDLE_TIMEOUT_SECS, MAX_BACKOFF_SECS,
+    };
     use std::time::Duration;
 
     /// Backoff doubles and caps, matching the gateway adapter (1,2,4,8,16,30,30…).
@@ -2401,8 +2421,11 @@ mod socket_keepalive_tests {
 
     /// Regression test for #1279: a stalled WebSocket handshake during reconnect
     /// must surface as a timeout instead of parking the reconnect task forever.
-    /// `start_paused` lets the 30s timeout resolve instantly under Tokio's
-    /// virtual clock instead of a real wall-clock wait.
+    /// Calls `connect_with_reconnect_timeout` directly (the same helper
+    /// `run_slack_adapter` calls) so this pins the actual production code
+    /// path, not just a copy of the timeout expression. `start_paused` lets
+    /// the 30s timeout resolve instantly under Tokio's virtual clock instead
+    /// of a real wall-clock wait.
     #[tokio::test(start_paused = true)]
     async fn connect_async_timeout_fires_on_stalled_handshake() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -2419,15 +2442,32 @@ mod socket_keepalive_tests {
         });
 
         let ws_url = format!("ws://{addr}");
-        let result = tokio::time::timeout(
-            Duration::from_secs(RECONNECT_TIMEOUT_SECS),
-            tokio_tungstenite::connect_async(&ws_url),
-        )
-        .await;
+        let result = connect_with_reconnect_timeout(&ws_url).await;
 
         assert!(
             result.is_err(),
             "connect_async on a stalled handshake must time out, not hang"
         );
+    }
+
+    /// With no shutdown signal, `wait_backoff_or_shutdown` sleeps out the
+    /// backoff and returns the next (doubled) value. `start_paused` resolves
+    /// the sleep instantly under Tokio's virtual clock.
+    #[tokio::test(start_paused = true)]
+    async fn wait_backoff_or_shutdown_returns_next_backoff_when_no_shutdown() {
+        let (_tx, mut rx) = tokio::sync::watch::channel(false);
+        let result = wait_backoff_or_shutdown(2, &mut rx).await;
+        assert_eq!(result, Some(next_backoff(2)));
+    }
+
+    /// A shutdown signal wins the race against an arbitrarily long backoff,
+    /// returning `None` so the caller returns immediately instead of parking
+    /// until the backoff elapses.
+    #[tokio::test(start_paused = true)]
+    async fn wait_backoff_or_shutdown_returns_none_on_shutdown() {
+        let (tx, mut rx) = tokio::sync::watch::channel(false);
+        tx.send(true).expect("receiver still open");
+        let result = wait_backoff_or_shutdown(3600, &mut rx).await;
+        assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491969620754567270/1524555735294410812

## What problem does this solve?

Continuation of #1281, which was auto-closed by the stale-contributor bot for inactivity before its final round of review feedback could be addressed. All prior review rounds (Claude + Codex mob review, `@dogzzdogzz`'s consolidated Claude+Codex review) had converged to LGTM on the core fix; this PR rebases those commits onto current `main` and additionally addresses the one unresolved finding from the last review round.

Original problem (from #1279): `get_socket_mode_url` and `tokio_tungstenite::connect_async` in the Slack Socket Mode reconnect loop (`crates/openab-core/src/slack.rs`) had no timeout, unlike the post-connect idle watchdog (`IDLE_TIMEOUT_SECS`) and `SlackAdapter::new`'s Web API client. A stalled network path during reconnect parked the reconnect task in `.await` forever — no error, no log, process alive but the bot permanently dark on Slack until manually restarted. This caused an 11+ hour production outage on openab-viola.

Closes #1279

## What's carried over from #1281 (unchanged, already LGTM'd)

1. Wrap `get_socket_mode_url(...)` in `tokio::time::timeout(35s)` (`RECONNECT_HTTP_TIMEOUT_SECS`), set strictly above the adapter client's own 30s timeout so the diagnosable inner error fires first.
2. Wrap `connect_async` in `tokio::time::timeout(30s)` (`RECONNECT_TIMEOUT_SECS`) via `connect_with_reconnect_timeout()`.
3. Reuse `SlackAdapter`'s bounded `reqwest::Client` in `get_socket_mode_url` instead of constructing an unbounded one per call (folds in #386).
4. Extract `wait_backoff_or_shutdown()` to deduplicate the backoff+shutdown `select!` block that was copy-pasted at three retry points.
5. Regression test `connect_async_timeout_fires_on_stalled_handshake` (`start_paused = true` against a local `TcpListener` that never completes the handshake).

## New in this PR (addresses #1281's last review round)

`@dogzzdogzz`'s consolidated review on #1281 flagged that the reconnect **handshake** was bounded, but the live socket loop still had unbounded writes — the same bug class as #1279, just on the write side:

- `slack.rs`: envelope ack send, pong send, keepalive ping send, shutdown close send were all unbounded `write.send(...).await`. If any of these stalls on the same flaky/half-open socket that motivated #1279, the task parks inside that `select!` branch — and since it can never return to `ping_interval.tick()`, `IDLE_TIMEOUT_SECS` can't fire either.

Fix: extracted `send_with_timeout()` (bounded by a new `WRITE_TIMEOUT_SECS = 10`) and used it at all four call sites; each now `break`s to force a reconnect on timeout, matching the existing keepalive-ping error-handling pattern.

**Intentional behaviour change — ack timeout now skips routing:** on an envelope ack-send timeout (or send error) the loop `break`s *before* the event is routed/dispatched, whereas previously the ack result was ignored and the event was routed regardless. This is deliberate and safer: Slack redelivers an un-acked envelope on the next connection, so skipping dispatch avoids double-processing an envelope Slack still considers pending. Called out explicitly so it isn't later mistaken for an oversight.

Also addressed from the same review round:

- Added a regression test for the previously-untested HTTP timeout leg (`get_socket_mode_url_with_timeout`), using a stalled local listener with `reqwest::Client::builder().resolve(...)` to redirect the `slack.com` host, mirroring the existing WS handshake test.
- Added `ConnectResult` / `SocketModeUrlResult` type aliases for the nested `Result` return types (readability nit).
- Aligned the ack and pong send sites to the keepalive-ping site's 3-arm match (`Ok(Err(e))` / `Err(_)` / `Ok(Ok(()))`) so a completed-but-erroring send (a real `tungstenite::Error`, e.g. broken pipe) forces a reconnect instead of being silently swallowed by an outer-`.is_err()`-only check.

## Validation

- [x] `cargo build -p openab-core` passes
- [x] `cargo test -p openab-core --lib slack` — 66/66 tests pass (including the 2 new regression tests)
- [x] `cargo clippy -p openab-core --all-targets` — no new warnings (4 pre-existing warnings in `cron.rs`/`discord.rs` are unrelated)
- [x] `cargo fmt -p openab-core -- --check` — no new formatting diffs introduced by this change (pre-existing unformatted regions elsewhere in the file are untouched)

## Supersedes

Closes/supersedes #1281 (auto-closed for inactivity, all review rounds there had converged to LGTM on the core fix).
