### PR TITLE
fix(build): add missing kimi stage to Dockerfile.package

### DIFF
--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -115,6 +115,33 @@ ENTRYPOINT ["tini", "--"]
 CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 
 # =============================================================================
+# Target: kimi
+# =============================================================================
+FROM node:24-trixie-slim AS kimi
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl procps ripgrep tini bubblewrap socat unzip git \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+ARG KIMI_CODE_VERSION=0.28.1
+RUN npm install -g @moonshot-ai/kimi-code@${KIMI_CODE_VERSION} --retry 3
+ENV HOME=/home/node
+WORKDIR /home/node
+COPY --from=bins --chown=node:node /openab /usr/local/bin/openab
+RUN mkdir -p /home/node/.kimi-code && chown -R node:node /home/node
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD pgrep -x openab || exit 1
+ENV OPENAB_AGENT_COMMAND="kimi acp"
+ENV OPENAB_AGENT_AUTH_COMMAND="kimi"
+ENTRYPOINT ["tini", "--"]
+CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
+
+# =============================================================================
 # Target: copilot
 # =============================================================================
 FROM base-node AS copilot


### PR DESCRIPTION
PR #1429 added the Kimi Code backend to `Dockerfile.unified` and to the pre-beta workflow's `ALL_AGENTS`, but `Dockerfile.package` — the file `pre-beta-build.yml` actually builds from — never got the stage. Every real (non-gate-skipped) pre-beta run since 2026-07-20 fails both kimi build jobs:

```
ERROR: failed to build: failed to solve: target stage "kimi" could not be found (did you mean kiro?)
```

(runs 29776844194, 29791564121, 29830138174 — `fail-fast: false` masked it, so all other agent tags published fine and only `ghcr.io/openabdev/openab:pre-beta-kimi` is missing, 404 on GHCR.)

This ports the kimi stage verbatim from `Dockerfile.unified` (node:24-trixie-slim base, gh CLI, `@moonshot-ai/kimi-code@0.28.1`), adapted to the package pattern: `COPY --from=bins --chown=node:node /openab` instead of the builder stage. Inserted between `codex` and `copilot`, matching the stage order in `Dockerfile.unified`.

## Review Contract

### Goal
Restore the pre-beta build for the kimi agent so `ghcr.io/openabdev/openab:pre-beta-kimi` is published by `pre-beta-build.yml`, matching the agent list added in #1429.

### Non-goals
- No changes to `Dockerfile.unified`, release builds (`build-images.yml`), or snapshot builds — those already have kimi coverage.
- No version bumps: `KIMI_CODE_VERSION=0.28.1` is kept identical to `Dockerfile.unified` on main.
- No workflow changes.

### Accepted Residual Risks
The two Dockerfiles duplicate the kimi stage and can drift again (this PR is itself a drift fix). Mitigation: any pin bump touching one file should touch both; a CI parity check is deferred to Follow-ups. Recovery: identical to this PR — port the stage and dispatch a rebuild.

### Acceptance Criteria
- `Dockerfile.package` contains a `kimi` stage differing from the `Dockerfile.unified` stage only in the openab binary COPY source (`bins` context vs builder stage) — verifiable by diffing the two stage blocks.
- After merge, a `pre-beta-build.yml` dispatch with `agents=kimi` completes with green `build (kimi, ...)` jobs on both amd64 and arm64, and `docker manifest inspect ghcr.io/openabdev/openab:pre-beta-kimi` succeeds.

### Follow-ups
Add a CI lint that asserts every agent in the workflows' `ALL_AGENTS` has a matching stage in both `Dockerfile.unified` and `Dockerfile.package`, to prevent the next backend addition from repeating this failure mode.
