### PR TITLE
fix(ci): accept discordapp.com URLs in PR discussion check

### DIFF
--- a/.github/workflows/pr-discussion-check.yml
+++ b/.github/workflows/pr-discussion-check.yml
@@ -30,7 +30,7 @@ jobs:
             const marker = '<!-- openab-pr-discussion-check -->';
             const label = 'closing-soon';
 
-            const hasDiscordUrl = /https:\/\/discord\.com\/channels\/\d+\/\d+/.test(body);
+            const hasDiscordUrl = /https:\/\/(discord\.com|discordapp\.com)\/channels\/\d+\/\d+/.test(body);
 
             const comments = await github.rest.issues.listComments({
               ...context.repo,


### PR DESCRIPTION
## Problem

PR #1343 has a valid Discord discussion URL using the legacy `discordapp.com` domain, but the `pr-discussion-check` workflow only matches `discord.com`. This causes a false-positive `closing-soon` label.

## Fix

Update the regex to accept both `discord.com` and `discordapp.com`:

```javascript
// Before
const hasDiscordUrl = /https:\/\/discord\.com\/channels\/\d+\/\d+/.test(body);

// After
const hasDiscordUrl = /https:\/\/(discord\.com|discordapp\.com)\/channels\/\d+\/\d+/.test(body);
```

Both domains resolve to the same Discord resource. The legacy domain is still commonly used in browser history and copy-pasted URLs.

Closes the false positive on #1343.