### PR TITLE
feat: add Kimi Code CLI backend

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -62,7 +62,7 @@ jobs:
           fi
 
           # Resolve variants
-          ALLOWED="kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore"
+          ALLOWED="kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,kimi,mimocode,opencode,antigravity,pi,native,agentcore"
           if [ "$VARIANTS_INPUT" = "all" ] || [ -z "$VARIANTS_INPUT" ]; then
             VARIANTS="$ALLOWED"
           else

--- a/.github/workflows/build-operator.yml
+++ b/.github/workflows/build-operator.yml
@@ -30,7 +30,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   # All agent variants built from Dockerfile.unified targets.
-  AGENTS: "kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore"
+  AGENTS: "kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,kimi,mimocode,opencode,antigravity,pi,native,agentcore"
 
 jobs:
   resolve-tag:

--- a/.github/workflows/docker-smoke-test-unified.yml
+++ b/.github/workflows/docker-smoke-test-unified.yml
@@ -57,6 +57,7 @@ jobs:
           - { name: gemini, agent: "gemini" }
           - { name: grok, agent: "grok" }
           - { name: hermes, agent: "hermes-acp" }
+          - { name: kimi, agent: "kimi" }
           - { name: mimocode, agent: "mimo" }
           - { name: opencode, agent: "opencode" }
           - { name: antigravity, agent: "agy-acp" }
@@ -122,6 +123,21 @@ jobs:
           echo "$RESPONSE" | jq -e \
             '.result.agentInfo.name == "@agentclientprotocol/codex-acp"' \
             >/dev/null
+
+      - name: Verify Kimi runtime version
+        if: matrix.target.name == 'kimi'
+        run: |
+          KIMI_CODE_VERSION=$(awk -F= '$1 == "ARG KIMI_CODE_VERSION" {print $2; exit}' Dockerfile.unified)
+          test -n "$KIMI_CODE_VERSION"
+          docker run --rm --entrypoint node openab-unified-kimi:test \
+            -e 'console.log(require("/usr/local/lib/node_modules/@moonshot-ai/kimi-code/package.json").version)' \
+            | grep -Fx "$KIMI_CODE_VERSION"
+
+      - name: Verify Kimi agent command uses native ACP
+        if: matrix.target.name == 'kimi'
+        run: |
+          docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' openab-unified-kimi:test \
+            | grep -Fx 'OPENAB_AGENT_COMMAND=kimi acp'
 
       - name: Verify Claude runtime versions
         if: matrix.target.name == 'claude'

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -28,6 +28,7 @@ jobs:
           - { dockerfile: Dockerfile.copilot, suffix: "-copilot", agent: "copilot", agent_args: "--acp", build_args: "" }
           - { dockerfile: Dockerfile.opencode, suffix: "-opencode", agent: "opencode", agent_args: "acp", build_args: "" }
           - { dockerfile: Dockerfile.cursor, suffix: "-cursor", agent: "cursor-agent", agent_args: "acp", build_args: "" }
+          - { dockerfile: Dockerfile.kimi, suffix: "-kimi", agent: "kimi", agent_args: "acp", build_args: "" }
           - { dockerfile: Dockerfile.mimocode, suffix: "-mimocode", agent: "mimo", agent_args: "acp", build_args: "" }
           - { dockerfile: Dockerfile.hermes, suffix: "-hermes", agent: "hermes-acp", agent_args: "", build_args: "" }
           - { dockerfile: Dockerfile.grok, suffix: "-grok", agent: "grok", agent_args: "agent stdio", build_args: "" }

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -25,6 +25,7 @@ on:
           - gemini
           - grok
           - hermes
+          - kimi
           - mimocode
           - native
           - opencode

--- a/.github/workflows/pre-beta-build.yml
+++ b/.github/workflows/pre-beta-build.yml
@@ -14,7 +14,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  ALL_AGENTS: 'kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,mimocode,opencode,antigravity,pi,native,agentcore'
+  ALL_AGENTS: 'kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,kimi,mimocode,opencode,antigravity,pi,native,agentcore'
 
 jobs:
   gate:

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -21,7 +21,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  ALL_VARIANTS: 'default,agentcore,antigravity,claude,codex,copilot,cursor,devin,gemini,grok,hermes,mimocode,native,opencode,pi'
+  ALL_VARIANTS: 'default,agentcore,antigravity,claude,codex,copilot,cursor,devin,gemini,grok,hermes,kimi,mimocode,native,opencode,pi'
 
 jobs:
   matrix:

