### PR TITLE
feat(line): first-class [line] trust section (Phase 1)

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -73,6 +73,18 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 # streaming           = true            # override; defaults to follow rich_messages
 # webhook_path        = "/webhook/telegram"   # default /webhook/telegram
 
+# --- LINE (first-class trust section; replaces uniform GATEWAY_* env for LINE) ---
+# L3 identity trust for the LINE adapter (identity-trust-none ADR). Each field
+# falls back to its LINE_* env var when unset, then to deny-all. Channel
+# credentials stay on LINE_CHANNEL_SECRET / LINE_CHANNEL_ACCESS_TOKEN env vars.
+# NOTE: relying on GATEWAY_ALLOW_ALL_USERS / GATEWAY_ALLOWED_USERS for LINE is
+# deprecated (warns at startup; becomes an error in Phase 2).
+# [line]
+# allow_all_users = false               # true = any user; omitted/false = deny-all except allowed_users
+#                                       # env fallback: LINE_ALLOW_ALL_USERS
+# allowed_users = ["U1234567890abcdef0123456789abcdef"]  # LINE user IDs (U…, 33 chars)
+#                                       # env fallback: LINE_ALLOWED_USERS (comma-separated)
+
 # --- AgentCore Runtime (alternative to [agent]) ---
 # When [agentcore] is set and [agent].command is not explicitly provided,
 # OAB auto-spawns the bundled agentcore-acp adapter. No manual wiring needed.

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -172,6 +172,7 @@ pub struct Config {
     pub slack: Option<SlackConfig>,
     pub gateway: Option<GatewayConfig>,
     pub telegram: Option<TelegramConfig>,
+    pub line: Option<LineConfig>,
     pub agentcore: Option<AgentCoreConfig>,
     #[serde(default)]
     pub agent: AgentConfig,
@@ -762,6 +763,74 @@ fn env_flag_not_false(key: &str) -> bool {
     std::env::var(key)
         .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
         .unwrap_or(true)
+}
+
+/// First-class `[line]` section — L3 identity trust for the LINE adapter
+/// (identity-trust-none ADR, Phase 1). Mirrors [`TelegramConfig`]'s trust
+/// fields and resolution order: `[line].field` (with `${}` expansion) →
+/// `LINE_*` env var → default.
+///
+/// Trust-only by design: LINE channel credentials stay on the gateway env vars
+/// (`LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN`) that the webhook
+/// adapter reads. Group policy (`open`/`members` for `"unknown"` senders) is a
+/// follow-up on #1355.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct LineConfig {
+    /// Explicit flag: true = allow all users, false = check `allowed_users`.
+    /// When not set, defaults to `false` (deny-all, per identity-trust-none ADR).
+    /// Set `true` explicitly to allow all users. Env fallback:
+    /// `LINE_ALLOW_ALL_USERS` (empty string treated as unset).
+    ///
+    /// **Note:** When this resolves to `true`, the `allowed_users` list is
+    /// bypassed entirely — all users are permitted regardless of list contents.
+    pub allow_all_users: Option<bool>,
+    /// LINE user IDs (`U…`, 33 chars) allowed to interact with the bot. Only
+    /// checked when `allow_all_users` resolves to `false`. Env fallback:
+    /// `LINE_ALLOWED_USERS` (comma-separated).
+    /// `None` = not set (fall back to env); `Some([])` = explicit empty (deny all).
+    pub allowed_users: Option<Vec<String>>,
+}
+
+/// Fully resolved LINE trust settings (config → env → default applied).
+#[derive(Debug, Clone)]
+pub struct ResolvedLine {
+    pub allow_all_users: bool,
+    pub allowed_users: Vec<String>,
+}
+
+impl LineConfig {
+    /// Resolve every field: config value (if set) → `LINE_*` env → default.
+    /// Same shape as [`TelegramConfig::resolve`] for the shared trust fields.
+    pub fn resolve(&self) -> ResolvedLine {
+        let allowed_users: Vec<String> = match &self.allowed_users {
+            Some(list) => list.clone(),
+            None => std::env::var("LINE_ALLOWED_USERS")
+                .unwrap_or_default()
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect(),
+        };
+        ResolvedLine {
+            allow_all_users: self.allow_all_users.unwrap_or_else(|| {
+                std::env::var("LINE_ALLOW_ALL_USERS")
+                    .ok()
+                    .filter(|v| !v.is_empty())
+                    .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+                    .unwrap_or(false)
+            }),
+            allowed_users,
+        }
+    }
+
+    /// Whether any first-class LINE trust configuration exists — a `[line]`
+    /// section or `LINE_ALLOW_ALL_USERS` / `LINE_ALLOWED_USERS` env. Used by
+    /// the binary to decide whether LINE trust still rides on the deprecated
+    /// uniform `GATEWAY_*` seed (and to warn when it does).
+    pub fn env_trust_present() -> bool {
+        std::env::var("LINE_ALLOW_ALL_USERS").is_ok() || std::env::var("LINE_ALLOWED_USERS").is_ok()
+    }
 }
 
 /// Raw intermediate struct for serde — uses `Option` to detect explicit fields.
