### PR TITLE
ci: pin third-party actions to commit SHA

### DIFF
--- a/.github/workflows/build-oabctl.yml
+++ b/.github/workflows/build-oabctl.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-07-13)
         with:
           targets: ${{ matrix.target == 'linux-aarch64' && 'aarch64-unknown-linux-gnu' || '' }}
 

--- a/.github/workflows/build-operator.yml
+++ b/.github/workflows/build-operator.yml
@@ -328,7 +328,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
       - uses: docker/login-action@v4
         with:

--- a/.github/workflows/bundle-pre-seed-utils.yml
+++ b/.github/workflows/bundle-pre-seed-utils.yml
@@ -184,7 +184,7 @@ jobs:
       contents: read
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/chart-test.yml
+++ b/.github/workflows/chart-test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.18.5
 

--- a/.github/workflows/ci-agy-acp.yml
+++ b/.github/workflows/ci-agy-acp.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-07-13)
 
       - name: Cache cargo
         uses: actions/cache@v4

--- a/.github/workflows/ci-auth-proxy.yml
+++ b/.github/workflows/ci-auth-proxy.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-07-13)
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (2026-03-12)
         with:
           workspaces: openab-auth-proxy
 

--- a/.github/workflows/ci-openab-agent.yml
+++ b/.github/workflows/ci-openab-agent.yml
@@ -18,10 +18,10 @@ jobs:
         working-directory: openab-agent
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-07-13)
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (2026-03-12)
         with:
           workspaces: openab-agent
       # openab-agent is a standalone crate, not a member of the parent openab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-07-13)
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (2026-03-12)
       - name: cargo check
         run: cargo check --workspace
       - name: cargo clippy
@@ -63,10 +63,10 @@ jobs:
         working-directory: operator
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-07-13)
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (2026-03-12)
         with:
           workspaces: operator
       - name: cargo check

--- a/.github/workflows/platform-schema-conformance.yml
+++ b/.github/workflows/platform-schema-conformance.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-07-13)
       # Standalone crate (serde + toml only); excluded from the root workspace
       # so it builds without the heavy adapter crates.
       # --locked: build strictly from the committed Cargo.lock; fail if it is

--- a/.github/workflows/pre-beta-build.yml
+++ b/.github/workflows/pre-beta-build.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-07-13)
 
       - name: Cache cargo registry & target
         uses: actions/cache@v4
@@ -261,7 +261,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-07-13)
         with:
           targets: ${{ matrix.target == 'linux-aarch64' && 'aarch64-unknown-linux-gnu' || '' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         with:
           skip_existing: true
         env:


### PR DESCRIPTION
## What

Pins the five third-party (non-`actions/*`, non-`docker/*`) GitHub Actions used in this repo's workflows to an immutable commit SHA, found during a follow-up audit after #1393.

| Action | Before | After |
|---|---|---|
| `dtolnay/rust-toolchain` | `@stable` (a branch, not a tag) | `@4be7066a` |
| `azure/setup-helm` | `@v4` | `@1a275c3b` (v4.3.1) |
| `aws-actions/configure-aws-credentials` | `@v4` | `@7474bc46` (v4.3.1) |
| `Swatinem/rust-cache` | `@v2` | `@e18b4977` (v2, 2026-03-12) |
| `helm/chart-releaser-action` | `@v1.6.0` | `@a917fd15` (v1.6.0) |

Each occurrence (18 total across 11 workflow files) keeps the version as a trailing comment for readability and to keep future bumps a one-line diff.

## Why

A tag — branch, lightweight, or annotated — can be moved by anyone with push access to the *upstream* action repo, silently swapping in different (potentially malicious) code the next time a workflow pulls it. A commit SHA is immutable regardless of what happens upstream. This is the mitigation [GitHub's own Actions security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommends for third-party actions specifically.

`helm/chart-releaser-action@v1.6.0` is already a full semver tag rather than a rolling major version, but the tag itself is still a mutable ref, so it's included for consistency.

First-party actions (`actions/*` maintained by GitHub, `docker/*` maintained by Docker) are left on major-version tags — lower supply-chain risk than individually- or org-maintained third-party actions, and this repo already follows that convention.

## Verification

- Every SHA resolved via `gh api repos/<owner>/<repo>/tags` (returns commit SHA directly — avoids the annotated-tag object-SHA vs. commit-SHA confusion some other lookup paths hit) and cross-checked against the tag name it corresponds to
- YAML parses cleanly on all 11 modified files
- `actionlint` clean on the diff (one pre-existing unrelated finding on `build-oabctl.yml` — an empty-string `choice` option — predates this change and is out of scope)
- No behavioral change: each SHA is the exact commit the previous tag pointed to at time of audit
