### PR TITLE
fix(wecom): enable config-only unified startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,24 @@ fn has_unified_platform_env() -> bool {
                 .unwrap_or(false))
 }
 
+/// Returns true when the first-class `[wecom]` section resolves all credentials
+/// required to construct the embedded WeCom adapter. This must remain separate
+/// from [`has_unified_platform_env`]: config-first deployments may intentionally
+/// provide literal or secret-substituted values without exporting `WECOM_*`.
+fn has_unified_wecom_config(cfg: &config::Config) -> bool {
+    if !cfg!(feature = "wecom") {
+        return false;
+    }
+    cfg.wecom.as_ref().is_some_and(|wecom| {
+        let resolved = wecom.resolve();
+        resolved.corp_id.is_some()
+            && resolved.secret.is_some()
+            && resolved.token.is_some()
+            && resolved.encoding_aes_key.is_some()
+            && resolved.agent_id.is_some()
+    })
+}
+
 /// Apply a platform's first-class trust section to the registry, or — when the
 /// platform is active but still trust-driven by the deprecated uniform
 /// `GATEWAY_ALLOW_ALL_USERS`/`GATEWAY_ALLOWED_USERS` env — log the Phase 1
@@ -267,9 +285,10 @@ async fn main() -> anyhow::Result<()> {
         && cfg.gateway.is_none()
         && cfg.telegram.is_none()
         && !has_unified_platform_env()
+        && !has_unified_wecom_config(&cfg)
     {
         anyhow::bail!(
-            "no adapter configured — add [discord], [slack], [telegram], or [gateway] to config, or set platform env vars (TELEGRAM_BOT_TOKEN, etc.)"
+            "no adapter configured — add [discord], [slack], [telegram], [wecom], or [gateway] to config, or set platform env vars (TELEGRAM_BOT_TOKEN, etc.)"
         );
     }
 
@@ -299,6 +318,18 @@ async fn main() -> anyhow::Result<()> {
         let substituted = secrets::substitute(&raw_expanded, &resolved);
         cfg = config::parse_config_str(&substituted, &config_source)?;
     }
+
+    // Compute before individual config fields are moved into their runtime
+    // components below. Secret-backed values have been substituted by now.
+    #[cfg(any(
+        feature = "telegram",
+        feature = "line",
+        feature = "feishu",
+        feature = "googlechat",
+        feature = "wecom",
+        feature = "teams",
+    ))]
+    let unified_wecom_configured = has_unified_wecom_config(&cfg);
 
     let shutdown_hook = cfg.hooks.pre_shutdown.clone();
 
@@ -846,7 +877,7 @@ async fn main() -> anyhow::Result<()> {
     let (_unified_handle, shared_unified_adapter) = {
         use openab_core::gateway::{process_gateway_event, GatewayEventContext};
 
-        if has_unified_platform_env() || cfg.telegram.is_some() {
+        if has_unified_platform_env() || cfg.telegram.is_some() || unified_wecom_configured {
             let listen_addr =
                 std::env::var("GATEWAY_LISTEN").unwrap_or_else(|_| "0.0.0.0:8080".into());
 
@@ -1501,5 +1532,23 @@ mod tests {
 
         // Cleanup
         clear_all();
+    }
+
+    #[test]
+    fn complete_wecom_section_enables_unified_startup_without_env() {
+        let cfg = config::parse_config_str(
+            r#"
+[wecom]
+corp_id = "ww1234567890abcdef"
+secret = "test-secret"
+token = "test-token"
+encoding_aes_key = "abcdefghijklmnopqrstuvwxyzABCDEFGH123456789"
+agent_id = "1000002"
+"#,
+            "test",
+        )
+        .unwrap();
+
+        assert_eq!(has_unified_wecom_config(&cfg), cfg!(feature = "wecom"));
     }
 }


### PR DESCRIPTION
## Summary

- recognize a complete first-class `[wecom]` section during no-adapter startup validation
- start the embedded unified gateway when WeCom credentials resolve from config without `WECOM_CORP_ID` being exported
- evaluate activation after secret substitution and before config fields are moved into runtime components
- add a regression test for config-only WeCom activation

## Root cause

#1382 made every WeCom field resolve `config -> WECOM_* env -> default`, but the outer startup gates still relied on `has_unified_platform_env()`. A literal or secret-substituted `[wecom]` section was therefore rejected before `apply_wecom_config()` could construct the adapter.

The new helper requires all five credentials needed by the WeCom adapter after config/env resolution, so incomplete sections do not become an activation signal.

## Validation

- `cargo clippy -- -D warnings`
- `cargo clippy --features unified -- -D warnings`
- `cargo test`
- `cargo test --features unified`
- config-only startup smoke with all `WECOM_*` variables unset: adapter configured, `/webhook/wecom` mounted, server listening, graceful shutdown successful
- changed hunks are rustfmt-clean; repository-wide `cargo fmt --all -- --check` remains blocked by pre-existing formatting drift across unrelated files

Closes #1388.

## Context

- [Discord discussion](https://discord.com/channels/1491295327620169908/1491365158868619404/1526200802824421486)