### PR TITLE
docs(readme): refresh architecture diagram and platform list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,31 +6,44 @@ English | [繁體中文](README.zh-TW.md)
 
 ![OpenAB banner](images/banner.jpg)
 
-A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Copilot CLI, Hermes, Grok Build, Devin, Antigravity, Pi, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat**, and other webhook-based platforms are supported via the standalone [Custom Gateway](crates/openab-gateway/).
+A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Copilot CLI, Hermes, Grok Build, Devin, Antigravity, Pi, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat, WeCom, and Microsoft Teams** are available through gateway adapters, either compiled into the unified binary or deployed as the standalone [Custom Gateway](crates/openab-gateway/).
 
 🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://openab.dev/discord)** 🎉
 
 ```
-┌──────────────┐  Gateway WS   ┌──────────────┐  ACP stdio    ┌──────────────────┐
-│   Discord    │◄─────────────►│              │──────────────►│   coding CLI     │
-│   User       │               │    openab    │◄── JSON-RPC ──│   (acp mode)     │
-├──────────────┤  Socket Mode  │    (Rust)    │               ├──────────────────┤
-│   Slack      │◄─────────────►│              │               │ kiro-cli acp     │
-│   User       │               └──────┬───────┘               │ claude-agent-acp │
-├──────────────┤                      │  WebSocket            │ codex-acp        │
-│   Telegram   │◄──webhook──┐         │   (outbound)          │ gemini --acp     │
-│   User       │            │         │                       │ copilot --acp    │
-├──────────────┤            ▼         ▼                       │ hermes-acp       │
-│   LINE       │◄──webhook──┌──────────────────┐              │ opencode acp     │
-│   User       │            │  Custom Gateway  │              │ mimo acp         │
-├──────────────┤            │  (standalone)    │              │ grok agent stdio │
-│  Feishu/Lark │◄───WS──────│                  │              │ devin acp        │
-│   User       │            │                  │              │ agy-acp          │
-├──────────────┤            │                  │              │ pi-acp           │
-│ Google Chat  │◄──webhook──│                  │              └──────────────────┘
-│   User       │            └──────────────────┘
+┌──────────────┐  Gateway WS  ┌─────────────────┐  ACP stdio   ┌─────────────────────────┐
+│ Discord      │◄────────────►│                 │─────────────►│ agent runtime           │
+│ User         │              │ openab (Rust)   │◄──JSON-RPC──│ (ACP process)           │
+├──────────────┤  Socket Mode │ thin ACP broker │             ├─────────────────────────┤
+│ Slack        │◄────────────►│                 │             │ kiro-cli acp            │
+│ User         │              └────────┬────────┘             │ claude-agent-acp        │
+├──────────────┤                       ▲                      │ codex-acp               │
+│ Telegram     │◄webhook/API─►┐        │                      │  └─ Codex app-server    │
+│ User         │              │        │ WebSocket            │ gemini --acp            │
+├──────────────┤              │        │ (standalone)         │ copilot --acp           │
+│ LINE         │◄webhook/API─►┤        │ or in-process        │ cursor-agent acp        │
+│ User         │              │        │ (unified)            │ hermes-acp              │
+├──────────────┤              │ ┌──────┴───────────┐          │ opencode acp            │
+│ Feishu/Lark  │◄─WS/webhook─►┼►│ gateway adapters │          │ mimo acp                │
+│ User         │              │ │ standalone or    │          │ grok agent stdio        │
+├──────────────┤              │ │ embedded unified │          │ devin acp               │
+│ Google Chat  │◄webhook/API─►┤ └──────────────────┘          │ agy-acp                 │
+│ User         │              │                               │ pi-acp                  │
+├──────────────┤              │                               │ openab-agent            │
+│ WeCom        │◄webhook/API─►┤                               │ agentcore-acp           │
+│ User         │              │                               │  └─ AWS AgentCore       │
+├──────────────┤              │                               │ custom ACP agent        │
+│ MS Teams     │◄webhook/API─►┘                               └─────────────────────────┘
+│ User         │
 └──────────────┘
 ```
+
+OpenAB remains a thin broker: platform adapters converge on the same
+dispatcher and session pool, then cross one ACP stdio boundary to the selected
+agent runtime. Gateway adapters can run as a standalone companion or be
+embedded in a unified build without changing that boundary. Platform-edge
+labels distinguish inbound delivery from outbound replies: `webhook/API` for
+webhook platforms and `WS/webhook` for Feishu/Lark.
 
 ## Demo
 
@@ -39,7 +52,7 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 ## Features
 
 - **Multi-platform** — supports Discord and Slack, run one or both simultaneously
