### PR TITLE
fix(pr-review): grant pull-requests write for /review ack reaction

### DIFF
--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -22,7 +22,9 @@ concurrency:
 permissions:
   statuses: write
   issues: write
-  pull-requests: read
+  # write needed for the 👀 ack reaction on /review comments — reactions on
+  # PR comments are pull-request scope (403 with read-only)
+  pull-requests: write
 
 jobs:
   poll-and-review:


### PR DESCRIPTION
## Summary

Follow-up to #1412. Live test on #1410 (run [29466027132](https://github.com/openabdev/openab/actions/runs/29466027132)) confirmed the `/review` command works end-to-end — job gate correctly skipped a non-command comment, forced re-review bypassed the already-reviewed skip, pending status set, Discord webhook fired.

One defect: the 👀 ack reaction on the triggering comment failed with `gh: Resource not accessible by integration (HTTP 403)` — reactions on PR comments are pull-request scope, and the workflow only had `pull-requests: read`. The `|| true` guard kept the pipeline alive but silently dropped the ack.

## Change

`pull-requests: read` → `pull-requests: write` (one line + comment).

## Testing

- YAML validated
- Will verify with a live `/review` after merge