### PR TITLE
feat(acp): forward configured MCP servers

### DIFF
--- a/crates/openab-core/src/acp/connection.rs
+++ b/crates/openab-core/src/acp/connection.rs
@@ -2,6 +2,7 @@ use crate::acp::protocol::{
     parse_config_options, parse_usage_report, ConfigOption, JsonRpcMessage, JsonRpcRequest,
     JsonRpcResponse, UsageReport,
 };
+use crate::config::McpServerConfig;
 use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -12,6 +13,31 @@ use tokio::process::{Child, ChildStdin};
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, trace};
+
+fn redact_acp_mcp_secrets(data: &str) -> String {
+    let Ok(mut message) = serde_json::from_str::<Value>(data) else {
+        return "<unparseable ACP message>".to_string();
+    };
+
+    if let Some(servers) = message
+        .pointer_mut("/params/mcpServers")
+        .and_then(Value::as_array_mut)
+    {
+        for server in servers {
+            for field in ["headers", "env"] {
+                if let Some(entries) = server.get_mut(field).and_then(Value::as_array_mut) {
+                    for entry in entries {
+                        if let Some(value) = entry.get_mut("value") {
+                            *value = Value::String("[REDACTED]".to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    serde_json::to_string(&message).unwrap_or_else(|_| "<unserializable ACP message>".to_string())
+}
 
 /// Pick the most permissive selectable permission option from ACP options.
 fn pick_best_option(options: &[Value]) -> Option<String> {
@@ -493,7 +519,7 @@ impl AcpConnection {
     }
 
     pub(crate) async fn send_raw(&self, data: &str) -> Result<()> {
-        debug!(data = data.trim(), "acp_send");
+        debug!(data = %redact_acp_mcp_secrets(data), "acp_send");
         // A hung agent can stop draining stdin; bound the write so callers
         // (and the mutexes they hold) can never block on it indefinitely.
         tokio::time::timeout(std::time::Duration::from_secs(10), async {
@@ -562,9 +588,16 @@ impl AcpConnection {
         Ok(())
     }
 
-    pub async fn session_new(&mut self, cwd: &str) -> Result<String> {
+    pub async fn session_new(
+        &mut self,
+        cwd: &str,
+        mcp_servers: &[McpServerConfig],
+    ) -> Result<String> {
         let resp = self
-            .send_request("session/new", Some(json!({"cwd": cwd, "mcpServers": []})))
+            .send_request(
+                "session/new",
+                Some(json!({"cwd": cwd, "mcpServers": mcp_servers})),
+            )
             .await?;
 
         let session_id = resp
@@ -777,11 +810,20 @@ impl AcpConnection {
 
     /// Resume a previous session by ID. Returns Ok(()) if the agent accepted
     /// the load, or an error if it failed (caller should fall back to session/new).
-    pub async fn session_load(&mut self, session_id: &str, cwd: &str) -> Result<()> {
+    pub async fn session_load(
+        &mut self,
+        session_id: &str,
+        cwd: &str,
+        mcp_servers: &[McpServerConfig],
+    ) -> Result<()> {
         let resp = self
             .send_request(
                 "session/load",
-                Some(json!({"sessionId": session_id, "cwd": cwd, "mcpServers": []})),
+                Some(json!({
+                    "sessionId": session_id,
+                    "cwd": cwd,
+                    "mcpServers": mcp_servers
+                })),
             )
             .await?;
         // Accept any non-error response as success
@@ -836,7 +878,9 @@ impl Drop for AcpConnection {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_agent_env, build_permission_response, pick_best_option};
+    use super::{
+        build_agent_env, build_permission_response, pick_best_option, redact_acp_mcp_secrets,
+    };
     use serde_json::json;
 
     #[test]
@@ -968,6 +1012,43 @@ mod tests {
 
         assert!(!result.contains_key("OAB_TEST_NONEXISTENT_VAR_12345"));
         assert!(inherited.is_empty());
+    }
+
+    #[test]
+    fn outbound_acp_logs_redact_mcp_credentials() {
+        let raw = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {
+                "cwd": "/workspace",
+                "mcpServers": [
+                    {
+                        "type": "http",
+                        "name": "github",
+                        "url": "http://octobroker:8080/mcp",
+                        "headers": [
+                            {"name": "X-Octobroker-Key", "value": "super-secret"}
+                        ]
+                    },
+                    {
+                        "name": "local",
+                        "command": "/bin/local",
+                        "env": [
+                            {"name": "LOCAL_TOKEN", "value": "local-secret"}
+                        ]
+                    }
+                ]
+            }
+        })
+        .to_string();
+
+        let redacted = redact_acp_mcp_secrets(&raw);
+
+        assert!(!redacted.contains("super-secret"));
+        assert!(!redacted.contains("local-secret"));
+        assert_eq!(redacted.matches("[REDACTED]").count(), 2);
+        assert!(redacted.contains("octobroker:8080/mcp"));
     }
 }
 

--- a/crates/openab-core/src/acp/pool.rs
+++ b/crates/openab-core/src/acp/pool.rs
@@ -364,7 +364,10 @@ impl SessionPool {
         let mut load_failed: Option<&str> = None;
         if let Some(ref sid) = saved_session_id {
             if new_conn.supports_load_session {
-                match new_conn.session_load(sid, &effective_workdir).await {
+                match new_conn
+                    .session_load(sid, &effective_workdir, &self.config.mcp_servers)
+                    .await
+                {
                     Ok(()) => {
                         info!(thread_id, session_id = %sid, "session resumed via session/load");
                         resumed = true;
@@ -401,7 +404,9 @@ impl SessionPool {
         }
 
         if !resumed {
-            new_conn.session_new(&effective_workdir).await?;
+            new_conn
+                .session_new(&effective_workdir, &self.config.mcp_servers)
+                .await?;
 
             // Apply default config options (e.g. mode=bypass, model=swe-1-6)
             for (config_id, value) in &self.default_config_options {

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -1,6 +1,6 @@
 use crate::markdown::TableMode;
 use regex::Regex;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -1425,6 +1425,52 @@ impl PlatformTrustConfig {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct McpConfigEntry {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum McpRemoteTransport {
+    Http,
+    Sse,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct McpRemoteServerConfig {
+    #[serde(rename = "type")]
+    pub transport: McpRemoteTransport,
+    pub name: String,
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub headers: Vec<McpConfigEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct McpStdioServerConfig {
+    pub name: String,
+    pub command: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<McpConfigEntry>,
+}
+
+/// ACP MCP server configuration forwarded to `session/new` and `session/load`.
+///
+/// HTTP/SSE servers carry a `type` discriminator. Stdio servers intentionally
+/// omit it to match the ACP v1 wire schema.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum McpServerConfig {
+    Remote(McpRemoteServerConfig),
+    Stdio(McpStdioServerConfig),
+}
+
 /// Raw intermediate struct for serde — uses `Option` to detect explicit fields.
 #[derive(Debug, Deserialize)]
 #[serde(default)]
@@ -1434,6 +1480,7 @@ struct AgentConfigRaw {
     working_dir: String,
     env: HashMap<String, String>,
     inherit_env: Vec<String>,
+    mcp_servers: Vec<McpServerConfig>,
 }
 
 impl Default for AgentConfigRaw {
@@ -1444,6 +1491,7 @@ impl Default for AgentConfigRaw {
             working_dir: default_working_dir(),
             env: HashMap::new(),
             inherit_env: Vec::new(),
+            mcp_servers: Vec::new(),
         }
     }
 }
@@ -1455,6 +1503,7 @@ pub struct AgentConfig {
     pub working_dir: String,
     pub env: HashMap<String, String>,
     pub inherit_env: Vec<String>,
+    pub mcp_servers: Vec<McpServerConfig>,
     /// Whether the command was explicitly set in config (vs defaulted from env/fallback).
     pub command_explicit: bool,
 }
@@ -1467,6 +1516,7 @@ impl Default for AgentConfig {
             working_dir: default_working_dir(),
             env: HashMap::new(),
             inherit_env: Vec::new(),
+            mcp_servers: Vec::new(),
             command_explicit: false,
         }
     }
@@ -1493,6 +1543,7 @@ impl<'de> serde::Deserialize<'de> for AgentConfig {
             working_dir: raw.working_dir,
             env: raw.env,
             inherit_env: raw.inherit_env,
+            mcp_servers: raw.mcp_servers,
             command_explicit: cmd_explicit,
         })
     }
@@ -2072,6 +2123,7 @@ fn parse_config_inner(expanded: &str, source: &str) -> anyhow::Result<Config> {
                 working_dir: config.agent.working_dir.clone(),
                 env: config.agent.env.clone(),
                 inherit_env: config.agent.inherit_env.clone(),
+                mcp_servers: config.agent.mcp_servers.clone(),
                 command_explicit: true, // synthesized counts as explicit
             };
         }
@@ -3629,5 +3681,56 @@ cancel_strategy = "noop"
         let cfg = parse_config(toml, "test").unwrap();
         let ac = cfg.agentcore.unwrap();
         assert_eq!(ac.cancel_strategy, AgentCoreCancelStrategy::Noop);
+    }
+
+    #[test]
+    fn agent_mcp_servers_parse_to_acp_wire_shapes() {
+        let cfg = parse_config_str(
+            r#"
+[agent]
+command = "claude-agent-acp"
+
+[[agent.mcp_servers]]
+type = "http"
+name = "github"
+url = "http://octobroker:8080/mcp"
+headers = [
+  { name = "X-Octobroker-Key", value = "test-secret" },
+]
+
+[[agent.mcp_servers]]
+name = "local-tools"
+command = "/usr/local/bin/local-tools"
+args = ["--stdio"]
+env = [
+  { name = "LOCAL_TOKEN", value = "test-local-secret" },
+]
+"#,
+            "test",
+        )
+        .unwrap();
+
+        assert_eq!(cfg.agent.mcp_servers.len(), 2);
+        assert_eq!(
+            serde_json::to_value(&cfg.agent.mcp_servers).unwrap(),
+            serde_json::json!([
+                {
+                    "type": "http",
+                    "name": "github",
+                    "url": "http://octobroker:8080/mcp",
+                    "headers": [
+                        {"name": "X-Octobroker-Key", "value": "test-secret"}
+                    ]
+                },
+                {
+                    "name": "local-tools",
+                    "command": "/usr/local/bin/local-tools",
+                    "args": ["--stdio"],
+                    "env": [
+                        {"name": "LOCAL_TOKEN", "value": "test-local-secret"}
+                    ]
+                }
+            ])
+        );
     }
 }

--- a/crates/openab-core/src/dispatch.rs
+++ b/crates/openab-core/src/dispatch.rs
@@ -1195,6 +1195,7 @@ mod tests {
             working_dir: "/tmp".into(),
             env: std::collections::HashMap::new(),
             inherit_env: vec![],
+            mcp_servers: vec![],
             command_explicit: true,
         };
         let pool = Arc::new(SessionPool::new(

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -288,8 +288,29 @@ The AI agent subprocess that OpenAB spawns to handle messages via ACP.
 | `working_dir` | string | `$HOME` | Working directory for the agent process. Optional — defaults to container's `$HOME`. |
 | `env` | map | `{}` | Extra environment variables (e.g. `{ OPENAI_API_KEY = "${OPENAI_API_KEY}" }`). |
 | `inherit_env` | string[] | `[]` | Env var names to inherit from the OAB process (e.g. vars injected via K8s `envFrom`). Keys in `env` take precedence. |
+| `mcp_servers` | table[] | `[]` | MCP servers forwarded to the ACP agent on every `session/new` and `session/load`. Supports ACP HTTP, SSE, and stdio server shapes. |
 
 > **Default inherited vars:** After `env_clear()`, the agent always receives `HOME`, `PATH`, and `USER` (on Windows: `USERPROFILE`, `USERNAME`, `PATH`, `SystemRoot`, `SystemDrive`). Use `inherit_env` to pass additional vars beyond this baseline.
+
+### ACP MCP servers
+
+OpenAB is the ACP client, so MCP servers configured here are attached to each
+agent session. This is distinct from MCP configuration read directly by an
+agent CLI outside OpenAB.
+
+```toml
+[[agent.mcp_servers]]
+type = "http"
+name = "github"
+url = "http://octobroker:8080/mcp"
+headers = [
+  { name = "X-Octobroker-Key", value = "${OCTOBROKER_KEY}" },
+]
+```
+
+HTTP header values and stdio environment values are redacted from OpenAB's ACP
+debug log. Keep their source values in environment variables or a configured
+secret provider rather than committing credentials.
 
 ### Authentication
 


### PR DESCRIPTION
## Summary

- add typed agent.mcp_servers config for ACP HTTP, SSE, and stdio servers
- forward the same server list on session/new and session/load
- redact MCP header and stdio environment values from ACP debug logs
- document the config shape and add regression tests

## Why

OpenAB currently hardcodes mcpServers to an empty list, so ACP-backed agents cannot use MCP servers provisioned by the OpenAB operator. This blocks a dev integration where Claude Code should read GitHub through OctoBroker without falling back to GitHub CLI.

## Verification

- cargo check -p openab-core
- cargo clippy -p openab-core -- -D warnings
- targeted config serialization and secret redaction tests pass
- cargo test -p openab-core: 662 passed; the one failure is the pre-existing secrets::tests::resolve_exec_nonzero_exit failure, and this branch does not modify secrets.rs
- all upstream Docker smoke-test variants passed, including Dockerfile.claude and the unified Claude target

## Dev rollout

Build a Claude canary image and deploy it only to the rev-claude service in opencodezebra-council-dev for a fail-closed OctoBroker E2E. Production is out of scope.

## Review Contract

### Goal

Allow an OpenAB operator to configure ACP MCP servers once and have OpenAB forward the exact typed server list on both new and loaded ACP sessions, without leaking header or stdio environment values in ACP debug logs.

### Non-goals

- OpenAB does not implement an MCP transport or broker.
- This does not add OctoBroker-specific behavior to OpenAB core.
- This does not remove GitHub CLI or credentials from existing images.
- This does not authorize a production rollout.

### Accepted Residual Risks

- An operator-controlled MCP server retains the capabilities the operator explicitly grants it; policy enforcement remains the responsibility of that server and the selected ACP agent.
- A configured stdio server is a local child process and therefore has the operating-system access of that process boundary.
- The unrelated resolve_exec_nonzero_exit test currently fails on the base branch and remains unchanged here.

### Acceptance Criteria

- HTTP, SSE, and stdio MCP server wire shapes deserialize from agent.mcp_servers.
- session/new and session/load receive the configured list.
- MCP header values and stdio environment values are redacted from ACP send logs.
- The public config reference documents the supported shape.
- cargo check and clippy pass, targeted regressions pass, and upstream Claude image smoke tests pass.
- A dev-only OctoBroker canary proves a real broker tool call without GitHub CLI fallback before production consideration.

### Follow-ups

The environment-specific OctoBroker dev E2E, direct credential removal, and any later production rollout are tracked in the private openab-control-plane-ops runbook rather than bundled into this core change.