### PR TITLE
feat(trust): [wecom]/[googlechat]/[teams] first-class trust sections (Phase 1)

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -85,6 +85,25 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 # allowed_users = ["U1234567890abcdef0123456789abcdef"]  # LINE user IDs (U…, 33 chars)
 #                                       # env fallback: LINE_ALLOWED_USERS (comma-separated)
 
+# --- WeCom / Google Chat / MS Teams (first-class trust sections) ---
+# Same shape as [line]: L3 identity trust per platform, replacing the uniform
+# GATEWAY_ALLOW_ALL_USERS / GATEWAY_ALLOWED_USERS env for that platform
+# (deprecated: warns at startup; becomes an error in Phase 2). Platform
+# credentials stay on their gateway env vars (WECOM_CORP_ID/WECOM_SECRET,
+# GOOGLE_CHAT_*, TEAMS_APP_ID/TEAMS_APP_SECRET).
+# [wecom]
+# allow_all_users = false               # env fallback: WECOM_ALLOW_ALL_USERS
+# allowed_users = ["zhangsan", "lisi"]  # WeCom UserIDs (tenant-assigned, freeform strings)
+#                                       # env fallback: WECOM_ALLOWED_USERS (comma-separated)
+# [googlechat]
+# allow_all_users = false               # env fallback: GOOGLE_CHAT_ALLOW_ALL_USERS
+# allowed_users = ["users/123456789"]   # Chat user resource names (users/<id>)
+#                                       # env fallback: GOOGLE_CHAT_ALLOWED_USERS (comma-separated)
+# [teams]
+# allow_all_users = false               # env fallback: TEAMS_ALLOW_ALL_USERS
+# allowed_users = ["29:1abc..."]        # Bot Framework activity.from.id values (29:…)
+#                                       # env fallback: TEAMS_ALLOWED_USERS (comma-separated)
+
 # --- AgentCore Runtime (alternative to [agent]) ---
 # When [agentcore] is set and [agent].command is not explicitly provided,
 # OAB auto-spawns the bundled agentcore-acp adapter. No manual wiring needed.

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -173,6 +173,9 @@ pub struct Config {
     pub gateway: Option<GatewayConfig>,
     pub telegram: Option<TelegramConfig>,
     pub line: Option<LineConfig>,
+    pub wecom: Option<PlatformTrustConfig>,
+    pub googlechat: Option<PlatformTrustConfig>,
+    pub teams: Option<PlatformTrustConfig>,
     pub agentcore: Option<AgentCoreConfig>,
     #[serde(default)]
     pub agent: AgentConfig,
@@ -830,6 +833,76 @@ impl LineConfig {
     /// uniform `GATEWAY_*` seed (and to warn when it does).
     pub fn env_trust_present() -> bool {
         std::env::var("LINE_ALLOW_ALL_USERS").is_ok() || std::env::var("LINE_ALLOWED_USERS").is_ok()
+    }
+}
+
+/// Shared first-class trust section for gateway platforms whose Phase 1 needs
+/// exactly the two L3 identity fields (identity-trust-none ADR): `[wecom]`,
+/// `[googlechat]`, `[teams]`. Same shape and resolution order as
+/// [`LineConfig`] / [`TelegramConfig`]: `[section].field` (with `${}`
+/// expansion) → `{PREFIX}_*` env var → deny-all default.
+///
+/// Trust-only by design — platform credentials stay on the gateway env vars
+/// the webhook adapters read (`WECOM_CORP_ID`/`WECOM_SECRET`,
+/// `GOOGLE_CHAT_*`, `TEAMS_APP_ID`/`TEAMS_APP_SECRET`). Platforms that later
+/// need extra trust fields (e.g. `trusted_bot_ids`) graduate to their own
+/// struct, as LINE will for group policy.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct PlatformTrustConfig {
+    /// Explicit flag: true = allow all users, false = check `allowed_users`.
+    /// When not set, defaults to `false` (deny-all, per identity-trust-none ADR).
+    /// Env fallback: `{PREFIX}_ALLOW_ALL_USERS` (empty string treated as unset).
+    ///
+    /// **Note:** When this resolves to `true`, the `allowed_users` list is
+    /// bypassed entirely — all users are permitted regardless of list contents.
+    pub allow_all_users: Option<bool>,
+    /// Platform user IDs allowed to interact with the bot. Only checked when
+    /// `allow_all_users` resolves to `false`. Env fallback:
+    /// `{PREFIX}_ALLOWED_USERS` (comma-separated).
+    /// `None` = not set (fall back to env); `Some([])` = explicit empty (deny all).
+    pub allowed_users: Option<Vec<String>>,
+}
+
+/// Fully resolved platform trust settings (config → env → default applied).
+#[derive(Debug, Clone)]
+pub struct ResolvedPlatformTrust {
+    pub allow_all_users: bool,
+    pub allowed_users: Vec<String>,
+}
+
+impl PlatformTrustConfig {
+    /// Resolve both fields against `{prefix}_ALLOW_ALL_USERS` /
+    /// `{prefix}_ALLOWED_USERS` env fallbacks (e.g. prefix `"WECOM"`,
+    /// `"GOOGLE_CHAT"`, `"TEAMS"`).
+    pub fn resolve_with_env(&self, prefix: &str) -> ResolvedPlatformTrust {
+        let allowed_users: Vec<String> = match &self.allowed_users {
+            Some(list) => list.clone(),
+            None => std::env::var(format!("{prefix}_ALLOWED_USERS"))
+                .unwrap_or_default()
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect(),
+        };
+        ResolvedPlatformTrust {
+            allow_all_users: self.allow_all_users.unwrap_or_else(|| {
+                std::env::var(format!("{prefix}_ALLOW_ALL_USERS"))
+                    .ok()
+                    .filter(|v| !v.is_empty())
+                    .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+                    .unwrap_or(false)
+            }),
+            allowed_users,
+        }
+    }
+
+    /// Whether first-class trust env vars exist for `prefix` — used by the
+    /// binary to decide whether the platform's trust still rides on the
+    /// deprecated uniform `GATEWAY_*` seed (and to warn when it does).
+    pub fn env_trust_present(prefix: &str) -> bool {
+        std::env::var(format!("{prefix}_ALLOW_ALL_USERS")).is_ok()
+            || std::env::var(format!("{prefix}_ALLOWED_USERS")).is_ok()
     }
 }
 
