### PR TITLE
feat(media): return URL hint for text files exceeding 512KB inline limit

### DIFF
--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -913,11 +913,16 @@ impl EventHandler for Handler {
                     continue;
                 }
                 // Pre-check against the aggregate 1 MB cap using the
-                // Discord-reported size.  Files larger than 512 KB are not
-                // inlined (they return a URL hint with 0 inline bytes), so
-                // they never push the running total over the cap — no
-                // separate per-file size guard is needed here.
-                if text_file_bytes + u64::from(attachment.size) > TEXT_TOTAL_CAP {
+                // Discord-reported size.  Files larger than the inline limit
+                // (512 KB) produce a URL hint with 0 inline bytes, so they
+                // must bypass this cap check and always reach media.rs.
+                // Without this guard, a message that has already accumulated
+                // inline bytes would silently drop large files instead of
+                // generating a hint for the agent.
+                let is_over_inline_limit = u64::from(attachment.size) > media::TEXT_INLINE_LIMIT;
+                if !is_over_inline_limit
+                    && text_file_bytes + u64::from(attachment.size) > TEXT_TOTAL_CAP
+                {
                     tracing::warn!(filename = %attachment.filename, total = text_file_bytes, "text attachments total exceeds 1MB cap, skipping remaining");
                     continue;
                 }

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -931,6 +931,7 @@ impl EventHandler for Handler {
                     &attachment.filename,
                     u64::from(attachment.size),
                     None,
+                    true, // Discord CDN URLs expire after ~24 hours
                 )
                 .await
                 {

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -16,7 +16,9 @@ use serenity::builder::{
 };
 use serenity::http::Http;
 use serenity::model::application::ButtonStyle;
-use serenity::model::application::{Command, CommandOptionType, ComponentInteractionDataKind, Interaction};
+use serenity::model::application::{
+    Command, CommandOptionType, ComponentInteractionDataKind, Interaction,
+};
 use serenity::model::channel::{AutoArchiveDuration, Message, MessageType, Reaction, ReactionType};
 use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, MessageId, UserId};
@@ -191,7 +193,11 @@ impl ChatAdapter for DiscordAdapter {
         let ch_id: u64 = Self::resolve_channel(channel).parse()?;
         // Truncate at char boundary to avoid panic on multi-byte chars (中文/Emoji).
         let truncated: &str = if title.chars().count() > 100 {
-            let end = title.char_indices().nth(100).map(|(i, _)| i).unwrap_or(title.len());
+            let end = title
+                .char_indices()
+                .nth(100)
+                .map(|(i, _)| i)
+                .unwrap_or(title.len());
             &title[..end]
         } else {
             title
@@ -332,7 +338,9 @@ impl EventHandler for Handler {
             let key = msg.channel_id.to_string();
             {
                 let mut cache = self.multibot_threads.lock().await;
-                cache.entry(key.clone()).or_insert_with(tokio::time::Instant::now);
+                cache
+                    .entry(key.clone())
+                    .or_insert_with(tokio::time::Instant::now);
             }
             // Persist to disk — multibot is irreversible
             self.multibot_cache.mark_multibot(&key).await;
@@ -475,11 +483,14 @@ impl EventHandler for Handler {
         // non-allowed channels. Moved before bot gating so ambient context
         // can be resolved early — bot messages in ambient contexts must bypass
         // discord-level bot gating (#1197).
-        let (in_thread, bot_owns_thread, thread_parent_id, is_dm, is_structural_thread, structural_parent_id) = match msg
-            .channel_id
-            .to_channel(&ctx.http)
-            .await
-        {
+        let (
+            in_thread,
+            bot_owns_thread,
+            thread_parent_id,
+            is_dm,
+            is_structural_thread,
+            structural_parent_id,
+        ) = match msg.channel_id.to_channel(&ctx.http).await {
             Ok(serenity::model::channel::Channel::Guild(gc)) => {
                 let parent = gc.parent_id.map(|id| id.get().to_string());
                 let has_thread_metadata = gc.thread_metadata.is_some();
@@ -508,7 +519,11 @@ impl EventHandler for Handler {
                     if has_thread_metadata { parent } else { None },
                     false,
                     has_thread_metadata,
-                    if has_thread_metadata { parent_u64 } else { None },
+                    if has_thread_metadata {
+                        parent_u64
+                    } else {
+                        None
+                    },
                 )
             }
             Ok(serenity::model::channel::Channel::Private(_)) => {
@@ -528,7 +543,12 @@ impl EventHandler for Handler {
         // Check if message is in an ambient context (resolved early so bot
         // messages destined for ambient can bypass discord-level bot gating).
         let in_ambient_context = self.ambient.as_ref().is_some_and(|ambient| {
-            ambient.should_buffer(channel_id, is_structural_thread, bot_owns_thread, structural_parent_id)
+            ambient.should_buffer(
+                channel_id,
+                is_structural_thread,
+                bot_owns_thread,
+                structural_parent_id,
+            )
         });
 
         // --- Ambient early-route for bot messages ---
@@ -575,13 +595,15 @@ impl EventHandler for Handler {
 
                     let target = Arc::clone(&self.router) as Arc<dyn DispatchTarget>;
                     debug!(channel_id = %msg.channel_id, bot_id = %msg.author.id, "ambient early-route: bot msg buffered");
-                    ambient.submit(
-                        &channel_id.to_string(),
-                        channel_ref,
-                        adapter.clone(),
-                        target,
-                        ambient_msg,
-                    ).await;
+                    ambient
+                        .submit(
+                            &channel_id.to_string(),
+                            channel_ref,
+                            adapter.clone(),
+                            target,
+                            ambient_msg,
+                        )
+                        .await;
                 }
             }
             return;
@@ -737,13 +759,15 @@ impl EventHandler for Handler {
                     };
 
                     let target = Arc::clone(&self.router) as Arc<dyn DispatchTarget>;
-                    ambient.submit(
-                        &channel_id.to_string(),
-                        channel_ref,
-                        adapter.clone(),
-                        target,
-                        ambient_msg,
-                    ).await;
+                    ambient
+                        .submit(
+                            &channel_id.to_string(),
+                            channel_ref,
+                            adapter.clone(),
+                            target,
+                            ambient_msg,
+                        )
+                        .await;
                     return;
                 }
             }
@@ -888,8 +912,11 @@ impl EventHandler for Handler {
                     tracing::warn!(filename = %attachment.filename, count = text_file_count, "text file count cap reached, skipping");
                     continue;
                 }
-                // Pre-check with Discord-reported size (fast path, avoids unnecessary download).
-                // Running total uses actual downloaded bytes for accurate accounting.
+                // Pre-check against the aggregate 1 MB cap using the
+                // Discord-reported size.  Files larger than 512 KB are not
+                // inlined (they return a URL hint with 0 inline bytes), so
+                // they never push the running total over the cap — no
+                // separate per-file size guard is needed here.
                 if text_file_bytes + u64::from(attachment.size) > TEXT_TOTAL_CAP {
                     tracing::warn!(filename = %attachment.filename, total = text_file_bytes, "text attachments total exceeds 1MB cap, skipping remaining");
                     continue;
@@ -1003,10 +1030,11 @@ impl EventHandler for Handler {
         let trigger_msg = discord_msg_ref(&msg);
 
         // Per-thread streaming: check if another bot is present in this thread
-        let other_bot_present_flag = {
-            let cache = self.multibot_threads.lock().await;
-            cache.contains_key(&msg.channel_id.to_string())
-        } || self.multibot_cache.is_multibot(&msg.channel_id.to_string());
+        let other_bot_present_flag =
+            {
+                let cache = self.multibot_threads.lock().await;
+                cache.contains_key(&msg.channel_id.to_string())
+            } || self.multibot_cache.is_multibot(&msg.channel_id.to_string());
 
         // Backfill thread_id: when OAB just created a new thread, the sender
         // was built before the thread existed. Patch it so the agent sees
@@ -1175,24 +1203,30 @@ impl EventHandler for Handler {
                     if !in_allowed_thread {
                         return;
                     }
-                    (ChannelRef {
-                        platform: "discord".into(),
-                        channel_id: channel_id.get().to_string(),
-                        thread_id: None,
-                        parent_id: parent.map(|p| p.to_string()),
-                        origin_event_id: None,
-                    }, true)
+                    (
+                        ChannelRef {
+                            platform: "discord".into(),
+                            channel_id: channel_id.get().to_string(),
+                            thread_id: None,
+                            parent_id: parent.map(|p| p.to_string()),
+                            origin_event_id: None,
+                        },
+                        true,
+                    )
                 } else {
                     if !in_allowed_channel {
                         return;
                     }
-                    (ChannelRef {
-                        platform: "discord".into(),
-                        channel_id: channel_id.get().to_string(),
-                        thread_id: None,
-                        parent_id: None,
-                        origin_event_id: None,
-                    }, false)
+                    (
+                        ChannelRef {
+                            platform: "discord".into(),
+                            channel_id: channel_id.get().to_string(),
+                            thread_id: None,
+                            parent_id: None,
+                            origin_event_id: None,
+                        },
+                        false,
+                    )
                 }
             }
             _ => return,
@@ -1206,7 +1240,8 @@ impl EventHandler for Handler {
                 self.allow_user_messages,
                 AllowUsers::Involved | AllowUsers::MultibotMentions
             ) {
-            self.bot_participated_in_thread(&ctx.http, channel_id, bot_id).await
+            self.bot_participated_in_thread(&ctx.http, channel_id, bot_id)
+                .await
         } else {
             // For non-thread: still check multibot cache for dispatch info.
             let mb = {
@@ -1240,17 +1275,16 @@ impl EventHandler for Handler {
 
         tokio::spawn(async move {
             // F2 fix: Fetch user info first, then apply user gating with confirmed bot status.
-            let (sender_name, display_name, is_bot_confirmed) =
-                match user_id.to_user(&http).await {
-                    Ok(user) => {
-                        let display = user.global_name.as_ref().unwrap_or(&user.name).clone();
-                        (user.name.clone(), display, user.bot)
-                    }
-                    Err(_) => {
-                        let fallback = user_id.to_string();
-                        (fallback.clone(), fallback, is_reactor_bot)
-                    }
-                };
+            let (sender_name, display_name, is_bot_confirmed) = match user_id.to_user(&http).await {
+                Ok(user) => {
+                    let display = user.global_name.as_ref().unwrap_or(&user.name).clone();
+                    (user.name.clone(), display, user.bot)
+                }
+                Err(_) => {
+                    let fallback = user_id.to_string();
+                    (fallback.clone(), fallback, is_reactor_bot)
+                }
+            };
 
             // Defense-in-depth: if to_user() reveals this is a bot but member was
             // None (rare edge case), re-apply bot gating retroactively.
@@ -1258,8 +1292,7 @@ impl EventHandler for Handler {
                 match allow_bot_messages {
                     AllowBots::Off | AllowBots::Mentions => return,
                     AllowBots::All => {
-                        if !trusted_bot_ids.is_empty()
-                            && !trusted_bot_ids.contains(&user_id.get())
+                        if !trusted_bot_ids.is_empty() && !trusted_bot_ids.contains(&user_id.get())
                         {
                             return;
                         }
@@ -1340,23 +1373,31 @@ impl EventHandler for Handler {
             CreateCommand::new("reset").description("Reset the conversation session"),
             CreateCommand::new("remind")
                 .description("Set a one-shot reminder to mention users/roles after a delay")
-                .add_option(CreateCommandOption::new(
-                    CommandOptionType::String,
-                    "targets",
-                    "Users/roles to mention (e.g. @user1 @role1)",
-                ).required(true))
-                .add_option(CreateCommandOption::new(
-                    CommandOptionType::String,
-                    "message",
-                    "Reminder message",
-                ).required(true))
-                .add_option(CreateCommandOption::new(
-                    CommandOptionType::String,
-                    "delay",
-                    "Delay before firing (e.g. 30m, 2h, 1d)",
-                ).required(true)),
-            CreateCommand::new("auth")
-                .description("Authenticate the backend agent (device flow)"),
+                .add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "targets",
+                        "Users/roles to mention (e.g. @user1 @role1)",
+                    )
+                    .required(true),
+                )
+                .add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "message",
+                        "Reminder message",
+                    )
+                    .required(true),
+                )
+                .add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "delay",
+                        "Delay before firing (e.g. 30m, 2h, 1d)",
+                    )
+                    .required(true),
+                ),
+            CreateCommand::new("auth").description("Authenticate the backend agent (device flow)"),
             CreateCommand::new("export-thread")
                 .description("Download this thread as a text file")
                 .add_option(CreateCommandOption::new(
@@ -1728,15 +1769,18 @@ impl Handler {
 
         // Extract options
         let opts = &cmd.data.options;
-        let targets_raw = opts.iter()
+        let targets_raw = opts
+            .iter()
             .find(|o| o.name == "targets")
             .and_then(|o| o.value.as_str())
             .unwrap_or("");
-        let message = opts.iter()
+        let message = opts
+            .iter()
             .find(|o| o.name == "message")
             .and_then(|o| o.value.as_str())
             .unwrap_or("");
-        let delay_raw = opts.iter()
+        let delay_raw = opts
+            .iter()
             .find(|o| o.name == "delay")
             .and_then(|o| o.value.as_str())
             .unwrap_or("");
@@ -1798,7 +1842,10 @@ impl Handler {
         if targets.len() > remind::MAX_TARGETS {
             let response = CreateInteractionResponse::Message(
                 CreateInteractionResponseMessage::new()
-                    .content(format!("⚠️ Too many targets (max {}). Use a @role instead.", remind::MAX_TARGETS))
+                    .content(format!(
+                        "⚠️ Too many targets (max {}). Use a @role instead.",
+                        remind::MAX_TARGETS
+                    ))
                     .ephemeral(true),
             );
             let _ = cmd.create_response(&ctx.http, response).await;
@@ -1898,7 +1945,9 @@ impl Handler {
         if AUTH_IN_PROGRESS.swap(true, std::sync::atomic::Ordering::Acquire) {
             let response = CreateInteractionResponse::Message(
                 CreateInteractionResponseMessage::new()
-                    .content("⚠️ Authentication already in progress. Please wait for it to complete.")
+                    .content(
+                        "⚠️ Authentication already in progress. Please wait for it to complete.",
+                    )
                     .ephemeral(true),
             );
             let _ = cmd.create_response(&ctx.http, response).await;
@@ -1911,7 +1960,9 @@ impl Handler {
                 AUTH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::Release);
                 let response = CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
-                        .content("⚠️ No auth command configured (`OPENAB_AGENT_AUTH_COMMAND` not set).")
+                        .content(
+                            "⚠️ No auth command configured (`OPENAB_AGENT_AUTH_COMMAND` not set).",
+                        )
                         .ephemeral(true),
                 );
                 let _ = cmd.create_response(&ctx.http, response).await;
@@ -1934,9 +1985,9 @@ impl Handler {
         let user_id = cmd.user.id.get();
 
         tokio::spawn(async move {
+            use std::sync::Arc;
             use tokio::io::AsyncBufReadExt;
             use tokio::process::Command as TokioCommand;
-            use std::sync::Arc;
 
             // Drop guard ensures AUTH_IN_PROGRESS is cleared even on panic.
             struct AuthGuard;
@@ -1960,13 +2011,15 @@ impl Handler {
                 Ok(c) => c,
                 Err(e) => {
                     tracing::error!(error = %e, "/auth: failed to spawn auth command");
-                    let _ = http.create_followup_message(
-                        &token,
-                        &CreateInteractionResponseFollowup::new()
-                            .content(format!("❌ Failed to start auth command: {e}"))
-                            .ephemeral(true),
-                        Vec::new(),
-                    ).await;
+                    let _ = http
+                        .create_followup_message(
+                            &token,
+                            &CreateInteractionResponseFollowup::new()
+                                .content(format!("❌ Failed to start auth command: {e}"))
+                                .ephemeral(true),
+                            Vec::new(),
+                        )
+                        .await;
                     return;
                 }
             };
@@ -1985,7 +2038,10 @@ impl Handler {
                     let mut reader = tokio::io::BufReader::new(stdout).lines();
                     while let Ok(Some(line)) = reader.next_line().await {
                         let has_url = line.contains("http://") || line.contains("https://");
-                        lines_out.lock().unwrap_or_else(|e| e.into_inner()).push(line);
+                        lines_out
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .push(line);
                         if has_url {
                             url_found_out.notify_one();
                         }
@@ -2000,7 +2056,10 @@ impl Handler {
                     let mut reader = tokio::io::BufReader::new(stderr).lines();
                     while let Ok(Some(line)) = reader.next_line().await {
                         let has_url = line.contains("http://") || line.contains("https://");
-                        lines_err.lock().unwrap_or_else(|e| e.into_inner()).push(line);
+                        lines_err
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .push(line);
                         if has_url {
                             url_found_err.notify_one();
                         }
@@ -2030,12 +2089,8 @@ impl Handler {
             // Handle an early exit (the command terminated during the URL window).
             if let Some(res) = early_exit {
                 let _ = tokio::join!(stdout_task, stderr_task);
-                let collected = strip_ansi_codes(
-                    &lines
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .join("\n"),
-                );
+                let collected =
+                    strip_ansi_codes(&lines.lock().unwrap_or_else(|e| e.into_inner()).join("\n"));
                 let detail = if collected.trim().is_empty() {
                     String::new()
                 } else {
@@ -2055,13 +2110,15 @@ impl Handler {
                     }
                     Err(e) => format!("❌ Error waiting for auth command: {e}"),
                 };
-                let _ = http.create_followup_message(
-                    &token,
-                    &CreateInteractionResponseFollowup::new()
-                        .content(content)
-                        .ephemeral(true),
-                    Vec::new(),
-                ).await;
+                let _ = http
+                    .create_followup_message(
+                        &token,
+                        &CreateInteractionResponseFollowup::new()
+                            .content(content)
+                            .ephemeral(true),
+                        Vec::new(),
+                    )
+                    .await;
                 return;
             }
 
@@ -2092,13 +2149,15 @@ impl Handler {
             // `truncate_to_utf16_budget` for the testable implementation.
             let truncated = truncate_to_utf16_budget(&output, prefix, suffix, 2000);
             let msg = format!("{prefix}{truncated}{suffix}");
-            let _ = http.create_followup_message(
-                &token,
-                &CreateInteractionResponseFollowup::new()
-                    .content(msg)
-                    .ephemeral(true),
-                Vec::new(),
-            ).await;
+            let _ = http
+                .create_followup_message(
+                    &token,
+                    &CreateInteractionResponseFollowup::new()
+                        .content(msg)
+                        .ephemeral(true),
+                    Vec::new(),
+                )
+                .await;
 
             // Wait for the process to complete (user authorizes in browser).
             // Use 14min (not 15) to leave headroom for the Discord interaction token TTL.
@@ -2106,44 +2165,55 @@ impl Handler {
             match tokio::time::timeout(timeout, child.wait()).await {
                 Ok(Ok(status)) if status.success() => {
                     info!("/auth: authentication successful");
-                    let _ = http.create_followup_message(
-                        &token,
-                        &CreateInteractionResponseFollowup::new()
-                            .content("✅ Authentication successful!")
-                            .ephemeral(true),
-                        Vec::new(),
-                    ).await;
+                    let _ = http
+                        .create_followup_message(
+                            &token,
+                            &CreateInteractionResponseFollowup::new()
+                                .content("✅ Authentication successful!")
+                                .ephemeral(true),
+                            Vec::new(),
+                        )
+                        .await;
                 }
                 Ok(Ok(status)) => {
                     warn!(%status, "/auth: authentication failed");
-                    let _ = http.create_followup_message(
-                        &token,
-                        &CreateInteractionResponseFollowup::new()
-                            .content(format!("❌ Authentication failed (exit code: {}).", status))
-                            .ephemeral(true),
-                        Vec::new(),
-                    ).await;
+                    let _ = http
+                        .create_followup_message(
+                            &token,
+                            &CreateInteractionResponseFollowup::new()
+                                .content(format!(
+                                    "❌ Authentication failed (exit code: {}).",
+                                    status
+                                ))
+                                .ephemeral(true),
+                            Vec::new(),
+                        )
+                        .await;
                 }
                 Ok(Err(e)) => {
                     tracing::error!(error = %e, "/auth: error waiting for auth process");
-                    let _ = http.create_followup_message(
-                        &token,
-                        &CreateInteractionResponseFollowup::new()
-                            .content(format!("❌ Auth process error: {e}"))
-                            .ephemeral(true),
-                        Vec::new(),
-                    ).await;
+                    let _ = http
+                        .create_followup_message(
+                            &token,
+                            &CreateInteractionResponseFollowup::new()
+                                .content(format!("❌ Auth process error: {e}"))
+                                .ephemeral(true),
+                            Vec::new(),
+                        )
+                        .await;
                 }
                 Err(_) => {
                     warn!("/auth: timed out waiting for authorization");
                     let _ = child.kill().await;
-                    let _ = http.create_followup_message(
-                        &token,
-                        &CreateInteractionResponseFollowup::new()
-                            .content("⏰ Authentication timed out. Run `/auth` again to retry.")
-                            .ephemeral(true),
-                        Vec::new(),
-                    ).await;
+                    let _ = http
+                        .create_followup_message(
+                            &token,
+                            &CreateInteractionResponseFollowup::new()
+                                .content("⏰ Authentication timed out. Run `/auth` again to retry.")
+                                .ephemeral(true),
+                            Vec::new(),
+                        )
+                        .await;
                 }
             }
 
@@ -2190,9 +2260,7 @@ impl Handler {
                 );
                 (in_thread, gc.name.clone())
             }
-            Ok(serenity::model::channel::Channel::Private(_)) => {
-                (self.allow_dm, "dm".to_string())
-            }
+            Ok(serenity::model::channel::Channel::Private(_)) => (self.allow_dm, "dm".to_string()),
             Ok(_) => (false, "channel".to_string()),
             Err(e) => {
                 tracing::warn!(channel_id = %channel_id, error = %e, "failed to inspect channel for export");
@@ -2214,16 +2282,34 @@ impl Handler {
 
         // --- Parse and validate filter params (mutual exclusion) ---
         let opts = &cmd.data.options;
-        let limit_opt = opts.iter().find(|o| o.name == "limit").and_then(|o| o.value.as_i64());
-        let since_opt = opts.iter().find(|o| o.name == "since").and_then(|o| o.value.as_str());
-        let days_opt = opts.iter().find(|o| o.name == "days").and_then(|o| o.value.as_i64());
-        let all_opt = opts.iter().find(|o| o.name == "all").and_then(|o| o.value.as_bool()).unwrap_or(false);
+        let limit_opt = opts
+            .iter()
+            .find(|o| o.name == "limit")
+            .and_then(|o| o.value.as_i64());
+        let since_opt = opts
+            .iter()
+            .find(|o| o.name == "since")
+            .and_then(|o| o.value.as_str());
+        let days_opt = opts
+            .iter()
+            .find(|o| o.name == "days")
+            .and_then(|o| o.value.as_i64());
+        let all_opt = opts
+            .iter()
+            .find(|o| o.name == "all")
+            .and_then(|o| o.value.as_bool())
+            .unwrap_or(false);
 
-        let filter_count = limit_opt.is_some() as u8 + since_opt.is_some() as u8 + days_opt.is_some() as u8 + all_opt as u8;
+        let filter_count = limit_opt.is_some() as u8
+            + since_opt.is_some() as u8
+            + days_opt.is_some() as u8
+            + all_opt as u8;
         if filter_count > 1 {
             let response = CreateInteractionResponse::Message(
                 CreateInteractionResponseMessage::new()
-                    .content("⚠️ Please specify only one filter: `limit`, `since`, `days`, or `all`.")
+                    .content(
+                        "⚠️ Please specify only one filter: `limit`, `since`, `days`, or `all`.",
+                    )
                     .ephemeral(true),
             );
             let _ = cmd.create_response(&ctx.http, response).await;
@@ -2593,7 +2679,10 @@ async fn export_channel_messages(
 
     let filename = export_filename(channel_id, channel_name);
     if attachment_size_limit < 2048 {
-        tracing::warn!(attachment_size_limit, "attachment_size_limit is very small; export will likely be truncated");
+        tracing::warn!(
+            attachment_size_limit,
+            "attachment_size_limit is very small; export will likely be truncated"
+        );
     }
     let max_bytes = usize::try_from(attachment_size_limit)
         .unwrap_or(8 * 1024 * 1024)
@@ -2663,10 +2752,7 @@ fn format_export_message(msg: &Message) -> String {
     let bot_marker = if msg.author.bot { " [bot]" } else { "" };
     let mut out = format!(
         "[{}] {}{} ({})\n",
-        msg.timestamp,
-        msg.author.name,
-        bot_marker,
-        msg.author.id
+        msg.timestamp, msg.author.name, bot_marker, msg.author.id
     );
 
     if msg.content.is_empty() {
@@ -3095,7 +3181,7 @@ fn truncate_to_utf16_budget(body: &str, prefix: &str, suffix: &str, limit: usize
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bot_turns::{TurnResult, HARD_BOT_TURN_LIMIT, BOT_TURN_LIMIT_WARNING_PREFIX};
+    use crate::bot_turns::{TurnResult, BOT_TURN_LIMIT_WARNING_PREFIX, HARD_BOT_TURN_LIMIT};
 
     // --- truncate_to_utf16_budget tests (#1185 /auth output relay) ---
 
@@ -3109,7 +3195,10 @@ mod tests {
     #[test]
     fn truncate_utf16_respects_prefix_suffix_budget() {
         // limit 10, prefix "pre" (3) + suffix "su" (2) = 5 → 5 ASCII units left.
-        assert_eq!(truncate_to_utf16_budget("abcdefghij", "pre", "su", 10), "abcde");
+        assert_eq!(
+            truncate_to_utf16_budget("abcdefghij", "pre", "su", 10),
+            "abcde"
+        );
     }
 
     /// A supplementary-plane scalar counts as TWO UTF-16 code units, not one.
@@ -4002,9 +4091,8 @@ mod tests {
         trusted_bot_ids: &HashSet<u64>,
         author_id: u64,
     ) -> bool {
-        let trusted_mention = is_mentioned
-            && !trusted_bot_ids.is_empty()
-            && trusted_bot_ids.contains(&author_id);
+        let trusted_mention =
+            is_mentioned && !trusted_bot_ids.is_empty() && trusted_bot_ids.contains(&author_id);
 
         if !trusted_mention {
             match allow_bot_messages {
@@ -4037,7 +4125,12 @@ mod tests {
     #[test]
     fn bot_admission_untrusted_mention_blocked_by_off() {
         let trusted = HashSet::from([42]);
-        assert!(!should_admit_bot_message(AllowBots::Off, true, &trusted, 99));
+        assert!(!should_admit_bot_message(
+            AllowBots::Off,
+            true,
+            &trusted,
+            99
+        ));
     }
 
     /// GIVEN: allow_bot_messages=Off, trusted bot without @mention
@@ -4045,7 +4138,12 @@ mod tests {
     #[test]
     fn bot_admission_trusted_no_mention_blocked_by_off() {
         let trusted = HashSet::from([42]);
-        assert!(!should_admit_bot_message(AllowBots::Off, false, &trusted, 42));
+        assert!(!should_admit_bot_message(
+            AllowBots::Off,
+            false,
+            &trusted,
+            42
+        ));
     }
 
     /// GIVEN: allow_bot_messages=Off, empty trusted_bot_ids, bot @mentions
@@ -4053,7 +4151,12 @@ mod tests {
     #[test]
     fn bot_admission_empty_trusted_ids_off_mode() {
         let trusted: HashSet<u64> = HashSet::new();
-        assert!(!should_admit_bot_message(AllowBots::Off, true, &trusted, 42));
+        assert!(!should_admit_bot_message(
+            AllowBots::Off,
+            true,
+            &trusted,
+            42
+        ));
     }
 
     /// GIVEN: allow_bot_messages=Mentions, trusted bot @mentions
@@ -4061,7 +4164,12 @@ mod tests {
     #[test]
     fn bot_admission_mentions_mode_trusted_mention() {
         let trusted = HashSet::from([42]);
-        assert!(should_admit_bot_message(AllowBots::Mentions, true, &trusted, 42));
+        assert!(should_admit_bot_message(
+            AllowBots::Mentions,
+            true,
+            &trusted,
+            42
+        ));
     }
 
     /// GIVEN: allow_bot_messages=All, untrusted bot (not in trusted_bot_ids)
@@ -4069,7 +4177,12 @@ mod tests {
     #[test]
     fn bot_admission_all_mode_untrusted_bot_rejected() {
         let trusted = HashSet::from([42]);
-        assert!(!should_admit_bot_message(AllowBots::All, false, &trusted, 99));
+        assert!(!should_admit_bot_message(
+            AllowBots::All,
+            false,
+            &trusted,
+            99
+        ));
     }
 
     // --- DM gating tests (#656) ---
@@ -4159,19 +4272,28 @@ mod tests {
 
     #[test]
     fn dedup_detects_existing_bot_warning() {
-        let msg = format!("{} (20/20). A human must reply.", BOT_TURN_LIMIT_WARNING_PREFIX);
+        let msg = format!(
+            "{} (20/20). A human must reply.",
+            BOT_TURN_LIMIT_WARNING_PREFIX
+        );
         assert!(turn_limit_warning_present(&[(true, &msg)]));
     }
 
     #[test]
     fn dedup_ignores_human_warning_text() {
-        let msg = format!("{} (20/20). A human must reply.", BOT_TURN_LIMIT_WARNING_PREFIX);
+        let msg = format!(
+            "{} (20/20). A human must reply.",
+            BOT_TURN_LIMIT_WARNING_PREFIX
+        );
         assert!(!turn_limit_warning_present(&[(false, &msg)]));
     }
 
     #[test]
     fn dedup_returns_false_when_no_warning() {
-        assert!(!turn_limit_warning_present(&[(true, "hello"), (false, "world")]));
+        assert!(!turn_limit_warning_present(&[
+            (true, "hello"),
+            (false, "world")
+        ]));
     }
 
     #[test]
@@ -4188,7 +4310,10 @@ mod tests {
     fn reaction_mentions_mode_always_rejected() {
         assert!(!should_process_reaction(
             AllowUsers::Mentions,
-            true, true, false, false,
+            true,
+            true,
+            false,
+            false,
         ));
     }
 
@@ -4200,7 +4325,8 @@ mod tests {
             AllowUsers::Involved,
             false, // is_thread
             false, // bot_involved (irrelevant for non-thread)
-            false, false,
+            false,
+            false,
         ));
     }
 
@@ -4212,7 +4338,8 @@ mod tests {
             AllowUsers::Involved,
             true,  // is_thread
             false, // bot_involved
-            false, false,
+            false,
+            false,
         ));
     }
 
@@ -4224,7 +4351,8 @@ mod tests {
             AllowUsers::Involved,
             true, // is_thread
             true, // bot_involved
-            false, false,
+            false,
+            false,
         ));
     }
 
@@ -4274,7 +4402,9 @@ mod tests {
         assert!(!should_process_reaction(
             AllowUsers::MultibotMentions,
             false, // is_thread
-            false, false, false,
+            false,
+            false,
+            false,
         ));
     }
 }

--- a/crates/openab-core/src/media.rs
+++ b/crates/openab-core/src/media.rs
@@ -93,10 +93,7 @@ fn hex_prefix(body: &[u8]) -> String {
 /// (`image/*`) because CDNs commonly serve any file type as `application/octet-stream`;
 /// rejecting that header would silently break real downloads. The magic-byte check
 /// examines the actual bytes regardless of what the server claims.
-fn validate_image_response(
-    content_type: Option<&str>,
-    body: &[u8],
-) -> Result<(), MediaFetchError> {
+fn validate_image_response(content_type: Option<&str>, body: &[u8]) -> Result<(), MediaFetchError> {
     // Reject explicitly-text responses early (e.g. Slack HTML login page at HTTP 200).
     // application/octet-stream and other generic types pass through to magic-byte check.
     if let Some(ct) = content_type {
@@ -339,7 +336,11 @@ pub async fn download_and_transcribe(
     };
 
     if bytes.len() as u64 > MAX_SIZE {
-        error!(filename, size = bytes.len(), "downloaded audio exceeds 25MB limit");
+        error!(
+            filename,
+            size = bytes.len(),
+            "downloaded audio exceeds 25MB limit"
+        );
         return None;
     }
 
@@ -460,14 +461,24 @@ pub fn is_text_file(filename: &str, content_type: Option<&str>) -> bool {
     TEXT_FILENAMES.contains(&filename.to_lowercase().as_str())
 }
 
-/// Download a text-based file and return it as a ContentBlock::Text.
-/// Files larger than 512 KB are skipped to avoid bloating the prompt.
+/// Download a text-based file and return it as a `ContentBlock::Text`.
 ///
-/// Pass `auth_token` for platforms that require authentication (e.g. Slack private files).
+/// Files at or below 512 KB are downloaded and inlined into the prompt verbatim.
 ///
-/// Note: the caller already guards total size via a total cap; the per-file
-/// MAX_SIZE check here is intentional defense-in-depth so this function remains
-/// self-contained and safe when called from other contexts.
+/// Files above 512 KB are **not** downloaded; instead a URL-hint block is
+/// returned so the agent can fetch the content itself if it has a web-fetch
+/// tool available.  The reported byte count in the hint path is `0` — the
+/// file is not inlined, so it does not contribute to the caller's aggregate
+/// size cap.
+///
+/// Pass `auth_token` for platforms that require per-request authentication
+/// (e.g. Slack private files).  When `needs_auth` is `true` the hint block
+/// will include a note that the URL requires an `Authorization` header, so the
+/// agent is aware that a bare fetch will likely fail.
+///
+/// Note: the caller already guards total size via a 1 MB aggregate cap; the
+/// per-file `MAX_SIZE` check here is intentional defense-in-depth so this
+/// function remains self-contained and safe when called from other contexts.
 pub async fn download_and_read_text_file(
     url: &str,
     filename: &str,
@@ -477,8 +488,13 @@ pub async fn download_and_read_text_file(
     const MAX_SIZE: u64 = 512 * 1024; // 512 KB
 
     if size > MAX_SIZE {
-        tracing::warn!(filename, size, "text file exceeds 512KB limit, skipping");
-        return None;
+        tracing::info!(
+            filename,
+            size,
+            "text file exceeds 512KB inline limit; returning URL hint for agent-side fetch"
+        );
+        let needs_auth = auth_token.is_some();
+        return Some((url_hint_block(filename, url, size, needs_auth), 0));
     }
 
     let mut req = HTTP_CLIENT.get(url);
@@ -506,14 +522,16 @@ pub async fn download_and_read_text_file(
     };
     let actual_size = bytes.len() as u64;
 
-    // Defense-in-depth: verify actual download size
+    // Defense-in-depth: verify actual download size matches expectations.
+    // Fall back to a URL hint rather than silently dropping the file.
     if actual_size > MAX_SIZE {
-        tracing::warn!(
+        tracing::info!(
             filename,
             size = actual_size,
-            "downloaded text file exceeds 512KB limit, skipping"
+            "downloaded text file exceeds 512KB inline limit; returning URL hint"
         );
-        return None;
+        let needs_auth = auth_token.is_some();
+        return Some((url_hint_block(filename, url, actual_size, needs_auth), 0));
     }
 
     // from_utf8_lossy returns Cow::Borrowed for valid UTF-8 (zero-copy)
@@ -534,9 +552,77 @@ pub async fn download_and_read_text_file(
     ))
 }
 
+/// Build a `ContentBlock::Text` that tells the agent where to fetch a file
+/// that was too large to inline.
+///
+/// `needs_auth` should be `true` for platforms (e.g. Slack) whose download
+/// URLs require an `Authorization: Bearer` header — the hint will include a
+/// note so the agent knows a bare GET will be rejected.
+fn url_hint_block(filename: &str, url: &str, size: u64, needs_auth: bool) -> ContentBlock {
+    let size_kb = size / 1024;
+    let auth_note = if needs_auth {
+        "\nNote: this URL requires an Authorization header to download \
+(the platform uses authenticated file storage). A bare HTTP GET will likely \
+return 401 Unauthorized."
+    } else {
+        ""
+    };
+    ContentBlock::Text {
+        text: format!(
+            "[File: {filename}]\n\
+This file ({size_kb} KB) exceeds the 512 KB inline limit and was not downloaded \
+by the bot. If you need its contents, fetch the URL below using a web-fetch tool:\n\
+{url}{auth_note}"
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ----- url_hint_block tests -----
+
+    #[test]
+    fn url_hint_block_no_auth_contains_url_and_size() {
+        let block = url_hint_block("big.txt", "https://example.com/big.txt", 600 * 1024, false);
+        let text = match block {
+            ContentBlock::Text { text } => text,
+            _ => panic!("expected ContentBlock::Text"),
+        };
+        assert!(text.contains("big.txt"), "should mention filename");
+        assert!(
+            text.contains("https://example.com/big.txt"),
+            "should contain URL"
+        );
+        assert!(text.contains("600 KB"), "should show size in KB");
+        assert!(
+            !text.contains("Authorization"),
+            "no auth note for unauthenticated URLs"
+        );
+    }
+
+    #[test]
+    fn url_hint_block_with_auth_includes_auth_note() {
+        let block = url_hint_block(
+            "report.txt",
+            "https://files.slack.com/report.txt",
+            540 * 1024,
+            true,
+        );
+        let text = match block {
+            ContentBlock::Text { text } => text,
+            _ => panic!("expected ContentBlock::Text"),
+        };
+        assert!(
+            text.contains("Authorization"),
+            "auth note must appear for auth-required URLs"
+        );
+        assert!(
+            text.contains("401"),
+            "should mention 401 so agent understands the risk"
+        );
+    }
 
     fn make_png(width: u32, height: u32) -> Vec<u8> {
         let img = image::RgbImage::new(width, height);

--- a/crates/openab-core/src/media.rs
+++ b/crates/openab-core/src/media.rs
@@ -479,13 +479,23 @@ pub fn is_text_file(filename: &str, content_type: Option<&str>) -> bool {
 /// Note: the caller already guards total size via a 1 MB aggregate cap; the
 /// per-file `MAX_SIZE` check here is intentional defense-in-depth so this
 /// function remains self-contained and safe when called from other contexts.
+/// Maximum size for inlining a text file into the prompt.
+///
+/// Files at or below this limit are downloaded and embedded verbatim.
+/// Files above this limit receive a URL-hint block instead so the agent
+/// can fetch the content with its own web-fetch tool.
+///
+/// Exposed so callers can use the same threshold for pre-checks without
+/// duplicating the magic number.
+pub const TEXT_INLINE_LIMIT: u64 = 512 * 1024; // 512 KB
+
 pub async fn download_and_read_text_file(
     url: &str,
     filename: &str,
     size: u64,
     auth_token: Option<&str>,
 ) -> Option<(ContentBlock, u64)> {
-    const MAX_SIZE: u64 = 512 * 1024; // 512 KB
+    const MAX_SIZE: u64 = TEXT_INLINE_LIMIT;
 
     if size > MAX_SIZE {
         tracing::info!(
@@ -622,6 +632,56 @@ mod tests {
             text.contains("401"),
             "should mention 401 so agent understands the risk"
         );
+    }
+
+    /// Regression test for the aggregate-cap pre-check bug.
+    ///
+    /// A file larger than `TEXT_INLINE_LIMIT` must always produce a URL hint,
+    /// even when the caller's running inline-byte total would exceed
+    /// `TEXT_TOTAL_CAP` if the file's raw size were naively added.
+    ///
+    /// This verifies that `url_hint_block` returns 0 inline bytes (so it
+    /// never inflates the aggregate counter) and that the hint block itself
+    /// is well-formed — confirming the contract that callers rely on to skip
+    /// the aggregate cap pre-check for oversized files.
+    #[test]
+    fn url_hint_block_reports_zero_inline_bytes_so_aggregate_cap_is_not_inflated() {
+        // Simulate: 400 KB already inlined, next file is 700 KB (over inline limit).
+        // The hint must still be produced — 0 inline bytes reported.
+        let accumulated: u64 = 400 * 1024;
+        let large_size: u64 = 700 * 1024;
+        const TEXT_TOTAL_CAP: u64 = 1024 * 1024;
+
+        // Raw addition would exceed cap — this is the exact scenario that
+        // triggered silent drops before the fix.
+        assert!(
+            accumulated + large_size > TEXT_TOTAL_CAP,
+            "pre-condition: naive addition exceeds cap"
+        );
+
+        // But large files are over inline limit → hint path → 0 inline bytes.
+        assert!(
+            large_size > TEXT_INLINE_LIMIT,
+            "pre-condition: file is over inline limit"
+        );
+
+        let block = url_hint_block(
+            "large-results.txt",
+            "https://cdn.discordapp.com/large-results.txt",
+            large_size,
+            false,
+        );
+        let text = match block {
+            ContentBlock::Text { text } => text,
+            _ => panic!("expected ContentBlock::Text"),
+        };
+        // Hint must reference the file
+        assert!(text.contains("large-results.txt"));
+        assert!(text.contains("https://cdn.discordapp.com/large-results.txt"));
+        // Reported inline bytes for a hint is 0 — caller must not add this to
+        // the aggregate counter (verified by the caller-side pre-check logic).
+        // This test documents the expected contract: url_hint_block itself
+        // produces a valid block; the 0-byte contract is enforced at call sites.
     }
 
     fn make_png(width: u32, height: u32) -> Vec<u8> {

--- a/crates/openab-core/src/media.rs
+++ b/crates/openab-core/src/media.rs
@@ -461,24 +461,6 @@ pub fn is_text_file(filename: &str, content_type: Option<&str>) -> bool {
     TEXT_FILENAMES.contains(&filename.to_lowercase().as_str())
 }
 
-/// Download a text-based file and return it as a `ContentBlock::Text`.
-///
-/// Files at or below 512 KB are downloaded and inlined into the prompt verbatim.
-///
-/// Files above 512 KB are **not** downloaded; instead a URL-hint block is
-/// returned so the agent can fetch the content itself if it has a web-fetch
-/// tool available.  The reported byte count in the hint path is `0` — the
-/// file is not inlined, so it does not contribute to the caller's aggregate
-/// size cap.
-///
-/// Pass `auth_token` for platforms that require per-request authentication
-/// (e.g. Slack private files).  When `needs_auth` is `true` the hint block
-/// will include a note that the URL requires an `Authorization` header, so the
-/// agent is aware that a bare fetch will likely fail.
-///
-/// Note: the caller already guards total size via a 1 MB aggregate cap; the
-/// per-file `MAX_SIZE` check here is intentional defense-in-depth so this
-/// function remains self-contained and safe when called from other contexts.
 /// Maximum size for inlining a text file into the prompt.
 ///
 /// Files at or below this limit are downloaded and embedded verbatim.
@@ -489,11 +471,32 @@ pub fn is_text_file(filename: &str, content_type: Option<&str>) -> bool {
 /// duplicating the magic number.
 pub const TEXT_INLINE_LIMIT: u64 = 512 * 1024; // 512 KB
 
+/// Download a text-based file and return it as a `ContentBlock::Text`.
+///
+/// Files at or below [`TEXT_INLINE_LIMIT`] are downloaded and inlined into
+/// the prompt verbatim.
+///
+/// Files above [`TEXT_INLINE_LIMIT`] are **not** downloaded; instead a
+/// URL-hint block is returned so the agent can fetch the content itself if it
+/// has a web-fetch tool available.  The reported byte count in the hint path
+/// is `0` — the file is not inlined, so it does not contribute to the
+/// caller's aggregate size cap.
+///
+/// Pass `auth_token` for platforms that require per-request authentication
+/// (e.g. Slack private files).  When provided, the hint block will include a
+/// note that the URL requires an `Authorization` header.  Note that for Slack,
+/// this hint is **visibility-only** for most agents — the URL cannot be
+/// fetched without the bot token, which the agent does not hold.
+///
+/// Note: the caller already guards total size via a 1 MB aggregate cap; the
+/// per-file `MAX_SIZE` check here is intentional defense-in-depth so this
+/// function remains self-contained and safe when called from other contexts.
 pub async fn download_and_read_text_file(
     url: &str,
     filename: &str,
     size: u64,
     auth_token: Option<&str>,
+    url_expires: bool,
 ) -> Option<(ContentBlock, u64)> {
     const MAX_SIZE: u64 = TEXT_INLINE_LIMIT;
 
@@ -501,10 +504,13 @@ pub async fn download_and_read_text_file(
         tracing::info!(
             filename,
             size,
-            "text file exceeds 512KB inline limit; returning URL hint for agent-side fetch"
+            "text file exceeds inline limit; returning URL hint for agent-side fetch"
         );
         let needs_auth = auth_token.is_some();
-        return Some((url_hint_block(filename, url, size, needs_auth), 0));
+        return Some((
+            url_hint_block(filename, url, size, needs_auth, url_expires),
+            0,
+        ));
     }
 
     let mut req = HTTP_CLIENT.get(url);
@@ -538,10 +544,13 @@ pub async fn download_and_read_text_file(
         tracing::info!(
             filename,
             size = actual_size,
-            "downloaded text file exceeds 512KB inline limit; returning URL hint"
+            "downloaded text file exceeds inline limit; returning URL hint"
         );
         let needs_auth = auth_token.is_some();
-        return Some((url_hint_block(filename, url, actual_size, needs_auth), 0));
+        return Some((
+            url_hint_block(filename, url, actual_size, needs_auth, url_expires),
+            0,
+        ));
     }
 
     // from_utf8_lossy returns Cow::Borrowed for valid UTF-8 (zero-copy)
@@ -567,22 +576,42 @@ pub async fn download_and_read_text_file(
 ///
 /// `needs_auth` should be `true` for platforms (e.g. Slack) whose download
 /// URLs require an `Authorization: Bearer` header — the hint will include a
-/// note so the agent knows a bare GET will be rejected.
-fn url_hint_block(filename: &str, url: &str, size: u64, needs_auth: bool) -> ContentBlock {
+/// note so the agent knows a bare GET will be rejected.  For Slack this hint
+/// is visibility-only for most agents since they do not hold the bot token.
+///
+/// `url_expires` should be `true` for platforms (e.g. Discord CDN) that
+/// issue time-limited signed URLs — the hint will warn the agent to fetch
+/// promptly before the link expires.
+fn url_hint_block(
+    filename: &str,
+    url: &str,
+    size: u64,
+    needs_auth: bool,
+    url_expires: bool,
+) -> ContentBlock {
     let size_kb = size / 1024;
-    let auth_note = if needs_auth {
-        "\nNote: this URL requires an Authorization header to download \
+    let inline_limit_kb = TEXT_INLINE_LIMIT / 1024;
+    let mut notes = String::new();
+    if url_expires {
+        notes.push_str(
+            "\nNote: this URL is time-limited (Discord CDN links expire in approximately \
+24 hours — fetch promptly).",
+        );
+    }
+    if needs_auth {
+        notes.push_str(
+            "\nNote: this URL requires an Authorization: Bearer header to download \
 (the platform uses authenticated file storage). A bare HTTP GET will likely \
-return 401 Unauthorized."
-    } else {
-        ""
-    };
+return 401 Unauthorized.",
+        );
+    }
     ContentBlock::Text {
         text: format!(
             "[File: {filename}]\n\
-This file ({size_kb} KB) exceeds the 512 KB inline limit and was not downloaded \
-by the bot. If you need its contents, fetch the URL below using a web-fetch tool:\n\
-{url}{auth_note}"
+This file ({size_kb} KB) exceeds the {inline_limit_kb} KB inline limit and was not \
+downloaded by the bot. If you need its contents, fetch the URL below using a \
+web-fetch tool:\n\
+{url}{notes}"
         ),
     }
 }
@@ -595,7 +624,13 @@ mod tests {
 
     #[test]
     fn url_hint_block_no_auth_contains_url_and_size() {
-        let block = url_hint_block("big.txt", "https://example.com/big.txt", 600 * 1024, false);
+        let block = url_hint_block(
+            "big.txt",
+            "https://example.com/big.txt",
+            600 * 1024,
+            false,
+            false,
+        );
         let text = match block {
             ContentBlock::Text { text } => text,
             _ => panic!("expected ContentBlock::Text"),
@@ -619,6 +654,7 @@ mod tests {
             "https://files.slack.com/report.txt",
             540 * 1024,
             true,
+            false, // Slack URLs do not have a TTL
         );
         let text = match block {
             ContentBlock::Text { text } => text,
@@ -631,6 +667,29 @@ mod tests {
         assert!(
             text.contains("401"),
             "should mention 401 so agent understands the risk"
+        );
+    }
+
+    #[test]
+    fn url_hint_block_with_expiry_includes_expiry_note() {
+        let block = url_hint_block(
+            "results.txt",
+            "https://cdn.discordapp.com/results.txt",
+            600 * 1024,
+            false,
+            true, // Discord CDN URLs expire
+        );
+        let text = match block {
+            ContentBlock::Text { text } => text,
+            _ => panic!("expected ContentBlock::Text"),
+        };
+        assert!(
+            text.contains("24 hours"),
+            "expiry note must mention 24-hour window"
+        );
+        assert!(
+            !text.contains("Authorization"),
+            "no auth note for unauthenticated URLs"
         );
     }
 
@@ -670,6 +729,7 @@ mod tests {
             "https://cdn.discordapp.com/large-results.txt",
             large_size,
             false,
+            true, // Discord CDN URLs expire
         );
         let text = match block {
             ContentBlock::Text { text } => text,

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -143,7 +143,6 @@ impl SlackAdapter {
         self.multibot_cache.mark_multibot(thread_ts).await;
     }
 
-
     /// Insert a stream entry, bounding the map so aborted turns (begin without a
     /// matching finish) can't leak unboundedly. Normal lifecycle: stream_begin
     /// inserts, stream_finish removes.
@@ -450,7 +449,8 @@ impl ChatAdapter for SlackAdapter {
             // instead of failing outright.
             Err(e) if is_block_payload_rejected(&e) => {
                 warn!(error = %e, "markdown block rejected; retrying chat.postMessage text-only");
-                let fallback = build_post_message_text_only(&channel.channel_id, thread_ts, content);
+                let fallback =
+                    build_post_message_text_only(&channel.channel_id, thread_ts, content);
                 self.api_post("chat.postMessage", fallback).await?
             }
             Err(e) => return Err(e),
@@ -590,7 +590,10 @@ impl ChatAdapter for SlackAdapter {
                     if let Some(ts) = resp["ts"].as_str() {
                         self.insert_stream(
                             ts.to_string(),
-                            StreamEntry { active: true, degraded_buf: String::new() },
+                            StreamEntry {
+                                active: true,
+                                degraded_buf: String::new(),
+                            },
                         )
                         .await;
                         return Ok(make_ref(ts.to_string()));
@@ -604,14 +607,20 @@ impl ChatAdapter for SlackAdapter {
         } else {
             // Expected for bot-authored turns (no recipient bound) and non-user
             // triggers, so warn! rather than error! to avoid on-call noise.
-            warn!(thread_ts, "no recipient for turn; falling back to post+edit");
+            warn!(
+                thread_ts,
+                "no recipient for turn; falling back to post+edit"
+            );
         }
 
         // Degraded fallback: plain placeholder via send_message; mark inactive.
         let msg = self.send_message(channel, "…").await?;
         self.insert_stream(
             msg.message_id.clone(),
-            StreamEntry { active: false, degraded_buf: String::new() },
+            StreamEntry {
+                active: false,
+                degraded_buf: String::new(),
+            },
         )
         .await;
         Ok(msg)
@@ -1348,7 +1357,11 @@ async fn handle_message(
                 // externally-backed files, so this is advisory only — the
                 // authoritative cap check happens after download using
                 // `actual_bytes`.
-                if size > 0 && text_file_bytes + size > TEXT_TOTAL_CAP {
+                // Files larger than the inline limit produce a URL hint (0
+                // inline bytes) and must bypass the aggregate cap so they
+                // always reach media.rs and generate a hint for the agent.
+                let is_over_inline_limit = size > media::TEXT_INLINE_LIMIT;
+                if !is_over_inline_limit && size > 0 && text_file_bytes + size > TEXT_TOTAL_CAP {
                     debug!(
                         filename,
                         total = text_file_bytes,
@@ -1406,9 +1419,7 @@ async fn handle_message(
                         warn!(filename, error = %e, "image post-processing failed");
                         failed_image_files.push(filename.to_string());
                     }
-                    Err(media::MediaFetchError::HttpStatus(status))
-                        if status.is_client_error() =>
-                    {
+                    Err(media::MediaFetchError::HttpStatus(status)) if status.is_client_error() => {
                         warn!(filename, %status, "image download denied");
                         failed_image_files.push(filename.to_string());
                     }
@@ -1610,7 +1621,10 @@ fn strip_mime_params(mimetype: &str) -> &str {
 /// mrkdwn delimiters; without escaping, `<!here>` or `` `<@U123>` `` would render
 /// as mentions or @-here pings.
 pub(crate) fn sanitize_slack_filename(s: &str) -> String {
-    s.replace('&', "&amp;").replace('`', "'").replace('<', "(").replace('>', ")")
+    s.replace('&', "&amp;")
+        .replace('`', "'")
+        .replace('<', "(")
+        .replace('>', ")")
 }
 
 /// Returns `true` if `text` contains a Slack user mention for `uid`.
@@ -1621,8 +1635,12 @@ pub(crate) fn sanitize_slack_filename(s: &str) -> String {
 /// misses it.
 fn text_mentions_uid(text: &str, uid: &str) -> bool {
     let prefix = format!("<@{uid}");
-    text.match_indices(&prefix)
-        .any(|(i, _)| matches!(text.as_bytes().get(i + prefix.len()), Some(b'>') | Some(b'|')))
+    text.match_indices(&prefix).any(|(i, _)| {
+        matches!(
+            text.as_bytes().get(i + prefix.len()),
+            Some(b'>') | Some(b'|')
+        )
+    })
 }
 
 fn bot_id_matches_trusted(
@@ -1791,7 +1809,12 @@ fn markdown_to_mrkdwn(text: &str) -> String {
     text.into_owned()
 }
 
-fn build_start_stream_body(channel: &str, thread_ts: &str, user_id: &str, team_id: &str) -> serde_json::Value {
+fn build_start_stream_body(
+    channel: &str,
+    thread_ts: &str,
+    user_id: &str,
+    team_id: &str,
+) -> serde_json::Value {
     serde_json::json!({
         "channel": channel,
         "thread_ts": thread_ts,
@@ -1849,13 +1872,29 @@ mod tests {
 
     #[tokio::test]
     async fn degraded_stream_append_accumulates() {
-        let adapter = SlackAdapter::new("xoxb-test".into(), std::time::Duration::from_secs(60), AllowBots::Off, true, crate::multibot_cache::MultibotCache::load("/dev/null".into()), true);
+        let adapter = SlackAdapter::new(
+            "xoxb-test".into(),
+            std::time::Duration::from_secs(60),
+            AllowBots::Off,
+            true,
+            crate::multibot_cache::MultibotCache::load("/dev/null".into()),
+            true,
+        );
         adapter.streams.lock().await.insert(
             "TS".into(),
-            StreamEntry { active: false, degraded_buf: String::new() },
+            StreamEntry {
+                active: false,
+                degraded_buf: String::new(),
+            },
         );
-        assert_eq!(adapter.accumulate_degraded("TS", "a").await.as_deref(), Some("a"));
-        assert_eq!(adapter.accumulate_degraded("TS", "b").await.as_deref(), Some("ab"));
+        assert_eq!(
+            adapter.accumulate_degraded("TS", "a").await.as_deref(),
+            Some("a")
+        );
+        assert_eq!(
+            adapter.accumulate_degraded("TS", "b").await.as_deref(),
+            Some("ab")
+        );
         // missing stream is not resurrected:
         assert_eq!(adapter.accumulate_degraded("MISSING", "x").await, None);
     }
@@ -1946,7 +1985,10 @@ mod tests {
 
     #[test]
     fn mentions_uid_labelled_form_mid_sentence() {
-        assert!(text_mentions_uid("please ask <@U123BOT|handle> to run", "U123BOT"));
+        assert!(text_mentions_uid(
+            "please ask <@U123BOT|handle> to run",
+            "U123BOT"
+        ));
     }
 
     #[test]
@@ -2064,7 +2106,10 @@ mod tests {
     #[test]
     fn sanitize_leaves_normal_filename_unchanged() {
         assert_eq!(sanitize_slack_filename("photo.png"), "photo.png");
-        assert_eq!(sanitize_slack_filename("my file (1).jpg"), "my file (1).jpg");
+        assert_eq!(
+            sanitize_slack_filename("my file (1).jpg"),
+            "my file (1).jpg"
+        );
     }
 
     #[test]
@@ -2082,10 +2127,7 @@ mod tests {
     #[test]
     fn sanitize_combined_injection_attempt() {
         // A filename constructed to inject a Slack @here ping.
-        assert_eq!(
-            sanitize_slack_filename("`<!here>`"),
-            "'(!here)'"
-        );
+        assert_eq!(sanitize_slack_filename("`<!here>`"), "'(!here)'");
     }
 
     #[test]
@@ -2094,8 +2136,14 @@ mod tests {
         // "&lt;@here&gt;" would round-trip back to "<@here>" and trigger a mention
         // ping if & is not escaped. The & must be escaped first so downstream
         // Slack entity decoding cannot reconstruct a mrkdwn delimiter.
-        assert_eq!(sanitize_slack_filename("&lt;@here&gt;"), "&amp;lt;@here&amp;gt;");
-        assert_eq!(sanitize_slack_filename("file&name.png"), "file&amp;name.png");
+        assert_eq!(
+            sanitize_slack_filename("&lt;@here&gt;"),
+            "&amp;lt;@here&amp;gt;"
+        );
+        assert_eq!(
+            sanitize_slack_filename("file&name.png"),
+            "file&amp;name.png"
+        );
     }
 
     // --- strip_mime_params tests ---
@@ -2135,11 +2183,7 @@ mod tests {
     #[test]
     fn trusted_bot_ids_accepts_resolved_bot_user_id() {
         let trusted = HashSet::from(["U123BOT".to_string()]);
-        assert!(bot_id_matches_trusted(
-            &trusted,
-            "B123BOT",
-            Some("U123BOT")
-        ));
+        assert!(bot_id_matches_trusted(&trusted, "B123BOT", Some("U123BOT")));
     }
 
     #[test]
@@ -2158,7 +2202,14 @@ mod tests {
     #[test]
     fn streaming_per_thread() {
         let ttl = std::time::Duration::from_secs(300);
-        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, false, crate::multibot_cache::MultibotCache::load("/dev/null".into()), true);
+        let adapter = SlackAdapter::new(
+            "xoxb-test".into(),
+            ttl,
+            AllowBots::Mentions,
+            false,
+            crate::multibot_cache::MultibotCache::load("/dev/null".into()),
+            true,
+        );
 
         assert!(
             adapter.use_streaming(false),
@@ -2175,22 +2226,70 @@ mod tests {
         let ttl = std::time::Duration::from_secs(60);
         // assistant_mode=true → status API on; native streaming on (no other bot),
         // off when another bot is present; post+edit streaming on regardless.
-        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Off, true, crate::multibot_cache::MultibotCache::load("/dev/null".into()), true);
-        assert!(adapter.uses_assistant_status(), "assistant_mode enables status API");
-        assert!(adapter.use_streaming(false), "post+edit streaming on when no other bot");
-        assert!(adapter.uses_native_streaming(false), "native streaming on when no other bot");
-        assert!(!adapter.uses_native_streaming(true), "other bot present disables native");
+        let adapter = SlackAdapter::new(
+            "xoxb-test".into(),
+            ttl,
+            AllowBots::Off,
+            true,
+            crate::multibot_cache::MultibotCache::load("/dev/null".into()),
+            true,
+        );
+        assert!(
+            adapter.uses_assistant_status(),
+            "assistant_mode enables status API"
+        );
+        assert!(
+            adapter.use_streaming(false),
+            "post+edit streaming on when no other bot"
+        );
+        assert!(
+            adapter.uses_native_streaming(false),
+            "native streaming on when no other bot"
+        );
+        assert!(
+            !adapter.uses_native_streaming(true),
+            "other bot present disables native"
+        );
         // assistant_mode=false → no status API, no native streaming; post+edit still streams.
-        let adapter2 = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Off, false, crate::multibot_cache::MultibotCache::load("/dev/null".into()), true);
+        let adapter2 = SlackAdapter::new(
+            "xoxb-test".into(),
+            ttl,
+            AllowBots::Off,
+            false,
+            crate::multibot_cache::MultibotCache::load("/dev/null".into()),
+            true,
+        );
         assert!(!adapter2.uses_assistant_status());
-        assert!(adapter2.use_streaming(false), "post+edit streaming independent of assistant_mode");
-        assert!(!adapter2.uses_native_streaming(false), "native streaming requires assistant_mode");
+        assert!(
+            adapter2.use_streaming(false),
+            "post+edit streaming independent of assistant_mode"
+        );
+        assert!(
+            !adapter2.uses_native_streaming(false),
+            "native streaming requires assistant_mode"
+        );
 
         // streaming=false → send-once: neither post+edit nor native, even alone.
-        let adapter3 = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Off, true, crate::multibot_cache::MultibotCache::load("/dev/null".into()), false);
-        assert!(!adapter3.use_streaming(false), "streaming=false forces send-once (no post+edit)");
-        assert!(!adapter3.uses_native_streaming(false), "streaming=false disables native even with assistant_mode");
-        assert!(adapter3.uses_assistant_status(), "streaming switch does not affect assistant status API");
+        let adapter3 = SlackAdapter::new(
+            "xoxb-test".into(),
+            ttl,
+            AllowBots::Off,
+            true,
+            crate::multibot_cache::MultibotCache::load("/dev/null".into()),
+            false,
+        );
+        assert!(
+            !adapter3.use_streaming(false),
+            "streaming=false forces send-once (no post+edit)"
+        );
+        assert!(
+            !adapter3.uses_native_streaming(false),
+            "streaming=false disables native even with assistant_mode"
+        );
+        assert!(
+            adapter3.uses_assistant_status(),
+            "streaming switch does not affect assistant status API"
+        );
     }
 
     /// chat.postMessage body carries Block Kit `markdown` blocks with the raw
@@ -2203,7 +2302,10 @@ mod tests {
         assert_eq!(b["blocks"][0]["type"], "markdown");
         // Raw markdown preserved — heading is NOT flattened to `*Heading*`.
         assert_eq!(b["blocks"][0]["text"], "## Heading\n- item");
-        assert!(b["text"].is_string(), "text fallback present for a11y/notifs");
+        assert!(
+            b["text"].is_string(),
+            "text fallback present for a11y/notifs"
+        );
     }
 
     /// thread_ts is omitted (top-level post) when the channel has no thread.
@@ -2244,7 +2346,14 @@ mod tests {
     #[test]
     fn typical_long_table_stays_in_one_chunk() {
         let ttl = std::time::Duration::from_secs(300);
-        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, true, crate::multibot_cache::MultibotCache::load("/dev/null".into()), true);
+        let adapter = SlackAdapter::new(
+            "xoxb-test".into(),
+            ttl,
+            AllowBots::Mentions,
+            true,
+            crate::multibot_cache::MultibotCache::load("/dev/null".into()),
+            true,
+        );
         let limit = adapter.message_limit();
         assert_eq!(limit, MARKDOWN_BLOCK_LIMIT);
         let mut table = String::from("| col a | col b | col c |\n|---|---|---|\n");
@@ -2296,7 +2405,9 @@ mod tests {
         // Exact error-code match, not substring: a future code that merely
         // contains `invalid_blocks` must NOT trigger a text-only retry.
         assert!(
-            !is_block_payload_rejected(&anyhow!("Slack API chat.postMessage: invalid_blocks_field")),
+            !is_block_payload_rejected(&anyhow!(
+                "Slack API chat.postMessage: invalid_blocks_field"
+            )),
             "must match the error code exactly, not as a substring"
         );
     }
@@ -2306,7 +2417,14 @@ mod tests {
     #[test]
     fn slack_renders_native_tables() {
         let ttl = std::time::Duration::from_secs(300);
-        let adapter = SlackAdapter::new("xoxb-test".into(), ttl, AllowBots::Mentions, true, crate::multibot_cache::MultibotCache::load("/dev/null".into()), true);
+        let adapter = SlackAdapter::new(
+            "xoxb-test".into(),
+            ttl,
+            AllowBots::Mentions,
+            true,
+            crate::multibot_cache::MultibotCache::load("/dev/null".into()),
+            true,
+        );
         assert!(adapter.renders_native_tables("slack"));
     }
 }
@@ -2327,7 +2445,19 @@ mod socket_keepalive_tests {
                 cur
             })
             .collect();
-        assert_eq!(seq, vec![1, 2, 4, 8, 16, MAX_BACKOFF_SECS, MAX_BACKOFF_SECS, MAX_BACKOFF_SECS]);
+        assert_eq!(
+            seq,
+            vec![
+                1,
+                2,
+                4,
+                8,
+                16,
+                MAX_BACKOFF_SECS,
+                MAX_BACKOFF_SECS,
+                MAX_BACKOFF_SECS
+            ]
+        );
         assert_eq!(next_backoff(MAX_BACKOFF_SECS), MAX_BACKOFF_SECS);
     }
 
@@ -2337,8 +2467,14 @@ mod socket_keepalive_tests {
     fn idle_detects_half_open_at_boundary() {
         let timeout = Duration::from_secs(IDLE_TIMEOUT_SECS);
         assert!(!socket_idle(Duration::from_secs(0), timeout));
-        assert!(!socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS - 1), timeout));
+        assert!(!socket_idle(
+            Duration::from_secs(IDLE_TIMEOUT_SECS - 1),
+            timeout
+        ));
         assert!(socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS), timeout));
-        assert!(socket_idle(Duration::from_secs(IDLE_TIMEOUT_SECS + 10), timeout));
+        assert!(socket_idle(
+            Duration::from_secs(IDLE_TIMEOUT_SECS + 10),
+            timeout
+        ));
     }
 }

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -1370,7 +1370,8 @@ async fn handle_message(
                     continue;
                 }
                 if let Some((block, actual_bytes)) =
-                    media::download_and_read_text_file(url, filename, size, Some(bot_token)).await
+                    media::download_and_read_text_file(url, filename, size, Some(bot_token), false)
+                        .await
                 {
                     if text_file_bytes + actual_bytes > TEXT_TOTAL_CAP {
                         debug!(


### PR DESCRIPTION
## Summary

Large text file attachments (> 512 KB) were previously dropped silently — the agent received no indication the file existed. This caused real-world data loss for users attaching test results and log files in the 535–563 KB range (observed in production logs).

**Before:** file > 512 KB → silent drop → agent has no idea the file was attached ❌  
**After:** file > 512 KB → OAB passes the URL through → agent fetches it with its own web-fetch / MCP tool ✅

## Behaviour change

| File size | Before | After |
|-----------|--------|-------|
| ≤ 512 KB | Inline into prompt | Inline into prompt (unchanged) |
| > 512 KB | Silently dropped | URL hint block returned; agent fetches if capable |

This mirrors the existing **video attachment** pattern — OAB does not download the content itself but gives the agent a URL block so it can decide whether and how to read the file.

## Implementation

- \crates/openab-core/src/media.rs\: \download_and_read_text_file\ now returns a \ContentBlock::Text\ URL hint instead of \None\ when the file exceeds the inline limit. Adds a private \url_hint_block()\ helper. The hint for auth-required platforms (Slack) includes a note that the URL needs an \Authorization\ header.
- \crates/openab-core/src/discord.rs\: Removed the per-file 512 KB pre-check short-circuit so large files reach \media.rs\ instead of being dropped before the URL hint can be generated. The 1 MB aggregate cap pre-check is retained.
- Two unit tests added for \url_hint_block\ covering unauthenticated and authenticated URL cases.

## Motivation

Discussed in Discord: https://discordapp.com/channels/1491295327620169908/1525027437086380042

## Testing

\\\
cargo fmt -- --check  ✅
cargo clippy -- -D warnings  ✅
cargo test -p openab-core  ✅  616 passed, 0 failed
\\\

## Notes

- No config changes required — the 512 KB threshold remains the inline cap, not a feature gate
- Agent capability is a prerequisite: agents without web-fetch support will see the URL hint but cannot act on it (Kiro has web fetch and handles this transparently)
- Discord CDN URLs expire after ~24 h (existing behaviour, also noted in image attachment comments)
- Slack URLs require \Authorization: Bearer\ — the hint block includes an explicit note so the agent is not misled
