### PR TITLE
fix(feishu): start websocket in unified mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1081,6 +1081,36 @@ async fn main() -> anyhow::Result<()> {
                 );
             }
 
+            // Feishu bot identity + WebSocket long-connection (unified mode).
+            // This mirrors the standalone gateway: the default websocket mode
+            // otherwise mounts only the webhook route and receives no events.
+            #[cfg(feature = "feishu")]
+            if let Some(ref f) = gw_state.feishu {
+                use openab_gateway::adapters::feishu;
+                f.resolve_bot_identity().await;
+                if f.config.streaming_mode != feishu::StreamingMode::Post {
+                    let idle_ms = f.config.card_idle_finalize_ms;
+                    tokio::spawn(feishu::run_idle_reaper(
+                        f.stream_sessions.clone(),
+                        f.token_cache.clone(),
+                        f.client.clone(),
+                        f.config.api_base(),
+                        idle_ms,
+                    ));
+                    info!(idle_ms, "unified: feishu card-streaming idle reaper started");
+                }
+                if f.config.connection_mode == feishu::ConnectionMode::Websocket {
+                    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+                    match feishu::start_websocket(f, event_tx.clone(), shutdown_rx).await {
+                        Ok(_handle) => info!("unified: feishu websocket task spawned"),
+                        Err(e) => error!(err = %e, "unified: feishu websocket startup failed"),
+                    }
+                    // Keep the sender alive so dropping it cannot terminate the
+                    // reconnect loop through shutdown_rx.changed().
+                    std::mem::forget(shutdown_tx);
+                }
+            }
+
             #[cfg(feature = "wecom")]
             if let Some(ref w) = gw_state.wecom {
                 info!(path = %w.config.webhook_path, "unified: wecom adapter enabled");


### PR DESCRIPTION
## What problem does this solve?

Unified mode registers the Feishu webhook route but does not resolve the bot identity or start the Feishu WebSocket client. Since WebSocket is the default connection mode, a configured Feishu bot can start without receiving inbound events. This is tracked under #1356.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1529851383321329765

This is a minimal rebase of @angmeng (Jaz Lim)'s prior closed implementation in #1293.

## Review Contract

### Goal

Make unified mode receive Feishu events in its default WebSocket configuration by matching the standalone gateway startup sequence: resolve bot identity, start the card idle reaper when applicable, and start the WebSocket client.

### Non-goals

This PR does not change Feishu webhook routing, configuration precedence, CardKit rendering, card streaming behavior, proxy/TLS handling, or any non-Feishu unified adapter.

### Accepted Residual Risks

The WebSocket shutdown sender is intentionally retained for the process lifetime because dropping it terminates the reconnect loop. As with the standalone gateway, shutdown is process-lifecycle based; operators recover from a failed service by restarting OpenAB.

### Acceptance Criteria

- [x] With `connection_mode=websocket`, unified mode resolves the Feishu bot identity and starts a WebSocket task.
- [x] The WebSocket client connects and Feishu direct messages reach the agent.
- [x] Card streaming idle reaping remains enabled for non-Post modes, matching the standalone gateway.
- [x] The change is limited to unified Feishu startup.

### Follow-ups

Config-only unified Feishu activation and the broader webhook/long-connection mode alignment remain tracked under #1356. Card streaming behavior is intentionally deferred to a separate change.

## At a Glance

```text
Feishu Cloud -- WebSocket --> unified OpenAB -- ACP --> agent
                               | resolve bot identity
                               | start idle reaper
                               | retain reconnect task
```

## Prior Art & Industry Research

**OpenClaw:** #703 documents the Feishu/Lark adapter's WebSocket long-connection as the default transport: https://github.com/openabdev/openab/issues/703

**Hermes Agent:** #703 records Hermes Agent as prior art for a Feishu adapter supporting WebSocket plus webhook fallback; this PR preserves that outbound-long-connection model in unified mode.

**Other references:** Adapted from @angmeng's verified unified-mode fix in #1293: https://github.com/openabdev/openab/pull/1293

## Proposed Solution

After unified mode registers the Feishu webhook route, mirror the standalone gateway startup path: call `resolve_bot_identity`, spawn `run_idle_reaper` when CardKit streaming is active, and call `start_websocket` for WebSocket connection mode. Keep the watch sender alive so the reconnect loop is not terminated by a dropped sender.

## Why this approach?

It reuses the already-established standalone gateway lifecycle and the prior #1293 implementation instead of introducing a separate unified-only receiver. The change is small, preserves webhook support, and restores compatibility with Feishu's default WebSocket mode.

## Alternatives Considered

- Require operators to use public HTTPS webhooks: rejected because it contradicts Feishu's default long-connection mode and adds unnecessary deployment infrastructure.
- Move all startup lifecycle code into a new abstraction: deferred because it expands the scope beyond restoring missing parity.
- Change CardKit streaming in this PR: deferred to keep runtime delivery behavior isolated from transport startup.

## Validation

- [x] `cargo test --features unified --bin openab has_unified_platform_checks_config_and_env`
- [x] `cargo build --release --features unified`
- [x] `cargo clippy --features unified -- -D warnings`
- [x] Manual Windows validation: deployed the release build behind the configured HTTP proxy; logs confirmed bot identity resolution and a connected Feishu WebSocket; an OpenCode Feishu direct message round-tripped successfully.