@@ -1830,6 +1899,92 @@ webhook_path = "/hook/tg"
         assert_eq!(tg.rich_messages, Some(false));
         assert_eq!(tg.streaming, Some(true));
         assert_eq!(tg.webhook_path.as_deref(), Some("/hook/tg"));
+    }
+
+    #[test]
+    fn line_section_parses_from_toml() {
+        let toml_str = r#"
+[discord]
+bot_token = "x"
+
+[line]
+allow_all_users = false
+allowed_users = ["U1234567890abcdef0123456789abcdef"]
+"#;
+        let cfg = parse_config_str(toml_str, "test").unwrap();
+        let line = cfg.line.expect("line section");
+        assert_eq!(line.allow_all_users, Some(false));
+        assert_eq!(
+            line.allowed_users.as_deref(),
+            Some(&["U1234567890abcdef0123456789abcdef".to_string()][..])
+        );
+
+        // Absent section → None (trust falls back to legacy GATEWAY_* seed).
+        let cfg = parse_config_str("[discord]\nbot_token = \"x\"\n", "test").unwrap();
+        assert!(cfg.line.is_none());
+    }
+
+    /// All `LINE_*` env scenarios in ONE test — std::env is process-global and
+    /// cargo runs tests in parallel, so splitting these would race (same
+    /// pattern as `telegram_resolve_all_scenarios`).
+    #[test]
+    fn line_resolve_all_scenarios() {
+        // --- Scenario 1: defaults — deny-all per identity-trust-none ADR ---
+        std::env::remove_var("LINE_ALLOW_ALL_USERS");
+        std::env::remove_var("LINE_ALLOWED_USERS");
+        let r = LineConfig::default().resolve();
+        assert!(!r.allow_all_users);
+        assert!(r.allowed_users.is_empty());
+        assert!(!LineConfig::env_trust_present());
+
+        // --- Scenario 2: config wins over env ---
+        std::env::set_var("LINE_ALLOW_ALL_USERS", "true");
+        std::env::set_var("LINE_ALLOWED_USERS", "Uzzz"); // must be ignored — config list wins
+        let cfg = LineConfig {
+            allow_all_users: Some(false),
+            allowed_users: Some(vec!["Uaaa".into(), "Ubbb".into()]),
+        };
+        let r = cfg.resolve();
+        assert!(!r.allow_all_users);
+        assert_eq!(
+            r.allowed_users,
+            vec!["Uaaa".to_string(), "Ubbb".to_string()]
+        );
+
+        // --- Scenario 3: env fallback when config unset (comma-separated,
+        //     trimmed, empties dropped) ---
+        std::env::set_var("LINE_ALLOWED_USERS", " Uaaa , Ubbb,,Uccc ");
+        let r = LineConfig::default().resolve();
+        assert!(r.allow_all_users); // from LINE_ALLOW_ALL_USERS=true
+        assert_eq!(
+            r.allowed_users,
+            vec!["Uaaa".to_string(), "Ubbb".to_string(), "Uccc".to_string()]
+        );
+        assert!(LineConfig::env_trust_present());
+
+        // --- Scenario 4: empty-string env flag treated as unset → deny-all ---
+        std::env::set_var("LINE_ALLOW_ALL_USERS", "");
+        std::env::remove_var("LINE_ALLOWED_USERS");
+        let r = LineConfig::default().resolve();
+        assert!(!r.allow_all_users);
+
+        // --- Scenario 5: "0"/"false" env values resolve false ---
+        std::env::set_var("LINE_ALLOW_ALL_USERS", "0");
+        assert!(!LineConfig::default().resolve().allow_all_users);
+        std::env::set_var("LINE_ALLOW_ALL_USERS", "false");
+        assert!(!LineConfig::default().resolve().allow_all_users);
+
+        // --- Scenario 6: explicit empty config list = deny-all, ignores env ---
+        std::env::set_var("LINE_ALLOWED_USERS", "Uzzz");
+        let cfg = LineConfig {
+            allow_all_users: None,
+            allowed_users: Some(vec![]),
+        };
+        let r = cfg.resolve();
+        assert!(r.allowed_users.is_empty());
+
+        std::env::remove_var("LINE_ALLOW_ALL_USERS");
+        std::env::remove_var("LINE_ALLOWED_USERS");
     }
 
     #[test]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -135,6 +135,25 @@ Custom Gateway adapter for platforms like Telegram, LINE, Feishu/Lark, and Googl
 
 ---
 
