### PR TITLE
feat(gateway): warn when webhook L1 auth is unenforceable (#1356 Phase 1)

### DIFF
--- a/crates/openab-gateway/src/adapters/feishu.rs
+++ b/crates/openab-gateway/src/adapters/feishu.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::RwLock;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use super::feishu_card;
 
@@ -3332,7 +3332,9 @@ pub async fn webhook(
             }
         }
     } else {
-        warn!("FEISHU_ENCRYPT_KEY not configured — webhook signature verification is SKIPPED (insecure)");
+        // L1 unenforceable is surfaced once at startup by
+        // AppState::warn_unenforceable_l1 (#1356); avoid a per-request warn flood.
+        debug!("FEISHU_ENCRYPT_KEY not configured — webhook signature verification is SKIPPED");
     }
 
     // Parse body — may be encrypted

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -216,18 +216,27 @@ impl AppState {
     /// active-but-unconfigured.
     pub fn warn_unenforceable_l1(&self) {
         use tracing::warn;
-        // (platform, active, l1_configured)
+        // (platform, active, l1_configured, remediation hint)
         #[allow(unused_mut)]
-        let mut checks: Vec<(&str, bool, bool)> = vec![
+        let mut checks: Vec<(&str, bool, bool, &str)> = vec![
             (
                 "telegram",
                 self.telegram_bot_token.is_some(),
-                self.telegram_secret_token.is_some(),
+                // secret_token is the primary L1; the trusted_source_only IP
+                // allowlist is a weaker-but-real alternate L1 (ADR Layer 1).
+                self.telegram_secret_token.is_some() || self.telegram_trusted_source_only,
+                "set TELEGRAM_SECRET_TOKEN (or [telegram].secret_token), or enable \
+                 TELEGRAM_TRUSTED_SOURCE_ONLY",
             ),
             (
                 "line",
+                // Any LINE env present = an operator intends to run LINE. With
+                // no LINE env at all the route still mounts, but spoofed events
+                // then face the core trust gate's deny-all default, so we avoid
+                // a false-positive warn on gateways that don't use LINE.
                 self.line_channel_secret.is_some() || self.line_access_token.is_some(),
                 self.line_channel_secret.is_some(),
+                "set LINE_CHANNEL_SECRET",
             ),
         ];
         #[cfg(feature = "feishu")]
@@ -238,6 +247,7 @@ impl AppState {
                 .as_ref()
                 .map(|f| f.config.encrypt_key.is_some())
                 .unwrap_or(false),
+            "set FEISHU_ENCRYPT_KEY",
         ));
         #[cfg(feature = "googlechat")]
         checks.push((
@@ -247,11 +257,13 @@ impl AppState {
                 .as_ref()
                 .map(|a| a.jwt_verifier.is_some())
                 .unwrap_or(false),
+            "set GOOGLE_CHAT_AUDIENCE",
         ));
-        for (platform, active, l1_configured) in checks {
+        for (platform, active, l1_configured, hint) in checks {
             if l1_unenforceable(active, l1_configured) {
                 warn!(
                     platform,
+                    hint,
                     "L1 webhook authentication is NOT configured — this webhook accepts \
                      unauthenticated requests, so the per-platform allowed_users (L3) allowlist \
                      is forgeable: an attacker can POST a spoofed allowlisted sender id and pass \
@@ -335,9 +347,8 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
     if telegram_bot_token.is_some() {
         let webhook_path =
             std::env::var("TELEGRAM_WEBHOOK_PATH").unwrap_or_else(|_| "/webhook/telegram".into());
-        if telegram_secret_token.is_none() {
-            warn!("TELEGRAM_SECRET_TOKEN not set — webhook requests are NOT validated (insecure)");
-        }
+        // Missing-secret warning is emitted by warn_unenforceable_l1 below,
+        // which also accounts for the trusted_source_only IP-allowlist L1.
         info!(path = %webhook_path, "telegram adapter enabled");
         app = app.route(&webhook_path, post(adapters::telegram::webhook));
     }

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -24,6 +24,13 @@ pub const LINE_WEBHOOK_CONCURRENCY_MAX: usize = 8;
 
 // --- App state (shared across all adapters) ---
 
+/// Whether a webhook platform's L1 (transport authentication) is unenforceable:
+/// the platform is active (configured to receive traffic) but its verification
+/// secret is not configured, so it accepts unauthenticated POSTs. See #1356.
+fn l1_unenforceable(active: bool, l1_configured: bool) -> bool {
+    active && !l1_configured
+}
+
 pub struct AppState {
     pub telegram_bot_token: Option<String>,
     pub telegram_secret_token: Option<String>,
@@ -189,6 +196,70 @@ impl AppState {
             reply_token_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             line_webhook_semaphore: Arc::new(Semaphore::new(LINE_WEBHOOK_CONCURRENCY_MAX)),
             client,
+        }
+    }
+
+    /// Phase 1 L1 audit (#1356): warn loudly for each **active** webhook
+    /// platform whose transport authentication (L1) secret is unconfigured.
+    ///
+    /// When L1 is skipped, the webhook accepts unauthenticated POSTs, so the
+    /// per-platform `allowed_users` (L3) allowlist is forgeable — an attacker
+    /// can POST an envelope with an allowlisted sender id and pass the trust
+    /// gate. Phase 1 only warns (backward-compatible: existing no-secret
+    /// deployments keep running); a later phase may escalate to a hard error.
+    ///
+    /// Call this once at startup **after** all config overrides are applied
+    /// (e.g. after `apply_telegram_config`), so a config-supplied secret is not
+    /// falsely reported as missing. WeCom and MS Teams are intentionally
+    /// omitted: their adapters treat the L1 secret as a construction
+    /// precondition (`from_env` returns `None` without it), so they cannot be
+    /// active-but-unconfigured.
+    pub fn warn_unenforceable_l1(&self) {
+        use tracing::warn;
+        // (platform, active, l1_configured)
+        #[allow(unused_mut)]
+        let mut checks: Vec<(&str, bool, bool)> = vec![
+            (
+                "telegram",
+                self.telegram_bot_token.is_some(),
+                self.telegram_secret_token.is_some(),
+            ),
+            (
+                "line",
+                self.line_channel_secret.is_some() || self.line_access_token.is_some(),
+                self.line_channel_secret.is_some(),
+            ),
+        ];
+        #[cfg(feature = "feishu")]
+        checks.push((
+            "feishu",
+            self.feishu.is_some(),
+            self.feishu
+                .as_ref()
+                .map(|f| f.config.encrypt_key.is_some())
+                .unwrap_or(false),
+        ));
+        #[cfg(feature = "googlechat")]
+        checks.push((
+            "googlechat",
+            self.google_chat.is_some(),
+            self.google_chat
+                .as_ref()
+                .map(|a| a.jwt_verifier.is_some())
+                .unwrap_or(false),
+        ));
+        for (platform, active, l1_configured) in checks {
+            if l1_unenforceable(active, l1_configured) {
+                warn!(
+                    platform,
+                    "L1 webhook authentication is NOT configured — this webhook accepts \
+                     unauthenticated requests, so the per-platform allowed_users (L3) allowlist \
+                     is forgeable: an attacker can POST a spoofed allowlisted sender id and pass \
+                     the trust gate. Configure the platform's webhook secret/signature to make \
+                     identity trust enforceable. \
+                     See https://github.com/openabdev/openab/issues/1356."
+                );
+            }
         }
     }
 
@@ -452,6 +523,10 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
         client,
     });
 
+    // Phase 1 L1 audit (#1356): warn if any active webhook platform has no
+    // transport authentication configured (identity trust unenforceable).
+    state.warn_unenforceable_l1();
+
     // Background: sweep expired reply tokens
     {
         let cache_state = state.clone();
@@ -670,4 +745,20 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
 
 async fn health() -> &'static str {
     "ok"
+}
+
+#[cfg(test)]
+mod l1_audit_tests {
+    use super::l1_unenforceable;
+
+    #[test]
+    fn warns_only_when_active_and_secret_missing() {
+        // active platform, no L1 secret → unenforceable (warn)
+        assert!(l1_unenforceable(true, false));
+        // active with L1 configured → fine
+        assert!(!l1_unenforceable(true, true));
+        // inactive platform → never warn, regardless of L1
+        assert!(!l1_unenforceable(false, false));
+        assert!(!l1_unenforceable(false, true));
+    }
 }

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -208,15 +208,22 @@ impl AppState {
     /// gate. Phase 1 only warns (backward-compatible: existing no-secret
     /// deployments keep running); a later phase may escalate to a hard error.
     ///
+    /// `feishu_webhook_route_mounted`: whether the caller actually mounted the
+    /// Feishu webhook route. The two binaries differ — the standalone gateway
+    /// mounts it only in Webhook connection mode, while the unified binary
+    /// mounts it unconditionally — so exposure is the caller's knowledge, not
+    /// derivable from `AppState` alone.
+    ///
     /// Call this once at startup **after** all config overrides are applied
     /// (e.g. after `apply_telegram_config`), so a config-supplied secret is not
     /// falsely reported as missing. WeCom and MS Teams are intentionally
     /// omitted: their adapters treat the L1 secret as a construction
-    /// precondition (`from_env` returns `None` without it), so they cannot be
-    /// active-but-unconfigured.
-    pub fn warn_unenforceable_l1(&self) {
+    /// precondition (`from_env` returns `None` without it) and verify every
+    /// request, so they cannot be active-but-unconfigured.
+    #[cfg_attr(not(feature = "feishu"), allow(unused_variables))]
+    pub fn warn_unenforceable_l1(&self, feishu_webhook_route_mounted: bool) {
         use tracing::warn;
-        for (platform, hint) in self.unenforceable_l1() {
+        for (platform, hint) in self.unenforceable_l1(feishu_webhook_route_mounted) {
             warn!(
                 platform,
                 hint,
@@ -233,7 +240,11 @@ impl AppState {
     /// The platforms whose L1 is unenforceable right now, with a remediation
     /// hint each. Separated from the warn wrapper so the per-platform
     /// active/configured wiring is unit-testable.
-    fn unenforceable_l1(&self) -> Vec<(&'static str, &'static str)> {
+    #[cfg_attr(not(feature = "feishu"), allow(unused_variables))]
+    fn unenforceable_l1(
+        &self,
+        feishu_webhook_route_mounted: bool,
+    ) -> Vec<(&'static str, &'static str)> {
         // (platform, active, l1_configured, remediation hint)
         #[allow(unused_mut)]
         let mut checks: Vec<(&str, bool, bool, &str)> = vec![
@@ -260,7 +271,12 @@ impl AppState {
         #[cfg(feature = "feishu")]
         checks.push((
             "feishu",
-            self.feishu.is_some(),
+            // Active = the webhook route is actually exposed (caller-supplied:
+            // the standalone gateway mounts it only in Webhook connection
+            // mode; the unified binary mounts it unconditionally). Websocket
+            // delivery itself needs no L1 secret — events arrive over an
+            // outbound long-connection.
+            self.feishu.is_some() && feishu_webhook_route_mounted,
             self.feishu
                 .as_ref()
                 .map(|f| f.config.encrypt_key.is_some())
@@ -545,7 +561,17 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
 
     // Phase 1 L1 audit (#1356): warn if any active webhook platform has no
     // transport authentication configured (identity trust unenforceable).
-    state.warn_unenforceable_l1();
+    // The standalone gateway mounts the feishu webhook route only in Webhook
+    // connection mode (see the route setup above).
+    #[cfg(feature = "feishu")]
+    let feishu_webhook_route_mounted = state
+        .feishu
+        .as_ref()
+        .map(|f| f.config.connection_mode == adapters::feishu::ConnectionMode::Webhook)
+        .unwrap_or(false);
+    #[cfg(not(feature = "feishu"))]
+    let feishu_webhook_route_mounted = false;
+    state.warn_unenforceable_l1(feishu_webhook_route_mounted);
 
     // Background: sweep expired reply tokens
     {
@@ -789,13 +815,18 @@ mod l1_audit_tests {
     }
 
     fn flagged(s: &AppState) -> Vec<&'static str> {
-        s.unenforceable_l1().into_iter().map(|(p, _)| p).collect()
+        s.unenforceable_l1(false)
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect()
     }
 
     #[test]
     fn inactive_platforms_are_never_flagged() {
         // test_default is all-None → nothing configured, nothing active.
         assert!(flagged(&state()).is_empty());
+        // …even when a feishu webhook route is reported as mounted (no adapter).
+        assert!(state().unenforceable_l1(true).is_empty());
     }
 
     #[test]

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -216,6 +216,24 @@ impl AppState {
     /// active-but-unconfigured.
     pub fn warn_unenforceable_l1(&self) {
         use tracing::warn;
+        for (platform, hint) in self.unenforceable_l1() {
+            warn!(
+                platform,
+                hint,
+                "L1 webhook authentication is NOT configured — this webhook accepts \
+                 unauthenticated requests, so the per-platform allowed_users (L3) allowlist \
+                 is forgeable: an attacker can POST a spoofed allowlisted sender id and pass \
+                 the trust gate. Configure the platform's webhook secret/signature to make \
+                 identity trust enforceable. \
+                 See https://github.com/openabdev/openab/issues/1356."
+            );
+        }
+    }
+
+    /// The platforms whose L1 is unenforceable right now, with a remediation
+    /// hint each. Separated from the warn wrapper so the per-platform
+    /// active/configured wiring is unit-testable.
+    fn unenforceable_l1(&self) -> Vec<(&'static str, &'static str)> {
         // (platform, active, l1_configured, remediation hint)
         #[allow(unused_mut)]
         let mut checks: Vec<(&str, bool, bool, &str)> = vec![
@@ -259,20 +277,11 @@ impl AppState {
                 .unwrap_or(false),
             "set GOOGLE_CHAT_AUDIENCE",
         ));
-        for (platform, active, l1_configured, hint) in checks {
-            if l1_unenforceable(active, l1_configured) {
-                warn!(
-                    platform,
-                    hint,
-                    "L1 webhook authentication is NOT configured — this webhook accepts \
-                     unauthenticated requests, so the per-platform allowed_users (L3) allowlist \
-                     is forgeable: an attacker can POST a spoofed allowlisted sender id and pass \
-                     the trust gate. Configure the platform's webhook secret/signature to make \
-                     identity trust enforceable. \
-                     See https://github.com/openabdev/openab/issues/1356."
-                );
-            }
-        }
+        checks
+            .into_iter()
+            .filter(|(_, active, l1_configured, _)| l1_unenforceable(*active, *l1_configured))
+            .map(|(platform, _, _, hint)| (platform, hint))
+            .collect()
     }
 
     /// Apply resolved `[telegram]` config values, overriding the env-derived
@@ -760,7 +769,8 @@ async fn health() -> &'static str {
 
 #[cfg(test)]
 mod l1_audit_tests {
-    use super::l1_unenforceable;
+    use super::{l1_unenforceable, AppState};
+    use tokio::sync::broadcast;
 
     #[test]
     fn warns_only_when_active_and_secret_missing() {
@@ -771,5 +781,48 @@ mod l1_audit_tests {
         // inactive platform → never warn, regardless of L1
         assert!(!l1_unenforceable(false, false));
         assert!(!l1_unenforceable(false, true));
+    }
+
+    fn state() -> AppState {
+        let (tx, _rx) = broadcast::channel(4);
+        AppState::test_default(tx)
+    }
+
+    fn flagged(s: &AppState) -> Vec<&'static str> {
+        s.unenforceable_l1().into_iter().map(|(p, _)| p).collect()
+    }
+
+    #[test]
+    fn inactive_platforms_are_never_flagged() {
+        // test_default is all-None → nothing configured, nothing active.
+        assert!(flagged(&state()).is_empty());
+    }
+
+    #[test]
+    fn telegram_active_without_l1_is_flagged() {
+        let mut s = state();
+        s.telegram_bot_token = Some("bot".into());
+        assert_eq!(flagged(&s), vec!["telegram"]);
+
+        // secret_token satisfies L1
+        s.telegram_secret_token = Some("sec".into());
+        assert!(flagged(&s).is_empty());
+
+        // trusted_source_only is an accepted alternate L1
+        s.telegram_secret_token = None;
+        s.telegram_trusted_source_only = true;
+        assert!(flagged(&s).is_empty());
+    }
+
+    #[test]
+    fn line_flagged_only_when_active_without_secret() {
+        let mut s = state();
+        // access token present but no channel secret → active, L1 missing
+        s.line_access_token = Some("tok".into());
+        assert_eq!(flagged(&s), vec!["line"]);
+
+        // channel secret present → L1 enforced
+        s.line_channel_secret = Some("csecret".into());
+        assert!(flagged(&s).is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -872,8 +872,10 @@ async fn main() -> anyhow::Result<()> {
             // Phase 1 L1 audit (#1356): warn if any active webhook platform has
             // no transport authentication configured. Called after
             // apply_telegram_config so a config-supplied secret is not falsely
-            // flagged as missing.
-            gw_state.warn_unenforceable_l1();
+            // flagged as missing. The unified binary mounts the feishu webhook
+            // route unconditionally (see NOTE at the mount below), so feishu
+            // exposure is `true` whenever the adapter is configured.
+            gw_state.warn_unenforceable_l1(true);
 
             // Build axum router with platform webhook routes
             let mut app =
@@ -903,6 +905,14 @@ async fn main() -> anyhow::Result<()> {
 
             #[cfg(feature = "feishu")]
             if gw_state.feishu.is_some() {
+                // NOTE (#1356 L1 audit): unlike the standalone gateway (which
+                // mounts this route only in Webhook connection mode), the
+                // unified binary mounts it unconditionally — and never spawns
+                // the Websocket client. Deployments relying on Feishu-side
+                // webhook delivery while FEISHU_CONNECTION_MODE is unset
+                // (default: websocket) work only because of this mount, so
+                // gating it is a behavior change that needs its own
+                // deprecation path — tracked on #1356, not changed here.
                 let path = std::env::var("FEISHU_WEBHOOK_PATH")
                     .unwrap_or_else(|_| "/webhook/feishu".into());
                 info!(path = %path, "unified: feishu adapter enabled");

--- a/src/main.rs
+++ b/src/main.rs
@@ -869,6 +869,12 @@ async fn main() -> anyhow::Result<()> {
             };
             let gw_state = Arc::new(gw_state_inner);
 
+            // Phase 1 L1 audit (#1356): warn if any active webhook platform has
+            // no transport authentication configured. Called after
+            // apply_telegram_config so a config-supplied secret is not falsely
+            // flagged as missing.
+            gw_state.warn_unenforceable_l1();
+
             // Build axum router with platform webhook routes
             let mut app =
                 axum::Router::new().route("/health", axum::routing::get(|| async { "ok" }));


### PR DESCRIPTION
## What problem does this solve?

Follows up a [contributor audit suggestion on #1356](https://github.com/openabdev/openab/issues/1356#issuecomment-4945674276): every webhook platform **skips L1 transport authentication when its secret is unconfigured**, and in that state the per-platform `allowed_users` (L3) allowlist delivered by the recent trust-migration PRs (#1363/#1365/#1366) is **forgeable** — an attacker can POST an envelope with an allowlisted sender id and walk straight through the trust gate. The behavior was also inconsistent across platforms (silent skip vs per-request warn vs mandatory).

## Audit Matrix (unconfigured-L1 behavior, before this PR)

| Platform | L1 mechanism | When secret unset | Before |
|----------|-------------|-------------------|--------|
| Telegram | `secret_token` header (or `trusted_source_only` IP allowlist) | Optional → skipped | 🟡 standalone warned at route-mount; unified was silent |
| LINE | HMAC-SHA256 signature | Optional → skipped; route mounts unconditionally | 🔴 silent skip |
| Google Chat | JWT via JWKS (`GOOGLE_CHAT_AUDIENCE`) | Optional → verifier not built | 🔴 silent skip |
| Feishu | `encrypt_key` signature | Optional → skipped | 🟡 per-request `warn` (noisy) |
| WeCom | token + AES signature | **Mandatory** — `from_env` returns `None` without it | 🟢 cannot be active-but-unconfigured |
| MS Teams | JWT (Bot Framework) | **Mandatory** — missing auth header → 401 | 🟢 cannot be active-but-unconfigured |

## After This PR (unconfigured-L1 behavior)

| Platform | When secret unset | After |
|----------|-------------------|-------|
| Telegram | `secret_token` unset **and** `trusted_source_only` off, bot token present | 🟠 one loud startup warning (`hint: set TELEGRAM_SECRET_TOKEN … or enable TELEGRAM_TRUSTED_SOURCE_ONLY`); the previous standalone route-mount warn is consolidated here — no double-warn |
| LINE | `LINE_CHANNEL_SECRET` unset while any LINE env present | 🟠 one loud startup warning (`hint: set LINE_CHANNEL_SECRET`) |
| Google Chat | `GOOGLE_CHAT_AUDIENCE` unset while adapter enabled | 🟠 one loud startup warning (`hint: set GOOGLE_CHAT_AUDIENCE`) |
| Feishu | `encrypt_key` unset **and** the webhook route is actually exposed (standalone: Webhook mode only; unified: always) | 🟠 one loud startup warning (`hint: set FEISHU_ENCRYPT_KEY`); per-request warn downgraded to `debug`. Websocket-mode standalone deployments are **not** flagged (no public webhook) |
| WeCom | n/a — secret is a construction precondition | 🟢 unchanged (cannot be active-but-unconfigured; every POST verified) |
| MS Teams | n/a — JWT validated on every request | 🟢 unchanged |

🟠 = warn-only in Phase 1 (enforcement behavior unchanged; deployments keep running). A later phase escalates to a hard startup error alongside the umbrella's Phase 2 legacy-env work.

## Proposed Solution

`AppState::warn_unenforceable_l1()` — a single **loud startup warning** per active platform whose L1 secret is missing, wired into both entry points:

- standalone gateway `run()` — after `AppState` construction
- unified binary (`src/main.rs`) — after `apply_telegram_config`, so a config-supplied Telegram secret isn't falsely flagged

Phase 1 **warns only** (per the DoD agreed on #1356) — backward-compatible, so existing no-secret deployments keep running; a later phase may escalate to a hard startup error alongside the umbrella's Phase 2 env-var work. WeCom/MS Teams are intentionally omitted (their L1 secret is a construction precondition). Feishu's per-request warn is downgraded to `debug` since the startup warning now covers it.

## Self-review (round 2 commit)

- Consolidated the pre-existing standalone telegram route-mount warning into `warn_unenforceable_l1` (was double-warning; also corrected the matrix row above — telegram's silent skip applied to the unified path only).
- `trusted_source_only` now counts as configured L1 for telegram (it is a real, weaker alternate L1 per the ADR) — removes a false positive.
- Warnings now carry per-platform remediation hints (exact env var to set).

## Self-review (round 3 commit)

- **Feishu false positive fixed**: default connection mode is Websocket (outbound long-connection, no public webhook) — a missing `encrypt_key` is not an L1 hole there. The warning is now keyed on actual webhook-route exposure, supplied by the caller because the two binaries differ: standalone mounts `/webhook/feishu` only in Webhook mode; the unified binary mounts it **unconditionally** (and never spawns the Websocket client).
- That unified unconditional mount is itself an inconsistency, but gating it would break misconfigured-but-working deployments (Feishu-side webhook delivery with `FEISHU_CONNECTION_MODE` unset) — documented in-code and left for its own deprecation path on #1356.
- Also verified (not just asserted) the WeCom/Teams exemption: both POST handlers verify every request (`verify_signature` / `validate_jwt`) and `from_env` returns `None` without the secret.

## Tests

- `l1_audit_tests::warns_only_when_active_and_secret_missing` — pins the pure predicate `l1_unenforceable(active, l1_configured)` (warn iff active ∧ ¬configured; never for inactive platforms)

## Validation

At head `26d05b5` (macOS arm64):

- `cargo clippy -p openab-gateway --all-features -- -D warnings` — clean
- `cargo clippy -p openab-gateway -- -D warnings` (no gateway features) — clean
- `cargo check --features unified` (main.rs call site) — pass
- `cargo test -p openab-gateway --all-features` — 255 passed, incl. the new test
- `rustfmt --check` — no new drift (edited regions are rustfmt-clean vs `origin/main`)

Refs #1356 (L1 optionality audit task). Does not change any enforcement behavior — purely adds a startup diagnostic.



