### PR TITLE
feat(googlechat): full [googlechat] section — credentials + connection config-first

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -107,6 +107,12 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 # allowed_users = ["zhangsan", "lisi"]  # WeCom UserIDs (tenant-assigned, freeform strings)
 #                                       # env fallback: WECOM_ALLOWED_USERS (comma-separated)
 # [googlechat]
+# enabled = true                        # env fallback: GOOGLE_CHAT_ENABLED
+# sa_key_json = "${GOOGLE_CHAT_SA_KEY_JSON}"   # inline SA key; wins over sa_key_file
+# sa_key_file = "/etc/openab/sa.json"   # env fallback: GOOGLE_CHAT_SA_KEY_FILE
+# access_token = "${GOOGLE_CHAT_ACCESS_TOKEN}" # static token alternative
+# audience = "projects/<n>/..."         # enables webhook JWT verification (L1)
+# webhook_path = "/webhook/googlechat"  # env fallback: GOOGLE_CHAT_WEBHOOK_PATH
 # allow_all_users = false               # env fallback: GOOGLE_CHAT_ALLOW_ALL_USERS
 # allowed_users = ["users/123456789"]   # Chat user resource names (users/<id>)
 #                                       # env fallback: GOOGLE_CHAT_ALLOWED_USERS (comma-separated)

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -1076,14 +1076,15 @@ impl GoogleChatConfig {
 }
 
 /// Shared first-class trust section for gateway platforms whose Phase 1 needs
-/// exactly the two L3 identity fields (identity-trust-none ADR): `[googlechat]`,
-/// `[teams]`. Same shape and resolution order as
+/// exactly the two L3 identity fields (identity-trust-none ADR): `[teams]`.
+/// Same shape and resolution order as
 /// [`LineConfig`] / [`TelegramConfig`]: `[section].field` (with `${}`
 /// expansion) → `{PREFIX}_*` env var → deny-all default.
 ///
 /// Trust-only by design — platform credentials stay on the gateway env vars
