### PR TITLE
docs: add AWESOME.md with openab-control-plane

### DIFF
--- a/AWESOME.md
+++ b/AWESOME.md
@@ -12,6 +12,14 @@ A curated list of projects, tools, and resources built on or for the OpenAB ecos
 
 ---
 
+## Articles
+
+| Title | Description | Author |
+|-------|-------------|--------|
+| [Read the Thread, Merge the PR: Building a First-Responder AIOps Bot with Grafana, OpenAB and More](https://medium.com/@yenchuang/read-the-thread-merge-the-pr-building-a-first-responder-aiops-bot-with-grafana-openab-and-e5467cf3b764) | Building a first-responder AIOps bot that reads alert threads and merges fix PRs, using Grafana and OpenAB. | [@yenchuang](https://medium.com/@yenchuang) |
+
+---
+
 ## Contributing
 
 Have a project built on OpenAB? Open a PR to add it here!

--- a/AWESOME.md
+++ b/AWESOME.md
@@ -1,0 +1,17 @@
+# Awesome OpenAB
+
+A curated list of projects, tools, and resources built on or for the OpenAB ecosystem.
+
+---
+
+## Control Planes
+
+| Project | Description | Author |
+|---------|-------------|--------|
+| [openab-control-plane](https://github.com/canyugs/openab-control-plane) | A gateway-native runtime for coordinating multiple stock OpenAB pods. PR review is the first product profile — supports council, solo, and pipeline coordinators with GitHub webhook integration and Zeabur deployment. | [@canyugs](https://github.com/canyugs) |
+
+---
+
+## Contributing
+
+Have a project built on OpenAB? Open a PR to add it here!


### PR DESCRIPTION
Add an AWESOME.md curated list to collect projects built on or for the OpenAB ecosystem.

## First entry

- [openab-control-plane](https://github.com/canyugs/openab-control-plane) — A gateway-native runtime for coordinating multiple stock OpenAB pods. PR review is the first product profile.

This gives the community a place to discover and showcase OpenAB-related projects.