### PR TITLE
build(antigravity): bump agy CLI 1.0.10 → 1.1.1

### DIFF
--- a/Dockerfile.antigravity
+++ b/Dockerfile.antigravity
@@ -27,7 +27,7 @@ FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps tini unzip && rm -rf /var/lib/apt/lists/*
 
 # Install agy (Google Antigravity CLI) — pinned version
-ENV AGY_VERSION=1.0.10
+ENV AGY_VERSION=1.1.1
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) ASSET="agy_cli_linux_x64.tar.gz" ;; \

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -305,7 +305,7 @@ CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 # Target: antigravity
 # =============================================================================
 FROM base-debian AS antigravity
-ENV AGY_VERSION=1.0.10
+ENV AGY_VERSION=1.1.1
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) ASSET="agy_cli_linux_x64.tar.gz" ;; \

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -352,7 +352,7 @@ CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 # Target: antigravity
 # =============================================================================
 FROM base-debian AS antigravity
-ENV AGY_VERSION=1.0.10
+ENV AGY_VERSION=1.1.1
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) ASSET="agy_cli_linux_x64.tar.gz" ;; \


### PR DESCRIPTION
## What problem does this solve?

Bumps the pinned Google Antigravity CLI from 1.0.10 to [1.1.1](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.1) in all three Dockerfile targets (`Dockerfile.antigravity`, `Dockerfile.unified`, `Dockerfile.package`).

Relevant fixes for OpenAB's subprocess usage:
- `agy -p` no longer hangs when run inside a shell script or subprocess (stops reading stdin when the prompt comes via flag)
- print mode no longer exits 0 with empty output on server-side failures — errors go to stderr with a non-zero exit code
- new `--agent` flag / `agent` subcommands

## Validation

- Release assets verified unchanged: `agy_cli_linux_{x64,arm64}.tar.gz` — the Dockerfile's arch-mapping logic needs no change
- No breaking changes in the release notes for the `agy-acp` integration
- E2E: preview image will be canaried on an isolated antigravity bot (evidence to follow in comments)

## Test plan

- [x] Docker Smoke Test (antigravity variant) via CI
- [ ] Preview build `variant=antigravity` + Discord E2E on isolated canary bot