### PR TITLE
fix(ci): eliminate script injection in pending-decision.yml

### DIFF
--- a/.github/workflows/pending-decision.yml
+++ b/.github/workflows/pending-decision.yml
@@ -18,12 +18,15 @@ jobs:
       issues: write
     steps:
       - uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          DECISION: ${{ inputs.decision }}
         with:
           script: |
             const MAINTAINER = 'pending-maintainer';
             const CONTRIBUTOR = 'pending-contributor';
-            const prNumber = ${{ inputs.pr_number }};
-            const decision = '${{ inputs.decision }}';
+            const prNumber = Number(process.env.PR_NUMBER);
+            const decision = process.env.DECISION;
 
             const addLabel = decision === 'maintainer' ? MAINTAINER : CONTRIBUTOR;
             const removeLabel = decision === 'maintainer' ? CONTRIBUTOR : MAINTAINER;


### PR DESCRIPTION
## What

Fixes a script-injection vulnerability in `pending-decision.yml`, found during a follow-up audit after #1393.

The `github-script` step interpolated both `workflow_call` inputs directly into the JS source string:

```js
const prNumber = ${{ inputs.pr_number }};
const decision = '${{ inputs.decision }}';
```

`inputs.decision` is `type: string` with no `choice` constraint or runtime validation — only a comment documents the expected values (`"maintainer"` / `"contributor"`). A crafted `decision` value could break out of the single-quoted JS literal and execute arbitrary code inside the `github-script` sandbox, which runs with `pull-requests: write` + `issues: write`.

## Blast radius

This `workflow_call` reusable workflow currently has **no caller** in the repo — searched `.github/workflows/` for any `uses:` reference and found none. `pending-maintainer.yml` / `issue-pending-maintainer.yml` both implement the label-flip logic inline rather than calling this workflow. So there's no live exploit path today, but the footgun is real the moment something calls it with attacker-influenced input (e.g. a bot command parsed from a PR comment).

## Fix

Same pattern as the GitHub Actions security hardening guide (and the one already applied in #1393): pass values through `env:` and read them via `process.env` inside the script, never string-interpolated into the JS source.

- `PR_NUMBER` → `Number(process.env.PR_NUMBER)`
- `DECISION` → `process.env.DECISION`

`process.env` values are never parsed as code, so this closes the injection regardless of the input's declared type — not just for the current `string`/`number` types but for any future schema change too.

No behavior change: same label-flip logic, just a safe value-delivery mechanism.

## Verification

- YAML parses cleanly
- `actionlint` clean (`exit=0`)
