### PR TITLE
feat(line): full [line] section — credentials + connection config-first

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -80,6 +80,9 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 # NOTE: relying on GATEWAY_ALLOW_ALL_USERS / GATEWAY_ALLOWED_USERS for LINE is
 # deprecated (warns at startup; becomes an error in Phase 2).
 # [line]
+# channel_secret       = "${LINE_CHANNEL_SECRET}"        # L1 webhook HMAC key; env fallback: LINE_CHANNEL_SECRET
+# channel_access_token = "${LINE_CHANNEL_ACCESS_TOKEN}"  # Reply/Push API; env fallback: LINE_CHANNEL_ACCESS_TOKEN
+# webhook_path = "/webhook/line"        # env fallback: LINE_WEBHOOK_PATH (default /webhook/line)
 # allow_all_users = false               # true = any user; omitted/false = deny-all except allowed_users
 #                                       # env fallback: LINE_ALLOW_ALL_USERS
 # allowed_users = ["U1234567890abcdef0123456789abcdef"]  # LINE user IDs (U…, 33 chars)

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -768,18 +768,22 @@ fn env_flag_not_false(key: &str) -> bool {
         .unwrap_or(true)
 }
 
-/// First-class `[line]` section — L3 identity trust for the LINE adapter
-/// (identity-trust-none ADR, Phase 1). Mirrors [`TelegramConfig`]'s trust
-/// fields and resolution order: `[line].field` (with `${}` expansion) →
-/// `LINE_*` env var → default.
-///
-/// Trust-only by design: LINE channel credentials stay on the gateway env vars
-/// (`LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN`) that the webhook
-/// adapter reads. Group policy (`open`/`members` for `"unknown"` senders) is a
-/// follow-up on #1355.
+/// First-class `[line]` section — credentials, connection, and L3 identity
+/// trust for the LINE adapter. Config-first invariant (#1375): each field
+/// resolves `[line].field` (with `${}` expansion) → `LINE_*` env var →
+/// default. Mirrors [`TelegramConfig`].
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct LineConfig {
+    /// Channel secret for webhook HMAC-SHA256 signature validation (L1).
+    /// Env fallback: `LINE_CHANNEL_SECRET`.
+    pub channel_secret: Option<String>,
+    /// Channel access token for the Reply/Push Message API and LINE-hosted
+    /// media downloads. Env fallback: `LINE_CHANNEL_ACCESS_TOKEN`.
+    pub channel_access_token: Option<String>,
+    /// Webhook mount path. Env fallback: `LINE_WEBHOOK_PATH`
+    /// (default `/webhook/line`).
+    pub webhook_path: Option<String>,
     /// Explicit flag: true = allow all users, false = check `allowed_users`.
     /// When not set, defaults to `false` (deny-all, per identity-trust-none ADR).
     /// Set `true` explicitly to allow all users. Env fallback:
@@ -795,16 +799,22 @@ pub struct LineConfig {
     pub allowed_users: Option<Vec<String>>,
 }
 
-/// Fully resolved LINE trust settings (config → env → default applied).
+/// Fully resolved LINE settings (config → env → default applied).
 #[derive(Debug, Clone)]
 pub struct ResolvedLine {
+    pub channel_secret: Option<String>,
+    pub channel_access_token: Option<String>,
+    pub webhook_path: String,
     pub allow_all_users: bool,
     pub allowed_users: Vec<String>,
 }
 
 impl LineConfig {
     /// Resolve every field: config value (if set) → `LINE_*` env → default.
-    /// Same shape as [`TelegramConfig::resolve`] for the shared trust fields.
+    /// Same shape as [`TelegramConfig::resolve`]. String fields filter out
+    /// empty strings produced by `${}` expansion of unset env vars, so
+    /// `channel_secret = "${UNSET}"` correctly falls through to the
+    /// `LINE_CHANNEL_SECRET` env fallback rather than holding `Some("")`.
     pub fn resolve(&self) -> ResolvedLine {
         let allowed_users: Vec<String> = match &self.allowed_users {
             Some(list) => list.clone(),
@@ -816,6 +826,25 @@ impl LineConfig {
                 .collect(),
         };
         ResolvedLine {
+            channel_secret: self
+                .channel_secret
+                .as_ref()
+                .filter(|s| !s.is_empty())
+                .cloned()
+                .or_else(|| std::env::var("LINE_CHANNEL_SECRET").ok()),
+            channel_access_token: self
+                .channel_access_token
+                .as_ref()
+                .filter(|s| !s.is_empty())
+                .cloned()
+                .or_else(|| std::env::var("LINE_CHANNEL_ACCESS_TOKEN").ok()),
+            webhook_path: self
+                .webhook_path
+                .as_ref()
+                .filter(|s| !s.is_empty())
+                .cloned()
+                .or_else(|| std::env::var("LINE_WEBHOOK_PATH").ok())
+                .unwrap_or_else(|| "/webhook/line".into()),
             allow_all_users: self.allow_all_users.unwrap_or_else(|| {
                 std::env::var("LINE_ALLOW_ALL_USERS")
                     .ok()
@@ -1981,11 +2010,17 @@ webhook_path = "/hook/tg"
 bot_token = "x"
 
 [line]
+channel_secret = "sec"
+channel_access_token = "tok"
+webhook_path = "/hook/line"
 allow_all_users = false
 allowed_users = ["U1234567890abcdef0123456789abcdef"]
 "#;
         let cfg = parse_config_str(toml_str, "test").unwrap();
         let line = cfg.line.expect("line section");
+        assert_eq!(line.channel_secret.as_deref(), Some("sec"));
+        assert_eq!(line.channel_access_token.as_deref(), Some("tok"));
+        assert_eq!(line.webhook_path.as_deref(), Some("/hook/line"));
         assert_eq!(line.allow_all_users, Some(false));
         assert_eq!(
             line.allowed_users.as_deref(),
@@ -2016,6 +2051,7 @@ allowed_users = ["U1234567890abcdef0123456789abcdef"]
         let cfg = LineConfig {
             allow_all_users: Some(false),
             allowed_users: Some(vec!["Uaaa".into(), "Ubbb".into()]),
+            ..Default::default()
         };
         let r = cfg.resolve();
         assert!(!r.allow_all_users);
@@ -2052,9 +2088,45 @@ allowed_users = ["U1234567890abcdef0123456789abcdef"]
         let cfg = LineConfig {
             allow_all_users: None,
             allowed_users: Some(vec![]),
+            ..Default::default()
         };
         let r = cfg.resolve();
         assert!(r.allowed_users.is_empty());
+
+        // --- Scenario 7 (#1376): credentials/path — config wins over env ---
+        std::env::set_var("LINE_CHANNEL_SECRET", "env-secret");
+        std::env::set_var("LINE_CHANNEL_ACCESS_TOKEN", "env-token");
+        std::env::set_var("LINE_WEBHOOK_PATH", "/hook/env");
+        let cfg = LineConfig {
+            channel_secret: Some("cfg-secret".into()),
+            channel_access_token: Some("cfg-token".into()),
+            webhook_path: Some("/hook/cfg".into()),
+            ..Default::default()
+        };
+        let r = cfg.resolve();
+        assert_eq!(r.channel_secret.as_deref(), Some("cfg-secret"));
+        assert_eq!(r.channel_access_token.as_deref(), Some("cfg-token"));
+        assert_eq!(r.webhook_path, "/hook/cfg");
+
+        // --- Scenario 8 (#1376): empty-string `${}` expansion falls through
+        //     to env; env fallback works when config unset ---
+        let cfg = LineConfig {
+            channel_secret: Some("".into()), // simulates ${UNSET_VAR} → ""
+            ..Default::default()
+        };
+        let r = cfg.resolve();
+        assert_eq!(r.channel_secret.as_deref(), Some("env-secret"));
+        assert_eq!(r.channel_access_token.as_deref(), Some("env-token"));
+        assert_eq!(r.webhook_path, "/hook/env");
+
+        // --- Scenario 9 (#1376): nothing set → defaults ---
+        std::env::remove_var("LINE_CHANNEL_SECRET");
+        std::env::remove_var("LINE_CHANNEL_ACCESS_TOKEN");
+        std::env::remove_var("LINE_WEBHOOK_PATH");
+        let r = LineConfig::default().resolve();
+        assert!(r.channel_secret.is_none());
+        assert!(r.channel_access_token.is_none());
+        assert_eq!(r.webhook_path, "/webhook/line");
 
         std::env::remove_var("LINE_ALLOW_ALL_USERS");
         std::env::remove_var("LINE_ALLOWED_USERS");

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -40,6 +40,9 @@ pub struct AppState {
     pub telegram_streaming: Option<bool>,
     pub line_channel_secret: Option<String>,
     pub line_access_token: Option<String>,
+    /// Webhook mount path for LINE (env: `LINE_WEBHOOK_PATH`; config-first via
+    /// `apply_line_config`, default `/webhook/line`).
+    pub line_webhook_path: String,
     #[cfg(feature = "teams")]
     pub teams: Option<adapters::teams::TeamsAdapter>,
     pub teams_service_urls: Mutex<HashMap<String, (String, Instant)>>,
@@ -76,6 +79,7 @@ impl AppState {
             telegram_streaming: None,
             line_channel_secret: None,
             line_access_token: None,
+            line_webhook_path: "/webhook/line".into(),
             #[cfg(feature = "teams")]
             teams: None,
             teams_service_urls: Mutex::new(HashMap::new()),
@@ -115,6 +119,8 @@ impl AppState {
         // LINE
         let line_channel_secret = std::env::var("LINE_CHANNEL_SECRET").ok();
         let line_access_token = std::env::var("LINE_CHANNEL_ACCESS_TOKEN").ok();
+        let line_webhook_path =
+            std::env::var("LINE_WEBHOOK_PATH").unwrap_or_else(|_| "/webhook/line".into());
 
         // Teams
         #[cfg(feature = "teams")]
@@ -182,6 +188,7 @@ impl AppState {
             telegram_streaming,
             line_channel_secret,
             line_access_token,
+            line_webhook_path,
             #[cfg(feature = "teams")]
             teams,
             teams_service_urls: Mutex::new(HashMap::new()),
@@ -310,6 +317,17 @@ impl AppState {
         self.telegram_trusted_source_only = cfg.trusted_source_only;
         self.telegram_streaming = cfg.streaming;
     }
+
+    /// Apply resolved `[line]` config values, overriding the env-derived
+    /// fields (#1376). Same crate-boundary pattern as
+    /// [`AppState::apply_telegram_config`]. Call before
+    /// [`AppState::warn_unenforceable_l1`] so a config-supplied
+    /// `channel_secret` is not falsely flagged as missing L1.
+    pub fn apply_line_config(&mut self, cfg: GatewayLineConfig) {
+        self.line_channel_secret = cfg.channel_secret;
+        self.line_access_token = cfg.channel_access_token;
+        self.line_webhook_path = cfg.webhook_path;
+    }
 }
 
 /// Parameter object for passing resolved Telegram config across the crate
@@ -321,6 +339,15 @@ pub struct GatewayTelegramConfig {
     pub rich_messages: bool,
     pub trusted_source_only: bool,
     pub streaming: Option<bool>,
+}
+
+/// Parameter object for passing resolved LINE config across the crate
+/// boundary without introducing a dependency on `openab-core` (#1376).
+#[derive(Debug, Clone)]
+pub struct GatewayLineConfig {
+    pub channel_secret: Option<String>,
+    pub channel_access_token: Option<String>,
+    pub webhook_path: String,
 }
 
 // --- Public serve() entry point ---
@@ -390,14 +417,19 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
     #[cfg(feature = "line")]
     let line_access_token = std::env::var("LINE_CHANNEL_ACCESS_TOKEN").ok();
     #[cfg(feature = "line")]
+    let line_webhook_path =
+        std::env::var("LINE_WEBHOOK_PATH").unwrap_or_else(|_| "/webhook/line".into());
+    #[cfg(feature = "line")]
     {
-        info!("line adapter enabled");
-        app = app.route("/webhook/line", post(adapters::line::webhook));
+        info!(path = %line_webhook_path, "line adapter enabled");
+        app = app.route(&line_webhook_path, post(adapters::line::webhook));
     }
     #[cfg(not(feature = "line"))]
     let line_channel_secret: Option<String> = None;
     #[cfg(not(feature = "line"))]
     let line_access_token: Option<String> = None;
+    #[cfg(not(feature = "line"))]
+    let line_webhook_path = "/webhook/line".to_string();
 
     // Teams adapter
     #[cfg(feature = "teams")]
@@ -543,6 +575,7 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
             .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false"))),
         line_channel_secret,
         line_access_token,
+        line_webhook_path,
         #[cfg(feature = "teams")]
         teams,
         teams_service_urls: Mutex::new(HashMap::new()),
@@ -854,6 +887,27 @@ mod l1_audit_tests {
 
         // channel secret present → L1 enforced
         s.line_channel_secret = Some("csecret".into());
+        assert!(flagged(&s).is_empty());
+    }
+
+    #[test]
+    fn apply_line_config_overrides_env_state_and_feeds_l1_warning() {
+        use super::GatewayLineConfig;
+        let mut s = state();
+        // Simulate env-derived state: token from env, no secret → flagged.
+        s.line_access_token = Some("env-tok".into());
+        assert_eq!(flagged(&s), vec!["line"]);
+
+        // Config-first override (#1376): [line] supplies the secret + path.
+        s.apply_line_config(GatewayLineConfig {
+            channel_secret: Some("cfg-secret".into()),
+            channel_access_token: Some("cfg-tok".into()),
+            webhook_path: "/hook/line".into(),
+        });
+        assert_eq!(s.line_channel_secret.as_deref(), Some("cfg-secret"));
+        assert_eq!(s.line_access_token.as_deref(), Some("cfg-tok"));
+        assert_eq!(s.line_webhook_path, "/hook/line");
+        // Config-supplied secret satisfies the L1 startup check.
         assert!(flagged(&s).is_empty());
     }
 }

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -137,7 +137,7 @@ Custom Gateway adapter for platforms like Telegram, LINE, Feishu/Lark, and Googl
 
 ## `[line]`
 
-First-class L3 identity trust for the LINE adapter (identity-trust-none ADR, Phase 1). Replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for LINE — relying on those for LINE is deprecated and warns at startup. Channel credentials remain on the `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` env vars.
+First-class LINE section — credentials, connection, and L3 identity trust (config-first parity, #1376). Replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for LINE trust — relying on those for LINE is deprecated and warns at startup.
 
 > **Mode scoping:** takes effect on the **embedded/unified adapter path** (see the note under `[wecom]` / `[googlechat]` / `[teams]` below — the same applies here).
 
@@ -145,6 +145,9 @@ Each field resolves: config value → `LINE_*` env var → default (deny-all).
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| `channel_secret` | string | — | Channel secret for webhook HMAC-SHA256 validation (L1). Env fallback: `LINE_CHANNEL_SECRET`. |
+| `channel_access_token` | string | — | Channel access token for the Reply/Push Message API and media downloads. Env fallback: `LINE_CHANNEL_ACCESS_TOKEN`. |
+| `webhook_path` | string | `/webhook/line` | Webhook mount path. Env fallback: `LINE_WEBHOOK_PATH`. |
 | `allow_all_users` | bool \| omit | `false` (deny-all) | `true` = any user may interact (bypasses `allowed_users` entirely); `false`/omitted = only `allowed_users`. Env fallback: `LINE_ALLOW_ALL_USERS`. |
 | `allowed_users` | string[] | `[]` | LINE user IDs (`U…`, 33 chars) allowed to interact. Only checked when `allow_all_users` resolves to false. Env fallback: `LINE_ALLOWED_USERS` (comma-separated). |
 

--- a/docs/line.md
+++ b/docs/line.md
@@ -120,7 +120,9 @@ Each field falls back to its `LINE_*` env var when unset. Since #1376 the sectio
 [line]
 channel_secret       = "${LINE_CHANNEL_SECRET}"
 channel_access_token = "${LINE_CHANNEL_ACCESS_TOKEN}"
-``` This replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for LINE:
+```
+
+This replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for LINE:
 
 > ⚠️ **Deprecated:** driving LINE trust through `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` still works but logs a startup warning; it will become a startup error in a later phase. Migrate to `[line]` (or `LINE_*` env vars).
 

--- a/docs/line.md
+++ b/docs/line.md
@@ -114,7 +114,13 @@ allowed_users = ["U1234567890abcdef0123456789abcdef"]  # LINE user IDs (U…, 33
 # allow_all_users = true   # explicit opt-in only — any user can drive the agent
 ```
 
-Each field falls back to its `LINE_ALLOW_ALL_USERS` / `LINE_ALLOWED_USERS` env var when unset. This replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for LINE:
+Each field falls back to its `LINE_*` env var when unset. Since #1376 the section also carries the channel credentials (`channel_secret`, `channel_access_token`) and `webhook_path` — config-first, env as fallback:
+
+```toml
+[line]
+channel_secret       = "${LINE_CHANNEL_SECRET}"
+channel_access_token = "${LINE_CHANNEL_ACCESS_TOKEN}"
+``` This replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for LINE:
 
 > ⚠️ **Deprecated:** driving LINE trust through `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` still works but logs a startup warning; it will become a startup error in a later phase. Migrate to `[line]` (or `LINE_*` env vars).
 
@@ -154,8 +160,9 @@ In the LINE Developers Console → **Messaging API** tab → scan the QR code wi
 
 | Variable | Required | Description |
 |---|---|---|
-| `LINE_CHANNEL_SECRET` | Yes | Channel secret for webhook signature validation |
-| `LINE_CHANNEL_ACCESS_TOKEN` | Yes | Channel access token for Reply/Push Message API and LINE-hosted image/audio downloads |
+| `LINE_CHANNEL_SECRET` | Yes* | Channel secret for webhook signature validation. *Fallback for `[line].channel_secret` — config wins |
+| `LINE_CHANNEL_ACCESS_TOKEN` | Yes* | Channel access token for Reply/Push Message API and LINE-hosted image/audio downloads. *Fallback for `[line].channel_access_token` — config wins |
+| `LINE_WEBHOOK_PATH` | No | Webhook mount path. Fallback for `[line].webhook_path` (default `/webhook/line`) |
 | `LINE_ALLOW_ALL_USERS` | No | `true` = any user may interact. Fallback for `[line].allow_all_users`; default deny-all |
 | `LINE_ALLOWED_USERS` | No | Comma-separated LINE user IDs. Fallback for `[line].allowed_users` |
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -867,6 +867,19 @@ async fn main() -> anyhow::Result<()> {
             } else {
                 None
             };
+
+            // First-class `[line]` config overrides env-derived values
+            // (config-authoritative + ${} expansion + LINE_* env fallback,
+            // #1376). Applied before warn_unenforceable_l1 so a
+            // config-supplied channel_secret is not falsely flagged.
+            if let Some(ref l) = cfg.line {
+                let r = l.resolve();
+                gw_state_inner.apply_line_config(openab_gateway::GatewayLineConfig {
+                    channel_secret: r.channel_secret,
+                    channel_access_token: r.channel_access_token,
+                    webhook_path: r.webhook_path,
+                });
+            }
             let gw_state = Arc::new(gw_state_inner);
 
             // Phase 1 L1 audit (#1356): warn if any active webhook platform has
@@ -896,9 +909,9 @@ async fn main() -> anyhow::Result<()> {
 
             #[cfg(feature = "line")]
             {
-                info!("unified: line adapter enabled");
+                info!(path = %gw_state.line_webhook_path, "unified: line adapter enabled");
                 app = app.route(
-                    "/webhook/line",
+                    &gw_state.line_webhook_path,
                     axum::routing::post(openab_gateway::adapters::line::webhook),
                 );
             }


### PR DESCRIPTION
## What problem does this solve?

First platform slice of the config-first parity umbrella #1375: LINE's channel credentials were env-only (`LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN`), violating the invariant that every platform setting resolves **`[section]` config → `PLATFORM_*` env → default** with config always winning.

## Proposed Solution

Mirrors the `TelegramConfig` reference pattern end-to-end:

| Layer | Change |
|-------|--------|
| core `config.rs` | `LineConfig` gains `channel_secret`, `channel_access_token`, `webhook_path`; `resolve()` applies config → `LINE_*` env → default per field (empty-string `${}` expansion falls through to env) |
| gateway `lib.rs` | `GatewayLineConfig` bridge + `AppState::apply_line_config()` (keeps the crate free of openab-core); new `line_webhook_path` state; standalone gateway honors `LINE_WEBHOOK_PATH` and mounts at the resolved path |
| unified `main.rs` | Applies `[line]` **before** `warn_unenforceable_l1`, so a config-supplied `channel_secret` satisfies the #1373 L1 startup check; route mounts at the resolved path |
| docs | `config.toml.example`, `config-reference.md` field table, `line.md` (`[line]` primary, env fallback) |

Backward compatible: env-only deployments resolve identically; default mount path unchanged.

## Tests

- `line_section_parses_from_toml` — new fields parse
- `line_resolve_all_scenarios` — 3 new scenarios: config-wins-over-env for all three fields; empty-string expansion falls through to env; nothing set → defaults
- `apply_line_config_overrides_env_state_and_feeds_l1_warning` — pins the #1373 integration: env-derived flagged state clears once config supplies the secret

## Validation

At head (macOS arm64, main `9af9fcd`):
- `cargo clippy -p openab-core -p openab-gateway --all-features -- -D warnings` — clean; gateway no-features also clean
- `cargo check --features unified` and default — pass
- core line tests 16/16; gateway l1_audit tests 5/5
- `rustfmt --check` isolated per file: zero drift vs main (all three files 0→0)

Closes #1376. Refs #1375 (umbrella), #1373 (L1 warning integration).