### PR TITLE
feat(feishu): full [feishu] section — all settings config-first

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -125,6 +125,32 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 # allowed_users = ["29:1abc..."]        # Bot Framework activity.from.id values (29:…)
 #                                       # env fallback: TEAMS_ALLOWED_USERS (comma-separated)
 
+# --- Feishu/Lark (first-class section; config-first with FEISHU_* env fallback) ---
+# app_id + app_secret are mandatory (after env fallback); incomplete = adapter disabled.
+# [feishu]
+# app_id     = "${FEISHU_APP_ID}"       # env fallback: FEISHU_APP_ID
+# app_secret = "${FEISHU_APP_SECRET}"   # env fallback: FEISHU_APP_SECRET
+# encrypt_key = "${FEISHU_ENCRYPT_KEY}" # webhook signature key (L1); env fallback: FEISHU_ENCRYPT_KEY
+# verification_token = "${FEISHU_VERIFICATION_TOKEN}"
+# domain = "feishu"                     # "feishu" | "lark"
+# connection_mode = "websocket"         # "websocket" (default, no public URL) | "webhook"
+# webhook_path = "/webhook/feishu"
+# allowed_users  = ["ou_xxxx"]          # open_id allowlist (per-app!); env: FEISHU_ALLOWED_USERS
+# allowed_groups = ["oc_xxxx"]          # env: FEISHU_ALLOWED_GROUPS
+# trusted_bot_ids = ["ou_bot1"]         # env: FEISHU_TRUSTED_BOT_IDS
+# require_mention = true                # env: FEISHU_REQUIRE_MENTION
+# allow_bots = "off"                    # off | mentions | all
+# allow_user_messages = "multibot_mentions"  # multibot_mentions | mentions | involved
+# max_bot_turns = 20
+# dedupe_ttl_secs = 300
+# message_limit = 4000
+# session_ttl_hours = 24                # 0 disables participation tracking
+# card_streaming_mode = "auto"          # auto | post | card
+# card_fallback_to_post = true
+# card_promote_bytes = 4000
+# card_idle_finalize_ms = 3000
+# allow_all_users = false               # L3 shared-gate opt-in; env: FEISHU_ALLOW_ALL_USERS
+
 # --- AgentCore Runtime (alternative to [agent]) ---
 # When [agentcore] is set and [agent].command is not explicitly provided,
 # OAB auto-spawns the bundled agentcore-acp adapter. No manual wiring needed.

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -176,6 +176,7 @@ pub struct Config {
     pub wecom: Option<WecomConfig>,
     pub googlechat: Option<GoogleChatConfig>,
     pub teams: Option<TeamsConfig>,
+    pub feishu: Option<FeishuConfig>,
     pub agentcore: Option<AgentCoreConfig>,
     #[serde(default)]
     pub agent: AgentConfig,
@@ -1164,6 +1165,159 @@ impl TeamsConfig {
     }
 
     /// Trust-fields view for the shared registry override path.
+    pub fn trust_config(&self) -> PlatformTrustConfig {
+        PlatformTrustConfig {
+            allow_all_users: self.allow_all_users,
+            allowed_users: self.allowed_users.clone(),
+        }
+    }
+}
+
+/// First-class `[feishu]` section — credentials, connection, behavior, and
+/// L3 identity trust for the Feishu/Lark adapter. Config-first invariant
+/// (#1375, #1377): each field resolves `[feishu].field` (with `${}`
+/// expansion) → `FEISHU_*` env var → default.
+///
+/// The gateway adapter's `from_reader` remains the single source of truth
+/// for parsing and defaults: `resolve()` renders the typed TOML fields into
+/// the same string form the env vars use, so no default value or enum
+/// parsing rule is duplicated here.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct FeishuConfig {
+    /// App ID (mandatory for the adapter). Env: `FEISHU_APP_ID`.
+    pub app_id: Option<String>,
+    /// App secret (mandatory). Env: `FEISHU_APP_SECRET`.
+    pub app_secret: Option<String>,
+    /// Event verification token. Env: `FEISHU_VERIFICATION_TOKEN`.
+    pub verification_token: Option<String>,
+    /// Event encrypt key — enables webhook signature verification (L1).
+    /// Env: `FEISHU_ENCRYPT_KEY`.
+    pub encrypt_key: Option<String>,
+    /// `"feishu"` or `"lark"`. Env: `FEISHU_DOMAIN` (default `feishu`).
+    pub domain: Option<String>,
+    /// `"websocket"` (default) or `"webhook"`. Env: `FEISHU_CONNECTION_MODE`.
+    pub connection_mode: Option<String>,
+    /// Webhook mount path. Env: `FEISHU_WEBHOOK_PATH`
+    /// (default `/webhook/feishu`).
+    pub webhook_path: Option<String>,
+    /// Group (chat) ID allowlist. Env: `FEISHU_ALLOWED_GROUPS` (CSV).
+    pub allowed_groups: Option<Vec<String>>,
+    /// User (open_id) allowlist — note open_id is per-app. Env:
+    /// `FEISHU_ALLOWED_USERS` (CSV).
+    pub allowed_users: Option<Vec<String>>,
+    /// Require @mention in groups. Env: `FEISHU_REQUIRE_MENTION`
+    /// (default true).
+    pub require_mention: Option<bool>,
+    /// `"off"` (default) / `"mentions"` / `"all"`. Env: `FEISHU_ALLOW_BOTS`.
+    pub allow_bots: Option<String>,
+    /// `"multibot_mentions"` (default) / `"mentions"` / `"involved"`.
+    /// Env: `FEISHU_ALLOW_USER_MESSAGES`.
+    pub allow_user_messages: Option<String>,
+    /// Bot open_ids treated as trusted senders. Env:
+    /// `FEISHU_TRUSTED_BOT_IDS` (CSV).
+    pub trusted_bot_ids: Option<Vec<String>>,
+    /// Max consecutive bot turns. Env: `FEISHU_MAX_BOT_TURNS` (default 20).
+    pub max_bot_turns: Option<u32>,
+    /// Event dedupe TTL seconds. Env: `FEISHU_DEDUPE_TTL_SECS` (default 300).
+    pub dedupe_ttl_secs: Option<u64>,
+    /// Outbound message split limit (bytes). Env: `FEISHU_MESSAGE_LIMIT`
+    /// (default 4000).
+    pub message_limit: Option<u64>,
+    /// Participated-thread TTL in hours (0 disables). Env:
+    /// `FEISHU_SESSION_TTL_HOURS` (default 24).
+    pub session_ttl_hours: Option<u64>,
+    /// `"auto"` (default) / `"post"` / `"card"`. Env:
+    /// `FEISHU_CARD_STREAMING_MODE`.
+    pub card_streaming_mode: Option<String>,
+    /// Fall back to post on CardKit failure. Env:
+    /// `FEISHU_CARD_FALLBACK_TO_POST` (default true).
+    pub card_fallback_to_post: Option<bool>,
+    /// Auto-mode promote threshold bytes. Env: `FEISHU_CARD_PROMOTE_BYTES`
+    /// (default 4000).
+    pub card_promote_bytes: Option<u64>,
+    /// Streaming-card idle finalize window ms. Env:
+    /// `FEISHU_CARD_IDLE_FINALIZE_MS` (default 3000).
+    pub card_idle_finalize_ms: Option<u64>,
+    /// Explicit flag: true = allow all users at the shared trust gate (L3),
+    /// false = check `allowed_users`. Defaults to `false` (deny-all). Env:
+    /// `FEISHU_ALLOW_ALL_USERS`. Registry-only — the gateway-side
+    /// `allowed_users` double-gate is tracked separately (#1357).
+    pub allow_all_users: Option<bool>,
+}
+
+impl FeishuConfig {
+    /// Render the typed fields into the env-var string form, config value
+    /// first, falling back to the corresponding `FEISHU_*` env var. The
+    /// result feeds the gateway adapter's `from_reader`, keeping its parsing
+    /// and defaults as the single source of truth.
+    pub fn resolve_pairs(&self) -> std::collections::HashMap<String, String> {
+        let mut m = std::collections::HashMap::new();
+        let mut put = |key: &str, v: Option<String>| {
+            let v = v
+                .filter(|s| !s.is_empty())
+                .or_else(|| std::env::var(key).ok());
+            if let Some(v) = v {
+                m.insert(key.to_string(), v);
+            }
+        };
+        let csv = |v: &Option<Vec<String>>| v.as_ref().map(|l| l.join(","));
+        put("FEISHU_APP_ID", self.app_id.clone());
+        put("FEISHU_APP_SECRET", self.app_secret.clone());
+        put("FEISHU_VERIFICATION_TOKEN", self.verification_token.clone());
+        put("FEISHU_ENCRYPT_KEY", self.encrypt_key.clone());
+        put("FEISHU_DOMAIN", self.domain.clone());
+        put("FEISHU_CONNECTION_MODE", self.connection_mode.clone());
+        put("FEISHU_WEBHOOK_PATH", self.webhook_path.clone());
+        put("FEISHU_ALLOWED_GROUPS", csv(&self.allowed_groups));
+        put("FEISHU_ALLOWED_USERS", csv(&self.allowed_users));
+        put(
+            "FEISHU_REQUIRE_MENTION",
+            self.require_mention.map(|b| b.to_string()),
+        );
+        put("FEISHU_ALLOW_BOTS", self.allow_bots.clone());
+        put(
+            "FEISHU_ALLOW_USER_MESSAGES",
+            self.allow_user_messages.clone(),
+        );
+        put("FEISHU_TRUSTED_BOT_IDS", csv(&self.trusted_bot_ids));
+        put(
+            "FEISHU_MAX_BOT_TURNS",
+            self.max_bot_turns.map(|v| v.to_string()),
+        );
+        put(
+            "FEISHU_DEDUPE_TTL_SECS",
+            self.dedupe_ttl_secs.map(|v| v.to_string()),
+        );
+        put(
+            "FEISHU_MESSAGE_LIMIT",
+            self.message_limit.map(|v| v.to_string()),
+        );
+        put(
+            "FEISHU_SESSION_TTL_HOURS",
+            self.session_ttl_hours.map(|v| v.to_string()),
+        );
+        put(
+            "FEISHU_CARD_STREAMING_MODE",
+            self.card_streaming_mode.clone(),
+        );
+        put(
+            "FEISHU_CARD_FALLBACK_TO_POST",
+            self.card_fallback_to_post.map(|b| b.to_string()),
+        );
+        put(
+            "FEISHU_CARD_PROMOTE_BYTES",
+            self.card_promote_bytes.map(|v| v.to_string()),
+        );
+        put(
+            "FEISHU_CARD_IDLE_FINALIZE_MS",
+            self.card_idle_finalize_ms.map(|v| v.to_string()),
+        );
+        m
+    }
+
+    /// Trust-fields view for the shared registry override path (#1357's
+    /// registry task): L3 identity at the shared gate.
     pub fn trust_config(&self) -> PlatformTrustConfig {
         PlatformTrustConfig {
             allow_all_users: self.allow_all_users,
@@ -2612,6 +2766,79 @@ allowed_users = ["U1234567890abcdef0123456789abcdef"]
 
         std::env::remove_var("TEAMS_APP_ID");
         std::env::remove_var("TEAMS_OAUTH_ENDPOINT");
+    }
+
+    /// All `FEISHU_*` env scenarios in ONE test (env is process-global).
+    #[test]
+    fn feishu_resolve_pairs_scenarios() {
+        for k in ["FEISHU_APP_ID", "FEISHU_DOMAIN", "FEISHU_ALLOWED_USERS"] {
+            std::env::remove_var(k);
+        }
+        // --- nothing set → keys absent (adapter from_reader applies defaults) ---
+        let m = FeishuConfig::default().resolve_pairs();
+        assert!(!m.contains_key("FEISHU_APP_ID"));
+        assert!(!m.contains_key("FEISHU_DOMAIN"));
+
+        // --- config wins over env; typed fields render to env string form ---
+        std::env::set_var("FEISHU_APP_ID", "env-app");
+        std::env::set_var("FEISHU_DOMAIN", "lark");
+        let cfg = FeishuConfig {
+            app_id: Some("cfg-app".into()),
+            require_mention: Some(false),
+            max_bot_turns: Some(7),
+            allowed_users: Some(vec!["ou_a".into(), "ou_b".into()]),
+            ..Default::default()
+        };
+        let m = cfg.resolve_pairs();
+        assert_eq!(m.get("FEISHU_APP_ID").unwrap(), "cfg-app");
+        assert_eq!(m.get("FEISHU_DOMAIN").unwrap(), "lark"); // env fallback
+        assert_eq!(m.get("FEISHU_REQUIRE_MENTION").unwrap(), "false");
+        assert_eq!(m.get("FEISHU_MAX_BOT_TURNS").unwrap(), "7");
+        assert_eq!(m.get("FEISHU_ALLOWED_USERS").unwrap(), "ou_a,ou_b");
+
+        // --- empty-string ${} expansion falls through to env ---
+        let cfg = FeishuConfig {
+            app_id: Some("".into()),
+            ..Default::default()
+        };
+        assert_eq!(cfg.resolve_pairs().get("FEISHU_APP_ID").unwrap(), "env-app");
+
+        // --- trust_config() view ---
+        let cfg = FeishuConfig {
+            allow_all_users: Some(true),
+            allowed_users: Some(vec!["ou_x".into()]),
+            ..Default::default()
+        };
+        let t = cfg.trust_config();
+        assert_eq!(t.allow_all_users, Some(true));
+        assert_eq!(t.allowed_users.as_deref(), Some(&["ou_x".to_string()][..]));
+
+        std::env::remove_var("FEISHU_APP_ID");
+        std::env::remove_var("FEISHU_DOMAIN");
+    }
+
+    #[test]
+    fn feishu_section_parses_from_toml() {
+        let toml_str = r#"
+[discord]
+bot_token = "x"
+
+[feishu]
+app_id = "cli_xxx"
+app_secret = "sec"
+connection_mode = "webhook"
+encrypt_key = "ek"
+allowed_users = ["ou_123"]
+max_bot_turns = 5
+card_streaming_mode = "post"
+"#;
+        let cfg = parse_config_str(toml_str, "test").unwrap();
+        let fe = cfg.feishu.expect("feishu section");
+        assert_eq!(fe.app_id.as_deref(), Some("cli_xxx"));
+        assert_eq!(fe.connection_mode.as_deref(), Some("webhook"));
+        assert_eq!(fe.encrypt_key.as_deref(), Some("ek"));
+        assert_eq!(fe.max_bot_turns, Some(5));
+        assert_eq!(fe.card_streaming_mode.as_deref(), Some("post"));
     }
 
     #[test]

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -1284,7 +1284,11 @@ impl FeishuConfig {
         );
         put(&mut m, "FEISHU_ENCRYPT_KEY", self.encrypt_key.clone());
         put(&mut m, "FEISHU_DOMAIN", self.domain.clone());
-        put(&mut m, "FEISHU_CONNECTION_MODE", self.connection_mode.clone());
+        put(
+            &mut m,
+            "FEISHU_CONNECTION_MODE",
+            self.connection_mode.clone(),
+        );
         put(&mut m, "FEISHU_WEBHOOK_PATH", self.webhook_path.clone());
         put_list(&mut m, "FEISHU_ALLOWED_GROUPS", csv(&self.allowed_groups));
         put_list(&mut m, "FEISHU_ALLOWED_USERS", csv(&self.allowed_users));

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -1252,64 +1252,91 @@ impl FeishuConfig {
     /// result feeds the gateway adapter's `from_reader`, keeping its parsing
     /// and defaults as the single source of truth.
     pub fn resolve_pairs(&self) -> std::collections::HashMap<String, String> {
-        let mut m = std::collections::HashMap::new();
-        let mut put = |key: &str, v: Option<String>| {
+        type Pairs = std::collections::HashMap<String, String>;
+        // String fields: empty string = `${UNSET}` expansion → fall through to
+        // env (same rule as every other platform section).
+        fn put(m: &mut Pairs, key: &str, v: Option<String>) {
             let v = v
                 .filter(|s| !s.is_empty())
                 .or_else(|| std::env::var(key).ok());
             if let Some(v) = v {
                 m.insert(key.to_string(), v);
             }
-        };
+        }
+        // List fields: `Some(vec![])` is an explicit empty list and must
+        // OVERRIDE the env var (deny-all semantics, matching `trust_config()`
+        // and the other sections' `allowed_users`), so no empty-filter here —
+        // `from_reader` splits "" into an empty vec.
+        fn put_list(m: &mut Pairs, key: &str, v: Option<String>) {
+            let v = v.or_else(|| std::env::var(key).ok());
+            if let Some(v) = v {
+                m.insert(key.to_string(), v);
+            }
+        }
         let csv = |v: &Option<Vec<String>>| v.as_ref().map(|l| l.join(","));
-        put("FEISHU_APP_ID", self.app_id.clone());
-        put("FEISHU_APP_SECRET", self.app_secret.clone());
-        put("FEISHU_VERIFICATION_TOKEN", self.verification_token.clone());
-        put("FEISHU_ENCRYPT_KEY", self.encrypt_key.clone());
-        put("FEISHU_DOMAIN", self.domain.clone());
-        put("FEISHU_CONNECTION_MODE", self.connection_mode.clone());
-        put("FEISHU_WEBHOOK_PATH", self.webhook_path.clone());
-        put("FEISHU_ALLOWED_GROUPS", csv(&self.allowed_groups));
-        put("FEISHU_ALLOWED_USERS", csv(&self.allowed_users));
+        let mut m = Pairs::new();
+        put(&mut m, "FEISHU_APP_ID", self.app_id.clone());
+        put(&mut m, "FEISHU_APP_SECRET", self.app_secret.clone());
         put(
+            &mut m,
+            "FEISHU_VERIFICATION_TOKEN",
+            self.verification_token.clone(),
+        );
+        put(&mut m, "FEISHU_ENCRYPT_KEY", self.encrypt_key.clone());
+        put(&mut m, "FEISHU_DOMAIN", self.domain.clone());
+        put(&mut m, "FEISHU_CONNECTION_MODE", self.connection_mode.clone());
+        put(&mut m, "FEISHU_WEBHOOK_PATH", self.webhook_path.clone());
+        put_list(&mut m, "FEISHU_ALLOWED_GROUPS", csv(&self.allowed_groups));
+        put_list(&mut m, "FEISHU_ALLOWED_USERS", csv(&self.allowed_users));
+        put(
+            &mut m,
             "FEISHU_REQUIRE_MENTION",
             self.require_mention.map(|b| b.to_string()),
         );
-        put("FEISHU_ALLOW_BOTS", self.allow_bots.clone());
+        put(&mut m, "FEISHU_ALLOW_BOTS", self.allow_bots.clone());
         put(
+            &mut m,
             "FEISHU_ALLOW_USER_MESSAGES",
             self.allow_user_messages.clone(),
         );
-        put("FEISHU_TRUSTED_BOT_IDS", csv(&self.trusted_bot_ids));
+        put_list(&mut m, "FEISHU_TRUSTED_BOT_IDS", csv(&self.trusted_bot_ids));
         put(
+            &mut m,
             "FEISHU_MAX_BOT_TURNS",
             self.max_bot_turns.map(|v| v.to_string()),
         );
         put(
+            &mut m,
             "FEISHU_DEDUPE_TTL_SECS",
             self.dedupe_ttl_secs.map(|v| v.to_string()),
         );
         put(
+            &mut m,
             "FEISHU_MESSAGE_LIMIT",
             self.message_limit.map(|v| v.to_string()),
         );
         put(
+            &mut m,
             "FEISHU_SESSION_TTL_HOURS",
             self.session_ttl_hours.map(|v| v.to_string()),
         );
         put(
+            &mut m,
             "FEISHU_CARD_STREAMING_MODE",
             self.card_streaming_mode.clone(),
         );
         put(
+            &mut m,
             "FEISHU_CARD_FALLBACK_TO_POST",
             self.card_fallback_to_post.map(|b| b.to_string()),
         );
         put(
+            &mut m,
             "FEISHU_CARD_PROMOTE_BYTES",
             self.card_promote_bytes.map(|v| v.to_string()),
         );
         put(
+            &mut m,
             "FEISHU_CARD_IDLE_FINALIZE_MS",
             self.card_idle_finalize_ms.map(|v| v.to_string()),
         );
@@ -2771,7 +2798,30 @@ allowed_users = ["U1234567890abcdef0123456789abcdef"]
     /// All `FEISHU_*` env scenarios in ONE test (env is process-global).
     #[test]
     fn feishu_resolve_pairs_scenarios() {
-        for k in ["FEISHU_APP_ID", "FEISHU_DOMAIN", "FEISHU_ALLOWED_USERS"] {
+        const ALL_FEISHU_KEYS: [&str; 21] = [
+            "FEISHU_APP_ID",
+            "FEISHU_APP_SECRET",
+            "FEISHU_VERIFICATION_TOKEN",
+            "FEISHU_ENCRYPT_KEY",
+            "FEISHU_DOMAIN",
+            "FEISHU_CONNECTION_MODE",
+            "FEISHU_WEBHOOK_PATH",
+            "FEISHU_ALLOWED_GROUPS",
+            "FEISHU_ALLOWED_USERS",
+            "FEISHU_REQUIRE_MENTION",
+            "FEISHU_ALLOW_BOTS",
+            "FEISHU_ALLOW_USER_MESSAGES",
+            "FEISHU_TRUSTED_BOT_IDS",
+            "FEISHU_MAX_BOT_TURNS",
+            "FEISHU_DEDUPE_TTL_SECS",
+            "FEISHU_MESSAGE_LIMIT",
+            "FEISHU_SESSION_TTL_HOURS",
+            "FEISHU_CARD_STREAMING_MODE",
+            "FEISHU_CARD_FALLBACK_TO_POST",
+            "FEISHU_CARD_PROMOTE_BYTES",
+            "FEISHU_CARD_IDLE_FINALIZE_MS",
+        ];
+        for k in ALL_FEISHU_KEYS {
             std::env::remove_var(k);
         }
         // --- nothing set → keys absent (adapter from_reader applies defaults) ---
@@ -2803,6 +2853,21 @@ allowed_users = ["U1234567890abcdef0123456789abcdef"]
         };
         assert_eq!(cfg.resolve_pairs().get("FEISHU_APP_ID").unwrap(), "env-app");
 
+        // --- F3 regression (#1385 review): explicit empty list OVERRIDES the
+        //     env var — Some(vec![]) renders "" which from_reader splits into
+        //     an empty vec (deny-all), instead of falling through to env ---
+        std::env::set_var("FEISHU_ALLOWED_USERS", "ou_env");
+        let cfg = FeishuConfig {
+            allowed_users: Some(vec![]),
+            ..Default::default()
+        };
+        let m = cfg.resolve_pairs();
+        assert_eq!(m.get("FEISHU_ALLOWED_USERS").unwrap(), "");
+        // …while an absent list still falls through to env:
+        let m = FeishuConfig::default().resolve_pairs();
+        assert_eq!(m.get("FEISHU_ALLOWED_USERS").unwrap(), "ou_env");
+        std::env::remove_var("FEISHU_ALLOWED_USERS");
+
         // --- trust_config() view ---
         let cfg = FeishuConfig {
             allow_all_users: Some(true),
@@ -2813,8 +2878,9 @@ allowed_users = ["U1234567890abcdef0123456789abcdef"]
         assert_eq!(t.allow_all_users, Some(true));
         assert_eq!(t.allowed_users.as_deref(), Some(&["ou_x".to_string()][..]));
 
-        std::env::remove_var("FEISHU_APP_ID");
-        std::env::remove_var("FEISHU_DOMAIN");
+        for k in ALL_FEISHU_KEYS {
+            std::env::remove_var(k);
+        }
     }
 
     #[test]

--- a/crates/openab-gateway/src/adapters/feishu.rs
+++ b/crates/openab-gateway/src/adapters/feishu.rs
@@ -173,32 +173,48 @@ impl FeishuConfig {
     /// Build config from environment variables. Returns None if FEISHU_APP_ID
     /// is not set (adapter disabled).
     pub fn from_env() -> Option<Self> {
-        let app_id = std::env::var("FEISHU_APP_ID").ok()?;
-        let app_secret = std::env::var("FEISHU_APP_SECRET").ok().unwrap_or_default();
+        Self::from_reader(|k| std::env::var(k).ok())
+    }
+
+    /// Build config from an arbitrary string reader (#1377) — shared by
+    /// env-derived construction and `apply_feishu_config`, so parsing rules
+    /// and defaults live in exactly one place.
+    pub(crate) fn from_reader<F: Fn(&str) -> Option<String>>(read: F) -> Option<Self> {
+        let app_id = read("FEISHU_APP_ID")?;
+        let app_secret = read("FEISHU_APP_SECRET").unwrap_or_default();
         if app_secret.is_empty() {
             warn!("FEISHU_APP_ID set but FEISHU_APP_SECRET is empty");
             return None;
         }
-        let domain = std::env::var("FEISHU_DOMAIN").unwrap_or_else(|_| "feishu".into());
-        let connection_mode = match std::env::var("FEISHU_CONNECTION_MODE")
-            .unwrap_or_else(|_| "websocket".into())
+        let domain = read("FEISHU_DOMAIN").unwrap_or_else(|| "feishu".into());
+        let connection_mode = match read("FEISHU_CONNECTION_MODE")
+            .unwrap_or_else(|| "websocket".into())
             .to_lowercase()
             .as_str()
         {
             "webhook" => ConnectionMode::Webhook,
             _ => ConnectionMode::Websocket,
         };
-        let webhook_path = std::env::var("FEISHU_WEBHOOK_PATH")
-            .unwrap_or_else(|_| "/webhook/feishu".into());
-        let verification_token = std::env::var("FEISHU_VERIFICATION_TOKEN").ok();
-        let encrypt_key = std::env::var("FEISHU_ENCRYPT_KEY").ok();
-        let allowed_groups = parse_csv("FEISHU_ALLOWED_GROUPS");
-        let allowed_users = parse_csv("FEISHU_ALLOWED_USERS");
-        let require_mention = std::env::var("FEISHU_REQUIRE_MENTION")
+        let webhook_path = read("FEISHU_WEBHOOK_PATH").unwrap_or_else(|| "/webhook/feishu".into());
+        let verification_token = read("FEISHU_VERIFICATION_TOKEN");
+        let encrypt_key = read("FEISHU_ENCRYPT_KEY");
+        let allowed_groups = read("FEISHU_ALLOWED_GROUPS")
+            .unwrap_or_default()
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        let allowed_users = read("FEISHU_ALLOWED_USERS")
+            .unwrap_or_default()
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        let require_mention = read("FEISHU_REQUIRE_MENTION")
             .map(|v| v != "false" && v != "0")
             .unwrap_or(true);
-        let allow_bots = match std::env::var("FEISHU_ALLOW_BOTS")
-            .unwrap_or_else(|_| "off".into())
+        let allow_bots = match read("FEISHU_ALLOW_BOTS")
+            .unwrap_or_else(|| "off".into())
             .to_lowercase()
             .as_str()
         {
@@ -206,9 +222,14 @@ impl FeishuConfig {
             "all" => AllowBots::All,
             _ => AllowBots::Off,
         };
-        let trusted_bot_ids = parse_csv("FEISHU_TRUSTED_BOT_IDS");
-        let allow_user_messages = match std::env::var("FEISHU_ALLOW_USER_MESSAGES")
-            .unwrap_or_else(|_| "multibot_mentions".into())
+        let trusted_bot_ids = read("FEISHU_TRUSTED_BOT_IDS")
+            .unwrap_or_default()
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        let allow_user_messages = match read("FEISHU_ALLOW_USER_MESSAGES")
+            .unwrap_or_else(|| "multibot_mentions".into())
             .to_lowercase()
             .replace('-', "_")
             .as_str()
@@ -217,20 +238,16 @@ impl FeishuConfig {
             "mentions" => AllowUsers::Mentions,
             _ => AllowUsers::MultibotMentions,
         };
-        let max_bot_turns = std::env::var("FEISHU_MAX_BOT_TURNS")
-            .ok()
+        let max_bot_turns = read("FEISHU_MAX_BOT_TURNS")
             .and_then(|v| v.parse().ok())
             .unwrap_or(20);
-        let dedupe_ttl_secs = std::env::var("FEISHU_DEDUPE_TTL_SECS")
-            .ok()
+        let dedupe_ttl_secs = read("FEISHU_DEDUPE_TTL_SECS")
             .and_then(|v| v.parse().ok())
             .unwrap_or(300);
-        let message_limit = std::env::var("FEISHU_MESSAGE_LIMIT")
-            .ok()
+        let message_limit = read("FEISHU_MESSAGE_LIMIT")
             .and_then(|v| v.parse().ok())
             .unwrap_or(4000);
-        let session_ttl_secs = std::env::var("FEISHU_SESSION_TTL_HOURS")
-            .ok()
+        let session_ttl_secs = read("FEISHU_SESSION_TTL_HOURS")
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(24)
             * 3600;
@@ -239,20 +256,17 @@ impl FeishuConfig {
         // is unset or empty, card streaming is on in auto mode (short → post,
         // long / code / table → card). FEISHU_CARD_STREAMING_MODE=post is the
         // no-recompile kill-switch back to today's post-only behavior. ---
-        let streaming_mode = std::env::var("FEISHU_CARD_STREAMING_MODE")
-            .ok()
+        let streaming_mode = read("FEISHU_CARD_STREAMING_MODE")
             .filter(|v| !v.trim().is_empty())
             .map(|v| StreamingMode::parse(&v))
             .unwrap_or_default();
-        let card_fallback_to_post = std::env::var("FEISHU_CARD_FALLBACK_TO_POST")
+        let card_fallback_to_post = read("FEISHU_CARD_FALLBACK_TO_POST")
             .map(|v| v != "false" && v != "0")
             .unwrap_or(true);
-        let card_promote_bytes = std::env::var("FEISHU_CARD_PROMOTE_BYTES")
-            .ok()
+        let card_promote_bytes = read("FEISHU_CARD_PROMOTE_BYTES")
             .and_then(|v| v.parse().ok())
             .unwrap_or(4000);
-        let card_idle_finalize_ms = std::env::var("FEISHU_CARD_IDLE_FINALIZE_MS")
-            .ok()
+        let card_idle_finalize_ms = read("FEISHU_CARD_IDLE_FINALIZE_MS")
             .and_then(|v| v.parse().ok())
             .unwrap_or(3000);
 
@@ -293,15 +307,6 @@ impl FeishuConfig {
             "https://open.feishu.cn".into()
         }
     }
-}
-
-fn parse_csv(var: &str) -> Vec<String> {
-    std::env::var(var)
-        .unwrap_or_default()
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -385,6 +385,17 @@ impl AppState {
         })
         .map(adapters::teams::TeamsAdapter::new);
     }
+
+    /// Apply resolved `[feishu]` config values (#1377), rebuilding the
+    /// adapter through the same `from_reader` construction as env-only
+    /// startup (app_id + app_secret mandatory; incomplete section disables
+    /// the adapter). Call before [`AppState::warn_unenforceable_l1`] so a
+    /// config-supplied `encrypt_key` is not falsely flagged.
+    #[cfg(feature = "feishu")]
+    pub fn apply_feishu_config(&mut self, cfg: GatewayFeishuConfig) {
+        self.feishu = adapters::feishu::FeishuConfig::from_reader(|k| cfg.pairs.get(k).cloned())
+            .map(adapters::feishu::FeishuAdapter::new);
+    }
 }
 
 /// Parameter object for passing resolved Telegram config across the crate
@@ -444,6 +455,15 @@ pub struct GatewayTeamsConfig {
     pub oauth_endpoint: String,
     pub openid_metadata: String,
     pub webhook_path: String,
+}
+
+/// Parameter object for passing resolved Feishu config across the crate
+/// boundary without introducing a dependency on `openab-core` (#1377).
+/// Carries the config-first key/value pairs in env-var string form; the
+/// adapter's `from_reader` performs all parsing and default resolution.
+#[derive(Debug, Clone)]
+pub struct GatewayFeishuConfig {
+    pub pairs: std::collections::HashMap<String, String>,
 }
 
 // --- Public serve() entry point ---
@@ -967,6 +987,39 @@ mod l1_audit_tests {
         // channel secret present → L1 enforced
         s.line_channel_secret = Some("csecret".into());
         assert!(flagged(&s).is_empty());
+    }
+
+    #[cfg(feature = "feishu")]
+    #[test]
+    fn apply_feishu_config_requires_credentials() {
+        use super::GatewayFeishuConfig;
+        use std::collections::HashMap;
+        let mut s = state();
+        // Complete credentials → adapter built via the shared from_reader.
+        let mut pairs = HashMap::new();
+        pairs.insert("FEISHU_APP_ID".to_string(), "cli_x".to_string());
+        pairs.insert("FEISHU_APP_SECRET".to_string(), "sec".to_string());
+        pairs.insert("FEISHU_CONNECTION_MODE".to_string(), "webhook".to_string());
+        pairs.insert("FEISHU_ENCRYPT_KEY".to_string(), "ek".to_string());
+        s.apply_feishu_config(GatewayFeishuConfig {
+            pairs: pairs.clone(),
+        });
+        assert!(s.feishu.is_some());
+        let cfg = &s.feishu.as_ref().unwrap().config;
+        assert_eq!(cfg.app_id, "cli_x");
+        assert!(matches!(
+            cfg.connection_mode,
+            super::adapters::feishu::ConnectionMode::Webhook
+        ));
+        assert_eq!(cfg.encrypt_key.as_deref(), Some("ek"));
+        // Config-supplied encrypt_key satisfies the L1 startup check
+        // when the webhook route is exposed.
+        assert!(s.unenforceable_l1(true).is_empty());
+
+        // Missing secret → adapter disabled.
+        pairs.remove("FEISHU_APP_SECRET");
+        s.apply_feishu_config(GatewayFeishuConfig { pairs });
+        assert!(s.feishu.is_none());
     }
 
     #[cfg(feature = "teams")]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -239,6 +239,38 @@ allowed_users = ["29:1abc..."]
 
 ---
 
+## `[feishu]`
+
+Full first-class Feishu/Lark section (config-first parity, #1377) — credentials, connection, behavior, and L3 identity trust. Each field resolves: config → `FEISHU_*` env → default. `app_id` + `app_secret` are mandatory (after env fallback); an incomplete section disables the adapter. The gateway adapter's parser remains the single source of truth — the section renders into the same form the env vars use, so defaults and enum rules cannot diverge.
+
+| Key | Type | Default | Env |
+|-----|------|---------|-----|
+| `app_id` / `app_secret` | string | — (mandatory) | `FEISHU_APP_ID` / `FEISHU_APP_SECRET` |
+| `verification_token` | string | — | `FEISHU_VERIFICATION_TOKEN` |
+| `encrypt_key` | string | — (enables webhook signature, L1) | `FEISHU_ENCRYPT_KEY` |
+| `domain` | string | `feishu` (`feishu`\|`lark`) | `FEISHU_DOMAIN` |
+| `connection_mode` | string | `websocket` (`websocket`\|`webhook`) | `FEISHU_CONNECTION_MODE` |
+| `webhook_path` | string | `/webhook/feishu` | `FEISHU_WEBHOOK_PATH` |
+| `allowed_users` | string[] | `[]` (open_ids — per-app!) | `FEISHU_ALLOWED_USERS` |
+| `allowed_groups` | string[] | `[]` | `FEISHU_ALLOWED_GROUPS` |
+| `trusted_bot_ids` | string[] | `[]` | `FEISHU_TRUSTED_BOT_IDS` |
+| `require_mention` | bool | `true` | `FEISHU_REQUIRE_MENTION` |
+| `allow_bots` | string | `off` (`off`\|`mentions`\|`all`) | `FEISHU_ALLOW_BOTS` |
+| `allow_user_messages` | string | `multibot_mentions` | `FEISHU_ALLOW_USER_MESSAGES` |
+| `max_bot_turns` | u32 | `20` | `FEISHU_MAX_BOT_TURNS` |
+| `dedupe_ttl_secs` | u64 | `300` | `FEISHU_DEDUPE_TTL_SECS` |
+| `message_limit` | u64 | `4000` | `FEISHU_MESSAGE_LIMIT` |
+| `session_ttl_hours` | u64 | `24` (`0` disables) | `FEISHU_SESSION_TTL_HOURS` |
+| `card_streaming_mode` | string | `auto` (`auto`\|`post`\|`card`) | `FEISHU_CARD_STREAMING_MODE` |
+| `card_fallback_to_post` | bool | `true` | `FEISHU_CARD_FALLBACK_TO_POST` |
+| `card_promote_bytes` | u64 | `4000` | `FEISHU_CARD_PROMOTE_BYTES` |
+| `card_idle_finalize_ms` | u64 | `3000` | `FEISHU_CARD_IDLE_FINALIZE_MS` |
+| `allow_all_users` | bool \| omit | `false` (deny-all at the shared L3 gate) | `FEISHU_ALLOW_ALL_USERS` |
+
+> The `[feishu]` section also feeds the shared trust registry (feishu was the last platform on the uniform `GATEWAY_*` seed). The gateway-side `allowed_users`/`allowed_groups` double-gate elimination is tracked on #1357.
+
+---
+
 ## `[agent]`
 
 The AI agent subprocess that OpenAB spawns to handle messages via ACP.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -256,7 +256,7 @@ Full first-class Feishu/Lark section (config-first parity, #1377) — credential
 | `trusted_bot_ids` | string[] | `[]` | `FEISHU_TRUSTED_BOT_IDS` |
 | `require_mention` | bool | `true` | `FEISHU_REQUIRE_MENTION` |
 | `allow_bots` | string | `off` (`off`\|`mentions`\|`all`) | `FEISHU_ALLOW_BOTS` |
-| `allow_user_messages` | string | `multibot_mentions` | `FEISHU_ALLOW_USER_MESSAGES` |
+| `allow_user_messages` | string | `multibot_mentions` (`multibot_mentions`\|`mentions`\|`involved`) | `FEISHU_ALLOW_USER_MESSAGES` |
 | `max_bot_turns` | u32 | `20` | `FEISHU_MAX_BOT_TURNS` |
 | `dedupe_ttl_secs` | u64 | `300` | `FEISHU_DEDUPE_TTL_SECS` |
 | `message_limit` | u64 | `4000` | `FEISHU_MESSAGE_LIMIT` |

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -34,6 +34,21 @@ Set `FEISHU_APP_ID` (and related platform env vars) on the container. No `[gatew
 
 Connect OpenAB to Feishu (China) or Lark (international) so users can chat with an AI agent in DMs or group chats.
 
+## `[feishu]` Section (config-first)
+
+Since #1377 all Feishu settings can live in a first-class `[feishu]` section — config-first with `FEISHU_*` env fallback:
+
+```toml
+[feishu]
+app_id     = "${FEISHU_APP_ID}"
+app_secret = "${FEISHU_APP_SECRET}"
+encrypt_key = "${FEISHU_ENCRYPT_KEY}"   # enables webhook signature verification (L1)
+connection_mode = "websocket"           # default; "webhook" for HTTP callback mode
+allowed_users = ["ou_xxxx"]             # open_id allowlist (note: open_id is per-app)
+```
+
+See [config-reference.md](config-reference.md#feishu) for the full field table.
+
 ## Prerequisites
 
 1. Create a Feishu/Lark app at [open.feishu.cn](https://open.feishu.cn/) or [open.larksuite.com](https://open.larksuite.com/).

--- a/src/main.rs
+++ b/src/main.rs
@@ -540,6 +540,15 @@ async fn main() -> anyhow::Result<()> {
             allow_all_channels,
             &allowed_channels,
         );
+        platform_trust_override(
+            &mut reg,
+            "feishu",
+            &cfg.feishu.as_ref().map(|f| f.trust_config()),
+            "FEISHU",
+            cfg!(feature = "feishu") && std::env::var("FEISHU_APP_ID").is_ok(),
+            allow_all_channels,
+            &allowed_channels,
+        );
         reg
     };
 
@@ -930,6 +939,16 @@ async fn main() -> anyhow::Result<()> {
                     webhook_path: r.webhook_path,
                 });
             }
+            // First-class `[feishu]` config overrides env-derived values
+            // (config-authoritative + ${} expansion + FEISHU_* env fallback,
+            // #1377). Applied before warn_unenforceable_l1 so a
+            // config-supplied encrypt_key is not falsely flagged.
+            #[cfg(feature = "feishu")]
+            if let Some(ref fe) = cfg.feishu {
+                gw_state_inner.apply_feishu_config(openab_gateway::GatewayFeishuConfig {
+                    pairs: fe.resolve_pairs(),
+                });
+            }
             let gw_state = Arc::new(gw_state_inner);
 
             // Phase 1 L1 audit (#1356): warn if any active webhook platform has
@@ -976,8 +995,11 @@ async fn main() -> anyhow::Result<()> {
                 // (default: websocket) work only because of this mount, so
                 // gating it is a behavior change that needs its own
                 // deprecation path — tracked on #1356, not changed here.
-                let path = std::env::var("FEISHU_WEBHOOK_PATH")
-                    .unwrap_or_else(|_| "/webhook/feishu".into());
+                let path = gw_state
+                    .feishu
+                    .as_ref()
+                    .map(|f| f.config.webhook_path.clone())
+                    .unwrap_or_else(|| "/webhook/feishu".into());
                 info!(path = %path, "unified: feishu adapter enabled");
                 app = app.route(
                     &path,


### PR DESCRIPTION
## What problem does this solve?

Final platform slice of the config-first parity umbrella #1375: Feishu was the only platform with **no config section at all** — 21 settings were env-only. The new `[feishu]` section covers credentials, connection, behavior, and L3 identity trust, resolving each field **config → `FEISHU_*` env → default**.

## How It Works

**Single source of truth design**: the gateway adapter's parser keeps all parsing rules and defaults. `FeishuConfig::from_env` is refactored onto a `from_reader`, and the core section's `resolve_pairs()` renders typed TOML fields into the same string form the env vars use — no default value or enum rule is duplicated between crates (with 21 fields, duplicated defaults would drift).

| Layer | Change |
|-------|--------|
| core | `FeishuConfig` (21 typed fields) + `resolve_pairs()` + `trust_config()` view |
| gateway | `from_reader` refactor (`parse_csv` inlined through the reader); `GatewayFeishuConfig` bridge + `apply_feishu_config()` — `app_id`+`app_secret` mandatory, incomplete section disables the adapter |
| unified | Applies `[feishu]` before `warn_unenforceable_l1` (config-supplied `encrypt_key` satisfies the #1373 L1 check — test-pinned); **feishu joins the per-platform trust registry override** — it was the last platform riding the uniform `GATEWAY_*` seed (the registry half of #1357; gateway-side double-gate elimination stays there); webhook mount honors the resolved path |
| docs | example (full commented block), config-reference (21-field table), feishu.md |

## Tests

- `feishu_resolve_pairs_scenarios` — absent keys passthrough, config-wins-over-env, typed→string rendering (bool/u32/CSV), empty-string `${}` fallthrough, `trust_config()`
- `feishu_section_parses_from_toml` — TOML parse of typed fields
- `apply_feishu_config_requires_credentials` — adapter built via shared `from_reader` (connection_mode/encrypt_key verified), config-supplied `encrypt_key` clears the L1 flag, missing secret disables

## Validation

- clippy `-D warnings` clean (core+gateway all-features; gateway no-features); unified + default builds pass
- core 665 passed (1 known pre-existing macOS `secrets` failure); gateway 262/262
- rustfmt isolated: feishu.rs 93 vs baseline 94 (no new drift; one pre-existing diff incidentally fixed), other files 0→0

Closes #1377. Refs #1375 (umbrella — completes the platform matrix), #1357 (registry task), #1373.