@@ -1985,6 +2058,126 @@ allowed_users = ["U1234567890abcdef0123456789abcdef"]
 
         std::env::remove_var("LINE_ALLOW_ALL_USERS");
         std::env::remove_var("LINE_ALLOWED_USERS");
+    }
+
+    #[test]
+    fn platform_trust_sections_parse_from_toml() {
+        let toml_str = r#"
+[discord]
+bot_token = "x"
+
+[wecom]
+allowed_users = ["zhangsan", "lisi"]
+
+[googlechat]
+allowed_users = ["users/123456789"]
+
+[teams]
+allow_all_users = true
+"#;
+        let cfg = parse_config_str(toml_str, "test").unwrap();
+        let wecom = cfg.wecom.expect("wecom section");
+        assert_eq!(
+            wecom.allowed_users.as_deref(),
+            Some(&["zhangsan".to_string(), "lisi".to_string()][..])
+        );
+        assert_eq!(wecom.allow_all_users, None);
+        let gc = cfg.googlechat.expect("googlechat section");
+        assert_eq!(
+            gc.allowed_users.as_deref(),
+            Some(&["users/123456789".to_string()][..])
+        );
+        let teams = cfg.teams.expect("teams section");
+        assert_eq!(teams.allow_all_users, Some(true));
+
+        // Absent sections → None (trust falls back to legacy GATEWAY_* seed).
+        let cfg = parse_config_str("[discord]\nbot_token = \"x\"\n", "test").unwrap();
+        assert!(cfg.wecom.is_none());
+        assert!(cfg.googlechat.is_none());
+        assert!(cfg.teams.is_none());
+    }
+
+    /// All `WECOM_*` env scenarios in ONE test — std::env is process-global and
+    /// cargo runs tests in parallel (same pattern as
+    /// `line_resolve_all_scenarios`). The WECOM prefix stands in for all
+    /// `PlatformTrustConfig` users; the prefix is a plain format argument, so
+    /// GOOGLE_CHAT/TEAMS behave identically by construction.
+    #[test]
+    fn platform_trust_resolve_all_scenarios() {
+        // --- Scenario 1: defaults — deny-all per identity-trust-none ADR ---
+        std::env::remove_var("WECOM_ALLOW_ALL_USERS");
+        std::env::remove_var("WECOM_ALLOWED_USERS");
+        let r = PlatformTrustConfig::default().resolve_with_env("WECOM");
+        assert!(!r.allow_all_users);
+        assert!(r.allowed_users.is_empty());
+        assert!(!PlatformTrustConfig::env_trust_present("WECOM"));
+
+        // --- Scenario 2: config wins over env ---
+        std::env::set_var("WECOM_ALLOW_ALL_USERS", "true");
+        std::env::set_var("WECOM_ALLOWED_USERS", "mallory"); // ignored — config list wins
+        let cfg = PlatformTrustConfig {
+            allow_all_users: Some(false),
+            allowed_users: Some(vec!["zhangsan".into()]),
+        };
+        let r = cfg.resolve_with_env("WECOM");
+        assert!(!r.allow_all_users);
+        assert_eq!(r.allowed_users, vec!["zhangsan".to_string()]);
+
+        // --- Scenario 3: env fallback (comma-separated, trimmed, empties dropped) ---
+        std::env::set_var("WECOM_ALLOWED_USERS", " zhangsan , lisi,,wangwu ");
+        let r = PlatformTrustConfig::default().resolve_with_env("WECOM");
+        assert!(r.allow_all_users); // from WECOM_ALLOW_ALL_USERS=true
+        assert_eq!(
+            r.allowed_users,
+            vec![
+                "zhangsan".to_string(),
+                "lisi".to_string(),
+                "wangwu".to_string()
+            ]
+        );
+        assert!(PlatformTrustConfig::env_trust_present("WECOM"));
+
+        // --- Scenario 4: empty-string env flag treated as unset → deny-all ---
+        std::env::set_var("WECOM_ALLOW_ALL_USERS", "");
+        std::env::remove_var("WECOM_ALLOWED_USERS");
+        assert!(
+            !PlatformTrustConfig::default()
+                .resolve_with_env("WECOM")
+                .allow_all_users
+        );
+
+        // --- Scenario 5: "0"/"false" env values resolve false ---
+        std::env::set_var("WECOM_ALLOW_ALL_USERS", "0");
+        assert!(
+            !PlatformTrustConfig::default()
+                .resolve_with_env("WECOM")
+                .allow_all_users
+        );
+        std::env::set_var("WECOM_ALLOW_ALL_USERS", "false");
+        assert!(
+            !PlatformTrustConfig::default()
+                .resolve_with_env("WECOM")
+                .allow_all_users
+        );
+
+        // --- Scenario 6: explicit empty config list = deny-all, ignores env ---
+        std::env::set_var("WECOM_ALLOWED_USERS", "mallory");
+        let cfg = PlatformTrustConfig {
+            allow_all_users: None,
+            allowed_users: Some(vec![]),
+        };
+        assert!(cfg.resolve_with_env("WECOM").allowed_users.is_empty());
+
+        // --- Scenario 7: prefixes are independent — WECOM env must not bleed
+        //     into another prefix ---
+        assert!(!PlatformTrustConfig::env_trust_present("TEAMS"));
+        assert!(PlatformTrustConfig::default()
+            .resolve_with_env("TEAMS")
+            .allowed_users
+            .is_empty());
+
+        std::env::remove_var("WECOM_ALLOW_ALL_USERS");
+        std::env::remove_var("WECOM_ALLOWED_USERS");
     }
 
     #[test]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -154,6 +154,39 @@ allowed_users = ["U1234567890abcdef0123456789abcdef"]
 
 ---
 
