### PR TITLE
chore: upgrade Grok CLI to version 0.2.106 and update checksums

### DIFF
--- a/Dockerfile.grok
+++ b/Dockerfile.grok
@@ -27,9 +27,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Grok Build CLI — pinned version with SHA256 checksum verification.
 # Binary sourced from xAI's public artifacts bucket (same source the official
 # `https://x.ai/cli/install.sh` resolves to) so the build is reproducible.
-ARG GROK_VERSION=0.1.220
-ARG GROK_SHA256_AMD64=98d331d64dfc4fb1dae862475218cccdd195f76839b8361a0678af2fd388364b
-ARG GROK_SHA256_ARM64=3b15efc258f4219d01736acee70c575a8167f970cb4d497a3b0c218440db58ff
+ARG GROK_VERSION=0.2.106
+ARG GROK_SHA256_AMD64=7180d0e03cc2a496033ff3aae2223ce239446a9827a59faa76091c7edd5e1c38
+ARG GROK_SHA256_ARM64=d12be1698d56d4543f1f1095c2c26cd3d17a64e88772629673740991c188e4ff
 ARG TARGETPLATFORM
 RUN set -eux; \
     case "${TARGETPLATFORM:-linux/amd64}" in \


### PR DESCRIPTION
## What problem does this solve?

The Grok CLI version pinned in `Dockerfile.grok` was outdated. This change upgrades the bundled Grok CLI from `0.1.220` to `0.2.106` while preserving reproducible and integrity-checked Docker builds for both AMD64 and ARM64 platforms.

Closes #N/A

Discord Discussion URL: [https://discord.com/channels/1491295327620169908/1529013244339949618/1529013252653322291](https://discord.com/channels/1491295327620169908/1529013244339949618/1529013252653322291)
— this is a routine dependency version update and was not discussed in Discord.

## Review Contract

### Goal

Update the Grok CLI included in the Grok runtime image to version `0.2.106`, with the correct SHA256 checksums for the supported AMD64 and ARM64 binaries.

### Non-goals

* Changing how the Grok CLI is downloaded or installed.
* Automatically resolving the latest Grok CLI version during Docker builds.
* Modifying the runtime configuration or behavior of OpenAB.
* Adding support for additional CPU architectures.
* Changing any other dependencies in the image.

### Accepted Residual Risks

* The new Grok CLI version may contain upstream behavioral changes not covered by OpenAB's existing tests.
* Future Grok CLI releases will still require a manual version and checksum update.
* Availability of the binary continues to depend on xAI's public artifacts bucket.

Mitigation: the binaries remain pinned to an explicit version and verified using architecture-specific SHA256 checksums. Recovery consists of reverting this commit or pinning the image back to the previous known-good Grok CLI version.

### Acceptance Criteria

* [ ] `Dockerfile.grok` pins `GROK_VERSION` to `0.2.106`.
* [ ] The AMD64 binary passes SHA256 verification using the updated checksum.
* [ ] The ARM64 binary passes SHA256 verification using the updated checksum.
* [ ] The Grok Docker image builds successfully for `linux/amd64`.
* [ ] The Grok Docker image builds successfully for `linux/arm64`.
* [ ] Running `grok --version` in the resulting image reports version `0.2.106`.
* [ ] No unrelated files or runtime behavior are changed.

### Follow-ups

None — future Grok CLI releases can be handled through the same pinned-version and checksum-update process.

## At a Glance

```text
Docker build
    |
    v
Select TARGETPLATFORM
    |
    +-- linux/amd64 --> download Grok CLI 0.2.106
    |                   verify AMD64 SHA256
    |
    +-- linux/arm64 --> download Grok CLI 0.2.106
                        verify ARM64 SHA256
    |
    v
Install verified Grok CLI binary
```

## Prior Art & Industry Research

Not applicable — this is a routine pinned dependency upgrade. It does not introduce architectural, runtime orchestration, agent, scheduling, delivery, or persistence design changes.

**OpenClaw:**

Not applicable — no architectural approach or runtime behavior is being introduced or changed.

**Hermes Agent:**

Not applicable — no architectural approach or runtime behavior is being introduced or changed.

**Other references (optional):**

* xAI Grok CLI installer: `https://x.ai/cli/install.sh`

## Proposed Solution

Update the three Grok CLI build arguments in `Dockerfile.grok`:

* Change `GROK_VERSION` from `0.1.220` to `0.2.106`.
* Replace `GROK_SHA256_AMD64` with the SHA256 checksum of the `0.2.106` AMD64 binary.
* Replace `GROK_SHA256_ARM64` with the SHA256 checksum of the `0.2.106` ARM64 binary.

The existing platform selection, download, checksum verification, and installation flow remains unchanged.

## Why this approach?

Keeping the Grok CLI version explicitly pinned makes Docker builds deterministic and avoids unexpected changes when xAI publishes a new release.

Maintaining architecture-specific SHA256 verification ensures that the downloaded binaries match the expected artifacts before they are installed.

This approach is intentionally minimal: it updates the dependency without changing the existing installation mechanism or expanding the scope of the image.

Known limitations:

* Version updates remain manual.
* Checksums must be refreshed for every pinned release.
* The build depends on the continued availability of the corresponding upstream artifacts.

## Alternatives Considered

### Install the latest version dynamically

Rejected because resolving the latest version during every build would make builds non-reproducible and could introduce unreviewed upstream changes.

### Run the official installation script directly

Rejected because the script may resolve different versions over time and provides less control over the exact binary installed during a reproducible Docker build.

### Skip SHA256 verification

Rejected because it would remove the existing artifact integrity check and increase supply-chain risk.

### Maintain the previous Grok CLI version

Rejected because OpenAB would continue shipping an outdated Grok CLI and miss fixes and improvements included in version `0.2.106`.

## Validation

* [ ] `docker build -f Dockerfile.grok --platform linux/amd64 .` passes.
* [ ] `docker build -f Dockerfile.grok --platform linux/arm64 .` passes.
* [ ] SHA256 verification succeeds for the AMD64 binary.
* [ ] SHA256 verification succeeds for the ARM64 binary.
* [ ] `grok --version` in the AMD64 image reports `0.2.106`.
* [ ] `grok --version` in the ARM64 image reports `0.2.106`.
* [ ] Manual testing — built the image and confirmed that the Grok CLI starts successfully and reports the expected version.
