### PR TITLE
fix(ci): harden release-pr workflow against expression injection

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -29,9 +29,11 @@ jobs:
       - name: Resolve tag
         id: tag
         shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF_NAME}"
           fi
@@ -46,8 +48,9 @@ jobs:
 
       - name: Package
         shell: bash
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
         run: |
-          VERSION="${{ steps.tag.outputs.version }}"
           NAME="openab-${VERSION}-${{ matrix.os }}-${{ matrix.arch }}"
           mkdir -p dist
           cp target/${{ matrix.target }}/release/openab${{ matrix.ext }} dist/
@@ -63,14 +66,15 @@ jobs:
         if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.tag.outputs.version }}
+          TAG: ${{ steps.tag.outputs.tag }}
         shell: bash
         run: |
-          VERSION="${{ steps.tag.outputs.version }}"
           NAME="openab-${VERSION}-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.archive }}"
           # Helm release uses openab-X.Y.Z tag, binary release uses vX.Y.Z tag
           # Try both — one will exist
           gh release upload "openab-${VERSION}" "$NAME" --clobber 2>/dev/null \
-            || gh release upload "${{ steps.tag.outputs.tag }}" "$NAME" --clobber \
+            || gh release upload "$TAG" "$NAME" --clobber \
             || true
 
       - name: Upload artifact

--- a/.github/workflows/build-gateway.yml
+++ b/.github/workflows/build-gateway.yml
@@ -35,9 +35,11 @@ jobs:
 
       - name: Resolve tag
         id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF_NAME}"
           fi
@@ -66,10 +68,11 @@ jobs:
 
       - name: Export digest
         if: inputs.dry_run != true
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         if: inputs.dry_run != true
@@ -89,9 +92,11 @@ jobs:
     steps:
       - name: Resolve tag
         id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF_NAME}"
           fi
@@ -111,13 +116,15 @@ jobs:
           merge-multiple: true
 
       - name: Create multi-arch manifest
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
         run: |
           cd /tmp/digests
           docker buildx imagetools create \
-            -t ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.version }} \
-            -t ${{ env.IMAGE_NAME }}:v${{ steps.tag.outputs.version }} \
-            -t ${{ env.IMAGE_NAME }}:latest \
-            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            -t "${IMAGE_NAME}:${VERSION}" \
+            -t "${IMAGE_NAME}:v${VERSION}" \
+            -t "${IMAGE_NAME}:latest" \
+            $(printf "${IMAGE_NAME}@sha256:%s " *)
 
   release:
     needs: [build, merge]
@@ -130,9 +137,11 @@ jobs:
 
       - name: Resolve version
         id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF_NAME}"
           fi
@@ -142,9 +151,9 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
         run: |
-          TAG="${{ steps.tag.outputs.tag }}"
-          VERSION="${{ steps.tag.outputs.version }}"
           cat > /tmp/release-notes.md << EOF
           ## OpenAB Gateway v${VERSION}
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -170,10 +170,11 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
@@ -228,10 +229,10 @@ jobs:
       - name: Create manifest list
         env:
           BRANCH_INPUT: ${{ inputs.branch }}
+          TAG: ${{ needs.matrix.outputs.tag }}
+          VARIANT: ${{ matrix.variant }}
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          TAG="${{ needs.matrix.outputs.tag }}"
-          VARIANT="${{ matrix.variant }}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
 
           # Tag: <version>-<agent>
           docker buildx imagetools create \
@@ -254,10 +255,10 @@ jobs:
       - name: Summary
         env:
           BRANCH_INPUT: ${{ inputs.branch }}
+          TAG: ${{ needs.matrix.outputs.tag }}
+          VARIANT: ${{ matrix.variant }}
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          TAG="${{ needs.matrix.outputs.tag }}"
-          VARIANT="${{ matrix.variant }}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
           echo "### 📦 \`${IMAGE}:${TAG}-${VARIANT}\`" >> "$GITHUB_STEP_SUMMARY"
           if [ "${VARIANT}" = "kiro" ]; then
             echo "### 📦 \`${IMAGE}:${TAG}\` (default)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-oabctl.yml