+## `[wecom]` / `[googlechat]` / `[teams]`
+
+First-class L3 identity trust for the remaining gateway platforms — same shape and semantics as `[line]`. Each section replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for its platform (deprecated: warns at startup, becomes an error in Phase 2). Platform credentials remain on the gateway env vars (`WECOM_CORP_ID`/`WECOM_SECRET`, `GOOGLE_CHAT_*`, `TEAMS_APP_ID`/`TEAMS_APP_SECRET`).
+
+Each field resolves: config value → `{PREFIX}_*` env var → default (deny-all). Env prefixes: `WECOM`, `GOOGLE_CHAT`, `TEAMS`.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `allow_all_users` | bool \| omit | `false` (deny-all) | `true` = any user may interact (bypasses `allowed_users` entirely). Env fallback: `{PREFIX}_ALLOW_ALL_USERS`. |
+| `allowed_users` | string[] | `[]` | Platform user IDs allowed to interact. Only checked when `allow_all_users` resolves to false. Env fallback: `{PREFIX}_ALLOWED_USERS` (comma-separated). |
+
+Sender ID formats per platform:
+
+| Platform | Sender ID format | Example |
+|----------|-----------------|---------|
+| WeCom | Tenant-assigned UserID (freeform string) | `"zhangsan"` |
+| Google Chat | User resource name | `"users/123456789"` |
+| MS Teams | Bot Framework `activity.from.id` | `"29:1abc..."` |
+
+```toml
+[wecom]
+allowed_users = ["zhangsan", "lisi"]
+
+[googlechat]
+allowed_users = ["users/123456789"]
+
+[teams]
+allowed_users = ["29:1abc..."]
+# allow_all_users = true   # explicit opt-in only
+```
+
+---
+
 ## `[agent]`
 
 The AI agent subprocess that OpenAB spawns to handle messages via ACP.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -139,6 +139,8 @@ Custom Gateway adapter for platforms like Telegram, LINE, Feishu/Lark, and Googl
 
 First-class L3 identity trust for the LINE adapter (identity-trust-none ADR, Phase 1). Replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for LINE — relying on those for LINE is deprecated and warns at startup. Channel credentials remain on the `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` env vars.
 