+## `[line]`
+
+First-class L3 identity trust for the LINE adapter (identity-trust-none ADR, Phase 1). Replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for LINE — relying on those for LINE is deprecated and warns at startup. Channel credentials remain on the `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` env vars.
+
+Each field resolves: config value → `LINE_*` env var → default (deny-all).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `allow_all_users` | bool \| omit | `false` (deny-all) | `true` = any user may interact (bypasses `allowed_users` entirely); `false`/omitted = only `allowed_users`. Env fallback: `LINE_ALLOW_ALL_USERS`. |
+| `allowed_users` | string[] | `[]` | LINE user IDs (`U…`, 33 chars) allowed to interact. Only checked when `allow_all_users` resolves to false. Env fallback: `LINE_ALLOWED_USERS` (comma-separated). |
+
+```toml
+[line]
+allowed_users = ["U1234567890abcdef0123456789abcdef"]
+# allow_all_users = true   # explicit opt-in only — any user can drive the agent
+```
+
+---
+
 ## `[agent]`
 
 The AI agent subprocess that OpenAB spawns to handle messages via ACP.

--- a/docs/line.md
+++ b/docs/line.md
@@ -102,6 +102,20 @@ platform = "line"
 
 > **Tip:** To find a LINE user ID, check the gateway logs — the sender ID is logged for each incoming message. By default all users and channels are allowed. Setting `allowed_users` or `allowed_channels` automatically restricts access to only those listed.
 
+### User Trust (`[line]` section)
+
+Identity trust defaults to **deny-all** (identity-trust-none ADR): unknown senders are rejected until explicitly admitted. Configure trust with a first-class `[line]` section:
+
+```toml
+[line]
+allowed_users = ["U1234567890abcdef0123456789abcdef"]  # LINE user IDs (U…, 33 chars)
+# allow_all_users = true   # explicit opt-in only — any user can drive the agent
+```
+
+Each field falls back to its `LINE_ALLOW_ALL_USERS` / `LINE_ALLOWED_USERS` env var when unset. This replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for LINE:
+
+> ⚠️ **Deprecated:** driving LINE trust through `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` still works but logs a startup warning; it will become a startup error in a later phase. Migrate to `[line]` (or `LINE_*` env vars).
+
 ## 6. Add the Bot as Friend
 
 In the LINE Developers Console → **Messaging API** tab → scan the QR code with your LINE app, or search for the bot by its LINE ID.
@@ -140,6 +154,8 @@ In the LINE Developers Console → **Messaging API** tab → scan the QR code wi
 |---|---|---|
 | `LINE_CHANNEL_SECRET` | Yes | Channel secret for webhook signature validation |
 | `LINE_CHANNEL_ACCESS_TOKEN` | Yes | Channel access token for Reply/Push Message API and LINE-hosted image/audio downloads |
+| `LINE_ALLOW_ALL_USERS` | No | `true` = any user may interact. Fallback for `[line].allow_all_users`; default deny-all |
+| `LINE_ALLOWED_USERS` | No | Comma-separated LINE user IDs. Fallback for `[line].allowed_users` |
 
 ## Troubleshooting
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,6 +368,58 @@ async fn main() -> anyhow::Result<()> {
                 ),
             );
         }
