### PR TITLE
refactor(oabctl): move --with-schedule to independent schedule create subcommand

### DIFF
--- a/docs/oabctl.md
+++ b/docs/oabctl.md
@@ -583,7 +583,7 @@ s3://oab-control-plane-{account}/
 | `oabctl exec <agent> -- <cmd>` | Execute command in container |
 | `oabctl cp <src> <dst>` | Copy files to/from container |
 | `oabctl sync <src> <dst>` | Sync directories (bidirectional) |
-| `oabctl scale <alias> <size>` | Immediately set desired task count (0–100) |
+| `oabctl scale <alias> <size>` | Immediately set desired task count (0 or 1) |
 | `oabctl schedule create <alias> <size> --expr '<expression>'` | Create/update recurring schedule |
 | `oabctl schedule create <alias> <size> --expr '<expression>' --timezone 'Asia/Taipei'` | Schedule with IANA timezone |
 | `oabctl schedule list` | List all scaling schedules |

--- a/docs/oabctl.md
+++ b/docs/oabctl.md
@@ -584,8 +584,8 @@ s3://oab-control-plane-{account}/
 | `oabctl cp <src> <dst>` | Copy files to/from container |
 | `oabctl sync <src> <dst>` | Sync directories (bidirectional) |
 | `oabctl scale <alias> <size>` | Immediately set desired task count (0–100) |
-| `oabctl scale <alias> <size> --with-schedule '<expr>'` | Create/update recurring schedule |
-| `oabctl scale <alias> <size> --with-schedule '<expr>' --timezone 'Asia/Taipei'` | Schedule with IANA timezone |
+| `oabctl schedule create <alias> <size> --expr '<expression>'` | Create/update recurring schedule |
+| `oabctl schedule create <alias> <size> --expr '<expression>' --timezone 'Asia/Taipei'` | Schedule with IANA timezone |
 | `oabctl schedule list` | List all scaling schedules |
 | `oabctl schedule delete <name>` | Remove a scaling schedule |
 