+> **Mode scoping:** takes effect on the **embedded/unified adapter path** (see the note under `[wecom]` / `[googlechat]` / `[teams]` below — the same applies here).
+
 Each field resolves: config value → `LINE_*` env var → default (deny-all).
 
 | Key | Type | Default | Description |
@@ -157,6 +159,8 @@ allowed_users = ["U1234567890abcdef0123456789abcdef"]
 ## `[wecom]` / `[googlechat]` / `[teams]`
 
 First-class L3 identity trust for the remaining gateway platforms — same shape and semantics as `[line]`. Each section replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for its platform (deprecated: warns at startup, becomes an error in Phase 2). Platform credentials remain on the gateway env vars (`WECOM_CORP_ID`/`WECOM_SECRET`, `GOOGLE_CHAT_*`, `TEAMS_APP_ID`/`TEAMS_APP_SECRET`).
+
+> **Mode scoping:** these sections (like `[line]`) take effect on the **embedded/unified adapter path**, where events pass the shared ingress trust gate. Deployments using the standalone `openab-gateway` companion over WebSocket enforce trust via `[gateway].allow_all_users` / `allowed_users` instead; Phase 1c consolidates the two paths.
 
 Each field resolves: config value → `{PREFIX}_*` env var → default (deny-all). Env prefixes: `WECOM`, `GOOGLE_CHAT`, `TEAMS`.
 

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -154,6 +154,8 @@ allow_all_users = true
 
 ### User Trust (`[googlechat]` section)
 
+> **Mode scoping:** the `[googlechat]` section applies when the Google Chat adapter is **embedded in the OAB binary** (unified mode, `GOOGLE_CHAT_ENABLED=true` env set on the OAB container). In the standalone-gateway mode shown above, trust is enforced by `[gateway].allow_all_users` / `allowed_users` instead — the `[googlechat]` section has no effect on that path yet (Phase 1c consolidates the two).
+
 Identity trust defaults to **deny-all** (identity-trust-none ADR): unknown senders are rejected until explicitly admitted. Configure trust with a first-class `[googlechat]` section:
 
 ```toml

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -152,6 +152,20 @@ allow_all_users = true
 [agent]
 ```
 