+
+        // LINE: L3 (identity) mirrors the resolved
+        // [line].allow_all_users/allowed_users, so config.toml can restrict
+        // who can message the bot without the uniform
+        // GATEWAY_ALLOW_ALL_USERS/GATEWAY_ALLOWED_USERS env vars (#1355). L2
+        // (channels) has no LINE-specific concept distinct from the generic
+        // gateway model yet (group policy is a follow-up), so it stays on the
+        // shared GATEWAY_* values set above.
+        //
+        // Also resolves when running env-only (no [line] section but
+        // LINE_ALLOW_ALL_USERS / LINE_ALLOWED_USERS set), matching the
+        // Telegram pattern.
+        let line_resolved = if let Some(l) = &cfg.line {
+            Some(l.resolve())
+        } else if config::LineConfig::env_trust_present() {
+            Some(config::LineConfig::default().resolve())
+        } else {
+            None
+        };
+        match line_resolved {
+            Some(r) => {
+                reg.insert(
+                    "line",
+                    TrustConfig::new(
+                        Some(allow_all_channels),
+                        allowed_channels.clone(),
+                        None,
+                        Some(r.allow_all_users),
+                        r.allowed_users,
+                    ),
+                );
+            }
+            None => {
+                // Phase 1 deprecation (#1355/#1356): LINE trust still rides on
+                // the uniform GATEWAY_* seed. Warn when the unified LINE
+                // adapter is active and the legacy env is what admits users,
+                // so operators migrate before Phase 2 turns this into an error.
+                let line_active =
+                    cfg!(feature = "line") && std::env::var("LINE_CHANNEL_SECRET").is_ok();
+                let legacy_env_set = std::env::var("GATEWAY_ALLOW_ALL_USERS").is_ok()
+                    || std::env::var("GATEWAY_ALLOWED_USERS").is_ok();
+                if line_active && legacy_env_set {
+                    warn!(
+                        "LINE trust is driven by deprecated GATEWAY_ALLOW_ALL_USERS/\
+                         GATEWAY_ALLOWED_USERS env vars — migrate to a [line] section \
+                         (allow_all_users/allowed_users) or LINE_ALLOW_ALL_USERS/\
+                         LINE_ALLOWED_USERS; the uniform GATEWAY_* fallback will \
+                         become a startup error in Phase 2 (#1356)"
+                    );
+                }
+            }
+        }
         reg
     };
 


### PR DESCRIPTION
## What problem does this solve?

LINE trust is currently controlled only by the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars, which apply to ALL gateway platforms at once — no per-platform granularity. Since the Phase 3 deny-all default flip, LINE deployments must set `GATEWAY_ALLOW_ALL_USERS=true` (opening every gateway platform) just to keep LINE working — the exact operator pain reported on the issue.

First slice of #1355 (umbrella #1356): a first-class `[line]` section, mirroring the `[telegram]` pattern from #1297. Group policy (`open`/`members`) and Reply-API deny-echo remain on the issue as follow-ups.

## At a Glance

