### PR TITLE
docs(review): add frozen Review Contract policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,39 @@ Closes #
 
 Discord Discussion URL: <!-- Strongly recommended. Link the Discord thread where this was discussed. -->
 
+## Review Contract
+
+<!--
+The contract is the review boundary for this PR. Read docs/review-contract.md.
+Every subsection must contain meaningful content; template comments and empty
+checkboxes do not count. Use "None — [reason]" for a genuinely empty section.
+-->
+
+### Goal
+
+<!-- What user problem must this PR solve? -->
+
+### Non-goals
+
+<!-- What does this PR intentionally not attempt to solve? -->
+
+### Accepted Residual Risks
+
+<!--
+List known failure modes or trade-offs accepted for this version, including
+mitigations and recovery procedures. Maintainer/owner approval is required.
+-->
+
+### Acceptance Criteria
+
+<!-- Concrete, testable conditions required for LGTM. -->
+
+- [ ]
+
+### Follow-ups
+
+<!-- Hardening or broader designs explicitly deferred and non-blocking. -->
+
 ## At a Glance
 
 <!-- ASCII diagram showing the high-level flow or where this change fits in the system. For docs-only or trivial changes, write "N/A". -->

--- a/.github/scripts/review_contract.pl
+++ b/.github/scripts/review_contract.pl
@@ -1,0 +1,187 @@
+#!/usr/bin/env perl
+
+package ReviewContract;
+
+use strict;
+use warnings;
+use Getopt::Long qw(GetOptionsFromArray);
+use JSON::PP qw(decode_json);
+
+our $CONTRACT_TITLE = '## Review Contract';
+our @SECTION_HEADINGS = (
+    '### Goal',
+    '### Non-goals',
+    '### Accepted Residual Risks',
+    '### Acceptance Criteria',
+    '### Follow-ups',
+);
+our @REQUIRED_HEADINGS = ($CONTRACT_TITLE, @SECTION_HEADINGS);
+our $EXEMPT_LABEL = 'review-contract-exempt';
+
+sub _trim {
+    my ($value) = @_;
+    $value =~ s/^\s+|\s+$//g;
+    return $value;
+}
+
+sub _required_heading_matches {
+    my ($line, $heading) = @_;
+    return $line =~ /^ {0,3}\Q$heading\E\s*$/;
+}
+
+sub _visible_lines {
+    my ($body) = @_;
+    $body =~ s/<!--.*?(?:-->|$)//gs;
+
+    my @visible;
+    my ($fence_character, $fence_length);
+    for my $line (split /\n/, $body, -1) {
+        if (defined $fence_character) {
+            my $required = $fence_character x $fence_length;
+            if ($line =~ /^ {0,3}\Q$required\E\Q$fence_character\E*\s*$/) {
+                undef $fence_character;
+                undef $fence_length;
+            }
+            push @visible, '';
+            next;
+        }
+
+        if ($line =~ /^ {0,3}(`{3,}|~{3,})/) {
+            $fence_character = substr($1, 0, 1);
+            $fence_length = length $1;
+            push @visible, '';
+            next;
+        }
+
+        push @visible, $line;
+    }
+    return @visible;
+}
+
+sub _meaningful_content {
+    my ($raw) = @_;
+    my @meaningful;
+    for my $line (split /\n/, $raw) {
+        my $stripped = _trim($line);
+        next if $stripped eq '' || $stripped =~ /^[-*+]$/;
+        next if $stripped =~ /^(?:(?:[-*+]|\d+[.)])\s*)?\[[ xX]\]\s*(?:\.\.\.)?$/i;
+        push @meaningful, $stripped;
+    }
+
+    return 0 unless @meaningful;
+    my $combined = join ' ', @meaningful;
+    return 0 if $combined =~ /^(?:tbd|todo)\b/i;
+    return 0 if $combined =~ /^(?:none|n\/?a|not applicable)(?:[.!]|\s*(?:[-:]|\x{2014}|\xE2\x80\x94)\s*)?$/i;
+    return 0 if $combined =~ /^(?:fill (?:this|me) in|your (?:text|answer) here|\.\.\.)[.!]?$/i;
+    return 1;
+}
+
+sub validate_review_contract {
+    my ($body) = @_;
+    my @lines = _visible_lines($body);
+    my %positions;
+    my @errors;
+
+    for my $heading (@REQUIRED_HEADINGS) {
+        my @matches = grep {
+            _required_heading_matches($lines[$_], $heading)
+        } 0 .. $#lines;
+        if (!@matches) {
+            push @errors, "Missing required heading: $heading";
+        } elsif (@matches > 1) {
+            push @errors, "Heading must appear exactly once: $heading";
+        } else {
+            $positions{$heading} = $matches[0];
+        }
+    }
+
+    return @errors if @errors;
+
+    my @ordered = map { $positions{$_} } @REQUIRED_HEADINGS;
+    for my $index (1 .. $#ordered) {
+        if ($ordered[$index] < $ordered[$index - 1]) {
+            return ('Review Contract headings must appear in the required order');
+        }
+    }
+
+    for my $index (0 .. $#SECTION_HEADINGS) {
+        my $heading = $SECTION_HEADINGS[$index];
+        my $start = $positions{$heading} + 1;
+        my $limit = $index < $#SECTION_HEADINGS
+            ? $positions{$SECTION_HEADINGS[$index + 1]} - 1
+            : $#lines;
+        my $end = $limit;
+        for my $candidate ($start .. $limit) {
+            if ($lines[$candidate] =~ /^ {0,3}#{1,3}\s+/) {
+                $end = $candidate - 1;
+                last;
+            }
+        }
+        my $content = $start <= $end ? join("\n", @lines[$start .. $end]) : '';
+        push @errors, "Section has no meaningful content: $heading"
+            unless _meaningful_content($content);
+    }
+
+    return @errors;
+}
+
+sub _read_file {
+    my ($path) = @_;
+    open my $handle, '<:raw', $path or die "Cannot read $path: $!\n";
+    local $/;
+    return <$handle>;
+}
+
+sub load_event {
+    my ($path) = @_;
+    my $payload = decode_json(_read_file($path));
+    my $pr = ref $payload->{pull_request} eq 'HASH' ? $payload->{pull_request} : {};
+    my $body = defined $pr->{body} ? $pr->{body} : '';
+    my $labels = ref $pr->{labels} eq 'ARRAY' ? $pr->{labels} : [];
+    my $exempt = grep {
+        ref $_ eq 'HASH' && defined $_->{name} && $_->{name} eq $EXEMPT_LABEL
+    } @$labels;
+    return ($body, $exempt ? 1 : 0);
+}
+
+sub main {
+    my (@args) = @_;
+    my ($event, $body_file);
+    GetOptionsFromArray(
+        \@args,
+        'event=s' => \$event,
+        'body-file=s' => \$body_file,
+    ) or die "Usage: $0 (--event FILE | --body-file FILE|-)\n";
+    die "Usage: $0 (--event FILE | --body-file FILE|-)\n"
+        if (defined $event) == (defined $body_file);
+
+    my ($body, $exempt);
+    if (defined $event) {
+        ($body, $exempt) = load_event($event);
+    } elsif ($body_file eq '-') {
+        local $/;
+        $body = <STDIN>;
+        $exempt = 0;
+    } else {
+        $body = _read_file($body_file);
+        $exempt = 0;
+    }
+
+    if ($exempt) {
+        print "Review Contract validation exempted by label: $EXEMPT_LABEL\n";
+        return 0;
+    }
+
+    my @errors = validate_review_contract($body);
+    if (@errors) {
+        print "Review Contract validation failed:\n";
+        print "- $_\n" for @errors;
+        return 1;
+    }
+
+    print "Review Contract validation passed\n";
+    return 0;
+}
+
+exit main(@ARGV) unless caller;
+1;

--- a/.github/scripts/test_review_contract.pl
+++ b/.github/scripts/test_review_contract.pl
@@ -1,0 +1,165 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use File::Temp qw(tempfile);
+use JSON::PP qw(encode_json);
+use Test::More;
+
+require "$Bin/review_contract.pl";
+
+my $valid_body = <<'MARKDOWN';
+# Summary
+
+## Review Contract
+
+### Goal
+Ensure every PR declares a stable review boundary.
+
+### Non-goals
+This does not evaluate whether the proposed design is correct.
+
+### Accepted Residual Risks
+The validator checks structure only; maintainers review semantics.
+
+### Acceptance Criteria
+- [ ] All required sections contain meaningful content.
+- [ ] Required headings appear once and in order.
+
+### Follow-ups
+None — semantic automation remains a maintainer decision.
+MARKDOWN
+
+is_deeply(
+    [ReviewContract::validate_review_contract($valid_body)],
+    [],
+    'accepts a complete contract',
+);
+
+my $missing = $valid_body;
+$missing =~ s/### Non-goals\n//;
+ok(
+    grep($_ eq 'Missing required heading: ### Non-goals',
+        ReviewContract::validate_review_contract($missing)),
+    'rejects a missing heading',
+);
+
+my $empty = $valid_body;
+$empty =~ s/Ensure every PR declares a stable review boundary\./<!-- Add the goal. -->\n- [ ]/;
+ok(
+    grep($_ eq 'Section has no meaningful content: ### Goal',
+        ReviewContract::validate_review_contract($empty)),
+    'comments and empty checkboxes are not content',
+);
+
+my $placeholder = $valid_body;
+$placeholder =~ s/This does not evaluate whether the proposed design is correct\./TBD/;
+ok(
+    grep($_ eq 'Section has no meaningful content: ### Non-goals',
+        ReviewContract::validate_review_contract($placeholder)),
+    'rejects placeholder-only content',
+);
+
+my $duplicate = $valid_body;
+$duplicate =~ s/### Goal/### Goal\nUseful text.\n### Goal/;
+ok(
+    grep($_ eq 'Heading must appear exactly once: ### Goal',
+        ReviewContract::validate_review_contract($duplicate)),
+    'rejects duplicate headings',
+);
+
+my $wrong_order = $valid_body;
+$wrong_order =~ s{### Goal\nEnsure every PR declares a stable review boundary\.\n\n### Non-goals\nThis does not evaluate whether the proposed design is correct\.}{### Non-goals\nThis does not evaluate whether the proposed design is correct.\n\n### Goal\nEnsure every PR declares a stable review boundary.};
+is_deeply(
+    [ReviewContract::validate_review_contract($wrong_order)],
+    ['Review Contract headings must appear in the required order'],
+    'rejects headings in the wrong order',
+);
+
+my $bare_none = $valid_body;
+$bare_none =~ s/None — semantic automation remains a maintainer decision\./None/;
+ok(
+    grep($_ eq 'Section has no meaningful content: ### Follow-ups',
+        ReviewContract::validate_review_contract($bare_none)),
+    'bare None requires a reason',
+);
+
+my $todo_variant = $valid_body;
+$todo_variant =~ s/The validator checks structure only; maintainers review semantics\./TODO: explain this later/;
+ok(
+    grep($_ eq 'Section has no meaningful content: ### Accepted Residual Risks',
+        ReviewContract::validate_review_contract($todo_variant)),
+    'rejects TODO placeholder variants',
+);
+
+my $fenced = "```markdown\n$valid_body```\n";
+ok(
+    grep($_ eq 'Missing required heading: ## Review Contract',
+        ReviewContract::validate_review_contract($fenced)),
+    'headings inside a fenced code block do not count',
+);
+
+my $commented = "<!--\n$valid_body-->\n";
+ok(
+    grep($_ eq 'Missing required heading: ## Review Contract',
+        ReviewContract::validate_review_contract($commented)),
+    'headings inside an HTML comment do not count',
+);
+
+my $leaked_follow_up = $valid_body;
+$leaked_follow_up =~ s/None — semantic automation remains a maintainer decision\./## Validation\nUnrelated content must not satisfy Follow-ups./;
+ok(
+    grep($_ eq 'Section has no meaningful content: ### Follow-ups',
+        ReviewContract::validate_review_contract($leaked_follow_up)),
+    'content from the next peer heading cannot satisfy a section',
+);
+
+my $indented_heading = $valid_body;
+$indented_heading =~ s/^## Review Contract/    ## Review Contract/m;
+ok(
+    grep($_ eq 'Missing required heading: ## Review Contract',
+        ReviewContract::validate_review_contract($indented_heading)),
+    'four-space-indented pseudo-headings do not count',
+);
+
+for my $empty_value ('None —', '[ ]', '1. [ ]') {
+    my $empty_follow_up = $valid_body;
+    $empty_follow_up =~ s/None — semantic automation remains a maintainer decision\./$empty_value/;
+    ok(
+        grep($_ eq 'Section has no meaningful content: ### Follow-ups',
+            ReviewContract::validate_review_contract($empty_follow_up)),
+        "rejects reasonless or empty Follow-ups: $empty_value",
+    );
+}
+
+my ($body_handle, $body_path) = tempfile();
+print {$body_handle} $valid_body;
+close $body_handle;
+is(
+    system($^X, "$Bin/review_contract.pl", '--body-file', $body_path),
+    0,
+    'CLI succeeds for a valid contract',
+);
+open $body_handle, '>', $body_path or die "Cannot rewrite $body_path: $!";
+print {$body_handle} "## Review Contract\n";
+close $body_handle;
+isnt(
+    system($^X, "$Bin/review_contract.pl", '--body-file', $body_path),
+    0,
+    'CLI fails for an invalid contract',
+);
+
+my ($event_handle, $event_path) = tempfile();
+print {$event_handle} encode_json({
+    pull_request => {
+        body => '',
+        labels => [{name => 'review-contract-exempt'}],
+    },
+});
+close $event_handle;
+my ($event_body, $exempt) = ReviewContract::load_event($event_path);
+is($event_body, '', 'loads an empty event body');
+ok($exempt, 'recognizes the maintainer exemption label');
+
+done_testing();

--- a/.github/workflows/review-contract.yml
+++ b/.github/workflows/review-contract.yml
@@ -1,0 +1,59 @@
+name: Review Contract
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: review-contract-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set exact-head status to pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f state=pending \
+            -f context='Review Contract' \
+            -f description='Review Contract validation in progress' \
+            -f target_url='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+      # pull_request_target runs trusted base-branch code. Never check out the
+      # contributor's head in this workflow.
+      - name: Check out the default branch policy
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - name: Test Review Contract validator
+        run: perl .github/scripts/test_review_contract.pl
+      - name: Validate PR Review Contract
+        id: contract
+        continue-on-error: true
+        run: perl .github/scripts/review_contract.pl --event "$GITHUB_EVENT_PATH"
+      - name: Publish exact-head result
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          STATE=failure
+          DESCRIPTION='Review Contract validation failed'
+          if [ '${{ steps.contract.outcome }}' = 'success' ]; then
+            STATE=success
+            DESCRIPTION='Review Contract validation passed'
+          fi
+          gh api "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f state="$STATE" \
+            -f context='Review Contract' \
+            -f description="$DESCRIPTION" \
+            -f target_url='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+      - name: Enforce validation result
+        if: always() && steps.contract.outcome != 'success'
+        run: exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,10 @@ cargo check --target x86_64-pc-windows-gnu
 - Commit message: `type(scope): description` — types: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `build`
 - Include regression tests for bug fixes
 - Reference issues: `Closes #123` or `Fixes #456`
+- Every PR must include the Review Contract required by [`docs/review-contract.md`](docs/review-contract.md)
+- Round 1 may challenge and then freezes the contract; later rounds review only unresolved findings, incremental changes, regressions, and frozen acceptance criteria
+- Classify post-freeze findings as `ORIGINAL`, `REGRESSION`, `NEW EVIDENCE`, or `SCOPE EXPANSION`; scope expansion is a non-blocking follow-up unless direct correctness, security, or data-loss evidence passes the Late Blocker Gate
+- Use the default three-stage stopping rule: full review, fix verification, final regression check; only a maintainer/owner may revise the contract or authorize another round
 
 ## ADRs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,28 @@ To fix an `incomplete` issue, simply edit the issue body to add the missing sect
 
 Every PR must address the following in its description. The [PR template](/.github/pull_request_template.md) will prompt you for each section.
 
+### Review Contract
+
+Every PR must include the exact `## Review Contract` structure defined in the
+[Review Contract policy](/docs/review-contract.md): Goal, Non-goals, Accepted
+Residual Risks, Acceptance Criteria, and Follow-ups. Each subsection must
+contain meaningful content. For small changes, `None` or `Not applicable` must
+include a brief reason.
+
+The author proposes the contract, reviewers challenge it during the first full
+review, and a maintainer/owner freezes it. The author cannot unilaterally accept
+correctness, security, operational, or data-loss risks. After the freeze,
+review is incremental: unresolved findings, new changes, regressions, and the
+frozen Acceptance Criteria. Broader hardening is a non-blocking Follow-up
+unless it passes the policy's Late Blocker Gate.
+
+The default stopping sequence is full review and freeze, fix verification, then
+a final regression check. Contract revisions and additional rounds require an
+explicit maintainer/owner decision. The `Review Contract` workflow validates
+structure only; maintainers remain responsible for semantic approval. A
+maintainer may document an exceptional case and apply the
+`review-contract-exempt` label.
+
 ### 0. Discord Discussion URL
 
 All PRs **must** include a Discord Discussion URL in the PR body (e.g. `https://discord.com/channels/...`). Discussing your idea in Discord before opening a PR helps align on direction and avoids wasted effort. PRs without a Discord Discussion URL will be **automatically closed in 24 hours**.

--- a/docs/adr/pr-contribution-guidelines.md
+++ b/docs/adr/pr-contribution-guidelines.md
@@ -23,6 +23,21 @@ This front-loads research cost onto the contributor (who understands the problem
 
 Establish a standard PR template and tiered contribution guidelines. All PRs document the problem, approach, tradeoffs, and alternatives. Architectural and runtime changes additionally require prior art research (at minimum OpenClaw and Hermes Agent). Docs-only, chore, CI, release, and trivial bug fixes use a lighter process.
 
+### Review Contract Amendment (2026-07-18)
+
+Every PR also defines a Review Contract with five required fields: Goal,
+Non-goals, Accepted Residual Risks, Acceptance Criteria, and Follow-ups. The
+contract is proposed by the author, challenged and frozen in the first review
+round by a maintainer/owner, and then used as the boundary for incremental
+review. Authors cannot unilaterally accept correctness, security, operational,
+or data-loss risks.
+
+The canonical policy is [`docs/review-contract.md`](../review-contract.md). It
+defines finding lineage, the Late Blocker Gate, contract revision rules, a
+default three-stage stopping rule, and structural workflow validation. This ADR
+continues to define the surrounding contribution fields and tiered prior-art
+requirements.
+
 ### Required PR Sections
 
 Every PR must include these sections in its description:

--- a/docs/review-contract.md
+++ b/docs/review-contract.md
@@ -1,0 +1,150 @@
+# Review Contract
+
+A Review Contract defines the agreed boundary for a pull request: what problem it
+must solve, what it intentionally does not solve, which risks are accepted, and
+what evidence is required for LGTM. Its purpose is to make review rigorous
+without allowing the acceptance bar to expand indefinitely between rounds.
+
+## Required PR Body
+
+Every pull request must contain this exact structure and provide meaningful
+content under every subsection:
+
+```markdown
+## Review Contract
+
+### Goal
+What user problem this PR must solve.
+
+### Non-goals
+What this PR intentionally does not attempt to solve.
+
+### Accepted Residual Risks
+Known failure modes or trade-offs accepted for this version, including
+mitigations and recovery procedures.
+
+### Acceptance Criteria
+Concrete, testable conditions required for LGTM.
+
+### Follow-ups
+Useful hardening or broader designs explicitly deferred from this PR.
+```
+
+For a small or documentation-only change, a section may say `None` or `Not
+applicable` only when it also gives a brief reason. Do not leave template
+comments, `TBD`, or an empty checkbox as the section's only content.
+
+## Responsibilities
+
+- **Author:** proposes the initial contract and supplies validation evidence.
+- **Reviewers:** challenge omissions, unsafe assumptions, and untestable
+  acceptance criteria during the first review round.
+- **Maintainer/owner:** freezes the contract and explicitly decides whether
+  residual correctness, security, operational, or data-loss risks are
+  acceptable. An author cannot accept those risks unilaterally.
+
+The PR description is the canonical current copy of the contract. Discussion
+comments may explain decisions, but they do not silently change the contract.
+
+## Review Lifecycle
+
+### Round 1: define and freeze
+
+Round 1 is the full review. It may challenge the implementation and the proposed
+Goal, Non-goals, Accepted Residual Risks, Acceptance Criteria, and Follow-ups.
+Before requesting fixes, the maintainer should resolve material contract
+questions and state that the contract is frozen.
+
+The freeze must also be durable: record a contract revision identifier, the
+exact reviewed head commit, and either the full contract text or a SHA-256 of
+that exact text in a submitted review or equivalent immutable review record.
+That freeze record identifies the approved version if the PR description later
+changes. Any mismatch is a proposed contract revision and must follow the
+revision process below.
+
+A frozen contract is not permission to merge broken code. It is the agreed test
+for what counts as broken within this PR.
+
+### Later rounds: incremental verification
+
+After the freeze, review only:
+
+1. unresolved findings from earlier rounds;
+2. changes since the last reviewed commit;
+3. regressions caused by those changes; and
+4. compliance with the frozen Acceptance Criteria.
+
+Do not restart unrestricted architecture discovery on every push. Preferences
+for broader hardening or a different future architecture belong in Follow-ups
+unless they pass the Late Blocker Gate below.
+
+## Finding Lineage
+
+Every blocking finding raised after Round 1 should identify its lineage:
+
+| Lineage | Meaning |
+|---------|---------|
+| `ORIGINAL` | An unresolved finding already raised within the frozen scope. |
+| `REGRESSION` | A new defect introduced by changes made during this PR. |
+| `NEW EVIDENCE` | Newly discovered, direct evidence that the PR violates the frozen contract. |
+| `SCOPE EXPANSION` | A request outside the frozen Goal or Acceptance Criteria. |
+
+`SCOPE EXPANSION` is non-blocking by default and should be recorded under
+Follow-ups or in a separate issue.
+
+## Late Blocker Gate
+
+A new blocker raised after Round 1 must provide concrete, reproducible evidence
+of at least one of the following:
+
+- an Acceptance Criterion is not met;
+- the implementation does not achieve the frozen Goal;
+- the PR introduces a correctness, security, or data-loss defect within the
+  frozen scope; or
+- the latest changes regress behavior covered by the frozen contract.
+
+The finding must state the affected contract clause, evidence, impact, and a
+testable requested change. Hypothetical hardening, general architecture
+preferences, unrelated pre-existing defects, and requests to eliminate an
+explicitly accepted residual risk do not pass this gate.
+
+## Contract Revisions
+
+A contract may change after it is frozen only with explicit maintainer/owner
+approval. Update the PR description and record:
+
+- what changed;
+- why the prior contract was insufficient; and
+- which earlier findings or decisions must be reconsidered.
+
+The revised portion receives a new full review. Unchanged portions remain
+frozen.
+
+## Stopping Rule
+
+The default review sequence is capped at three stages:
+
+1. full review and contract freeze;
+2. fix verification; and
+3. final regression check.
+
+If the PR still cannot meet the contract, the maintainer/owner chooses whether
+to authorize another focused round, revise or split the contract, or close the
+PR. The cap does not force LGTM and never suppresses a blocker that passes the
+Late Blocker Gate.
+
+## LGTM and Follow-ups
+
+LGTM requires all frozen Acceptance Criteria to be satisfied, all blocking
+findings to be resolved, and required CI to pass. Follow-ups are explicitly
+non-blocking for this PR unless the contract is formally revised.
+
+## Automated Validation and Exemptions
+
+The `Review Contract` workflow checks only structure: all required headings
+must appear once, in order, with non-placeholder content. It does not decide
+whether the contract is safe or sufficient.
+
+A maintainer may apply the `review-contract-exempt` label to generated,
+emergency, or otherwise exceptional PRs. The reason should be documented in the
+PR. Exemption is an auditable maintainer decision, not an author opt-out.

--- a/docs/steering/pr-review.md
+++ b/docs/steering/pr-review.md
@@ -1,8 +1,29 @@
 # PR Review Guide for openabdev/openab
 
-## Review Framework
+## Review Contract Boundary
 
-When reviewing a PR, always address these four questions:
+Read the PR's [`Review Contract`](../review-contract.md) before reviewing the
+implementation. Round 1 is the only unrestricted full review: challenge missing
+scope, unsafe residual risks, and untestable acceptance criteria, then obtain a
+maintainer/owner freeze.
+
+After the freeze, review only unresolved findings, the incremental diff,
+regressions, and the frozen Acceptance Criteria. Label every post-freeze blocker
+as `ORIGINAL`, `REGRESSION`, or `NEW EVIDENCE` and cite the affected contract
+clause. A `SCOPE EXPANSION` is a non-blocking Follow-up unless concrete,
+reproducible correctness, security, or data-loss evidence within the frozen
+scope passes the Late Blocker Gate.
+
+Use the default stopping sequence: full review and freeze, fix verification,
+then final regression check. Do not keep raising the acceptance bar. If the PR
+still cannot meet its contract, ask the maintainer/owner to authorize another
+focused round, revise or split the contract, or close the PR. Never treat the
+round cap as automatic LGTM, and never suppress a blocker that passes the Late
+Blocker Gate.
+
+## Round 1 Review Framework
+
+During the unrestricted first review, address these four questions:
 
 1. **What problem does it solve** — What pain point or requirement does this PR address? Explain the background in plain language.
 2. **How does it solve it** — The specific technical approach, architecture decisions, and key implementation details.


### PR DESCRIPTION
## What problem does this solve?

Pull requests currently describe implementation and validation, but they do not freeze an explicit review boundary. Later review rounds can therefore introduce unrelated architecture preferences as new blockers, increasing review latency and making "done" unstable.

Discord Discussion URL: Not applicable — this repository-policy change was requested directly by the repository owner, and its rationale is fully captured here.

## Review Contract

### Goal

Require every non-exempt pull request to declare a durable review boundary, then constrain later review rounds to prior findings, incremental changes, regressions, and frozen acceptance criteria.

### Non-goals

This PR does not automate semantic approval, alter merge permissions, replace maintainer judgment, or configure repository branch-protection settings.

### Accepted Residual Risks

The validator checks structure rather than whether a proposed contract is safe or sufficient; maintainer review remains mandatory. The trusted `pull_request_target` workflow receives `statuses: write` solely to publish pending/final results on the exact PR head, checks out only the default branch, uses a SHA-pinned checkout action, and never executes contributor code. Maintainers can recover from exceptional workflow behavior by reverting the workflow or applying the documented exemption label with a reason.

### Acceptance Criteria

- [x] `docs/review-contract.md` is the single authoritative policy and defines freeze records, finding lineage, the Late Blocker Gate, revisions, and the stopping rule.
- [x] The PR template and contributor guide require and link to the same five-field contract.
- [x] Agent/reviewer guidance limits unrestricted architecture review to Round 1 and makes later rounds incremental.
- [x] A trusted workflow validates meaningful headings and publishes the result to the exact PR head SHA.
- [x] Focused tests cover valid input, missing/duplicate/out-of-order headings, placeholders, fenced/commented pseudo-headings, section leakage, exemptions, and CLI exit behavior.

### Follow-ups

After this PR merges, repository administrators can make the exact-head `Review Contract` status required in branch protection. Organization-wide reusable enforcement remains a separate optional improvement.

## At a Glance

```text
PR template / CONTRIBUTING / reviewer guidance
                      |
                      v
          docs/review-contract.md
                      |
                      v
       trusted structural validator
                      |
                      v
        exact-head commit status
```

## Prior Art & Industry Research

Not applicable — this is a repository contribution/review-process policy change, not an architectural, runtime, scheduling, delivery, or persistence change.

## Proposed Solution

Add one canonical policy document, link all author and reviewer entry points to it, and add a low-permission structural validator. Round 1 freezes a durable contract snapshot; later findings require lineage and direct evidence within the frozen scope. The default sequence stops after full review, fix verification, and final regression check unless the owner explicitly authorizes another action.

## Why this approach?

A template alone is removable, CONTRIBUTING alone is easy to miss, and duplicated full policies drift. One canonical document plus thin entry-point summaries and mechanical structure validation separates policy ownership from enforcement while preserving maintainer judgment.

## Alternatives Considered

- **Template only:** visible but unenforced and insufficient for reviewer behavior.
- **CONTRIBUTING only:** authoritative but easy for authors and automation to miss.
- **Semantic automated approval:** rejected because risk acceptance and scope sufficiency require human judgment.
- **Organization-level policy only:** deferred so each repository can adopt and review the rule independently.

## Validation

- [x] `perl -c .github/scripts/review_contract.pl`
- [x] `perl -c .github/scripts/test_review_contract.pl`
- [x] `perl .github/scripts/test_review_contract.pl` — 19/19 passed
- [x] Additional adversarial matrix — 13/13 passed
- [x] `git diff --check`
- [x] Changed Markdown relative-link scan
- [x] Public-content privacy scan
- [x] Shared policy/validator/tests/workflow are byte-identical with the ecsctl proposal