+### User Trust (`[googlechat]` section)
+
+Identity trust defaults to **deny-all** (identity-trust-none ADR): unknown senders are rejected until explicitly admitted. Configure trust with a first-class `[googlechat]` section:
+
+```toml
+[googlechat]
+allowed_users = ["users/123456789"]  # Chat user resource names (users/<id>)
+# allow_all_users = true   # explicit opt-in only — any user can drive the agent
+```
+
+Each field falls back to its `GOOGLE_CHAT_ALLOW_ALL_USERS` / `GOOGLE_CHAT_ALLOWED_USERS` env var when unset.
+
+> ⚠️ **Deprecated:** driving Google Chat trust through the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars still works but logs a startup warning; it will become a startup error in a later phase. Migrate to `[googlechat]` (or `GOOGLE_CHAT_*` env vars).
+
 ## Features
 
 ### Supported

--- a/docs/line.md
+++ b/docs/line.md
@@ -104,6 +104,8 @@ platform = "line"
 
 ### User Trust (`[line]` section)
 
+> **Mode scoping:** the `[line]` section applies when the LINE adapter is **embedded in the OAB binary** (unified mode, `LINE_CHANNEL_SECRET` env set on the OAB container). In the standalone-gateway mode shown above, trust is enforced by `[gateway].allow_all_users` / `allowed_users` instead — the `[line]` section has no effect on that path yet (Phase 1c consolidates the two).
+
 Identity trust defaults to **deny-all** (identity-trust-none ADR): unknown senders are rejected until explicitly admitted. Configure trust with a first-class `[line]` section:
 
 ```toml

--- a/docs/msteams-selfhosted.md
+++ b/docs/msteams-selfhosted.md
@@ -43,6 +43,8 @@ allowed_users = ["29:1abc..."]  # Bot Framework activity.from.id values
 
 Each field falls back to its `TEAMS_ALLOW_ALL_USERS` / `TEAMS_ALLOWED_USERS` env var when unset. To find a user's `29:…` ID, check the OAB logs — the sender ID is logged for each incoming message.
 
+> **Mode scoping:** the `[teams]` section applies to this unified (embedded) mode. In the legacy standalone-gateway mode below, trust is enforced by `[gateway].allow_all_users` / `allowed_users` instead — the `[teams]` section has no effect on that path yet (Phase 1c consolidates the two).
+
 > ⚠️ **Deprecated:** driving Teams trust through the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars still works but logs a startup warning; it will become a startup error in a later phase. Migrate to `[teams]` (or `TEAMS_*` env vars).
 
 ---

--- a/docs/msteams-selfhosted.md
+++ b/docs/msteams-selfhosted.md
@@ -31,6 +31,20 @@ tables = "off"
 
 Set `TEAMS_APP_ID` and `TEAMS_APP_SECRET` on the container. No `[gateway]` needed.
 
+### User Trust (`[teams]` section)
+
+Identity trust defaults to **deny-all** (identity-trust-none ADR): unknown senders are rejected until explicitly admitted. Configure trust with a first-class `[teams]` section:
+
+```toml
+[teams]
+allowed_users = ["29:1abc..."]  # Bot Framework activity.from.id values
+# allow_all_users = true   # explicit opt-in only — any user can drive the agent
+```
+
+Each field falls back to its `TEAMS_ALLOW_ALL_USERS` / `TEAMS_ALLOWED_USERS` env var when unset. To find a user's `29:…` ID, check the OAB logs — the sender ID is logged for each incoming message.
+
+> ⚠️ **Deprecated:** driving Teams trust through the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars still works but logs a startup warning; it will become a startup error in a later phase. Migrate to `[teams]` (or `TEAMS_*` env vars).
+
 ---
 
 ## Standalone Gateway Mode (Legacy)

--- a/docs/wecom.md
+++ b/docs/wecom.md
@@ -129,6 +129,20 @@ max_sessions = 10
 | `allow_all_channels` | No | Allow messages from all channels (default: `false`) |
 | `allow_all_users` | No | Allow messages from all users (default: `false`) |
 
+### User Trust (`[wecom]` section)
+
+Identity trust defaults to **deny-all** (identity-trust-none ADR): unknown senders are rejected until explicitly admitted. Configure trust with a first-class `[wecom]` section:
+
+```toml
+[wecom]
+allowed_users = ["zhangsan", "lisi"]  # WeCom UserIDs (tenant-assigned, freeform strings)
+# allow_all_users = true   # explicit opt-in only — any user can drive the agent
+```
+
+Each field falls back to its `WECOM_ALLOW_ALL_USERS` / `WECOM_ALLOWED_USERS` env var when unset.
+
+> ⚠️ **Deprecated:** driving WeCom trust through the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars still works but logs a startup warning; it will become a startup error in a later phase. Migrate to `[wecom]` (or `WECOM_*` env vars).
+
 ## 6. Expose the Gateway (HTTPS)
 
 WeCom requires a publicly accessible HTTPS URL for callbacks.

--- a/docs/wecom.md
+++ b/docs/wecom.md
@@ -131,6 +131,8 @@ max_sessions = 10
 
 ### User Trust (`[wecom]` section)
 
+> **Mode scoping:** the `[wecom]` section applies when the WeCom adapter is **embedded in the OAB binary** (unified mode, `WECOM_CORP_ID` env set on the OAB container). In the standalone-gateway mode shown above, trust is enforced by `[gateway].allow_all_users` / `allowed_users` instead — the `[wecom]` section has no effect on that path yet (Phase 1c consolidates the two).
+
 Identity trust defaults to **deny-all** (identity-trust-none ADR): unknown senders are rejected until explicitly admitted. Configure trust with a first-class `[wecom]` section:
 
 ```toml

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,62 @@ fn has_unified_platform_env() -> bool {
                 .unwrap_or(false))
 }
 
