### PR TITLE
feat(cron): support Google Chat platform for scheduled messages

### DIFF
--- a/crates/openab-core/src/cron.rs
+++ b/crates/openab-core/src/cron.rs
@@ -238,7 +238,18 @@ pub fn should_fire(schedule: &Schedule, tz: Tz) -> bool {
 }
 
 /// Known platforms that have adapter support.
-const VALID_PLATFORMS: &[&str] = &["discord", "slack", "telegram"];
+const VALID_PLATFORMS: &[&str] = &["discord", "slack", "telegram", "googlechat"];
+
+fn should_create_cron_thread(job: &CronJobConfig) -> bool {
+    job.thread_id.is_none() && job.platform != "googlechat"
+}
+
+fn cron_sender_thread_id(channel: &ChannelRef) -> Option<String> {
+    channel
+        .thread_id
+        .clone()
+        .or_else(|| channel.parent_id.as_ref().map(|_| channel.channel_id.clone()))
+}
 
 /// Validate all cronjob configs (fail-fast on bad cron expressions or timezones).
 pub fn validate_cronjobs(
@@ -660,9 +671,7 @@ async fn fire_cronjob(
         }
     };
 
-    let reply_channel = if job.thread_id.is_some() {
-        thread_channel.clone()
-    } else {
+    let reply_channel = if should_create_cron_thread(job) {
         let thread_name = format::shorten_thread_name(&job.message);
         match adapter
             .create_thread(&thread_channel, &trigger_msg, &thread_name)
@@ -692,6 +701,8 @@ async fn fire_cronjob(
                 return;
             }
         }
+    } else {
+        thread_channel.clone()
     };
 
     let sender = SenderContext {
@@ -705,10 +716,7 @@ async fn fire_cronjob(
             .as_deref()
             .unwrap_or(&reply_channel.channel_id)
             .to_string(),
-        thread_id: reply_channel
-            .thread_id
-            .clone()
-            .or(Some(reply_channel.channel_id.clone())),
+        thread_id: cron_sender_thread_id(&reply_channel),
         is_bot: true,
         timestamp: Some(Utc::now().to_rfc3339()),
         message_id: None, // cron jobs don't originate from a message
@@ -1546,6 +1554,66 @@ message = "a"
         }
     }
 
+    #[test]
+    fn googlechat_cron_stays_top_level_without_explicit_thread() {
+        let mut job = test_cron_job();
+        job.platform = "googlechat".into();
+
+        assert!(!should_create_cron_thread(&job));
+
+        job.thread_id = Some("spaces/TEST/threads/THREAD".into());
+        assert!(!should_create_cron_thread(&job));
+    }
+
+    #[test]
+    fn thread_capable_cron_platform_creates_thread_when_unspecified() {
+        let job = test_cron_job();
+
+        assert!(should_create_cron_thread(&job));
+    }
+
+    #[test]
+    fn googlechat_top_level_sender_has_no_thread_id() {
+        let channel = ChannelRef {
+            platform: "googlechat".into(),
+            channel_id: "spaces/TEST".into(),
+            thread_id: None,
+            parent_id: None,
+            origin_event_id: None,
+        };
+
+        assert_eq!(cron_sender_thread_id(&channel), None);
+    }
+
+    #[test]
+    fn cron_sender_preserves_explicit_thread_id() {
+        let channel = ChannelRef {
+            platform: "googlechat".into(),
+            channel_id: "spaces/TEST".into(),
+            thread_id: Some("spaces/TEST/threads/THREAD".into()),
+            parent_id: None,
+            origin_event_id: None,
+        };
+
+        assert_eq!(
+            cron_sender_thread_id(&channel).as_deref(),
+            Some("spaces/TEST/threads/THREAD")
+        );
+    }
+
+    #[test]
+    fn cron_sender_uses_child_channel_id_for_thread_platforms() {
+        let channel = ChannelRef {
+            platform: "discord".into(),
+            channel_id: "thread-456".into(),
+            thread_id: None,
+            parent_id: Some("channel-123".into()),
+            origin_event_id: None,
+        };
+
+        assert_eq!(cron_sender_thread_id(&channel).as_deref(), Some("thread-456"));
+    }
+
     // --- validate_cronjobs tests ---
 
     #[test]