--- a/Dockerfile.kimi
+++ b/Dockerfile.kimi
@@ -1,0 +1,51 @@
+# --- Build stage ---
+FROM rust:1-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY crates/openab-core/Cargo.toml crates/openab-core/Cargo.toml
+COPY crates/openab-gateway/Cargo.toml crates/openab-gateway/Cargo.toml
+RUN mkdir -p src crates/openab-core/src crates/openab-gateway/src \
+    && echo 'fn main() {}' > src/main.rs \
+    && echo '' > crates/openab-core/src/lib.rs \
+    && echo '' > crates/openab-gateway/src/lib.rs \
+    && cargo build --release \
+    && rm -rf src crates/openab-core/src crates/openab-gateway/src
+COPY crates/ crates/
+COPY src/ src/
+RUN touch src/main.rs crates/openab-core/src/lib.rs crates/openab-gateway/src/lib.rs \
+    && cargo build --release
+
+# --- Runtime stage ---
+# Kimi Code CLI is published as @moonshot-ai/kimi-code and exposes the
+# `kimi` binary. Its native ACP adapter is started with `kimi acp`.
+# Keep the package version pinned so image rebuilds are reproducible.
+FROM node:24-trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl procps ripgrep tini unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG KIMI_CODE_VERSION=0.28.1
+RUN npm install -g @moonshot-ai/kimi-code@${KIMI_CODE_VERSION} --retry 3
+
+# Install gh CLI for agent shell workflows.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/node
+WORKDIR /home/node
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/node/.kimi-code && chown -R node:node /home/node
+
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="kimi acp"
+# Kimi authentication is initiated by running `kimi` and entering `/login`.
+ENV OPENAB_AGENT_AUTH_COMMAND="kimi"
+
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -154,6 +154,33 @@ ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 
 # =============================================================================
+# Target: kimi
+# =============================================================================
+FROM node:24-trixie-slim AS kimi
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl procps ripgrep tini bubblewrap socat unzip git \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+ARG KIMI_CODE_VERSION=0.28.1
+RUN npm install -g @moonshot-ai/kimi-code@${KIMI_CODE_VERSION} --retry 3
+ENV HOME=/home/node
+WORKDIR /home/node
+COPY --from=builder --chown=node:node /build/target/release/openab /usr/local/bin/openab
+RUN mkdir -p /home/node/.kimi-code && chown -R node:node /home/node
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="kimi acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="kimi"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
 # Target: copilot
 # =============================================================================
 FROM base-node AS copilot

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ English | [繁體中文](README.zh-TW.md)
 
 ![OpenAB banner](images/banner.jpg)
 