+/// Apply a platform's first-class trust section to the registry, or — when the
+/// platform is active but still trust-driven by the deprecated uniform
+/// `GATEWAY_ALLOW_ALL_USERS`/`GATEWAY_ALLOWED_USERS` env — log the Phase 1
+/// deprecation warning (#1356). Shared by the `[wecom]`/`[googlechat]`/`[teams]`
+/// overrides; same override shape as the bespoke `[telegram]`/`[line]` blocks.
+///
+/// L2 (channels) stays on the shared gateway values passed in; L3 mirrors the
+/// resolved section (config → `{env_prefix}_*` env → deny-all).
+#[allow(clippy::too_many_arguments)]
+fn platform_trust_override(
+    reg: &mut openab_core::trust::PlatformTrustConfigs,
+    platform: &str,
+    section: &Option<config::PlatformTrustConfig>,
+    env_prefix: &str,
+    platform_active: bool,
+    allow_all_channels: bool,
+    allowed_channels: &[String],
+) {
+    use openab_core::trust::TrustConfig;
+    let resolved = if let Some(s) = section {
+        Some(s.resolve_with_env(env_prefix))
+    } else if config::PlatformTrustConfig::env_trust_present(env_prefix) {
+        Some(config::PlatformTrustConfig::default().resolve_with_env(env_prefix))
+    } else {
+        None
+    };
+    match resolved {
+        Some(r) => {
+            reg.insert(
+                platform,
+                TrustConfig::new(
+                    Some(allow_all_channels),
+                    allowed_channels.to_vec(),
+                    None,
+                    Some(r.allow_all_users),
+                    r.allowed_users,
+                ),
+            );
+        }
+        None => {
+            let legacy_env_set = std::env::var("GATEWAY_ALLOW_ALL_USERS").is_ok()
+                || std::env::var("GATEWAY_ALLOWED_USERS").is_ok();
+            if platform_active && legacy_env_set {
+                warn!(
+                    platform,
+                    "platform trust is driven by deprecated GATEWAY_ALLOW_ALL_USERS/\
+                     GATEWAY_ALLOWED_USERS env vars — migrate to a [{platform}] section \
+                     (allow_all_users/allowed_users) or {env_prefix}_ALLOW_ALL_USERS/\
+                     {env_prefix}_ALLOWED_USERS; the uniform GATEWAY_* fallback will \
+                     become a startup error in Phase 2 (#1356)"
+                );
+            }
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
@@ -444,6 +500,41 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
+
+        // WeCom / Google Chat / MS Teams: same first-class override shape as
+        // LINE above, via the shared [wecom]/[googlechat]/[teams] trust
+        // sections (#1358, #1359, #1360). L2 stays on the shared GATEWAY_*
+        // channel values; L3 mirrors the resolved per-platform section.
+        platform_trust_override(
+            &mut reg,
+            "wecom",
+            &cfg.wecom,
+            "WECOM",
+            cfg!(feature = "wecom") && std::env::var("WECOM_CORP_ID").is_ok(),
+            allow_all_channels,
+            &allowed_channels,
+        );
+        platform_trust_override(
+            &mut reg,
+            "googlechat",
+            &cfg.googlechat,
+            "GOOGLE_CHAT",
+            cfg!(feature = "googlechat")
+                && std::env::var("GOOGLE_CHAT_ENABLED")
+                    .map(|v| v == "true" || v == "1")
+                    .unwrap_or(false),
+            allow_all_channels,
+            &allowed_channels,
+        );
+        platform_trust_override(
+            &mut reg,
+            "teams",
+            &cfg.teams,
+            "TEAMS",
+            cfg!(feature = "teams") && std::env::var("TEAMS_APP_ID").is_ok(),
+            allow_all_channels,
+            &allowed_channels,
+        );
         reg
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -457,6 +457,11 @@ async fn main() -> anyhow::Result<()> {
         // gateway model yet (group policy is a follow-up), so it stays on the
         // shared GATEWAY_* values set above.
         //
+        // NOTE: deliberately NOT routed through platform_trust_override —
+        // LineConfig is a bespoke type that grows group-policy fields next
+        // (#1355 follow-up), unlike the shared PlatformTrustConfig used by
+        // wecom/googlechat/teams below.
+        //
         // Also resolves when running env-only (no [line] section but
         // LINE_ALLOW_ALL_USERS / LINE_ALLOWED_USERS set), matching the
         // Telegram pattern.


### PR DESCRIPTION
> [!NOTE]
> Was stacked on #1365; now rebased onto `main` (`ddc9e5d`) after #1363/#1365 merged. Diff is standalone.

## What problem does this solve?

WeCom, Google Chat, and MS Teams are the last gateway platforms whose identity trust is controlled only by the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars — no per-platform granularity. This clones the `[line]` pattern (#1365) to all three, completing the "first-class `[section]` per platform" row for the simple cases in umbrella #1356.

Implements the config-section + registry-wiring + deprecation tasks of #1358 (WeCom), #1359 (Google Chat), #1360 (Teams). Platform-specific `is_bot` derivation and deny-echo tasks on those issues remain follow-ups, as with LINE.

## At a Glance

```text
┌─ Trust sources ───────────────────┐  ┌─ PlatformTrustConfigs ────────────┐
│                                   │  │                                   │
│  ┌─────────────────────────────┐  │  │  ┌─────────────────────────────┐  │
│  │ [wecom]      / WECOM_*  NEW │──┼──┼─▶│ wecom      ← override   NEW │  │
│  ├─────────────────────────────┤  │  │  ├─────────────────────────────┤  │
│  │ [googlechat] / GOOGLE_  NEW │──┼──┼─▶│ googlechat ← override   NEW │  │
│  │                CHAT_*       │  │  │  ├─────────────────────────────┤  │
│  ├─────────────────────────────┤  │  │  │ teams      ← override   NEW │  │
│  │ [teams]      / TEAMS_*  NEW │──┼──┼─▶├─────────────────────────────┤  │
│  └─────────────────────────────┘  │  │  │ line       ← [line] (#1365) │  │
│  ┌─────────────────────────────┐  │  │  ├─────────────────────────────┤  │
│  │ [line] (#1365)              │  │  │  │ telegram   ← [telegram]     │  │
│  │ [telegram] (#1297)          │  │  │  ├─────────────────────────────┤  │
│  └─────────────────────────────┘  │  │  │ feishu     ← uniform seed   │  │
│  ┌─────────────────────────────┐  │  │  │ (last one — #1357, needs    │  │
│  │ GATEWAY_* env (legacy)      │  │  │  │  double-gate elimination)   │  │
│  │ ⚠ warns per platform when   │  │  │  └─────────────────────────────┘  │
│  │ it still drives trust       │  │  └───────────────────────────────────┘
│  └─────────────────────────────┘  │
└───────────────────────────────────┘
```

## Proposed Solution

- **`config.rs`** — one shared `PlatformTrustConfig { allow_all_users, allowed_users }` + `resolve_with_env(prefix)` / `env_trust_present(prefix)`, instead of three copy-pasted structs (the duplication lesson from #1363's self-review, applied proactively). Env prefixes follow each adapter's existing convention: `WECOM`, `GOOGLE_CHAT`, `TEAMS`. Platforms that later need richer fields (e.g. `trusted_bot_ids` for WeCom/Teams) graduate to their own struct, as LINE will for group policy.
- **`main.rs`** — a `platform_trust_override` helper applies the section (or its env) over the uniform `GATEWAY_*` seed and logs the shared Phase 1 deprecation warning when an active platform is still trust-driven by legacy env. Activity signals reuse `has_unified_platform_env`'s exact conditions: `WECOM_CORP_ID`, `GOOGLE_CHAT_ENABLED`, `TEAMS_APP_ID`.
- **Docs** — `config.toml.example`, `config-reference.md` (combined `[wecom]`/`[googlechat]`/`[teams]` section with per-platform sender-ID formats), `wecom.md`, `google-chat.md`, `msteams-selfhosted.md` User Trust sections with deprecation callouts.

## Why this approach?

Backward-compatible by construction (warning only; overrides are opt-in), and identical semantics to the accepted `[telegram]`/`[line]` shape so operators learn one pattern. The shared struct + helper means #1357 (Feishu, the remaining platform) only needs to handle its extra complexity (double-gate elimination, `trusted_bot_ids`), not re-implement resolution.

## Self-review

Reviewed with the standard SOP after opening:

- ✅ **Registry/override audit**: overrides run after the uniform seed; HashMap insert semantics replace correctly; activity signals verified identical to `has_unified_platform_env`.
- ✅ **Prefix-independence**: covered by test scenario 7 (WECOM env must not bleed into TEAMS).
- 🟡→fixed **Mode-scoping docs gap** (`c058cbf`): `gate_incoming` runs only on the embedded/unified adapter path; the standalone-gateway WebSocket path enforces trust via `[gateway].allow_all_users`/`allowed_users` and never consults the registry. The User Trust doc sections were placed in standalone-gateway setup guides without saying so. Added mode-scoping callouts to wecom.md, google-chat.md, msteams-selfhosted.md, config-reference.md — and to line.md, since the merged #1365 docs had the same gap.
- ℹ️ **LINE block stays bespoke** (documented in-code): `LineConfig` grows group-policy fields next, so routing it through `platform_trust_override` would be undone by the roadmap.

## Validation

At `ddc9e5d` (macOS arm64, rebased onto main `6cf869d`; full suite re-run post-rebase — 660 passed, 1 known pre-existing failure):

- `cargo clippy --workspace --all-features -- -D warnings` — clean
- `cargo clippy --workspace -- -D warnings` (default features) — clean
- `cargo check --features unified` (wecom/googlechat/teams features on) — pass
- `cargo check -p openab-core --no-default-features` — pass
- `cargo test -p openab-core --all-features` — 658 passed, 1 failed: `secrets::tests::resolve_exec_nonzero_exit` (known pre-existing macOS-only failure, also fails on unmodified `main`)
- New tests — 2/2 (`platform_trust_sections_parse_from_toml`, `platform_trust_resolve_all_scenarios`)
- `rustfmt --check` — no new drift (config.rs 0→0 after fixing one introduced diff, main.rs 4→4)

## Tests

- `platform_trust_sections_parse_from_toml` — all three sections parse; absent sections → `None`
- `platform_trust_resolve_all_scenarios` — seven env-resolution scenarios in one env-race-safe test fn (same pattern as `line_resolve_all_scenarios`), including a prefix-independence scenario (WECOM env must not bleed into TEAMS)

Refs #1358 #1359 #1360 (config-section/registry/deprecation tasks — `is_bot` derivation and deny-echo remain), umbrella #1356, ADR #1291.