@@ -607,13 +607,13 @@ oabctl scale my-bot 0
 
 ```bash
 # Scale to 0 at 9PM Taipei time, every day
-oabctl scale my-bot 0 --with-schedule 'cron(0 21 * * ? *)' --timezone 'Asia/Taipei'
+oabctl schedule create my-bot 0 --expr 'cron(0 21 * * ? *)' --timezone 'Asia/Taipei'
 
 # Scale to 1 at 8AM
-oabctl scale my-bot 1 --with-schedule 'cron(0 8 * * ? *)' --timezone 'Asia/Taipei'
+oabctl schedule create my-bot 1 --expr 'cron(0 8 * * ? *)' --timezone 'Asia/Taipei'
 
 # Scale every 6 hours
-oabctl scale my-bot 1 --with-schedule 'rate(6 hours)'
+oabctl schedule create my-bot 1 --expr 'rate(6 hours)'
 ```
 
 **Schedule expressions** — must be one of:

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -95,7 +95,7 @@ enum Commands {
     },
     /// Scale an OAB service (set desired task count)
     Scale {
-        /// Agent name or ecsctl alias
+        /// Agent name (OAB service)
         alias: String,
         /// Desired task count (0 or 1)
         #[arg(value_parser = clap::value_parser!(i32).range(0..=1))]

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -97,7 +97,7 @@ enum Commands {
     Scale {
         /// Agent name or ecsctl alias
         alias: String,
-        /// Desired task count (0–100)
+        /// Desired task count (0 or 1)
         #[arg(value_parser = clap::value_parser!(i32).range(0..=1))]
         size: i32,
     },
@@ -144,7 +144,7 @@ enum ScheduleAction {
     Create {
         /// Agent name (OAB service)
         alias: String,
-        /// Desired task count (0–100)
+        /// Desired task count (0 or 1)
         #[arg(value_parser = clap::value_parser!(i32).range(0..=1))]
         size: i32,
         /// Schedule expression: cron(...), rate(...), or at(...)

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -100,13 +100,6 @@ enum Commands {
         /// Desired task count (0–100)
         #[arg(value_parser = clap::value_parser!(i32).range(0..=100))]
         size: i32,
-        /// Create/update a recurring schedule (e.g. "cron(0 8 * * ? *)" or "rate(1 hour)").
-        /// Omit for immediate scaling.
-        #[arg(long)]
-        with_schedule: Option<String>,
-        /// IANA timezone for schedule expression (e.g. "Asia/Taipei", default: UTC)
-        #[arg(long, default_value = "UTC")]
-        timezone: String,
     },
     /// Manage scaling schedules
     Schedule {
@@ -147,6 +140,20 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum ScheduleAction {
+    /// Create a recurring scaling schedule
+    Create {
+        /// Agent name or ecsctl alias
+        alias: String,
+        /// Desired task count (0 or 1)
+        #[arg(value_parser = clap::value_parser!(i32).range(0..=100))]
+        size: i32,
+        /// Schedule expression: cron(...), rate(...), or at(...)
+        #[arg(long = "expression", alias = "expr")]
+        expression: String,
+        /// IANA timezone for schedule expression (default: UTC)
+        #[arg(long, default_value = "UTC")]
+        timezone: String,
+    },
     /// List all scaling schedules
     List,
     /// Delete a scaling schedule
@@ -245,17 +252,18 @@ async fn main() -> anyhow::Result<()> {
         Commands::Scale {
             alias,
             size,
-            with_schedule,
-            timezone,
         } => {
-            if let Some(schedule_expr) = with_schedule {
-                scale::run_with_schedule(&config, &alias, size, &schedule_expr, Some(&timezone))
-                    .await
-            } else {
-                scale::run(&config, &alias, size).await
-            }
+            scale::run(&config, &alias, size).await
         }
         Commands::Schedule { action } => match action {
+            ScheduleAction::Create {
+                alias,
+                size,
+                expression,
+                timezone,
+            } => {
+                scale::run_with_schedule(&config, &alias, size, &expression, Some(&timezone)).await
+            }
             ScheduleAction::List => scale::list_schedules(&config).await,
             ScheduleAction::Delete { name } => scale::delete_schedule(&config, &name).await,
         },

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -142,7 +142,7 @@ enum Commands {
 enum ScheduleAction {
     /// Create a recurring scaling schedule
     Create {
-        /// Agent name or ecsctl alias
+        /// Agent name (OAB service)
         alias: String,
         /// Desired task count (0–100)
         #[arg(value_parser = clap::value_parser!(i32).range(0..=100))]

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -144,7 +144,7 @@ enum ScheduleAction {
     Create {
         /// Agent name or ecsctl alias
         alias: String,
-        /// Desired task count (0 or 1)
+        /// Desired task count (0–100)
         #[arg(value_parser = clap::value_parser!(i32).range(0..=100))]
         size: i32,
         /// Schedule expression: cron(...), rate(...), or at(...)

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -98,7 +98,7 @@ enum Commands {
         /// Agent name or ecsctl alias
         alias: String,
         /// Desired task count (0–100)
-        #[arg(value_parser = clap::value_parser!(i32).range(0..=100))]
+        #[arg(value_parser = clap::value_parser!(i32).range(0..=1))]
         size: i32,
     },
     /// Manage scaling schedules
@@ -145,7 +145,7 @@ enum ScheduleAction {
         /// Agent name (OAB service)
         alias: String,
         /// Desired task count (0–100)
-        #[arg(value_parser = clap::value_parser!(i32).range(0..=100))]
+        #[arg(value_parser = clap::value_parser!(i32).range(0..=1))]
         size: i32,
         /// Schedule expression: cron(...), rate(...), or at(...)
         #[arg(long = "expression", alias = "expr")]

--- a/operator/src/scale.rs
+++ b/operator/src/scale.rs
@@ -351,7 +351,7 @@ pub async fn list_schedules(aws_config: &aws_config::SdkConfig) -> Result<()> {
                 {
                     println!("No schedules configured yet.");
                     println!(
-                        "  Use 'oabctl scale <alias> <size> --with-schedule <expr>' to create one."
+                        "  Use 'oabctl schedule create <alias> <size> --expr <expression>' to create one."
                     );
                     return Ok(());
                 } else {
@@ -363,7 +363,7 @@ pub async fn list_schedules(aws_config: &aws_config::SdkConfig) -> Result<()> {
 
     if all_schedules.is_empty() {
         println!("No schedules found in group '{group_name}'.");
-        println!("  Use 'oabctl scale <alias> <size> --with-schedule <expr>' to create one.");
+        println!("  Use 'oabctl schedule create <alias> <size> --expr <expression>' to create one.");
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

Aligns oabctl with ecsctl v0.10.0 design where `scale` and `schedule` are independent commands.

### Migration

```bash
# OLD (removed)
oabctl scale my-bot 0 --with-schedule 'cron(0 22 * * ? *)'

# NEW
oabctl scale my-bot 0                                           # immediate only
oabctl schedule create my-bot 0 --expr 'cron(0 22 * * ? *)'    # recurring
```

### Changes

- Remove `--with-schedule` and `--timezone` flags from `scale` command
- Add `schedule create` subcommand with `--expression` (alias `--expr`) and `--timezone` flags
- Update `docs/oabctl.md` examples to use new syntax
- Update suggestion messages in `scale.rs`

### Why

1. **`scale` stays pure** — immediate scaling only, no schedule side-effects
2. **`schedule` gets its own lifecycle** — create/list/delete as independent operations
3. **Aligns with ecsctl v0.10.0** — same architectural decision, enables future library consumption

### Next step

Adopt ecsctl as library crate (tracked in #1335) to share scheduler infrastructure:
- Config, validation, retry/backoff, collision-resistant naming
- Eliminate duplicated EventBridge Scheduler code

Refs #1335