-- **Custom Gateway** — extend to Telegram, LINE, Feishu/Lark, Google Chat, MS Teams via standalone [gateway](crates/openab-gateway/)
+- **Gateway adapters** — extend to Telegram, LINE, Feishu/Lark, Google Chat, WeCom, and Microsoft Teams through the standalone [gateway](crates/openab-gateway/) or an opt-in unified build
 - **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Copilot CLI, Hermes, Grok Build, Devin, Antigravity, Pi via config
 - **@mention trigger** — mention the bot in an allowed channel to start a conversation
 - **Thread-based multi-turn** — auto-creates threads; no @mention needed for follow-ups

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**,
 🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://openab.dev/discord)** 🎉
 
 ```
-┌──────────────┐  Gateway WS  ┌─────────────────┐  ACP stdio   ┌─────────────────────────┐
-│ Discord      │◄────────────►│                 │─────────────►│ agent runtime           │
+┌──────────────┐  Gateway WS  ┌─────────────────┐  ACP stdio  ┌─────────────────────────┐
+│ Discord      │◄────────────►│                 │────────────►│ agent runtime           │
 │ User         │              │ openab (Rust)   │◄──JSON-RPC──│ (ACP process)           │
 ├──────────────┤  Socket Mode │ thin ACP broker │             ├─────────────────────────┤
 │ Slack        │◄────────────►│                 │             │ kiro-cli acp            │

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -6,31 +6,44 @@
 
 ![OpenAB banner](images/banner.jpg)
 
-一個輕量、安全、雲端原生的 ACP harness，透過 stdio JSON-RPC 將 **Discord、Slack** 與任何相容於 [Agent Client Protocol](https://github.com/anthropics/agent-protocol) 的程式開發 CLI（Kiro CLI、Claude Code、Codex、Gemini、OpenCode、MiMo-Code、Copilot CLI、Hermes、Grok Build、Devin、Antigravity、Pi 等）連接起來，帶來新一代的開發體驗。**Telegram、LINE、Feishu/Lark、Google Chat** 以及其他以 webhook 為基礎的平台，則透過獨立的 [Custom Gateway](crates/openab-gateway/) 支援。
+一個輕量、安全、雲端原生的 ACP harness，透過 stdio JSON-RPC 將 **Discord、Slack** 與任何相容於 [Agent Client Protocol](https://github.com/anthropics/agent-protocol) 的程式開發 CLI（Kiro CLI、Claude Code、Codex、Gemini、OpenCode、MiMo-Code、Copilot CLI、Hermes、Grok Build、Devin、Antigravity、Pi 等）連接起來，帶來新一代的開發體驗。**Telegram、LINE、Feishu/Lark、Google Chat、WeCom 與 Microsoft Teams** 則由 gateway adapters 支援；可將 adapters 編入 unified binary，或部署為獨立的 [Custom Gateway](crates/openab-gateway/)。
 
 🪼 **加入我們的社群！** 歡迎到 Discord 和大家打招呼：**[🪼 OpenAB — Official](https://openab.dev/discord)** 🎉
 
 ```