@@ -1566,6 +1634,17 @@ message = "a"
             disable_on_success_working_dir: None,
         }];
         assert!(validate_cronjobs(&jobs, &["discord"]).is_ok());
+    }
+
+    #[test]
+    fn validate_cronjobs_googlechat_passes_when_configured() {
+        let mut job = test_cron_job();
+        job.platform = "googlechat".into();
+        job.channel = "spaces/TEST".into();
+        job.disable_on_success = None;
+        job.disable_on_success_match = None;
+
+        assert!(validate_cronjobs(&[job], &["googlechat"]).is_ok());
     }
 
     #[test]

--- a/docs/cronjob.md
+++ b/docs/cronjob.md
@@ -346,7 +346,7 @@ Use `sender_name` to distinguish different scheduled tasks in logs and thread ti
 | `discord` | (always enabled) | `[discord]` section in config.toml |
 | `slack` | `--features slack` | `[slack]` section in config.toml |
 | `telegram` | `--features telegram` | `[telegram]` section in config.toml **or** `TELEGRAM_BOT_TOKEN` env var |
-| `googlechat` | `--features googlechat` | `GOOGLE_CHAT_ENABLED=true` and `GOOGLE_CHAT_SA_KEY_JSON`, `GOOGLE_CHAT_SA_KEY_FILE`, or `GOOGLE_CHAT_ACCESS_TOKEN` |
+| `googlechat` | `--features googlechat` | `[googlechat] enabled = true` in config.toml **or** `GOOGLE_CHAT_ENABLED=true` env var, plus credentials (`sa_key_json`/`sa_key_file`/`access_token` fields or their `GOOGLE_CHAT_*` env equivalents) |
 
 > **Note:** The `channel` field for Telegram should be the numeric chat ID (e.g. `"176096071"`). Use [@userinfobot](https://t.me/userinfobot) or the Telegram Bot API `getUpdates` to find your chat ID.
 

--- a/docs/cronjob.md
+++ b/docs/cronjob.md
@@ -44,9 +44,9 @@ thread_id = ""                               # optional: post to existing thread
 |-------|----------|---------|-------------|
 | `enabled` | | `true` | Set `false` to disable without removing the entry |
 | `schedule` | ✅ | — | 5-field POSIX cron expression |
-| `channel` | ✅ | — | Discord channel/thread ID, Slack channel ID, or Telegram chat ID |
+| `channel` | ✅ | — | Discord channel/thread ID, Slack channel ID, Telegram chat ID, or Google Chat space name |
 | `message` | ✅ | — | Message sent to the agent as a prompt |
-| `platform` | | `"discord"` | `"discord"`, `"slack"`, or `"telegram"` (requires `telegram` feature) |
+| `platform` | | `"discord"` | `"discord"`, `"slack"`, `"telegram"`, or `"googlechat"` (non-default platforms require their feature) |
 | `sender_name` | | `"openab-cron"` | Attribution shown in prompt context |
 | `timezone` | | `"UTC"` | IANA timezone (e.g. `"America/New_York"`, `"Europe/Berlin"`) |
 | `thread_id` | | — | Post into an existing thread instead of the channel |
@@ -120,6 +120,14 @@ channel = "176096071"
 message = "講一個冷笑話"
 platform = "telegram"
 sender_name = "JokeBot"
+
+[[cron.jobs]]
+schedule = "0 9 * * 1-5"
+channel = "spaces/AAAA1234567"
+message = "summarize the new support escalations"
+platform = "googlechat"
+sender_name = "SupportDigest"
+timezone = "Asia/Taipei"
 ```
 
 ## Helm Deployment
@@ -338,8 +346,11 @@ Use `sender_name` to distinguish different scheduled tasks in logs and thread ti
 | `discord` | (always enabled) | `[discord]` section in config.toml |
 | `slack` | `--features slack` | `[slack]` section in config.toml |
 | `telegram` | `--features telegram` | `[telegram]` section in config.toml **or** `TELEGRAM_BOT_TOKEN` env var |
+| `googlechat` | `--features googlechat` | `GOOGLE_CHAT_ENABLED=true` and `GOOGLE_CHAT_SA_KEY_JSON`, `GOOGLE_CHAT_SA_KEY_FILE`, or `GOOGLE_CHAT_ACCESS_TOKEN` |
 
 > **Note:** The `channel` field for Telegram should be the numeric chat ID (e.g. `"176096071"`). Use [@userinfobot](https://t.me/userinfobot) or the Telegram Bot API `getUpdates` to find your chat ID.
+
+For Google Chat, use the space resource name (for example, `"spaces/AAAA1234567"`). Jobs without `thread_id` stay at the top level of the space because Google Chat does not implement OpenAB's `create_topic` command. To post into an existing thread, set `thread_id` to its full Google Chat thread resource name.
 
 ## When to Use External Schedulers Instead
 

--- a/docs/platforms/schema/googlechat.toml
+++ b/docs/platforms/schema/googlechat.toml
@@ -230,7 +230,7 @@ pr      = ""
 [[openab_features]]
 feature = "cron_dispatch"
 status  = "implemented"
-note    = "`cronjob.toml` jobs with `platform = \"googlechat\"` fire through the unified adapter when the `googlechat` feature and `GOOGLE_CHAT_ENABLED` are active. Jobs without an explicit `thread_id` remain at the top level of the configured space because Google Chat does not implement the gateway `create_topic` command."
+note    = "`cronjob.toml` jobs with `platform = \"googlechat\"` fire through the unified adapter when the `googlechat` feature is compiled and the platform is enabled (`[googlechat] enabled = true` or `GOOGLE_CHAT_ENABLED` env — config-first, per the first-class-platform-config ADR). Jobs without an explicit `thread_id` remain at the top level of the configured space because Google Chat does not implement the gateway `create_topic` command."
 source  = ["crates/openab-core/src/cron.rs#VALID_PLATFORMS", "crates/openab-core/src/cron.rs#fire_cronjob", "src/main.rs#cron_adapters"]
 pr      = ""
 

--- a/docs/platforms/schema/googlechat.toml
+++ b/docs/platforms/schema/googlechat.toml
@@ -229,9 +229,9 @@ pr      = ""
 
 [[openab_features]]
 feature = "cron_dispatch"
-status  = "not_implemented"
-note    = "Not wired for scheduled cron dispatch: `VALID_PLATFORMS` (cron.rs) covers only discord/slack/telegram and no adapter is registered for this platform in `cron_adapters`, so `cronjob.toml` jobs targeting it are rejected at startup by `validate_cronjobs`."
-source  = []
+status  = "implemented"
+note    = "`cronjob.toml` jobs with `platform = \"googlechat\"` fire through the unified adapter when the `googlechat` feature and `GOOGLE_CHAT_ENABLED` are active. Jobs without an explicit `thread_id` remain at the top level of the configured space because Google Chat does not implement the gateway `create_topic` command."
+source  = ["crates/openab-core/src/cron.rs#VALID_PLATFORMS", "crates/openab-core/src/cron.rs#fire_cronjob", "src/main.rs#cron_adapters"]
 pr      = ""
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -687,9 +687,12 @@ async fn main() -> anyhow::Result<()> {
         configured_platforms.push("telegram");
     }
     #[cfg(feature = "googlechat")]
-    if std::env::var("GOOGLE_CHAT_ENABLED")
-        .map(|v| v == "true" || v == "1")
-        .unwrap_or(false)
+    if cfg
+        .googlechat
+        .clone()
+        .unwrap_or_default()
+        .resolve()
+        .enabled
     {
         configured_platforms.push("googlechat");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -677,6 +677,13 @@ async fn main() -> anyhow::Result<()> {
     if cfg.telegram.is_some() || std::env::var("TELEGRAM_BOT_TOKEN").is_ok() {
         configured_platforms.push("telegram");
     }
+    #[cfg(feature = "googlechat")]
+    if std::env::var("GOOGLE_CHAT_ENABLED")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false)
+    {
+        configured_platforms.push("googlechat");
+    }
     cron::validate_cronjobs(&cfg.cron.jobs, &configured_platforms)?;
 
     // Spawn Slack adapter (background task)
@@ -1082,6 +1089,10 @@ async fn main() -> anyhow::Result<()> {
         #[cfg(feature = "telegram")]
         if let Some(ref a) = shared_unified_adapter {
             cron_adapters.insert("telegram".into(), a.clone());
+        }
+        #[cfg(feature = "googlechat")]
+        if let Some(ref a) = shared_unified_adapter {
+            cron_adapters.insert("googlechat".into(), a.clone());
         }
         let cron_platforms: Vec<String> =
             configured_platforms.iter().map(|s| s.to_string()).collect();


### PR DESCRIPTION
## What problem does this solve?

OpenAB's Google Chat adapter already supports inbound messages and outbound replies through `UnifiedGatewayAdapter`, but native cron rejects `platform = "googlechat"` and does not register the adapter with the scheduler.

This affects both the latest published beta and current `main`.

Related to #866. This implements only the Google Chat scheduled-message portion and does not close the broader DM and gateway-target proposal.

This is the core transport prerequisite for cron-driven workflows such as Google Sheets reporting. Sheet reads/writes, meeting retrieval, deduplication, alert evaluation, private space IDs, schedules, and credentials remain agent/deployment configuration and are not added to OpenAB core.

Discord Discussion URL: N/A - maintainer-authored follow-up to #866 and merged PR #1315.

## At a Glance — before vs after

```text
BEFORE                                     AFTER
======                                     =====
[[cron.jobs]]                              [[cron.jobs]]
platform = "googlechat"                    platform = "googlechat"
        |                                          |
        v                                          v
validate_cronjobs()                        validate_cronjobs()
        |                                          |
        X  rejected at startup:                    v  (accepted: googlechat in
           "unknown platform"                      |   VALID_PLATFORMS + platform
                                                   |   enabled config-first)
   bot refuses to start                            v
                                             cron scheduler
                                                   |
                                                   v
                                           UnifiedGatewayAdapter
                                             ("googlechat" cron key)
                                                   |
                                                   v
                                           Google Chat adapter
                                             spaces.messages.create
                                                   |
                                                   v
                                           configured Chat space

                                           No thread_id       -> top level (no
                                                                 synthetic thread;
                                                                 create_topic is
                                                                 not implemented)
                                           Explicit thread_id -> that existing
                                                                 thread
```

## Config sample

```toml
# config.toml — enable the platform (config-first; GOOGLE_CHAT_ENABLED env
# remains the fallback)
[googlechat]
enabled = true
sa_key_file = "/etc/openab/gchat-sa.json"   # or sa_key_json / access_token
allowed_users = ["users/123456789"]          # inbound trust — does NOT
                                             # restrict scheduled outbound

[[cron.jobs]]
schedule    = "0 9 * * 1-5"                  # weekdays 09:00
channel     = "spaces/AAAA1234567"           # Chat space resource name
message     = "summarize the new support escalations"
platform    = "googlechat"
sender_name = "SupportDigest"
timezone    = "Asia/Taipei"
# thread_id = "spaces/AAAA1234567/threads/XYZ"  # optional: post into an
#                                               # existing thread instead
```

## Prior Art & Industry Research

**OpenClaw:**

[OpenClaw scheduled tasks](https://github.com/openclaw/openclaw/blob/main/docs/automation/cron-jobs.md#delivery-and-output) separates scheduling from delivery and stores an explicit platform and destination using `delivery.channel` and `delivery.to`. It also treats scheduled delivery as an operator automation path rather than an inbound user event.

**Hermes Agent:**

[Hermes scheduled tasks](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/cron.md#delivery-options) automatically delivers an agent's final response to a configured platform target. Its continuation behavior is platform-specific: thread-capable targets may create threads, while flat surfaces remain top-level.

**Other references:**

- #866 proposes broader DM and gateway-platform cron targets.
- #1315 established OpenAB's current pattern for registering a unified gateway platform with cron by adding Telegram validation, platform detection, and adapter registration.

## Proposed Solution

1. Add `googlechat` to the scheduler's valid platforms.
2. Treat Google Chat as configured when the feature is compiled and the platform is enabled — resolved config-first via `GoogleChatConfig::resolve().enabled` (`[googlechat] enabled = true` → `GOOGLE_CHAT_ENABLED` env → default), matching the first-class-platform-config ADR.
3. Register the existing unified adapter under the `googlechat` cron key.
4. Keep jobs without `thread_id` at the top level of the configured space.
5. Preserve explicit Google Chat thread resource names when supplied.
6. Add validation and thread-selection unit tests.
7. Update the cron documentation and Google Chat capability schema.

### Thread behavior

Google Chat currently ignores OpenAB's `create_topic` gateway command. Calling the generic unified `create_thread` implementation would therefore create no remote thread but return a synthetic local thread ID, which could then be used or persisted as though it were a real Google Chat resource.

This change avoids that invalid state. Automatic thread creation remains unchanged for Discord, Slack, and Telegram.

### Trust behavior

Cron dispatch intentionally does not pass through the inbound Google Chat trust gate because no external user event initiates the run. The authority comes from trusted baseline cron configuration or an enabled writable usercron file.

Consequently, `[googlechat].allowed_users` controls inbound messages but does not restrict scheduled outbound delivery. Anyone authorized to modify cron configuration can select a space where the Chat app already has permission to post. This PR does not introduce a separate outbound target allowlist.

## Why this approach?

It follows the narrow registration pattern already merged for Telegram in #1315 and reuses Google Chat's existing outbound adapter instead of adding a second delivery implementation.

The Google Chat-specific thread decision is necessary because the platform adapter does not implement `create_topic`. Remaining top-level is safer than manufacturing and persisting a nonexistent thread ID.

Known limitations:

- Cron cannot automatically create a new Google Chat thread.
- Posting to an existing thread requires an explicit full thread resource name.
- Delivery acknowledgement and retry behavior remain those of the existing unified adapter.
- Outbound destination authorization remains an operational configuration responsibility.
- Google Sheets and meeting workflow logic remain outside OpenAB core.

## Alternatives Considered

- **External scheduler or webhook:** Functional, but duplicates native scheduling and adapter routing.
- **Implement all gateway and DM targets from #866:** Broader than the Google Chat requirement and harder to review independently.
- **Implement Google Chat thread creation:** Requires separate adapter/API semantics and is unnecessary for basic scheduled delivery.
- **Put Google Sheets or meeting-alert logic in cron core:** Rejected because those are workflow-specific agent tools and policies, not transport behavior.

## Validation

- [x] `cargo build --features googlechat`
- [x] `cargo check --workspace`
- [x] `cargo test -p openab-core cron::tests` - 74 passed
- [x] `cargo test --workspace` - 15 OpenAB, 667 core, and 254 gateway tests passed
- [x] `cargo test --workspace --features unified` - 15 OpenAB, 667 core, and 254 gateway tests passed
- [x] Platform schema tests - 4 unit and 8 conformance tests passed
- [x] `git diff --check`
- [x] Required GitHub CI - workspace check, default/unified Clippy, and workspace tests passed
- [x] Default and unified Clippy pass when allowing the existing baseline lint:
  - `cargo clippy --workspace -- -D warnings -A clippy::collapsible_else_if`
  - `cargo clippy --workspace --features unified -- -D warnings -A clippy::collapsible_else_if`

Local Rust 1.92 additionally reports a pre-existing `clippy::collapsible_else_if` finding at `crates/openab-core/src/pre_seed.rs:471`; the repository's required GitHub Clippy jobs pass unchanged.

**Maintainer update (`4174a0f`):** merged current `main` (post #1381–#1385/#1387) and fixed the enablement check to be config-first — the original read only the `GOOGLE_CHAT_ENABLED` env var, so a `[googlechat] enabled = true` config-only deployment would have its cron jobs rejected at startup. Re-verified on the updated branch: all-features clippy clean, cron tests 74 pass, bin tests 15 pass, schema conformance green.

Manual integration testing used an every-minute usercron job against a private test Google Chat space. The equivalent scheduled delivery path and agent response were observed through the unified adapter. Private target IDs, credentials, meeting content, and Google Sheets data are intentionally excluded from this PR.

The deployed test build also contained deployment-specific workflow extensions; those are not part of this change.

