### PR TITLE
docs: add openab-dashboard to AWESOME.md

### DIFF
--- a/AWESOME.md
+++ b/AWESOME.md
@@ -12,6 +12,14 @@ A curated list of projects, tools, and resources built on or for the OpenAB ecos
 
 ---
 
+## Monitoring & Observability
+
+| Project | Description | Author |
+|---------|-------------|--------|
+| [openab-dashboard](https://github.com/masami-agent/openab-dashboard) | A lightweight, single-binary monitoring dashboard for OpenAB agent pods. Track token usage, response times, and pod health across all AI coding agents. Built with Rust + axum + SQLite. | [@masami-agent](https://github.com/masami-agent) |
+
+---
+
 ## Articles
 
 | Title | Description | Author |


### PR DESCRIPTION
## Summary

Add [openab-dashboard](https://github.com/masami-agent/openab-dashboard) to the Awesome OpenAB list under a new **Monitoring & Observability** section.

## What is openab-dashboard?

A lightweight, single-binary monitoring dashboard for OpenAB agent pods:

- Track token usage per agent per day
- Monitor pod health (uptime, restarts, version)
- Average response time tracking
- Agent leaderboard
- Generic provider system (add new CLIs via config only)
- Built with Rust + axum + SQLite, zero infrastructure needed

Repository: https://github.com/masami-agent/openab-dashboard