### PR TITLE
chore(filestore): hardening and cleanup follow-ups

### DIFF
--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -124,8 +124,8 @@ fn default_agentcore_cancel_strategy() -> AgentCoreCancelStrategy {
     AgentCoreCancelStrategy::Stop
 }
 
-/// Configuration for the S3/R2-compatible object store used to upload large
-/// text file attachments (>512 KB) and return presigned GET URLs.
+/// Configuration for the S3/R2-compatible object store used to upload
+/// file attachments and return presigned GET URLs.
 #[derive(Debug, Clone, Deserialize)]
 #[cfg(feature = "filestore")]
 pub struct FilestoreConfig {

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -213,7 +213,7 @@ pub struct Handler {
     pub allowed_users: HashSet<u64>,
     pub stt_config: SttConfig,
     pub adapter: OnceLock<Arc<dyn ChatAdapter>>,
-    /// Optional filestore for uploading large text file attachments.
+    /// Optional filestore for uploading file attachments.
     #[cfg(feature = "filestore")]
     pub filestore: Option<Arc<crate::filestore::Filestore>>,
     pub allow_bot_messages: AllowBots,
@@ -897,7 +897,7 @@ impl EventHandler for Handler {
                 // be uploaded to S3, not inlined).
                 let attachment_size = u64::from(attachment.size);
                 #[cfg(feature = "filestore")]
-                let skip_cap = self.filestore.is_some() && attachment_size > 512 * 1024;
+                let skip_cap = self.filestore.is_some() && attachment_size > crate::media::TEXT_INLINE_LIMIT;
                 #[cfg(not(feature = "filestore"))]
                 let skip_cap = false;
                 if !skip_cap && text_file_bytes + attachment_size > TEXT_TOTAL_CAP {

--- a/crates/openab-core/src/filestore.rs
+++ b/crates/openab-core/src/filestore.rs
@@ -1,4 +1,4 @@
-//! S3/R2-compatible object store for uploading large text file attachments
+//! S3/R2-compatible object store for uploading file attachments
 //! and returning presigned GET URLs.
 
 use crate::config::FilestoreConfig;
@@ -97,10 +97,11 @@ impl Filestore {
         filename: &str,
         data: &[u8],
     ) -> anyhow::Result<String> {
-        // Sanitize filename: strip path separators, traversal sequences, and
+        // Sanitize filename: strip path separators, traversal sequences,
+        // double quotes (breaks Content-Disposition header parsing), and
         // non-ASCII chars. Limit length to prevent excessively long S3 keys.
         let safe_name: String = filename
-            .replace(['/', '\\', '\0'], "_")
+            .replace(['/', '\\', '\0', '"'], "_")
             .replace("..", "_")
             .chars()
             .filter(|c| c.is_ascii_graphic() || *c == ' ')
@@ -122,6 +123,7 @@ impl Filestore {
             .bucket(&self.bucket)
             .key(&key)
             .content_type("text/plain; charset=utf-8")
+            .content_disposition(format!("attachment; filename=\"{safe_name}\""))
             .body(aws_sdk_s3::primitives::ByteStream::from(data.to_vec()))
             .send();
 
@@ -175,7 +177,7 @@ impl Filestore {
 
         // Sanitize filename (same logic as upload_and_presign)
         let safe_name: String = filename
-            .replace(['/', '\\', '\0'], "_")
+            .replace(['/', '\\', '\0', '"'], "_")
             .replace("..", "_")
             .chars()
             .filter(|c| c.is_ascii_graphic() || *c == ' ')
@@ -203,6 +205,7 @@ impl Filestore {
             .bucket(&self.bucket)
             .key(&key)
             .content_type(content_type.unwrap_or("application/octet-stream"))
+            .content_disposition(format!("attachment; filename=\"{safe_name}\""))
             .send()
             .await
             .map_err(|e| {
@@ -258,13 +261,21 @@ impl Filestore {
                     .await
                 {
                     Ok(resp) => {
-                        parts.push(
-                            CompletedPart::builder()
-                                .part_number(part_number)
-                                .e_tag(resp.e_tag.unwrap_or_default())
-                                .build(),
-                        );
-                        part_number += 1;
+                        match resp.e_tag {
+                            Some(tag) => {
+                                parts.push(
+                                    CompletedPart::builder()
+                                        .part_number(part_number)
+                                        .e_tag(tag)
+                                        .build(),
+                                );
+                                part_number += 1;
+                            }
+                            None => {
+                                upload_error = Some(anyhow::anyhow!("upload_part {part_number} returned no ETag"));
+                                break;
+                            }
+                        }
                     }
                     Err(e) => {
                         upload_error = Some(anyhow::anyhow!("upload_part {part_number} failed: {e}"));
@@ -288,12 +299,19 @@ impl Filestore {
                 .await
             {
                 Ok(resp) => {
-                    parts.push(
-                        CompletedPart::builder()
-                            .part_number(part_number)
-                            .e_tag(resp.e_tag.unwrap_or_default())
-                            .build(),
-                    );
+                    match resp.e_tag {
+                        Some(tag) => {
+                            parts.push(
+                                CompletedPart::builder()
+                                    .part_number(part_number)
+                                    .e_tag(tag)
+                                    .build(),
+                            );
+                        }
+                        None => {
+                            upload_error = Some(anyhow::anyhow!("upload_part {part_number} (final) returned no ETag"));
+                        }
+                    }
                 }
                 Err(e) => {
                     upload_error = Some(anyhow::anyhow!("upload_part {part_number} (final) failed: {e}"));
@@ -361,10 +379,24 @@ impl Filestore {
                 .await
             {
                 Ok(resp) => {
+                    let e_tag = match resp.e_tag {
+                        Some(tag) => tag,
+                        None => {
+                            error!(bucket = %self.bucket, key = %key, "upload single part returned no ETag, aborting");
+                            let _ = self.client
+                                .abort_multipart_upload()
+                                .bucket(&self.bucket)
+                                .key(&key)
+                                .upload_id(&upload_id)
+                                .send()
+                                .await;
+                            return Err(anyhow::anyhow!("upload single part returned no ETag"));
+                        }
+                    };
                     parts.push(
                         CompletedPart::builder()
                             .part_number(1)
-                            .e_tag(resp.e_tag.unwrap_or_default())
+                            .e_tag(e_tag)
                             .build(),
                     );
                 }

--- a/crates/openab-core/src/gateway.rs
+++ b/crates/openab-core/src/gateway.rs
@@ -997,9 +997,8 @@ pub async fn run_gateway_adapter(
                                             }
                                             "text_file" => {
                                                 if let Ok(bytes) = bytes_result {
-                                                    const INLINE_LIMIT: u64 = 512 * 1024;
                                                     let size = bytes.len() as u64;
-                                                    if size <= INLINE_LIMIT {
+                                                    if size <= crate::media::TEXT_INLINE_LIMIT {
                                                         let text = String::from_utf8_lossy(&bytes);
                                                         extra_blocks.push(ContentBlock::Text {
                                                             text: format!("```{}\n{}\n```", att.filename, text),
@@ -1416,9 +1415,8 @@ pub async fn process_gateway_event(
             "text_file" => {
                 match bytes_result {
                     Ok(bytes) => {
-                        const INLINE_LIMIT: u64 = 512 * 1024;
                         let size = bytes.len() as u64;
-                        if size <= INLINE_LIMIT {
+                        if size <= crate::media::TEXT_INLINE_LIMIT {
                             let text = String::from_utf8_lossy(&bytes);
                             extra_blocks.push(ContentBlock::Text {
                                 text: format!("```{}\n{}\n```", att.filename, text),

--- a/crates/openab-core/src/gateway.rs
+++ b/crates/openab-core/src/gateway.rs
@@ -997,11 +997,16 @@ pub async fn run_gateway_adapter(
                                             }
                                             "text_file" => {
                                                 if let Ok(bytes) = bytes_result {
+                                                    let safe_filename: String = att.filename
+                                                        .chars()
+                                                        .filter(|c| !c.is_control())
+                                                        .take(200)
+                                                        .collect();
                                                     let size = bytes.len() as u64;
                                                     if size <= crate::media::TEXT_INLINE_LIMIT {
                                                         let text = String::from_utf8_lossy(&bytes);
                                                         extra_blocks.push(ContentBlock::Text {
-                                                            text: format!("```{}\n{}\n```", att.filename, text),
+                                                            text: format!("[File: {safe_filename}]\n```\n{text}\n```"),
                                                         });
                                                     } else {
                                                         // Large file — upload to filestore if available
@@ -1015,8 +1020,7 @@ pub async fn run_gateway_adapter(
                                                                 tracing::warn!(filename = %att.filename, size = bytes.len(), "filestore upload refused; emitting degraded hint");
                                                                 extra_blocks.push(ContentBlock::Text {
                                                                     text: format!(
-                                                                        "[File: {}]\nThis file ({} KB) exceeds the configured upload limit and could not be stored.",
-                                                                        att.filename, size_kb
+                                                                        "[File: {safe_filename}]\nThis file ({size_kb} KB) exceeds the configured upload limit and could not be stored."
                                                                     ),
                                                                 });
                                                             }
@@ -1024,7 +1028,7 @@ pub async fn run_gateway_adapter(
                                                             // No filestore configured — fall back to inline (original behavior)
                                                             let text = String::from_utf8_lossy(&bytes);
                                                             extra_blocks.push(ContentBlock::Text {
-                                                                text: format!("```{}\n{}\n```", att.filename, text),
+                                                                text: format!("[File: {safe_filename}]\n```\n{text}\n```"),
                                                             });
                                                         }
                                                         #[cfg(not(feature = "filestore"))]
@@ -1032,7 +1036,7 @@ pub async fn run_gateway_adapter(
                                                             // Feature not compiled — inline as before
                                                             let text = String::from_utf8_lossy(&bytes);
                                                             extra_blocks.push(ContentBlock::Text {
-                                                                text: format!("```{}\n{}\n```", att.filename, text),
+                                                                text: format!("[File: {safe_filename}]\n```\n{text}\n```"),
                                                             });
                                                         }
                                                     }
@@ -1415,11 +1419,16 @@ pub async fn process_gateway_event(
             "text_file" => {
                 match bytes_result {
                     Ok(bytes) => {
+                        let safe_filename: String = att.filename
+                            .chars()
+                            .filter(|c| !c.is_control())
+                            .take(200)
+                            .collect();
                         let size = bytes.len() as u64;
                         if size <= crate::media::TEXT_INLINE_LIMIT {
                             let text = String::from_utf8_lossy(&bytes);
                             extra_blocks.push(ContentBlock::Text {
-                                text: format!("```{}\n{}\n```", att.filename, text),
+                                text: format!("[File: {safe_filename}]\n```\n{text}\n```"),
                             });
                         } else {
                             // Large file — upload to filestore if available
@@ -1433,8 +1442,7 @@ pub async fn process_gateway_event(
                                     tracing::warn!(filename = %att.filename, size = bytes.len(), "filestore upload refused; emitting degraded hint");
                                     extra_blocks.push(ContentBlock::Text {
                                         text: format!(
-                                            "[File: {}]\nThis file ({} KB) exceeds the configured upload limit and could not be stored.",
-                                            att.filename, size_kb
+                                            "[File: {safe_filename}]\nThis file ({size_kb} KB) exceeds the configured upload limit and could not be stored."
                                         ),
                                     });
                                 }
@@ -1442,7 +1450,7 @@ pub async fn process_gateway_event(
                                 // No filestore configured — fall back to inline (original behavior)
                                 let text = String::from_utf8_lossy(&bytes);
                                 extra_blocks.push(ContentBlock::Text {
-                                    text: format!("```{}\n{}\n```", att.filename, text),
+                                    text: format!("[File: {safe_filename}]\n```\n{text}\n```"),
                                 });
                             }
                             #[cfg(not(feature = "filestore"))]
@@ -1450,7 +1458,7 @@ pub async fn process_gateway_event(
                                 // Feature not compiled — inline as before
                                 let text = String::from_utf8_lossy(&bytes);
                                 extra_blocks.push(ContentBlock::Text {
-                                    text: format!("```{}\n{}\n```", att.filename, text),
+                                    text: format!("[File: {safe_filename}]\n```\n{text}\n```"),
                                 });
                             }
                         }

--- a/crates/openab-core/src/media.rs
+++ b/crates/openab-core/src/media.rs
@@ -22,6 +22,11 @@ const IMAGE_MAX_DIMENSION_PX: u32 = 1200;
 /// JPEG quality for compressed output.
 const IMAGE_JPEG_QUALITY: u8 = 75;
 
+/// Maximum file size (in bytes) for inline text content in prompts.
+/// Files larger than this are routed to the filestore (when configured)
+/// instead of being embedded directly in the conversation context.
+pub const TEXT_INLINE_LIMIT: u64 = 512 * 1024; // 512 KB
+
 /// Error variants for `download_and_encode_image`.
 #[derive(Debug)]
 pub enum MediaFetchError {
@@ -480,9 +485,7 @@ pub async fn download_and_read_text_file(
     auth_token: Option<&str>,
     filestore: Option<&crate::filestore::Filestore>,
 ) -> Option<(ContentBlock, u64)> {
-    const MAX_SIZE: u64 = 512 * 1024; // 512 KB
-
-    if size > MAX_SIZE {
+    if size > TEXT_INLINE_LIMIT {
         // When filestore is available, download the oversized file and upload it.
         if let Some(fs) = filestore {
             return download_and_upload_to_filestore(url, filename, size, auth_token, fs).await;
@@ -509,9 +512,7 @@ pub async fn download_and_read_text_file(
     size: u64,
     auth_token: Option<&str>,
 ) -> Option<(ContentBlock, u64)> {
-    const MAX_SIZE: u64 = 512 * 1024; // 512 KB
-
-    if size > MAX_SIZE {
+    if size > TEXT_INLINE_LIMIT {
         tracing::warn!(filename, size, "text file exceeds 512KB limit, skipping");
         return None;
     }
@@ -528,8 +529,11 @@ async fn download_text_file_inner(
     auth_token: Option<&str>,
     filestore: Option<&crate::filestore::Filestore>,
 ) -> Option<(ContentBlock, u64)> {
-    const MAX_SIZE: u64 = 512 * 1024;
-
+    let safe_filename: String = filename
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(200)
+        .collect();
     // Use extended timeout when filestore is available — Content-Length > 512KB
     // may trigger streaming upload which needs the full 10-minute window.
     let timeout = if filestore.is_some() {
@@ -559,7 +563,7 @@ async fn download_text_file_inner(
     // instead of buffering the entire file in memory.
     if let Some(fs) = filestore {
         if let Some(content_length) = resp.content_length() {
-            if content_length > MAX_SIZE {
+            if content_length > TEXT_INLINE_LIMIT {
                 tracing::info!(
                     url,
                     content_length,
@@ -585,7 +589,7 @@ async fn download_text_file_inner(
                         tracing::error!(filename, error = %e, "filestore stream upload failed (inline fallback)");
                         let size_kb = content_length / 1024;
                         let hint = format!(
-                            "[File: {filename}]\n\
+                            "[File: {safe_filename}]\n\
                              This file ({size_kb} KB) could not be uploaded to temporary storage \
                              (upload failed). The file content is unavailable."
                         );
@@ -595,7 +599,7 @@ async fn download_text_file_inner(
                         tracing::error!(filename, "filestore stream upload timed out (inline fallback)");
                         let size_kb = content_length / 1024;
                         let hint = format!(
-                            "[File: {filename}]\n\
+                            "[File: {safe_filename}]\n\
                              This file ({size_kb} KB) upload timed out. \
                              The file content is unavailable."
                         );
@@ -616,7 +620,7 @@ async fn download_text_file_inner(
     let actual_size = bytes.len() as u64;
 
     // Defense-in-depth: verify actual download size
-    if actual_size > MAX_SIZE {
+    if actual_size > TEXT_INLINE_LIMIT {
         // When filestore is available, upload the oversized download.
         if let Some(fs) = filestore {
             return upload_bytes_to_filestore(filename, &bytes, fs).await;
@@ -641,7 +645,7 @@ async fn download_text_file_inner(
     debug!(filename, bytes = text.len(), "text file inlined");
     Some((
         ContentBlock::Text {
-            text: format!("[File: {filename}]\n{fence}\n{text}\n{fence}"),
+            text: format!("[File: {safe_filename}]\n{fence}\n{text}\n{fence}"),
         },
         actual_size,
     ))
@@ -654,7 +658,11 @@ async fn download_text_file_inner(
     filename: &str,
     auth_token: Option<&str>,
 ) -> Option<(ContentBlock, u64)> {
-    const MAX_SIZE: u64 = 512 * 1024;
+    let safe_filename: String = filename
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(200)
+        .collect();
 
     let mut req = HTTP_CLIENT.get(url);
     if let Some(token) = auth_token {
@@ -682,7 +690,7 @@ async fn download_text_file_inner(
     let actual_size = bytes.len() as u64;
 
     // Defense-in-depth: verify actual download size
-    if actual_size > MAX_SIZE {
+    if actual_size > TEXT_INLINE_LIMIT {
         tracing::warn!(
             filename,
             size = actual_size,
@@ -703,7 +711,7 @@ async fn download_text_file_inner(
     debug!(filename, bytes = text.len(), "text file inlined");
     Some((
         ContentBlock::Text {
-            text: format!("[File: {filename}]\n{fence}\n{text}\n{fence}"),
+            text: format!("[File: {safe_filename}]\n{fence}\n{text}\n{fence}"),
         },
         actual_size,
     ))
@@ -723,6 +731,11 @@ async fn download_and_upload_to_filestore(
     auth_token: Option<&str>,
     filestore: &crate::filestore::Filestore,
 ) -> Option<(ContentBlock, u64)> {
+    let safe_filename: String = filename
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(200)
+        .collect();
     // Cap file size to prevent abuse (configurable, default 250 MB, max 500 MB).
     let max_size = filestore.max_file_size();
     if size > max_size {
@@ -795,7 +808,7 @@ async fn download_and_upload_to_filestore(
             tracing::error!(filename, error = %e, "filestore stream upload failed");
             let size_kb = size / 1024;
             let hint = format!(
-                "[File: {filename}]\n\
+                "[File: {safe_filename}]\n\
                  This file ({size_kb} KB) could not be uploaded to temporary storage \
                  (upload failed). The file content is unavailable."
             );
@@ -805,7 +818,7 @@ async fn download_and_upload_to_filestore(
             tracing::error!(filename, "filestore stream upload timed out (600s)");
             let size_kb = size / 1024;
             let hint = format!(
-                "[File: {filename}]\n\
+                "[File: {safe_filename}]\n\
                  This file ({size_kb} KB) could not be uploaded to temporary storage \
                  (upload timed out). The file content is unavailable."
             );
@@ -942,6 +955,11 @@ async fn upload_bytes_to_filestore(
     bytes: &[u8],
     filestore: &crate::filestore::Filestore,
 ) -> Option<(ContentBlock, u64)> {
+    let safe_filename: String = filename
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(200)
+        .collect();
     let actual_size = bytes.len() as u64;
 
     // Centralized size cap — defense-in-depth regardless of which caller
@@ -977,7 +995,7 @@ async fn upload_bytes_to_filestore(
             // Return a degraded hint so the agent knows the file exists
             let size_kb = actual_size / 1024;
             let hint = format!(
-                "[File: {filename}]\n\
+                "[File: {safe_filename}]\n\
                  This file ({size_kb} KB) could not be uploaded to temporary storage \
                  (upload failed). The file content is unavailable."
             );

--- a/crates/openab-core/src/media.rs
+++ b/crates/openab-core/src/media.rs
@@ -490,7 +490,7 @@ pub async fn download_and_read_text_file(
         if let Some(fs) = filestore {
             return download_and_upload_to_filestore(url, filename, size, auth_token, fs).await;
         }
-        tracing::warn!(filename, size, "text file exceeds 512KB limit, skipping");
+        tracing::warn!(filename, size, "text file exceeds inline limit, skipping");
         return None;
     }
 
@@ -513,7 +513,7 @@ pub async fn download_and_read_text_file(
     auth_token: Option<&str>,
 ) -> Option<(ContentBlock, u64)> {
     if size > TEXT_INLINE_LIMIT {
-        tracing::warn!(filename, size, "text file exceeds 512KB limit, skipping");
+        tracing::warn!(filename, size, "text file exceeds inline limit, skipping");
         return None;
     }
 
@@ -628,7 +628,7 @@ async fn download_text_file_inner(
         tracing::warn!(
             filename,
             size = actual_size,
-            "downloaded text file exceeds 512KB limit, skipping"
+            "downloaded text file exceeds inline limit, skipping"
         );
         return None;
     }
@@ -694,7 +694,7 @@ async fn download_text_file_inner(
         tracing::warn!(
             filename,
             size = actual_size,
-            "downloaded text file exceeds 512KB limit, skipping"
+            "downloaded text file exceeds inline limit, skipping"
         );
         return None;
     }

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -1536,7 +1536,7 @@ async fn handle_message(
                 // When filestore is configured, skip the cap for files > 512KB (they'll
                 // be uploaded to S3, not inlined).
                 #[cfg(feature = "filestore")]
-                let skip_cap = filestore.is_some() && size > 512 * 1024;
+                let skip_cap = filestore.is_some() && size > crate::media::TEXT_INLINE_LIMIT;
                 #[cfg(not(feature = "filestore"))]
                 let skip_cap = false;
                 if !skip_cap && size > 0 && text_file_bytes + size > TEXT_TOTAL_CAP {
@@ -1592,18 +1592,27 @@ async fn handle_message(
                         extra_blocks.push(block);
                     }
                     Err(media::MediaFetchError::NotAnImage) => {
-                        // Upload unsupported file types to filestore if available
-                        #[cfg(feature = "filestore")]
-                        if let Some(fs) = filestore {
-                            if let Some((block, _)) = media::download_and_upload_any_file(
-                                url,
-                                filename,
-                                size,
-                                Some(mimetype),
-                                Some(bot_token),
-                                fs,
-                            ).await {
-                                extra_blocks.push(block);
+                        if media::is_video_file(filename, Some(mimetype)) {
+                            extra_blocks.push(ContentBlock::Text {
+                                text: format!(
+                                    "[Video attachment]\nfilename: {}\ncontent_type: {}\nsize_bytes: {}\nurl: {}",
+                                    filename, mimetype, size, url
+                                ),
+                            });
+                        } else {
+                            // Upload unsupported file types to filestore if available
+                            #[cfg(feature = "filestore")]
+                            if let Some(fs) = filestore {
+                                if let Some((block, _)) = media::download_and_upload_any_file(
+                                    url,
+                                    filename,
+                                    size,
+                                    Some(mimetype),
+                                    Some(bot_token),
+                                    fs,
+                                ).await {
+                                    extra_blocks.push(block);
+                                }
                             }
                         }
                     }

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -502,7 +502,7 @@ allow_bot_messages = true
 
 ## `[filestore]`
 
-Optional S3/R2-compatible object store for handling large text file attachments.
+Optional S3/R2-compatible object store for handling file attachments.
 
 When configured, text files exceeding the 512 KB inline limit are uploaded to the
 object store and a presigned GET URL is returned to the agent. This eliminates
@@ -542,13 +542,14 @@ presigned_ttl = 3600       # URL expiry in seconds (default: 3600 = 1 hour)
 
 - Text files ≤ 512 KB: inlined into the prompt as before (unchanged)
 - Text files > 512 KB: downloaded by OAB, uploaded to S3/R2, presigned URL returned
+- PDF, ZIP, binary, and other unsupported formats (Discord/Slack): uploaded to S3/R2, presigned URL returned
 - The presigned URL requires no authentication — any HTTP GET works
 - File count cap (5 files) still applies
 - Aggregate 1 MB cap only applies to inlined files; filestore uploads bypass it
 
 **Behavior when NOT configured (default):**
 
-- Text files > 512 KB are silently dropped (existing behavior)
+- Text files > 512 KB and unsupported formats are silently dropped (existing behavior)
 
 **Supported backends:**
 

--- a/docs/filestore.md
+++ b/docs/filestore.md
@@ -134,9 +134,9 @@ The streaming approach means a 500 MB file uses the same ~16 MB of memory as a 1
 
 | Platform | Download Method | Upload Method | File Types |
 |----------|----------------|---------------|------------|
-| Discord | Streaming download → streaming multipart (~16 MB) | All: text > 512KB + PDF/ZIP/binary |
-| Slack | Streaming download → streaming multipart (~16 MB) | All: text > 512KB + PDF/ZIP/binary |
-| Gateway (Telegram, Feishu, Google Chat, WeCom, LINE) | File on local disk → single PUT | Text files delivered by adapter pipeline; binary limited by adapter validation |
+| Discord | Streaming download | Streaming multipart (~16 MB chunks) | Text > 512KB + PDF/ZIP/binary (videos excluded — see Behavior) |
+| Slack | Streaming download | Streaming multipart (~16 MB chunks) | Text > 512KB + PDF/ZIP/binary (videos excluded — see Behavior) |
+| Gateway (Telegram, Feishu, Google Chat, WeCom, LINE) | File on local disk | Single PUT | Text files delivered by adapter pipeline; binary limited by adapter validation |
 
 Gateway adapters use their existing text-file pipeline (extension whitelist).
 When filestore is configured, large text files (>512 KB) that pass through
@@ -198,9 +198,10 @@ after 24 hours (no configuration needed).
 | Text ≤ 512 KB | any | Inlined into prompt (unchanged) |
 | Text > 512 KB | ✅ yes | Uploaded → presigned URL returned |
 | PDF, ZIP, DOCX, binary (Discord/Slack only) | ✅ yes | Uploaded → presigned URL returned |
+| Video (`video/*` MIME or `.mp4/.mov/.m4v/.webm/.mkv/.avi`) | any | **Never uploaded** — agent receives a `[Video attachment]` metadata block (filename, type, size, platform URL) |
 | Text > 512 KB | ❌ no | Silently dropped (legacy behavior) |
 | PDF, ZIP, DOCX, binary | ❌ no | Silently dropped (legacy behavior) |
-| > max_file_size_mb (default 250 MB, max 500 MB) | ✅ yes | Dropped (configurable cap) |
+| > max_file_size_mb (default 250 MB, max 500 MB) | ✅ yes | Dropped on Discord/Slack; degraded hint on gateway (see Error Handling) |
 
 ## What the Agent Sees
 
@@ -228,8 +229,21 @@ the file — no authentication headers required.
 ### Object Keys
 
 Object keys are server-generated: `{prefix}{uuid}_{filename}`. The UUID
-prevents collision and enumeration. The filename is appended for human
-readability in S3 console but is not security-critical.
+prevents collision and enumeration. The filename portion is sanitized before
+being embedded in the key: path separators (`/`, `\`), traversal sequences
+(`..`), double quotes, and non-ASCII characters are replaced or stripped,
+and the name is capped at 200 characters.
+
+### Filename Sanitization & Content-Disposition
+
+- **S3 objects** are uploaded with `Content-Disposition: attachment` so
+  browsers download the file instead of rendering it inline — this prevents
+  HTML/JS content from executing in the bucket's origin when a presigned URL
+  is opened in a browser. Double quotes are stripped from filenames so the
+  header cannot be broken out of.
+- **Agent-visible text** (inline file blocks and error/degraded hints) strips
+  control characters from filenames and caps them at 200 characters,
+  preventing prompt injection via crafted attachment filenames.
 
 ### Size Limits
 
@@ -346,7 +360,8 @@ mc ilm rule add myminio/oab-uploads \
 | S3 upload times out (>10 min) | Same as upload failure — degraded hint returned |
 | Download from platform fails | File is dropped (warn log), agent not notified |
 | Download times out (>10 min) | Same as download failure — file dropped |
-| File exceeds max_file_size_mb | File is dropped (warn log) |
+| File exceeds max_file_size_mb (Discord/Slack) | File is dropped (warn log), agent not notified |
+| File exceeds max_file_size_mb (gateway) | Agent receives degraded hint: "exceeds the configured upload limit and could not be stored" |
 | Presigned URL generation fails | Agent receives degraded hint |
 | Filestore not configured | Legacy behavior (>512KB files silently dropped) |
 

--- a/docs/filestore.md
+++ b/docs/filestore.md
@@ -150,7 +150,7 @@ Full binary support requires a gateway schema change (tracked in #1349).
 |-----------|---------|-------|
 | Download from platform (streaming path) | 10 minutes | HTTP request including body streaming |
 | Streaming upload to S3 | 10 minutes | Total for download + all parts + complete |
-| Download from platform (inline path) | 3 minutes | For files expected ≤512 KB |
+| Download from platform (inline path) | 30 seconds | For files expected ≤512 KB |
 | Individual part upload | SDK default | Per upload_part call |
 
 ### Incomplete Multipart Upload Cleanup

--- a/src/main.rs
+++ b/src/main.rs
@@ -429,7 +429,7 @@ async fn main() -> anyhow::Result<()> {
         .join("threads.json");
     let multibot_cache = multibot_cache::MultibotCache::load(multibot_cache_path);
 
-    // Initialize filestore (for uploading large text file attachments to S3/R2).
+    // Initialize filestore (for uploading file attachments to S3/R2).
     #[cfg(feature = "filestore")]
     let filestore: Option<Arc<openab_core::filestore::Filestore>> = if let Some(ref fs_cfg) =
         cfg.filestore


### PR DESCRIPTION
## Summary

Implements all non-blocking improvements identified during the PR #1348 review cycle (5+ rounds, 8 reviewers).

## Changes

### Code Quality
- **Extract `TEXT_INLINE_LIMIT` constant** — replaces the `512 * 1024` magic number scattered across 8 locations in 4 files (`media.rs`, `gateway.rs`, `discord.rs`, `slack.rs`)
- **Fix `e_tag.unwrap_or_default()`** — 3 occurrences in `stream_upload_and_presign` replaced with proper error handling that aborts the multipart upload on missing ETag

### Security Hardening
- **Filename sanitization** — all error/degraded hint paths (4 functions in `media.rs`) now sanitize filenames before embedding in agent-visible text, preventing control-char injection
- **Content-Disposition header** — both `upload_and_presign` and `stream_upload_and_presign` now set `Content-Disposition: attachment` on S3 objects to prevent inline execution in browsers

### Operational
- **Slack `NotAnImage` video exclusion** — Slack now checks `is_video_file()` before routing to filestore upload, matching existing Discord behavior (videos get a `[Video attachment]` text block)

### Documentation
- Updated outdated "text file attachments" comments → "file attachments" (4 source files)
- Fixed `docs/filestore.md` Timeouts table: inline path is 30s (not 3 min)
- Updated `docs/config-reference.md` to mention PDF/ZIP/binary support

## Testing

Unable to build locally (environment lacks C linker). All changes are mechanical refactors and straightforward additions verified by manual diff review. CI will validate.

## Not addressed (deferred)

These items from #1350 require larger scope or design decisions:
- Refactor dual `#[cfg]` implementation of `download_text_file_inner` (needs `HandlerContext` struct)
- Integration tests with mock S3
- File type allowlist/blocklist config
- Configurable stream timeout
- Per-message upload count cap for any-file path

Closes #1350