-A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Copilot CLI, Hermes, Grok Build, Devin, Antigravity, Pi, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat, WeCom, and Microsoft Teams** are available through gateway adapters, either compiled into the unified binary or deployed as the standalone [Custom Gateway](crates/openab-gateway/).
+A lightweight, secure, cloud-native ACP harness that bridges **Discord, Slack**, and any [Agent Client Protocol](https://github.com/anthropics/agent-protocol)-compatible coding CLI (Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Kimi Code, Copilot CLI, Hermes, Grok Build, Devin, Antigravity, Pi, etc.) over stdio JSON-RPC — delivering the next-generation development experience. **Telegram, LINE, Feishu/Lark, Google Chat, WeCom, and Microsoft Teams** are available through gateway adapters, either compiled into the unified binary or deployed as the standalone [Custom Gateway](crates/openab-gateway/).
 
 🪼 **Join our community!** Come say hi on Discord — we'd love to have you: **[🪼 OpenAB — Official](https://openab.dev/discord)** 🎉
 
@@ -53,7 +53,7 @@ webhook platforms and `WS/webhook` for Feishu/Lark.
 
 - **Multi-platform** — supports Discord and Slack, run one or both simultaneously
 - **Gateway adapters** — extend to Telegram, LINE, Feishu/Lark, Google Chat, WeCom, and Microsoft Teams through the standalone [gateway](crates/openab-gateway/) or an opt-in unified build
-- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Copilot CLI, Hermes, Grok Build, Devin, Antigravity, Pi via config
+- **Pluggable agent backend** — swap between Kiro CLI, Claude Code, Codex, Gemini, OpenCode, MiMo-Code, Kimi Code, Copilot CLI, Hermes, Grok Build, Devin, Antigravity, Pi via config
 - **@mention trigger** — mention the bot in an allowed channel to start a conversation
 - **Thread-based multi-turn** — auto-creates threads; no @mention needed for follow-ups
 - **Multi-agent collaboration** — bot-to-bot messaging for coordinated workflows ([docs/multi-agent.md](docs/multi-agent.md))
@@ -184,6 +184,7 @@ The bot creates a thread. After that, just type in the thread — no @mention ne
 | Gemini | `gemini --acp` | Native | [docs/gemini.md](docs/gemini.md) |
 | OpenCode | `opencode acp` | Native | [docs/opencode.md](docs/opencode.md) |
 | MiMo-Code | `mimo acp` | Native | [docs/mimocode.md](docs/mimocode.md) |
+| Kimi Code | `kimi acp` | Native | [docs/kimi.md](docs/kimi.md) |
 | Copilot CLI ⚠️ | `copilot --acp --stdio` | Native | [docs/copilot.md](docs/copilot.md) |
 | Cursor | `cursor-agent acp` | Native | [docs/cursor.md](docs/cursor.md) |
 | Hermes Agent | `hermes-acp` | Native | [docs/hermes.md](docs/hermes.md) |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -6,7 +6,7 @@
 
 ![OpenAB banner](images/banner.jpg)
 
-一個輕量、安全、雲端原生的 ACP harness，透過 stdio JSON-RPC 將 **Discord、Slack** 與任何相容於 [Agent Client Protocol](https://github.com/anthropics/agent-protocol) 的程式開發 CLI（Kiro CLI、Claude Code、Codex、Gemini、OpenCode、MiMo-Code、Copilot CLI、Hermes、Grok Build、Devin、Antigravity、Pi 等）連接起來，帶來新一代的開發體驗。**Telegram、LINE、Feishu/Lark、Google Chat、WeCom 與 Microsoft Teams** 則由 gateway adapters 支援；可將 adapters 編入 unified binary，或部署為獨立的 [Custom Gateway](crates/openab-gateway/)。
+一個輕量、安全、雲端原生的 ACP harness，透過 stdio JSON-RPC 將 **Discord、Slack** 與任何相容於 [Agent Client Protocol](https://github.com/anthropics/agent-protocol) 的程式開發 CLI（Kiro CLI、Claude Code、Codex、Gemini、OpenCode、MiMo-Code、Kimi Code、Copilot CLI、Hermes、Grok Build、Devin、Antigravity、Pi 等）連接起來，帶來新一代的開發體驗。**Telegram、LINE、Feishu/Lark、Google Chat、WeCom 與 Microsoft Teams** 則由 gateway adapters 支援；可將 adapters 編入 unified binary，或部署為獨立的 [Custom Gateway](crates/openab-gateway/)。
 
 🪼 **加入我們的社群！** 歡迎到 Discord 和大家打招呼：**[🪼 OpenAB — Official](https://openab.dev/discord)** 🎉
 
@@ -53,7 +53,7 @@ platforms 使用 `webhook/API`，Feishu/Lark 則使用 `WS/webhook`。
 
 - **多平台支援** — 支援 Discord 與 Slack，可單獨或同時執行
 - **Gateway adapters** — 可透過獨立的 [gateway](crates/openab-gateway/) 或 opt-in unified build 擴充至 Telegram、LINE、Feishu/Lark、Google Chat、WeCom 與 Microsoft Teams
-- **可替換的 agent backend** — 可透過設定在 Kiro CLI、Claude Code、Codex、Gemini、OpenCode、MiMo-Code、Copilot CLI、Hermes、Grok Build、Devin、Antigravity、Pi 之間切換
+- **可替換的 agent backend** — 可透過設定在 Kiro CLI、Claude Code、Codex、Gemini、OpenCode、MiMo-Code、Kimi Code、Copilot CLI、Hermes、Grok Build、Devin、Antigravity、Pi 之間切換
 - **@mention 觸發** — 在允許的頻道中 mention bot，即可開始對話
 - **以討論串進行多輪對話** — 自動建立討論串；後續訊息不需再次 @mention
 - **多 agent 協作** — 支援 bot-to-bot 訊息，實現協調式工作流程（[docs/multi-agent.md](docs/multi-agent.md)）
@@ -184,6 +184,7 @@ bot 會建立一個討論串。之後只要直接在討論串中輸入即可，�
 | Gemini | `gemini --acp` | Native | [docs/gemini.md](docs/gemini.md) |
 | OpenCode | `opencode acp` | Native | [docs/opencode.md](docs/opencode.md) |
 | MiMo-Code | `mimo acp` | Native | [docs/mimocode.md](docs/mimocode.md) |
+| Kimi Code | `kimi acp` | Native | [docs/kimi.md](docs/kimi.md) |
 | Copilot CLI ⚠️ | `copilot --acp --stdio` | Native | [docs/copilot.md](docs/copilot.md) |
 | Cursor | `cursor-agent acp` | Native | [docs/cursor.md](docs/cursor.md) |
 | Hermes Agent | `hermes-acp` | Native | [docs/hermes.md](docs/hermes.md) |

--- a/charts/openab/values.yaml
+++ b/charts/openab/values.yaml
@@ -148,6 +148,32 @@ agents:
     #   agentsMd: ""
     #   resources: {}
     #   image: ""  # leave empty → auto-resolves to openab:<tag>-opencode
+    # kimi:
+    #   command: kimi
+    #   args:
+    #     - acp
+    #   discord:
+    #     enabled: true
+    #     allowedChannels:
+    #       - "YOUR_CHANNEL_ID"
+    #     allowedUsers: []
+    #     allowBotMessages: "off"
+    #     trustedBotIds: []
+    #   workingDir: /home/node
+    #   env: {}
+    #   envFrom: []
+    #   secretEnv: []
+    #   pool:
+    #     maxSessions: 10
+    #     sessionTtlHours: 24
+    #   reactions:
+    #     enabled: true
+    #     removeAfterReply: false
+    #   persistence:
+    #     enabled: true
+    #     storageClass: ""
+    #     size: 1Gi
+    #   image: ""  # leave empty → auto-resolves to openab:<tag>-kimi
     # pi:
     #   command: pi-acp
     #   discord:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,7 +16,7 @@
 group "default" {
   targets = [
     "kiro", "claude", "codex", "copilot", "cursor",
-    "devin", "gemini", "grok", "hermes", "mimocode",
+    "devin", "gemini", "grok", "hermes", "kimi", "mimocode",
     "opencode", "antigravity", "pi", "gateway",
   ]
 }
@@ -86,6 +86,12 @@ target "grok" {
 target "hermes" {
   dockerfile = "Dockerfile.hermes"
   tags       = ["openab:hermes"]
+  contexts   = { builder = "target:builder" }
+}
+
+target "kimi" {
+  dockerfile = "Dockerfile.kimi"
+  tags       = ["openab:kimi"]
   contexts   = { builder = "target:builder" }
 }
 

--- a/docs/adr/openab-agent-oauth.md
+++ b/docs/adr/openab-agent-oauth.md
@@ -25,7 +25,7 @@ processes refreshing the same OAuth token → refresh-token-rotation reuse → w
 is what activates the bug.**
 
 ### 1.3 The wider demand
-openab packages 14 agent variants (`kiro, claude, codex, copilot, cursor, gemini, grok, hermes, mimocode,
+openab packages 15 agent variants (`kiro, claude, codex, copilot, cursor, gemini, grok, hermes, kimi, mimocode,
 opencode, antigravity, pi, native, agentcore`). Several wrap a model vendor reachable by subscription OAuth.
 A coherent extension model lets openab-agent (the `native` variant) host these directly. PR #1185 already
 shipped a Discord `/auth` slash command that relays a device-flow login — the agreed near-term auth UX.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -349,6 +349,12 @@ command = "opencode"
 args = ["acp"]
 working_dir = "/home/node"
 
+# Kimi Code CLI
+[agent]
+command = "kimi"
+args = ["acp"]
+working_dir = "/home/node"
+
 # Pi Agent
 [agent]
 command = "pi-acp"

--- a/docs/image-tags.md
+++ b/docs/image-tags.md
@@ -22,7 +22,7 @@ ghcr.io/openabdev/openab:<version>-<agent>
 > **No `latest` tag.** Use `beta-<agent>` or `stable-<agent>` for floating tags,
 > or pin to an exact version like `0.9.0-beta.1-kiro`.
 
-Available agents: `kiro`, `claude`, `codex`, `copilot`, `cursor`, `gemini`, `grok`, `hermes`, `mimocode`, `opencode`, `antigravity`, `pi`, `native`, `agentcore`
+Available agents: `kiro`, `claude`, `codex`, `copilot`, `cursor`, `gemini`, `grok`, `hermes`, `kimi`, `mimocode`, `opencode`, `antigravity`, `pi`, `native`, `agentcore`
 
 ### Migration from per-repo images (deprecated)
 

--- a/docs/kimi.md
+++ b/docs/kimi.md
@@ -1,0 +1,105 @@
+# Kimi Code CLI — Agent Backend Guide
+
+[Kimi Code CLI](https://github.com/MoonshotAI/kimi-code) is Moonshot AI's coding agent. It supports the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) natively through `kimi acp`, so OpenAB can launch it directly over stdio without an adapter.
+
+## Prerequisites
+
+- Kimi Code CLI installed, or the OpenAB Kimi image
+- A Kimi Code account or a Moonshot/Kimi Platform API key
+- Persistent storage for Kimi credentials and configuration in containerized deployments
+
+## Configuration
+
+```toml
+[agent]
+command = "kimi"
+args = ["acp"]
+working_dir = "/home/node"
+```
+
+`kimi acp` communicates with OpenAB using JSON-RPC over stdin/stdout. Kimi's logs are written to stderr, keeping the ACP stream clean.
+
+## Authentication
+
+Kimi Code uses an interactive login flow. In a running container, start the CLI and enter `/login`:
+
+```bash
+kubectl exec -it deployment/openab-kimi -- kimi
+# Select Kimi Code OAuth or Kimi Platform API key, then follow the prompts.
+```
+
+Credentials and configuration are stored under `~/.kimi-code/`. The Kimi image uses `/home/node` as `HOME`, so enable persistence for production deployments. For non-container usage, run `kimi` once in the desired home directory and complete `/login` before starting OpenAB.
+
+The chart/image exposes the same helper used by other backends:
+
+```bash
+kubectl exec -it deployment/openab-kimi -- sh -c "$OPENAB_AGENT_AUTH_COMMAND"
+```
+
+Then enter `/login` in the interactive Kimi session.
+
+## Docker
+
+Build the standalone image:
+
+```bash
+docker build -f Dockerfile.kimi -t openab-kimi .
+```
+
+Build the unified image target:
+
+```bash
+docker build --target kimi -f Dockerfile.unified -t openab-kimi .
+```
+
+The image pins `@moonshot-ai/kimi-code` to a specific version. Update `KIMI_CODE_VERSION` in the Dockerfiles through a dedicated version-bump change.
+
+## Helm
+
+Use the Kimi image variant and provide the raw OpenAB configuration through `configToml` or `configUrl`:
+
+```yaml
+agents:
+  kimi:
+    enabled: true
+    image: ghcr.io/openabdev/openab:beta-kimi
+    workingDir: /home/node
+    configToml: |
+      [discord]
+      allowed_channels = ["YOUR_CHANNEL_ID"]
+
+      [agent]
+      command = "kimi"
+      args = ["acp"]
+      working_dir = "/home/node"
+```
+
+For a complete deployment, inject `DISCORD_BOT_TOKEN` through a Secret and enable a persistent volume. Discord IDs should be passed with Helm's `--set-string` option when setting them on the command line.
+
+## Model providers
+
+Kimi Code can use its managed Kimi Code OAuth service or a Kimi/Moonshot API key. It also supports configuring Anthropic, OpenAI-compatible, OpenAI Responses, Google Gemini, and Vertex AI providers in `~/.kimi-code/config.toml`. See the [Kimi providers and models reference](https://moonshotai.github.io/kimi-code/en/configuration/providers).
+
+Example Kimi provider configuration:
+
+```toml
+[providers.kimi]
+type = "kimi"
+base_url = "https://api.moonshot.ai/v1"
+
+[providers.kimi.env]
+KIMI_API_KEY = "sk-..."
+```
+
+OpenAB's child-process environment is intentionally minimal. If the provider key is supplied through an environment variable, explicitly pass it using `[agent].inherit_env` or `[agent].env`; do not assume the broker's environment is forwarded automatically.
+
+## ACP capabilities
+
+Kimi Code's ACP adapter supports normal session creation/loading, prompts, tool calls, permission handling, image input, and MCP forwarding. Audio prompts are not currently supported by Kimi's ACP adapter.
+
+## Troubleshooting
+
+- **The process exits immediately:** run `kimi` interactively and complete `/login` first.
+- **`kimi` cannot be found:** use the Kimi image or set `[agent].command` to the absolute path returned by `which kimi`.
+- **Authentication disappears after restart:** enable the agent PVC and verify that `HOME=/home/node` is writable.
+- **No response from ACP:** run `kimi acp` directly and verify that it waits for JSON-RPC input rather than printing an interactive banner.

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -46,6 +46,7 @@ See individual agent docs for authentication steps:
 - [Kiro CLI](kiro.md)
 - [Claude Code](claude-code.md)
 - [Codex](codex.md)
+- [Kimi Code CLI](kimi.md)
 - [Gemini](gemini.md)
 
 ## Bot-to-Bot Communication

--- a/docs/steering-design-guide.md
+++ b/docs/steering-design-guide.md
@@ -10,13 +10,13 @@ AI coding agents load persistent instructions every session, but without deliber
 
 This guide establishes a universal framework for organizing agent memory into layers, so rules are reliably followed, context budgets are respected, and teams can onboard new agents without starting from scratch.
 
-OpenAB is designed to be agent-agnostic — it supports Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode, and Pi running side by side. This guide provides a shared memory architecture standard that allows all supported coding agents to maintain consistent behavior, collaborate effectively, and operate from a single source of truth regardless of their underlying platform differences.
+OpenAB is designed to be agent-agnostic — it supports Kiro, Claude Code, Codex, Gemini, Kimi Code, Copilot, OpenCode, and Pi running side by side. This guide provides a shared memory architecture standard that allows all supported coding agents to maintain consistent behavior, collaborate effectively, and operate from a single source of truth regardless of their underlying platform differences.
 
 ---
 
 How to organize AI agent memory across three tiers: hot (always loaded), warm (triggered on demand), and cold (searched when needed).
 
-Applies to: Kiro, Claude Code, Codex, Gemini, Copilot, OpenCode, Pi — any agent that supports persistent instruction files.
+Applies to: Kiro, Claude Code, Codex, Gemini, Kimi Code, Copilot, OpenCode, Pi — any agent that supports persistent instruction files.
 
 ---
 


### PR DESCRIPTION
## Problem Statement
OpenAB supports a growing set of ACP-compatible coding agents, but Kimi Code CLI is not currently available as a packaged backend. Users cannot select Kimi Code through the standard OpenAB image, Helm examples, image build workflows, or backend documentation.

Issue: No existing issue is referenced; this PR implements the requested Kimi Code CLI backend addition.

## At a Glance
```text
Discord / Slack / gateway
          │
          ▼
     OpenAB broker ── ACP stdio JSON-RPC ── kimi acp
          │                                  │
          └── persistent ~/.kimi-code auth ─┘
```

## Review Contract

### Goal
Package Kimi Code CLI as a first-class OpenAB ACP backend with reproducible images, the native `kimi acp` command, interactive `/login` authentication guidance, CI/build registration, Helm configuration examples, and user-facing documentation.

### Non-goals
This PR does not change OpenAB's broker protocol, ACP session handling, gateway behavior, or existing backend defaults. It does not add a new provider implementation to Kimi Code, automate account login, or merge the pull request.

### Accepted Residual Risks
- Kimi Code is pinned to npm version `0.28.1` and uses the documented Node 24 runtime floor; future Kimi releases may require a deliberate version and image update.
- Authentication remains interactive: operators run `kimi` and enter `/login`, then persist `/home/node/.kimi-code` through the existing deployment storage mechanism.
- Full workspace validation is not green on the current `origin/main` baseline: 697 of 698 library tests passed, with `secrets::tests::resolve_exec_nonzero_exit` failing independently of this PR; clippy reports four pre-existing warnings in `cron.rs` and `discord.rs`; repository-wide `cargo fmt --check` also reports pre-existing formatting differences. These are reported transparently and are not modified by this backend-only change.

### Acceptance Criteria
- Kimi is available through both the standalone `Dockerfile.kimi` image and the `Dockerfile.unified` `kimi` target.
- Both image variants install `@moonshot-ai/kimi-code@0.28.1`, expose `kimi`, and configure `OPENAB_AGENT_COMMAND=kimi acp` with `kimi` as the interactive auth helper.
- Docker Bake, image-build workflows, smoke tests, Helm examples, image-tag documentation, backend references, and both README files register Kimi consistently.
- The implementation preserves existing backend behavior and does not stage unrelated local files.
- Targeted configuration tests, YAML parsing, whitespace checks, Docker builds/smoke tests, and Docker Bake resolution provide reproducible evidence for the change.

### Follow-ups
- Add a dedicated live ACP integration test against a non-production Kimi account when safe credentials and CI policy are available.
- Revisit package/runtime update automation and whether common Node 24 layers should be shared by future backends with the same runtime floor.
- Address the unrelated baseline test, clippy warnings, and formatting drift separately.

## Prior Art & Industry Research
- [OpenClaw](https://github.com/openclaw/openclaw) demonstrates a multi-agent packaging and operational model where agent-specific runtime dependencies and persistent auth state are treated as deployment concerns.
- [Hermes Agent](https://github.com/NousResearch/hermes-agent) provides relevant ACP-compatible agent packaging precedent and reinforces the value of keeping the broker boundary protocol-agnostic.
- This is a packaging/backend integration only; it adds no broker protocol change and keeps OpenAB's existing ACP stdio JSON-RPC boundary intact.

## Proposed Solution
- Add a standalone Node 24 Kimi image and a corresponding unified Docker target.
- Pin `@moonshot-ai/kimi-code` to `0.28.1` and use its native `kimi acp` adapter.
- Set `OPENAB_AGENT_AUTH_COMMAND=kimi`, documenting that operators enter `/login` interactively.
- Register the backend across Docker Bake, build and smoke-test workflows, Helm examples, image documentation, configuration references, ADR inventory, multi-agent guidance, and README tables.
- Add Kimi-specific unified-image smoke checks for the package version and ACP command wiring.

## Why this approach?
It follows OpenAB's existing per-backend image and workflow conventions while respecting Kimi Code's documented Node 24 requirement. Using Kimi's native ACP command avoids an additional adapter process and preserves the current broker architecture. Pinning the npm package makes image rebuilds reproducible, while the existing persistent home-volume model preserves Kimi credentials.

## Alternatives Considered
- **Use the shared Node 22 runtime:** rejected because it does not meet Kimi Code's documented runtime requirement.
- **Wrap Kimi with a third-party ACP adapter:** rejected because Kimi provides a native ACP command and an extra adapter would add an unnecessary compatibility surface.
- **Install Kimi dynamically at container startup:** rejected because it makes startup dependent on network availability and weakens reproducibility.
- **Change the broker or ACP protocol:** rejected because the native `kimi acp` stdio boundary already matches OpenAB's existing architecture.

## Validation
- `git diff --check`: passed.
- YAML parsing with Ruby for all modified workflows and `charts/openab/values.yaml`: passed.
- Remote targeted Rust configuration tests on `macmini`: 57 passed, 0 failed.
- Remote full `cargo test --workspace` on `macmini`: 697 passed, 1 unrelated pre-existing failure (`secrets::tests::resolve_exec_nonzero_exit`).
- Remote `cargo clippy --workspace --all-targets -- -D warnings`: blocked by four unrelated pre-existing warnings in `cron.rs` and `discord.rs`.
- Remote `cargo fmt --all -- --check`: blocked by extensive pre-existing formatting differences on `origin/main`; no unrelated formatting was changed.
- Unified Kimi image: built successfully with OrbStack Docker; smoke checks confirmed `/usr/local/bin/openab`, `/usr/local/bin/kimi`, `OPENAB_AGENT_COMMAND=kimi acp`, and package version `0.28.1`.
- Standalone Kimi image: built successfully with the same smoke checks.
- `docker buildx bake --print kimi`: passed and resolved `Dockerfile.kimi`.


https://discord.com/channels/1491295327620169908/1491365150664560881/1528804085480951840