```text
Before — one env pair opens every gateway platform

┌─ Trust sources ───────────────────┐  ┌─ PlatformTrustConfigs ────────────┐
│                                   │  │                                   │
│  ┌─────────────────────────────┐  │  │  ┌─────────────────────────────┐  │
│  │ GATEWAY_ALLOW_ALL_USERS     │──┼──┼─▶│ line      ← uniform seed    │  │
│  │ GATEWAY_ALLOWED_USERS       │  │  │  │ feishu    ← uniform seed    │  │
│  │ (uniform, all platforms)    │  │  │  │ wecom     ← uniform seed    │  │
│  └─────────────────────────────┘  │  │  │ googlechat← uniform seed    │  │
│                                   │  │  │ teams     ← uniform seed    │  │
│  ┌─────────────────────────────┐  │  │  └─────────────────────────────┘  │
│  │ [telegram] section (#1297)  │──┼──┼─▶ telegram (override)             │
│  └─────────────────────────────┘  │  │                                   │
└───────────────────────────────────┘  └───────────────────────────────────┘

After — LINE gets its own section, legacy env warns

┌─ Trust sources ───────────────────┐  ┌─ PlatformTrustConfigs ────────────┐
│                                   │  │                                   │
│  ┌─────────────────────────────┐  │  │  ┌─────────────────────────────┐  │
│  │ [line] section          NEW │──┼──┼─▶│ line      ← [line] override │  │
│  │ allow_all_users /           │  │  │  │             (L3 identity)   │  │
│  │ allowed_users               │  │  │  └─────────────────────────────┘  │
│  │ env fallback: LINE_*    NEW │  │  │  ┌─────────────────────────────┐  │
│  └─────────────────────────────┘  │  │  │ telegram  ← [telegram]      │  │
│  ┌─────────────────────────────┐  │  │  └─────────────────────────────┘  │
│  │ [telegram] section (#1297)  │  │  │  ┌─────────────────────────────┐  │
│  └─────────────────────────────┘  │  │  │ feishu │ wecom │ googlechat │  │
│  ┌─────────────────────────────┐  │  │  │ teams  ← uniform seed       │  │
│  │ GATEWAY_* env (legacy)      │  │  │  │ (until #1357–#1360)         │  │
│  │ ⚠ warns at startup when it  │  │  │  └─────────────────────────────┘  │
│  │ still drives LINE trust     │  │  └───────────────────────────────────┘
│  └─────────────────────────────┘  │
└───────────────────────────────────┘
```

## Proposed Solution

- **`crates/openab-core/src/config.rs`** — `LineConfig { allow_all_users: Option<bool>, allowed_users: Option<Vec<String>> }` with per-field resolution `[line]` → `LINE_ALLOW_ALL_USERS` / `LINE_ALLOWED_USERS` env → deny-all default (identity-trust-none ADR). Trust-only by design: channel credentials stay on the `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` env vars the webhook adapter reads.
- **`src/main.rs`** — the resolved `[line]` values override the uniform `GATEWAY_*` seed in the trust registry, exactly like the telegram override (also resolves env-only, matching the Telegram pattern). When no first-class LINE trust config exists, the unified LINE adapter is active, and the legacy `GATEWAY_*` env is set, a Phase 1 deprecation warning tells operators to migrate before Phase 2 turns it into an error.
- **Docs** — `config.toml.example` `[line]` block, `docs/config-reference.md` new `## [line]` section, `docs/line.md` User Trust section + env var table rows with the deprecation callout.

## Why this approach?

Backward-compatible by construction: existing LINE deployments driven by `GATEWAY_*` env keep working unchanged (warning only, per the umbrella's Phase 1 → 2 → 3 plan), and the `[line]` override is opt-in. Reuses the exact `[telegram]` resolution/override shape (#1297), so the remaining platforms (#1358–#1360) become mechanical clones of this PR.

## Validation

At `57cc547` (macOS arm64, rebased on `2f0342b`):

- `cargo clippy --workspace --all-features -- -D warnings` — clean
- `cargo clippy --workspace -- -D warnings` (default features) — clean
- `cargo check -p openab-core --no-default-features` — pass
- `cargo check --features unified` (line feature on) — pass
- `cargo test -p openab-core --all-features` — 656 passed, 1 failed: `secrets::tests::resolve_exec_nonzero_exit`, the known pre-existing macOS-only failure (also fails on unmodified `main`)
- LINE-related tests — 16/16 including the two new ones
- `rustfmt --check` — no new drift (config.rs 0→0, main.rs 4→4 vs `main` baseline)
- `docs/platforms/schema/line.toml` reviewed: its trust-gate claims describe the shared ingress gate, which is unchanged by this PR — no schema update required (conformance CI not triggered).

## Tests

- `line_section_parses_from_toml` — `[line]` parse + absent-section → `None`
- `line_resolve_all_scenarios` — six env-resolution scenarios in one test fn (env vars are process-global; single-fn pattern mirrors `telegram_resolve_all_scenarios` for parallel-test safety): deny-all default, config-wins-over-env, comma-separated env fallback with trimming, empty-string flag treated as unset, `"0"`/`"false"` parsing, explicit empty list = deny-all

Refs #1355 (first slice — group policy + Reply-API deny-echo remain), umbrella #1356, ADR #1291.