-/// the webhook adapters read (`GOOGLE_CHAT_*`,
-/// `TEAMS_APP_ID`/`TEAMS_APP_SECRET`). Platforms that later
+/// the webhook adapters read (`TEAMS_APP_ID`/`TEAMS_APP_SECRET`).
+/// Also serves as the shared trust-fields view type returned by the
+/// graduated sections' `trust_config()`. Platforms that later
 /// need extra trust fields (e.g. `trusted_bot_ids`) graduate to their own
 /// struct, as LINE will for group policy.
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -174,7 +174,7 @@ pub struct Config {
     pub telegram: Option<TelegramConfig>,
     pub line: Option<LineConfig>,
     pub wecom: Option<WecomConfig>,
-    pub googlechat: Option<PlatformTrustConfig>,
+    pub googlechat: Option<GoogleChatConfig>,
     pub teams: Option<PlatformTrustConfig>,
     pub agentcore: Option<AgentCoreConfig>,
     #[serde(default)]
@@ -956,6 +956,106 @@ impl WecomConfig {
             allowed_users: match &self.allowed_users {
                 Some(list) => list.clone(),
                 None => std::env::var("WECOM_ALLOWED_USERS")
+                    .unwrap_or_default()
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect(),
+            },
+        }
+    }
+
+    /// Trust-fields view for the shared registry override path, preserving
+    /// the semantics the section had as a [`PlatformTrustConfig`].
+    pub fn trust_config(&self) -> PlatformTrustConfig {
+        PlatformTrustConfig {
+            allow_all_users: self.allow_all_users,
+            allowed_users: self.allowed_users.clone(),
+        }
+    }
+}
+
+/// First-class `[googlechat]` section — credentials, connection, and L3
+/// identity trust for the Google Chat adapter. Config-first invariant
+/// (#1375): each field resolves `[googlechat].field` (with `${}` expansion)
+/// → `GOOGLE_CHAT_*` env var → default. Graduates from the shared
+/// [`PlatformTrustConfig`] (#1379).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct GoogleChatConfig {
+    /// Enable the adapter. Env fallback: `GOOGLE_CHAT_ENABLED`
+    /// (`true`/`1`; default false).
+    pub enabled: Option<bool>,
+    /// Service-account key JSON (inline). Env fallback:
+    /// `GOOGLE_CHAT_SA_KEY_JSON`. Takes precedence over `sa_key_file`.
+    pub sa_key_json: Option<String>,
+    /// Path to a service-account key file. Env fallback:
+    /// `GOOGLE_CHAT_SA_KEY_FILE`.
+    pub sa_key_file: Option<String>,
+    /// Static access token (alternative to the service account). Env
+    /// fallback: `GOOGLE_CHAT_ACCESS_TOKEN`.
+    pub access_token: Option<String>,
+    /// JWT audience — enables webhook JWT verification (L1). Env fallback:
+    /// `GOOGLE_CHAT_AUDIENCE`.
+    pub audience: Option<String>,
+    /// Webhook mount path. Env fallback: `GOOGLE_CHAT_WEBHOOK_PATH`
+    /// (default `/webhook/googlechat`).
+    pub webhook_path: Option<String>,
+    /// Explicit flag: true = allow all users, false = check `allowed_users`.
+    /// When not set, defaults to `false` (deny-all, per identity-trust-none
+    /// ADR). Env fallback: `GOOGLE_CHAT_ALLOW_ALL_USERS` (empty = unset).
+    pub allow_all_users: Option<bool>,
+    /// Chat user resource names (`users/<id>`) allowed to interact. Only
+    /// checked when `allow_all_users` resolves to `false`. Env fallback:
+    /// `GOOGLE_CHAT_ALLOWED_USERS` (comma-separated).
+    pub allowed_users: Option<Vec<String>>,
+}
+
+/// Fully resolved Google Chat settings (config → env → default applied).
+#[derive(Debug, Clone)]
+pub struct ResolvedGoogleChat {
+    pub enabled: bool,
+    pub sa_key_json: Option<String>,
+    pub sa_key_file: Option<String>,
+    pub access_token: Option<String>,
+    pub audience: Option<String>,
+    pub webhook_path: String,
+    pub allow_all_users: bool,
+    pub allowed_users: Vec<String>,
+}
+
+impl GoogleChatConfig {
+    /// Resolve every field: config value (if set) → `GOOGLE_CHAT_*` env →
+    /// default. String fields filter empty strings from `${}` expansion.
+    pub fn resolve(&self) -> ResolvedGoogleChat {
+        let opt_str = |cfg: &Option<String>, env: &str| -> Option<String> {
+            cfg.as_ref()
+                .filter(|s| !s.is_empty())
+                .cloned()
+                .or_else(|| std::env::var(env).ok())
+        };
+        ResolvedGoogleChat {
+            enabled: self.enabled.unwrap_or_else(|| {
+                std::env::var("GOOGLE_CHAT_ENABLED")
+                    .map(|v| v == "true" || v == "1")
+                    .unwrap_or(false)
+            }),
+            sa_key_json: opt_str(&self.sa_key_json, "GOOGLE_CHAT_SA_KEY_JSON"),
+            sa_key_file: opt_str(&self.sa_key_file, "GOOGLE_CHAT_SA_KEY_FILE"),
+            access_token: opt_str(&self.access_token, "GOOGLE_CHAT_ACCESS_TOKEN"),
+            audience: opt_str(&self.audience, "GOOGLE_CHAT_AUDIENCE"),
+            webhook_path: opt_str(&self.webhook_path, "GOOGLE_CHAT_WEBHOOK_PATH")
+                .unwrap_or_else(|| "/webhook/googlechat".into()),
+            allow_all_users: self.allow_all_users.unwrap_or_else(|| {
+                std::env::var("GOOGLE_CHAT_ALLOW_ALL_USERS")
+                    .ok()
+                    .filter(|v| !v.is_empty())
+                    .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+                    .unwrap_or(false)
+            }),
+            allowed_users: match &self.allowed_users {
+                Some(list) => list.clone(),
+                None => std::env::var("GOOGLE_CHAT_ALLOWED_USERS")
                     .unwrap_or_default()
                     .split(',')
                     .map(|s| s.trim().to_string())
@@ -2304,6 +2404,63 @@ allowed_users = ["U1234567890abcdef0123456789abcdef"]
         std::env::remove_var("WECOM_DEBOUNCE_SECS");
     }
 
+    /// All `GOOGLE_CHAT_*` env scenarios in ONE test (env is process-global).
+    #[test]
+    fn googlechat_resolve_all_scenarios() {
+        for k in [
+            "GOOGLE_CHAT_ENABLED",
+            "GOOGLE_CHAT_SA_KEY_JSON",
+            "GOOGLE_CHAT_SA_KEY_FILE",
+            "GOOGLE_CHAT_ACCESS_TOKEN",
+            "GOOGLE_CHAT_AUDIENCE",
+            "GOOGLE_CHAT_WEBHOOK_PATH",
+        ] {
+            std::env::remove_var(k);
+        }
+        // --- defaults ---
+        let r = GoogleChatConfig::default().resolve();
+        assert!(!r.enabled);
+        assert!(r.audience.is_none());
+        assert_eq!(r.webhook_path, "/webhook/googlechat");
+
+        // --- config wins over env ---
+        std::env::set_var("GOOGLE_CHAT_ENABLED", "true");
+        std::env::set_var("GOOGLE_CHAT_AUDIENCE", "env-aud");
+        let cfg = GoogleChatConfig {
+            enabled: Some(false),
+            audience: Some("cfg-aud".into()),
+            ..Default::default()
+        };
+        let r = cfg.resolve();
+        assert!(!r.enabled); // config false wins over env true
+        assert_eq!(r.audience.as_deref(), Some("cfg-aud"));
+
+        // --- empty-string ${} expansion falls through to env ---
+        let cfg = GoogleChatConfig {
+            audience: Some("".into()),
+            ..Default::default()
+        };
+        let r = cfg.resolve();
+        assert!(r.enabled); // env fallback
+        assert_eq!(r.audience.as_deref(), Some("env-aud"));
+
+        // --- trust_config() preserves trust semantics ---
+        let cfg = GoogleChatConfig {
+            allow_all_users: Some(true),
+            allowed_users: Some(vec!["users/123".into()]),
+            ..Default::default()
+        };
+        let t = cfg.trust_config();
+        assert_eq!(t.allow_all_users, Some(true));
+        assert_eq!(
+            t.allowed_users.as_deref(),
+            Some(&["users/123".to_string()][..])
+        );
+
+        std::env::remove_var("GOOGLE_CHAT_ENABLED");
+        std::env::remove_var("GOOGLE_CHAT_AUDIENCE");
+    }
+
     #[test]
     fn platform_trust_sections_parse_from_toml() {
         let toml_str = r#"
@@ -2316,6 +2473,7 @@ token = "tok"
 allowed_users = ["zhangsan", "lisi"]
 
 [googlechat]
+audience = "projects/p/..."
 allowed_users = ["users/123456789"]
 
 [teams]
@@ -2331,6 +2489,7 @@ allow_all_users = true
         );
         assert_eq!(wecom.allow_all_users, None);
         let gc = cfg.googlechat.expect("googlechat section");
+        assert_eq!(gc.audience.as_deref(), Some("projects/p/..."));
         assert_eq!(
             gc.allowed_users.as_deref(),
             Some(&["users/123456789".to_string()][..])

--- a/crates/openab-gateway/src/adapters/googlechat.rs
+++ b/crates/openab-gateway/src/adapters/googlechat.rs
@@ -270,6 +270,38 @@ pub struct GoogleChatAdapter {
 }
 
 impl GoogleChatAdapter {
+    /// Build an adapter from resolved parts (#1379): SA key JSON (inline wins
+    /// over file path), optional static access token, optional JWT audience.
+    /// Shared by env-derived construction and `apply_googlechat_config`.
+    pub(crate) fn from_parts(
+        sa_key_json: Option<String>,
+        sa_key_file: Option<String>,
+        access_token: Option<String>,
+        audience: Option<String>,
+    ) -> Self {
+        use tracing::{info, warn};
+        let token_cache = sa_key_json
+            .or_else(|| {
+                sa_key_file.and_then(|path| {
+                    std::fs::read_to_string(&path)
+                        .map_err(|e| {
+                            warn!("failed to read Google Chat SA key file '{}': {e}", path);
+                        })
+                        .ok()
+                })
+            })
+            .and_then(|json| {
+                GoogleChatTokenCache::new(&json)
+                    .map_err(|e| warn!("googlechat SA key error: {e}"))
+                    .ok()
+            });
+        let jwt_verifier = audience.map(|aud| {
+            info!("googlechat webhook JWT verification enabled (audience={aud})");
+            GoogleChatJwtVerifier::new(aud)
+        });
+        Self::new(token_cache, access_token, jwt_verifier)
+    }
+
     pub fn new(
         token_cache: Option<GoogleChatTokenCache>,
         access_token: Option<String>,

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -50,6 +50,9 @@ pub struct AppState {
     pub feishu: Option<adapters::feishu::FeishuAdapter>,
     #[cfg(feature = "googlechat")]
     pub google_chat: Option<adapters::googlechat::GoogleChatAdapter>,
+    /// Webhook mount path for Google Chat (env: `GOOGLE_CHAT_WEBHOOK_PATH`;
+    /// config-first via `apply_googlechat_config`, default `/webhook/googlechat`).
+    pub googlechat_webhook_path: String,
     #[cfg(feature = "wecom")]
     pub wecom: Option<adapters::wecom::WecomAdapter>,
     pub ws_token: Option<String>,
@@ -87,6 +90,7 @@ impl AppState {
             feishu: None,
             #[cfg(feature = "googlechat")]
             google_chat: None,
+            googlechat_webhook_path: "/webhook/googlechat".into(),
             #[cfg(feature = "wecom")]
             wecom: None,
             ws_token: None,
@@ -101,7 +105,7 @@ impl AppState {
     /// Initializes all platform adapters based on available env vars.
     /// `ws_token` is passed separately (only needed for standalone gateway mode).
     pub fn from_env(event_tx: broadcast::Sender<String>, ws_token: Option<String>) -> Self {
-        use tracing::{info, warn};
+        use tracing::info;
 
         // Telegram
         let telegram_bot_token = std::env::var("TELEGRAM_BOT_TOKEN").ok();
@@ -141,34 +145,18 @@ impl AppState {
                 .map(|v| v == "true" || v == "1")
                 .unwrap_or(false);
             if enabled {
-                let token_cache = std::env::var("GOOGLE_CHAT_SA_KEY_JSON")
-                    .ok()
-                    .or_else(|| {
-                        std::env::var("GOOGLE_CHAT_SA_KEY_FILE")
-                            .ok()
-                            .and_then(|path| {
-                                std::fs::read_to_string(&path).map_err(|e| {
-                                    warn!("failed to read GOOGLE_CHAT_SA_KEY_FILE '{}': {e}", path);
-                                }).ok()
-                            })
-                    })
-                    .and_then(|json| {
-                        adapters::googlechat::GoogleChatTokenCache::new(&json)
-                            .map_err(|e| warn!("googlechat SA key error: {e}"))
-                            .ok()
-                    });
-                let access_token = std::env::var("GOOGLE_CHAT_ACCESS_TOKEN").ok();
-                let jwt_verifier = std::env::var("GOOGLE_CHAT_AUDIENCE").ok().map(|aud| {
-                    info!("googlechat JWT verification enabled (audience={aud})");
-                    adapters::googlechat::GoogleChatJwtVerifier::new(aud)
-                });
-                Some(adapters::googlechat::GoogleChatAdapter::new(
-                    token_cache, access_token, jwt_verifier,
+                Some(adapters::googlechat::GoogleChatAdapter::from_parts(
+                    std::env::var("GOOGLE_CHAT_SA_KEY_JSON").ok(),
+                    std::env::var("GOOGLE_CHAT_SA_KEY_FILE").ok(),
+                    std::env::var("GOOGLE_CHAT_ACCESS_TOKEN").ok(),
+                    std::env::var("GOOGLE_CHAT_AUDIENCE").ok(),
                 ))
             } else {
                 None
             }
         };
+        let googlechat_webhook_path = std::env::var("GOOGLE_CHAT_WEBHOOK_PATH")
+            .unwrap_or_else(|_| "/webhook/googlechat".into());
 
         // WeCom
         #[cfg(feature = "wecom")]
@@ -196,6 +184,7 @@ impl AppState {
             feishu,
             #[cfg(feature = "googlechat")]
             google_chat,
+            googlechat_webhook_path,
             #[cfg(feature = "wecom")]
             wecom,
             ws_token,
@@ -351,6 +340,25 @@ impl AppState {
         })
         .map(adapters::wecom::WecomAdapter::new);
     }
+
+    /// Apply resolved `[googlechat]` config values (#1379), rebuilding the
+    /// adapter from them via the same `from_parts` construction as env-only
+    /// startup. Call before [`AppState::warn_unenforceable_l1`] so a
+    /// config-supplied `audience` (JWT verifier) is not falsely flagged.
+    #[cfg(feature = "googlechat")]
+    pub fn apply_googlechat_config(&mut self, cfg: GatewayGoogleChatConfig) {
+        self.googlechat_webhook_path = cfg.webhook_path;
+        self.google_chat = if cfg.enabled {
+            Some(adapters::googlechat::GoogleChatAdapter::from_parts(
+                cfg.sa_key_json,
+                cfg.sa_key_file,
+                cfg.access_token,
+                cfg.audience,
+            ))
+        } else {
+            None
+        };
+    }
 }
 
 /// Parameter object for passing resolved Telegram config across the crate
@@ -386,6 +394,18 @@ pub struct GatewayWecomConfig {
     pub webhook_path: String,
     pub streaming_enabled: bool,
     pub debounce_secs: u64,
+}
+
+/// Parameter object for passing resolved Google Chat config across the crate
+/// boundary without introducing a dependency on `openab-core` (#1379).
+#[derive(Debug, Clone)]
+pub struct GatewayGoogleChatConfig {
+    pub enabled: bool,
+    pub sa_key_json: Option<String>,
+    pub sa_key_file: Option<String>,
+    pub access_token: Option<String>,
+    pub audience: Option<String>,
+    pub webhook_path: String,
 }
 
 // --- Public serve() entry point ---
@@ -533,42 +553,21 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
 
     // Google Chat adapter
     #[cfg(feature = "googlechat")]
+    let googlechat_webhook_path = std::env::var("GOOGLE_CHAT_WEBHOOK_PATH")
+        .unwrap_or_else(|_| "/webhook/googlechat".into());
+    #[cfg(feature = "googlechat")]
     let google_chat = {
         let enabled = std::env::var("GOOGLE_CHAT_ENABLED")
             .map(|v| v == "true" || v == "1")
             .unwrap_or(false);
         if enabled {
-            let token_cache = std::env::var("GOOGLE_CHAT_SA_KEY_JSON")
-                .ok()
-                .or_else(|| {
-                    std::env::var("GOOGLE_CHAT_SA_KEY_FILE")
-                        .ok()
-                        .and_then(|path| {
-                            std::fs::read_to_string(&path).map_err(|e| {
-                                warn!("failed to read GOOGLE_CHAT_SA_KEY_FILE '{}': {e}", path);
-                            }).ok()
-                        })
-                })
-                .and_then(|json| {
-                    adapters::googlechat::GoogleChatTokenCache::new(&json)
-                        .map_err(|e| warn!("googlechat SA key error: {e}"))
-                        .ok()
-                });
-            let access_token = std::env::var("GOOGLE_CHAT_ACCESS_TOKEN").ok();
-            let jwt_verifier = std::env::var("GOOGLE_CHAT_AUDIENCE").ok().map(|aud| {
-                info!("googlechat webhook JWT verification enabled (audience={aud})");
-                adapters::googlechat::GoogleChatJwtVerifier::new(aud)
-            });
-
-            let webhook_path = std::env::var("GOOGLE_CHAT_WEBHOOK_PATH")
-                .unwrap_or_else(|_| "/webhook/googlechat".into());
-            info!(path = %webhook_path, "googlechat adapter enabled");
-            app = app.route(&webhook_path, post(adapters::googlechat::webhook));
-
-            Some(adapters::googlechat::GoogleChatAdapter::new(
-                token_cache,
-                access_token,
-                jwt_verifier,
+            info!(path = %googlechat_webhook_path, "googlechat adapter enabled");
+            app = app.route(&googlechat_webhook_path, post(adapters::googlechat::webhook));
+            Some(adapters::googlechat::GoogleChatAdapter::from_parts(
+                std::env::var("GOOGLE_CHAT_SA_KEY_JSON").ok(),
+                std::env::var("GOOGLE_CHAT_SA_KEY_FILE").ok(),
+                std::env::var("GOOGLE_CHAT_ACCESS_TOKEN").ok(),
+                std::env::var("GOOGLE_CHAT_AUDIENCE").ok(),
             ))
         } else {
             None
@@ -576,6 +575,8 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
     };
     #[cfg(not(feature = "googlechat"))]
     let google_chat: Option<()> = None;
+    #[cfg(not(feature = "googlechat"))]
+    let googlechat_webhook_path = "/webhook/googlechat".to_string();
 
     // WeCom adapter
     #[cfg(feature = "wecom")]
@@ -621,6 +622,7 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
         feishu,
         #[cfg(feature = "googlechat")]
         google_chat,
+        googlechat_webhook_path,
         #[cfg(feature = "wecom")]
         wecom,
         ws_token,
@@ -926,6 +928,47 @@ mod l1_audit_tests {
         // channel secret present → L1 enforced
         s.line_channel_secret = Some("csecret".into());
         assert!(flagged(&s).is_empty());
+    }
+
+    #[cfg(feature = "googlechat")]
+    #[test]
+    fn apply_googlechat_config_builds_adapter_and_feeds_l1_warning() {
+        use super::GatewayGoogleChatConfig;
+        let mut s = state();
+        // Enabled without audience → adapter active, no JWT verifier → flagged.
+        s.apply_googlechat_config(GatewayGoogleChatConfig {
+            enabled: true,
+            sa_key_json: None,
+            sa_key_file: None,
+            access_token: Some("tok".into()),
+            audience: None,
+            webhook_path: "/hook/gc".into(),
+        });
+        assert!(s.google_chat.is_some());
+        assert_eq!(s.googlechat_webhook_path, "/hook/gc");
+        assert_eq!(flagged(&s), vec!["googlechat"]);
+
+        // Config-supplied audience builds the verifier → L1 satisfied.
+        s.apply_googlechat_config(GatewayGoogleChatConfig {
+            enabled: true,
+            sa_key_json: None,
+            sa_key_file: None,
+            access_token: Some("tok".into()),
+            audience: Some("aud".into()),
+            webhook_path: "/hook/gc".into(),
+        });
+        assert!(flagged(&s).is_empty());
+
+        // Disabled → adapter removed.
+        s.apply_googlechat_config(GatewayGoogleChatConfig {
+            enabled: false,
+            sa_key_json: None,
+            sa_key_file: None,
+            access_token: None,
+            audience: None,
+            webhook_path: "/hook/gc".into(),
+        });
+        assert!(s.google_chat.is_none());
     }
 
     #[test]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -178,13 +178,30 @@ Full first-class WeCom section (config-first parity, #1378) — credentials, con
 
 ---
 
-## `[googlechat]` / `[teams]`
+## `[googlechat]`
 
-First-class L3 identity trust — same shape and semantics as `[line]`. Each section replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for its platform (deprecated: warns at startup, becomes an error in Phase 2). Platform credentials remain on the gateway env vars (`GOOGLE_CHAT_*`, `TEAMS_APP_ID`/`TEAMS_APP_SECRET`) until their config-first parity slices land (#1379, #1380).
+Full first-class Google Chat section (config-first parity, #1379) — credentials, connection, and L3 identity trust. Each field resolves: config → `GOOGLE_CHAT_*` env → default.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `false` | Enable the adapter. Env: `GOOGLE_CHAT_ENABLED`. |
+| `sa_key_json` | string | — | Inline service-account key JSON (wins over `sa_key_file`). Env: `GOOGLE_CHAT_SA_KEY_JSON`. |
+| `sa_key_file` | string | — | Path to a service-account key file. Env: `GOOGLE_CHAT_SA_KEY_FILE`. |
+| `access_token` | string | — | Static access token alternative. Env: `GOOGLE_CHAT_ACCESS_TOKEN`. |
+| `audience` | string | — | JWT audience — enables webhook JWT verification (L1). Env: `GOOGLE_CHAT_AUDIENCE`. |
+| `webhook_path` | string | `/webhook/googlechat` | Env: `GOOGLE_CHAT_WEBHOOK_PATH`. |
+| `allow_all_users` | bool \| omit | `false` (deny-all) | Env: `GOOGLE_CHAT_ALLOW_ALL_USERS`. |
+| `allowed_users` | string[] | `[]` | User resource names (`users/<id>`). Env: `GOOGLE_CHAT_ALLOWED_USERS`. |
+
+---
+
+## `[teams]`
+
+First-class L3 identity trust — same shape and semantics as `[line]`. Each section replaces the uniform `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` env vars for its platform (deprecated: warns at startup, becomes an error in Phase 2). Platform credentials remain on the gateway env vars (`TEAMS_APP_ID`/`TEAMS_APP_SECRET`) until the Teams config-first parity slice lands (#1380).
 
 > **Mode scoping:** these sections (like `[line]`) take effect on the **embedded/unified adapter path**, where events pass the shared ingress trust gate. Deployments using the standalone `openab-gateway` companion over WebSocket enforce trust via `[gateway].allow_all_users` / `allowed_users` instead; Phase 1c consolidates the two paths.
 
-Each field resolves: config value → `{PREFIX}_*` env var → default (deny-all). Env prefixes: `GOOGLE_CHAT`, `TEAMS`.
+Each field resolves: config value → `TEAMS_*` env var → default (deny-all).
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -195,13 +212,9 @@ Sender ID formats per platform:
 
 | Platform | Sender ID format | Example |
 |----------|-----------------|---------|
-| Google Chat | User resource name | `"users/123456789"` |
 | MS Teams | Bot Framework `activity.from.id` | `"29:1abc..."` |
 
 ```toml
-[googlechat]
-allowed_users = ["users/123456789"]
-
 [teams]
 allowed_users = ["29:1abc..."]
 # allow_all_users = true   # explicit opt-in only

--- a/docs/google-chat.md
+++ b/docs/google-chat.md
@@ -152,6 +152,18 @@ allow_all_users = true
 [agent]
 ```
 
+### `[googlechat]` Section (credentials + trust)
+
+Since #1379 the `[googlechat]` section carries the full adapter configuration — config-first with `GOOGLE_CHAT_*` env fallback:
+
+```toml
+[googlechat]
+enabled     = true
+sa_key_json = "${GOOGLE_CHAT_SA_KEY_JSON}"
+audience    = "projects/<project-number>/..."   # enables webhook JWT verification (L1)
+allowed_users = ["users/123456789"]
+```
+
 ### User Trust (`[googlechat]` section)
 
 > **Mode scoping:** the `[googlechat]` section applies when the Google Chat adapter is **embedded in the OAB binary** (unified mode, `GOOGLE_CHAT_ENABLED=true` env set on the OAB container). In the standalone-gateway mode shown above, trust is enforced by `[gateway].allow_all_users` / `allowed_users` instead — the `[googlechat]` section has no effect on that path yet (Phase 1c consolidates the two).

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,7 +522,7 @@ async fn main() -> anyhow::Result<()> {
         platform_trust_override(
             &mut reg,
             "googlechat",
-            &cfg.googlechat,
+            &cfg.googlechat.as_ref().map(|g| g.trust_config()),
             "GOOGLE_CHAT",
             cfg!(feature = "googlechat")
                 && std::env::var("GOOGLE_CHAT_ENABLED")
@@ -899,6 +899,22 @@ async fn main() -> anyhow::Result<()> {
                     debounce_secs: r.debounce_secs,
                 });
             }
+            // First-class `[googlechat]` config overrides env-derived values
+            // (config-authoritative + ${} expansion + GOOGLE_CHAT_* env
+            // fallback, #1379). Applied before warn_unenforceable_l1 so a
+            // config-supplied audience (JWT verifier) is not falsely flagged.
+            #[cfg(feature = "googlechat")]
+            if let Some(ref g) = cfg.googlechat {
+                let r = g.resolve();
+                gw_state_inner.apply_googlechat_config(openab_gateway::GatewayGoogleChatConfig {
+                    enabled: r.enabled,
+                    sa_key_json: r.sa_key_json,
+                    sa_key_file: r.sa_key_file,
+                    access_token: r.access_token,
+                    audience: r.audience,
+                    webhook_path: r.webhook_path,
+                });
+            }
             let gw_state = Arc::new(gw_state_inner);
 
             // Phase 1 L1 audit (#1356): warn if any active webhook platform has
@@ -981,11 +997,9 @@ async fn main() -> anyhow::Result<()> {
 
             #[cfg(feature = "googlechat")]
             if gw_state.google_chat.is_some() {
-                let path = std::env::var("GOOGLE_CHAT_WEBHOOK_PATH")
-                    .unwrap_or_else(|_| "/webhook/googlechat".into());
-                info!(path = %path, "unified: googlechat adapter enabled");
+                info!(path = %gw_state.googlechat_webhook_path, "unified: googlechat adapter enabled");
                 app = app.route(
-                    &path,
+                    &gw_state.googlechat_webhook_path,
                     axum::routing::post(openab_gateway::adapters::googlechat::webhook),
                 );
             }


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #1382** (→ #1381 → main). Net-new diff = the last commit; will re-target as parents merge.

## What problem does this solve?

Third platform slice of #1375: Google Chat's credentials/connection were env-only. `[googlechat]` graduates from the shared trust-only struct to a dedicated `GoogleChatConfig` (6 fields + trust), resolving each field **config → `GOOGLE_CHAT_*` env → default**.

## How It Works

| Layer | Change |
|-------|--------|
| core | `GoogleChatConfig`/`ResolvedGoogleChat` + `resolve()`; `trust_config()` view keeps the registry path unchanged |
| gateway | **DRY bonus**: adapter construction was copy-pasted between `from_env` and standalone `run()` — deduplicated into `GoogleChatAdapter::from_parts`; `GatewayGoogleChatConfig` bridge + `apply_googlechat_config()`; new `googlechat_webhook_path` state honored by both binaries |
| unified | Applies `[googlechat]` before `warn_unenforceable_l1` — config-supplied `audience` builds the JWT verifier and satisfies the #1373 L1 check |
| docs | example, config-reference (dedicated section), google-chat.md |

## Tests

- `googlechat_resolve_all_scenarios` — defaults, config-wins (incl. explicit `enabled=false` beating env `true`), empty-string fallthrough, `trust_config()`
- `apply_googlechat_config_builds_adapter_and_feeds_l1_warning` — pins the L1 integration: enabled-without-audience flagged → config audience clears → disabled removes adapter

## Validation

- clippy `-D warnings` clean (all-features + gateway no-features); unified + default builds pass
- core 662 passed (1 known pre-existing macOS `secrets` failure); gateway l1_audit 6/6
- rustfmt isolated: 0 new drift (googlechat.rs 45→45 pre-existing)

Closes #1379. Refs #1375, #1373.