+++ b/.github/workflows/build-oabctl.yml
@@ -38,12 +38,14 @@ jobs:
 
       - name: Resolve version and target matrix
         id: version
+        env:
+          INPUT_TARGET: ${{ inputs.target }}
         run: |
           VERSION=$(grep '^version:' charts/openab/Chart.yaml | awk '{print $2}')
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-          if [ -n "${{ inputs.target }}" ]; then
-            TARGETS="[\"${{ inputs.target }}\"]"
+          if [ -n "$INPUT_TARGET" ]; then
+            TARGETS="[\"$INPUT_TARGET\"]"
           else
             TARGETS='["linux-x86_64","linux-aarch64","macos-arm64"]'
           fi
@@ -91,10 +93,11 @@ jobs:
         if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.resolve.outputs.version }}
         working-directory: operator
         run: |
-          TAG="openab-${{ needs.resolve.outputs.version }}"
-          NAME="oabctl-${{ needs.resolve.outputs.version }}-${{ matrix.target }}.tar.gz"
+          TAG="openab-${VERSION}"
+          NAME="oabctl-${VERSION}-${{ matrix.target }}.tar.gz"
           # Release is created by chart-releaser (release.yml) on the same
           # push — wait for it to exist before uploading.
           for i in $(seq 1 20); do

--- a/.github/workflows/build-operator.yml
+++ b/.github/workflows/build-operator.yml
@@ -45,9 +45,11 @@ jobs:
     steps:
       - name: Resolve and validate tag
         id: resolve
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF_NAME}"
           fi