-┌──────────────┐  Gateway WS   ┌──────────────┐  ACP stdio    ┌──────────────────┐
-│   Discord    │◄─────────────►│              │──────────────►│   coding CLI     │
-│   User       │               │    openab    │◄── JSON-RPC ──│   (acp mode)     │
-├──────────────┤  Socket Mode  │    (Rust)    │               ├──────────────────┤
-│   Slack      │◄─────────────►│              │               │ kiro-cli acp     │
-│   User       │               └──────┬───────┘               │ claude-agent-acp │
-├──────────────┤                      │  WebSocket            │ codex-acp        │
-│   Telegram   │◄──webhook──┐         │   (outbound)          │ gemini --acp     │
-│   User       │            │         │                       │ copilot --acp    │
-├──────────────┤            ▼         ▼                       │ hermes-acp       │
-│   LINE       │◄──webhook──┌──────────────────┐              │ opencode acp     │
-│   User       │            │  Custom Gateway  │              │ mimo acp         │
-├──────────────┤            │  (standalone)    │              │ grok agent stdio │
-│  Feishu/Lark │◄───WS──────│                  │              │ devin acp        │
-│   User       │            │                  │              │ agy-acp          │
-├──────────────┤            │                  │              │ pi-acp           │
-│ Google Chat  │◄──webhook──│                  │              └──────────────────┘
-│   User       │            └──────────────────┘
+┌──────────────┐  Gateway WS  ┌─────────────────┐  ACP stdio   ┌─────────────────────────┐
+│ Discord      │◄────────────►│                 │─────────────►│ agent runtime           │
+│ User         │              │ openab (Rust)   │◄──JSON-RPC──│ (ACP process)           │
+├──────────────┤  Socket Mode │ thin ACP broker │             ├─────────────────────────┤
+│ Slack        │◄────────────►│                 │             │ kiro-cli acp            │
+│ User         │              └────────┬────────┘             │ claude-agent-acp        │
+├──────────────┤                       ▲                      │ codex-acp               │
+│ Telegram     │◄webhook/API─►┐        │                      │  └─ Codex app-server    │
+│ User         │              │        │ WebSocket            │ gemini --acp            │
+├──────────────┤              │        │ (standalone)         │ copilot --acp           │
+│ LINE         │◄webhook/API─►┤        │ or in-process        │ cursor-agent acp        │
+│ User         │              │        │ (unified)            │ hermes-acp              │
+├──────────────┤              │ ┌──────┴───────────┐          │ opencode acp            │
+│ Feishu/Lark  │◄─WS/webhook─►┼►│ gateway adapters │          │ mimo acp                │
+│ User         │              │ │ standalone or    │          │ grok agent stdio        │
+├──────────────┤              │ │ embedded unified │          │ devin acp               │
+│ Google Chat  │◄webhook/API─►┤ └──────────────────┘          │ agy-acp                 │
+│ User         │              │                               │ pi-acp                  │
+├──────────────┤              │                               │ openab-agent            │
+│ WeCom        │◄webhook/API─►┤                               │ agentcore-acp           │
+│ User         │              │                               │  └─ AWS AgentCore       │
+├──────────────┤              │                               │ custom ACP agent        │
+│ MS Teams     │◄webhook/API─►┘                               └─────────────────────────┘
+│ User         │
 └──────────────┘
 ```
+
+OpenAB 仍是 thin broker：所有 platform adapters 都會進入同一套
+dispatcher 與 session pool，再透過單一 ACP stdio boundary 連接所選的
+agent runtime。Gateway adapters 可作為 standalone companion 執行，也可
+內嵌於 unified build，兩種部署方式都不會改變這個 boundary。Platform
+edge 的 labels 會分別呈現 inbound delivery 與 outbound reply：webhook
+platforms 使用 `webhook/API`，Feishu/Lark 則使用 `WS/webhook`。
 
 ## 示範
 
@@ -39,7 +52,7 @@
 ## 功能特色
 
 - **多平台支援** — 支援 Discord 與 Slack，可單獨或同時執行
-- **Custom Gateway** — 透過獨立的 [gateway](crates/openab-gateway/) 擴充至 Telegram、LINE、Feishu/Lark、Google Chat、MS Teams
+- **Gateway adapters** — 可透過獨立的 [gateway](crates/openab-gateway/) 或 opt-in unified build 擴充至 Telegram、LINE、Feishu/Lark、Google Chat、WeCom 與 Microsoft Teams
 - **可替換的 agent backend** — 可透過設定在 Kiro CLI、Claude Code、Codex、Gemini、OpenCode、MiMo-Code、Copilot CLI、Hermes、Grok Build、Devin、Antigravity、Pi 之間切換
 - **@mention 觸發** — 在允許的頻道中 mention bot，即可開始對話
 - **以討論串進行多輪對話** — 自動建立討論串；後續訊息不需再次 @mention

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -11,8 +11,8 @@
 🪼 **加入我們的社群！** 歡迎到 Discord 和大家打招呼：**[🪼 OpenAB — Official](https://openab.dev/discord)** 🎉
 
 ```
-┌──────────────┐  Gateway WS  ┌─────────────────┐  ACP stdio   ┌─────────────────────────┐
-│ Discord      │◄────────────►│                 │─────────────►│ agent runtime           │
+┌──────────────┐  Gateway WS  ┌─────────────────┐  ACP stdio  ┌─────────────────────────┐
+│ Discord      │◄────────────►│                 │────────────►│ agent runtime           │
 │ User         │              │ openab (Rust)   │◄──JSON-RPC──│ (ACP process)           │
 ├──────────────┤  Socket Mode │ thin ACP broker │             ├─────────────────────────┤
 │ Slack        │◄────────────►│                 │             │ kiro-cli acp            │


### PR DESCRIPTION
## What problem does this solve?

The README architecture diagram and platform list predate several shipped features: WeCom and MS Teams edges, gateway adapters embedded in the unified build (vs standalone only), cursor-agent / native openab-agent / agentcore-acp runtimes.

Extracted from #1353 per maintainer scope review so that PR stays a pure Codex adapter migration; original authorship by @vixenclawsastraagent (credited via Co-authored-by). The Codex adapter table row itself stays in #1353.

## Validation

- Markdown only — no code changes
- Diagram contents verified against the `Cargo.toml` `unified` feature list and `docs/adr/unified-binary.md`
- Both English and 繁體中文 READMEs updated symmetrically

Refs #1353.