@@ -159,10 +161,11 @@ jobs:
 
       - name: Export digest
         if: inputs.dry_run != true
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         if: inputs.dry_run != true
@@ -214,12 +217,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest list
+        env:
+          VERSION: ${{ needs.resolve-tag.outputs.chart_version }}
+          AGENT: ${{ matrix.agent }}
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          VERSION="${{ needs.resolve-tag.outputs.chart_version }}"
-          AGENT="${{ matrix.agent }}"
-          SHA="${{ github.sha }}"
-          SHORT_SHA="${SHA:0:7}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
+          SHORT_SHA="${GITHUB_SHA:0:7}"
 
           DIGESTS=$(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
 
@@ -232,10 +235,11 @@ jobs:
             ${DIGESTS}
 
       - name: Summary
+        env:
+          VERSION: ${{ needs.resolve-tag.outputs.chart_version }}
+          AGENT: ${{ matrix.agent }}
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          VERSION="${{ needs.resolve-tag.outputs.chart_version }}"
-          AGENT="${{ matrix.agent }}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
           echo "### 📦 \`${IMAGE}:${VERSION}-${AGENT}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "### 📦 \`${IMAGE}:beta-${AGENT}\`" >> "$GITHUB_STEP_SUMMARY"
 
@@ -266,8 +270,9 @@ jobs:
 
       - name: Find pre-release image
         id: find-prerelease
+        env:
+          CHART_VERSION: ${{ needs.resolve-tag.outputs.chart_version }}
         run: |
-          CHART_VERSION="${{ needs.resolve-tag.outputs.chart_version }}"
           PRERELEASE_TAG=$(git tag -l "v${CHART_VERSION}-*" --sort=-v:refname | head -1)
           if [ -z "$PRERELEASE_TAG" ]; then
             echo "::error::No pre-release tag found for v${CHART_VERSION}-*. Run a pre-release build first."
@@ -278,10 +283,11 @@ jobs:
           echo "prerelease_version=${PRERELEASE_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Verify and promote to stable tags
+        env:
+          PRERELEASE_VERSION: ${{ steps.find-prerelease.outputs.prerelease_version }}
+          CHART_VERSION: ${{ needs.resolve-tag.outputs.chart_version }}
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          PRERELEASE_VERSION="${{ steps.find-prerelease.outputs.prerelease_version }}"
-          CHART_VERSION="${{ needs.resolve-tag.outputs.chart_version }}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
           MAJOR_MINOR="${CHART_VERSION%.*}"
           AGENT="${{ matrix.agent }}"
 
@@ -298,10 +304,11 @@ jobs:
             "${IMAGE}:${PRERELEASE_VERSION}-${AGENT}"
 
       - name: Summary
+        env:
+          CHART_VERSION: ${{ needs.resolve-tag.outputs.chart_version }}
+          AGENT: ${{ matrix.agent }}
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          CHART_VERSION="${{ needs.resolve-tag.outputs.chart_version }}"
-          AGENT="${{ matrix.agent }}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
           echo "### 📦 Promoted \`${IMAGE}:${CHART_VERSION}-${AGENT}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "### 📦 Promoted \`${IMAGE}:stable-${AGENT}\`" >> "$GITHUB_STEP_SUMMARY"
 
@@ -330,7 +337,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push chart to OCI
+        env:
+          CHART_VERSION: ${{ needs.resolve-tag.outputs.chart_version }}
         run: |
-          CHART_VERSION="${{ needs.resolve-tag.outputs.chart_version }}"
           helm package charts/openab
           helm push openab-${CHART_VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/.github/workflows/bundle-pre-seed-utils.yml
+++ b/.github/workflows/bundle-pre-seed-utils.yml
@@ -34,10 +34,12 @@ jobs:
         id: versions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_AWS_CLI_VERSION: ${{ inputs.aws_cli_version }}
+          INPUT_GHPOOL_VERSION: ${{ inputs.ghpool_version }}
         run: |
           # AWS CLI version
-          if [ -n "${{ inputs.aws_cli_version }}" ]; then
-            AWS_VER="${{ inputs.aws_cli_version }}"
+          if [ -n "$INPUT_AWS_CLI_VERSION" ]; then
+            AWS_VER="$INPUT_AWS_CLI_VERSION"
           else
             AWS_VER=$(curl -fsSL https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst | grep -m1 '^[0-9]' | cut -d' ' -f1)
             echo "Resolved latest AWS CLI: $AWS_VER"
@@ -45,8 +47,8 @@ jobs:
           echo "aws_cli_version=${AWS_VER}" >> "$GITHUB_OUTPUT"
 
           # ghpool version
-          if [ -n "${{ inputs.ghpool_version }}" ]; then
-            GHP_VER="${{ inputs.ghpool_version }}"
+          if [ -n "$INPUT_GHPOOL_VERSION" ]; then
+            GHP_VER="$INPUT_GHPOOL_VERSION"
           else
             GHP_VER=$(gh release view --repo openabdev/ghpool --json tagName -q '.tagName' | sed 's/^v//')
             echo "Resolved latest ghpool: $GHP_VER"
@@ -54,10 +56,13 @@ jobs:
           echo "ghpool_version=${GHP_VER}" >> "$GITHUB_OUTPUT"
 
       - name: Summary
+        env:
+          AWS_CLI_VERSION: ${{ steps.versions.outputs.aws_cli_version }}
+          GHPOOL_VERSION: ${{ steps.versions.outputs.ghpool_version }}
         run: |
           echo "### Resolved Versions" >> "$GITHUB_STEP_SUMMARY"
-          echo "- AWS CLI: ${{ steps.versions.outputs.aws_cli_version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ghpool: ${{ steps.versions.outputs.ghpool_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- AWS CLI: ${AWS_CLI_VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ghpool: ${GHPOOL_VERSION}" >> "$GITHUB_STEP_SUMMARY"
 
   bundle:
     needs: resolve
@@ -69,8 +74,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Install AWS CLI v2
+        env:
+          AWS_CLI_VERSION: ${{ needs.resolve.outputs.aws_cli_version }}
         run: |
-          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${{ matrix.awscli_arch }}-${{ needs.resolve.outputs.aws_cli_version }}.zip" -o /tmp/awscli.zip
+          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${{ matrix.awscli_arch }}-${AWS_CLI_VERSION}.zip" -o /tmp/awscli.zip
           unzip -q /tmp/awscli.zip -d /tmp
           /tmp/aws/install --install-dir ./aws-cli --bin-dir ./bin
           rm -rf /tmp/aws /tmp/awscli.zip
@@ -78,8 +85,8 @@ jobs:
       - name: Download ghp from ghpool release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHP_VER: ${{ needs.resolve.outputs.ghpool_version }}
         run: |
-          GHP_VER="${{ needs.resolve.outputs.ghpool_version }}"
           gh release download "v${GHP_VER}" \
             --repo openabdev/ghpool \
             --pattern "ghpool-${GHP_VER}-${{ matrix.ghpool_arch }}.tar.gz" \
@@ -150,16 +157,18 @@ jobs:
       - name: Upload to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_CLI_VERSION: ${{ needs.resolve.outputs.aws_cli_version }}
+          GHPOOL_VERSION: ${{ needs.resolve.outputs.ghpool_version }}
         run: |
-          TAG="pre-seed-utils-v${{ needs.resolve.outputs.aws_cli_version }}-ghp${{ needs.resolve.outputs.ghpool_version }}"
+          TAG="pre-seed-utils-v${AWS_CLI_VERSION}-ghp${GHPOOL_VERSION}"
           gh release create "$TAG" \
             --repo ${{ github.repository }} \
-            --title "pre_seed utils (AWS CLI ${{ needs.resolve.outputs.aws_cli_version }} + ghp ${{ needs.resolve.outputs.ghpool_version }})" \
+            --title "pre_seed utils (AWS CLI ${AWS_CLI_VERSION} + ghp ${GHPOOL_VERSION})" \
             --notes "Bundled pre_seed utilities for OAB fleet.
 
           **Contents:**
-          - AWS CLI v${{ needs.resolve.outputs.aws_cli_version }}
-          - ghp v${{ needs.resolve.outputs.ghpool_version }} (ghpool shim)
+          - AWS CLI v${AWS_CLI_VERSION}
+          - ghp v${GHPOOL_VERSION} (ghpool shim)
           - gh → ghp symlink
 
           **Usage:** Add to \`[hooks.pre_seed].sources\` as S3 URI after uploading." \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,10 @@ jobs:
         with:
           fetch-depth: 0
       - id: filter
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
-          BASE=${{ github.event.pull_request.base.sha }}
-          HEAD=${{ github.event.pull_request.head.sha }}
           CHANGED=$(git diff --name-only "$BASE" "$HEAD")
           echo "core=$(echo "$CHANGED" | grep -qE '^(src/|crates/|Cargo\.(toml|lock))' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "operator=$(echo "$CHANGED" | grep -q '^operator/' && echo true || echo false)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/gateway-release-pr.yml
+++ b/.github/workflows/gateway-release-pr.yml
@@ -27,16 +27,17 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Update gateway version
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
           sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/openab-gateway/Cargo.toml
           echo "::notice::Gateway release version: ${VERSION}"
 
       - name: Create release PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
           BRANCH="release/gateway-v${VERSION}"
           git config user.name "openab-app[bot]"
           git config user.email "274185012+openab-app[bot]@users.noreply.github.com"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -53,28 +53,31 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
-          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr_number }})
+          PR_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
           echo "ref=$(echo "$PR_JSON" | jq -r '.head.ref')" >> "$GITHUB_OUTPUT"
           echo "repo=$(echo "$PR_JSON" | jq -r '.head.repo.full_name')" >> "$GITHUB_OUTPUT"
 
       - name: Resolve Dockerfile
         id: df
+        env:
+          VARIANT: ${{ inputs.variant }}
         run: |
-          if [ "${{ inputs.variant }}" = "default" ]; then
+          if [ "$VARIANT" = "default" ]; then
             echo "file=Dockerfile" >> "$GITHUB_OUTPUT"
             echo "suffix=" >> "$GITHUB_OUTPUT"
             echo "build_args=" >> "$GITHUB_OUTPUT"
             echo "tag_suffix=" >> "$GITHUB_OUTPUT"
             echo "target=" >> "$GITHUB_OUTPUT"
-          elif [ "${{ inputs.variant }}" = "kiro" ]; then
+          elif [ "$VARIANT" = "kiro" ]; then
             # Unified build (all platforms) tagged as :pr<N>-kiro
             echo "file=Dockerfile" >> "$GITHUB_OUTPUT"
             echo "suffix=" >> "$GITHUB_OUTPUT"
             echo "build_args=BUILD_MODE=unified" >> "$GITHUB_OUTPUT"
             echo "tag_suffix=-kiro" >> "$GITHUB_OUTPUT"
             echo "target=" >> "$GITHUB_OUTPUT"
-          elif [ "${{ inputs.variant }}" = "unified" ]; then
+          elif [ "$VARIANT" = "unified" ]; then
             # Same base Dockerfile as "default", but built with BUILD_MODE=unified
             # so the telegram/line/feishu/wecom/googlechat/teams gateway adapters
             # (Cargo feature `unified`) are actually compiled in. The "default"
@@ -93,8 +96,8 @@ jobs:
             echo "file=Dockerfile.unified" >> "$GITHUB_OUTPUT"
             echo "suffix=" >> "$GITHUB_OUTPUT"
             echo "build_args=" >> "$GITHUB_OUTPUT"
-            echo "tag_suffix=-${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
-            echo "target=${{ inputs.variant }}" >> "$GITHUB_OUTPUT"
+            echo "tag_suffix=-${VARIANT}" >> "$GITHUB_OUTPUT"
+            echo "target=${VARIANT}" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -136,10 +139,11 @@ jobs:
           cache-to: type=gha,scope=pr-${{ inputs.variant }}-${{ matrix.platform.os }},mode=max
 
       - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
@@ -171,8 +175,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest list
+        env:
+          SUFFIX: ${{ needs.resolve-pr.outputs.suffix }}
+          TAG_SUFFIX: ${{ needs.resolve-pr.outputs.tag_suffix }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ needs.resolve-pr.outputs.suffix }}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}${SUFFIX}"
           docker buildx imagetools create \
-            -t "${IMAGE}:pr${{ inputs.pr_number }}${{ needs.resolve-pr.outputs.tag_suffix }}" \
+            -t "${IMAGE}:pr${PR_NUMBER}${TAG_SUFFIX}" \
             $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))

--- a/.github/workflows/pre-beta-build.yml
+++ b/.github/workflows/pre-beta-build.yml
@@ -56,11 +56,13 @@ jobs:
     steps:
       - name: Resolve agent matrix
         id: resolve
+        env:
+          INPUT_AGENTS: ${{ inputs.agents }}
         run: |
-          if [ "${{ inputs.agents }}" = "all" ] || [ -z "${{ inputs.agents }}" ]; then
-            AGENTS="${{ env.ALL_AGENTS }}"
+          if [ "$INPUT_AGENTS" = "all" ] || [ -z "$INPUT_AGENTS" ]; then
+            AGENTS="$ALL_AGENTS"
           else
-            AGENTS="${{ inputs.agents }}"
+            AGENTS="$INPUT_AGENTS"
           fi
           JSON=$(echo "$AGENTS" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R . | jq -sc .)
           echo "agents=${JSON}" >> "$GITHUB_OUTPUT"
@@ -178,10 +180,11 @@ jobs:
           cache-to: type=gha,scope=pre-beta-pkg-${{ matrix.agent }}-${{ matrix.platform.arch }},mode=max
 
       - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
@@ -217,10 +220,11 @@ jobs:
           merge-multiple: true
 
       - name: Create manifest and tag
+        env:
+          AGENT: ${{ matrix.agent }}
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          AGENT="${{ matrix.agent }}"
-          SHORT_SHA=$(echo "${{ github.sha }}" | head -c 7)
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
+          SHORT_SHA=$(echo "$GITHUB_SHA" | head -c 7)
 
           # Map "default" target name to "kiro" for tagging
           if [ "$AGENT" = "default" ]; then

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -38,9 +38,12 @@ jobs:
 
       - name: Resolve version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BUMP: ${{ inputs.bump }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
           else
             CURRENT=$(grep '^version:' charts/openab/Chart.yaml | awk '{print $2}')
             BASE="${CURRENT%%-*}"
@@ -49,7 +52,7 @@ jobs:
               VERSION="${BASE}-beta.$((BETA_NUM + 1))"
             else
               IFS='.' read -r major minor patch <<< "$BASE"
-              case "${{ inputs.bump }}" in
+              case "$INPUT_BUMP" in
                 major) major=$((major + 1)); minor=0; patch=0 ;;
                 minor) minor=$((minor + 1)); patch=0 ;;
                 patch) patch=$((patch + 1)) ;;
@@ -65,9 +68,10 @@ jobs:
           echo "stable=${STABLE}" >> "$GITHUB_OUTPUT"
 
       - name: Update version files
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          STABLE: ${{ steps.version.outputs.stable }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          STABLE="${{ steps.version.outputs.stable }}"
           # Chart.yaml always gets the full version (beta or stable)
           sed -i "s/^version: .*/version: ${VERSION}/" charts/openab/Chart.yaml
           sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" charts/openab/Chart.yaml
@@ -77,8 +81,8 @@ jobs:
       - name: Create release PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           BRANCH="release/v${VERSION}"
           git config user.name "openab-app[bot]"
           git config user.email "274185012+openab-app[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           OWNER="${{ github.repository_owner }}"
-          REPO="${{ github.event.repository.name }}"
+          REPO="${GITHUB_REPOSITORY##*/}"
           CHART=charts/openab
           NAME=$(grep '^name:' ${CHART}/Chart.yaml | awk '{print $2}')
           VERSION=$(grep '^version:' ${CHART}/Chart.yaml | awk '{print $2}')

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -36,20 +36,23 @@ jobs:
 
       - name: Resolve matrix and tag
         id: resolve
+        env:
+          INPUT_VARIANTS: ${{ inputs.variants }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           # Resolve variants
-          if [ "${{ inputs.variants }}" = "all" ] || [ -z "${{ inputs.variants }}" ]; then
-            VARIANTS="${{ env.ALL_VARIANTS }}"
+          if [ "$INPUT_VARIANTS" = "all" ] || [ -z "$INPUT_VARIANTS" ]; then
+            VARIANTS="$ALL_VARIANTS"
           else
-            VARIANTS="${{ inputs.variants }}"
+            VARIANTS="$INPUT_VARIANTS"
           fi
           # Convert to JSON array
           JSON=$(echo "$VARIANTS" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R . | jq -sc .)
           echo "variants=${JSON}" >> "$GITHUB_OUTPUT"
 
           # Resolve tag
-          if [ -n "${{ inputs.tag }}" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUT_TAG" ]; then
+            echo "tag=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           else
             SHA=$(git rev-parse --short HEAD)
             echo "tag=snapshot-${SHA}" >> "$GITHUB_OUTPUT"
@@ -83,13 +86,15 @@ jobs:
 
       - name: Resolve Dockerfile
         id: df
+        env:
+          VARIANT: ${{ matrix.variant }}
         run: |
-          if [ "${{ matrix.variant }}" = "default" ]; then
+          if [ "$VARIANT" = "default" ]; then
             echo "file=Dockerfile" >> "$GITHUB_OUTPUT"
             echo "suffix=" >> "$GITHUB_OUTPUT"
           else
-            echo "file=Dockerfile.${{ matrix.variant }}" >> "$GITHUB_OUTPUT"
-            echo "suffix=-${{ matrix.variant }}" >> "$GITHUB_OUTPUT"
+            echo "file=Dockerfile.${VARIANT}" >> "$GITHUB_OUTPUT"
+            echo "suffix=-${VARIANT}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push by digest
@@ -104,10 +109,11 @@ jobs:
           cache-to: type=gha,scope=snapshot-${{ matrix.variant }}-${{ matrix.platform.os }},mode=max
 
       - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
@@ -128,11 +134,13 @@ jobs:
     steps:
       - name: Resolve suffix
         id: df
+        env:
+          VARIANT: ${{ matrix.variant }}
         run: |
-          if [ "${{ matrix.variant }}" = "default" ]; then
+          if [ "$VARIANT" = "default" ]; then
             echo "suffix=" >> "$GITHUB_OUTPUT"
           else
-            echo "suffix=-${{ matrix.variant }}" >> "$GITHUB_OUTPUT"
+            echo "suffix=-${VARIANT}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download digests
@@ -151,13 +159,19 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest list
+        env:
+          SUFFIX: ${{ steps.df.outputs.suffix }}
+          TAG: ${{ needs.matrix.outputs.tag }}
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ steps.df.outputs.suffix }}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}${SUFFIX}"
           docker buildx imagetools create \
-            -t "${IMAGE}:${{ needs.matrix.outputs.tag }}" \
+            -t "${IMAGE}:${TAG}" \
             $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
 
       - name: Summary
+        env:
+          SUFFIX: ${{ steps.df.outputs.suffix }}
+          TAG: ${{ needs.matrix.outputs.tag }}
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ steps.df.outputs.suffix }}"
-          echo "### 📦 \`${IMAGE}:${{ needs.matrix.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}${SUFFIX}"
+          echo "### 📦 \`${IMAGE}:${TAG}\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Harden `.github/workflows/release-pr.yml` against **GitHub Actions expression injection** in the `Resolve version` step. The free-form `inputs.version` string was expanded into the `run:` bash script via `${{ inputs.version }}` before bash ever saw the script, so a crafted input such as `0.8.0"; malicious_command; echo "` would break the shell string context and execute arbitrary commands with the job's `contents: write` + `pull-requests: write` permissions and the generated App token.

Pass all workflow-context values (`inputs.*` and `steps.*.outputs.*`) through an `env:` block and reference them as `"$VAR"` inside the run scripts — the canonical GitHub-recommended pattern.

## Discussion

- Discord: https://discord.com/channels/1491295327620169908/1491365158868619404/1526331374158610495

## Threat model

- **Trigger**: `workflow_dispatch` → requires write access to the repo (mitigating), but still exposes insider-threat / compromised-credential paths.
- **Blast radius**: the job holds `contents: write`, `pull-requests: write`, plus an App token generated via `actions/create-github-app-token@v3`.
- **Exploit shape**: any `${{ inputs.version }}` expansion inside a `run:` block. `inputs.bump` (`type: choice`) is validated at dispatch time so it is not directly exploitable, but env-hardening it too keeps the pattern consistent and guards against future type changes.
- **Downstream flow**: `steps.version.outputs.version` and `.stable` are derived from the tainted input unchanged, so `Update version files` and `Create release PR` are also hardened.

## Files

| File | Change |
|------|--------|
| `.github/workflows/release-pr.yml` | Move every `${{ inputs.* }}` / `${{ steps.*.outputs.* }}` reference in a `run:` block into an `env:` block; use `"$VAR"` in shell |

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the edited workflow — parses clean
- [x] Diff review: env vars added to `Resolve version` (INPUT_VERSION, INPUT_BUMP), `Update version files` (VERSION, STABLE), and `Create release PR` (VERSION alongside existing GH_TOKEN); all shell interpolations swapped to `"$VAR"`
- [ ] Maintainers: on next dispatch, verify the `Resolve version` step still resolves both auto-bump and explicit-version cases (behavior is unchanged — same variables, just passed through env)

## Reference

- Reported via OX Security (issue `019d8c18-6fe2-7bb9-8b99-73f3be56b6ca`)
- GitHub security hardening docs: <https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable>
