### PR TITLE
fix(ci): fork guard for pending-maintainer label writes

### DIFF
--- a/.github/workflows/pending-maintainer.yml
+++ b/.github/workflows/pending-maintainer.yml
@@ -11,7 +11,16 @@ on:
 
 jobs:
   check-pending:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.issue.pull_request != null || github.event.pull_request != null
+    # Fork guard: pull_request_review on a fork PR gets a read-only GITHUB_TOKEN,
+    # so label writes would 403 ("Resource not accessible by integration").
+    # Skip those runs — the hourly schedule / workflow_dispatch reconciliation
+    # (full token) keeps fork PR labels correct.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      github.event.issue.pull_request != null ||
+      (github.event.pull_request != null &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary

`pending-maintainer.yml` fails on every `pull_request_review` event triggered by a **fork** PR: those runs get a read-only `GITHUB_TOKEN`, so the label add/remove calls 403 with `Resource not accessible by integration` (e.g. run 30031123975 on #1440, `POST /issues/1440/labels`).

## Change

Job-level fork guard: only handle `pull_request_review` when `github.event.pull_request.head.repo.full_name == github.repository`. Fork-PR runs show as **skipped** instead of **failure**.

- Same-repo PRs: unchanged, labels applied immediately
- Fork PRs: labels stay eventually-consistent via the hourly `schedule` / `workflow_dispatch` reconciliation (runs on main with a full token — verified green)
- `issue_comment` and `schedule` paths untouched (both currently succeed)

## Testing

- YAML validated
- Root cause confirmed from failed run logs (403 on label write, `pull_request_review` event, head branch `feat/feishu-unified-websocket`)
- Not verifiable pre-merge: `pull_request_review` runs use the merge-ref workflow version, so the skip behavior on fork PRs takes effect once this lands on `main`

## Review Contract

### Goal

Stop `pending-maintainer.yml` from failing on every `pull_request_review` event triggered by a fork PR (read-only `GITHUB_TOKEN` → 403 on label writes), while keeping label behavior for same-repo PRs unchanged.

### Non-goals

- No change to label semantics, timing for same-repo PRs, or the `issue_comment` / `schedule` / `workflow_dispatch` paths
- Not attempting immediate (event-time) labeling of fork PRs — that requires a privileged trigger (e.g. `pull_request_target`) and is intentionally out of scope

### Accepted Residual Risks

- Fork PR labels are eventually-consistent (up to ~1h behind, via the hourly `schedule` reconciliation) instead of immediate on review submission
- Skipped runs show as "skipped" on fork PRs; anyone expecting a green check there sees a neutral state instead

### Acceptance Criteria

- `pull_request_review` on a fork PR (e.g. #1440): job is skipped, no failure
- `pull_request_review` on a same-repo PR: job runs and labels as before
- `schedule` / `workflow_dispatch` / `issue_comment` runs: unchanged and green
- YAML validates; job-level `if` only extends the existing condition

### Follow-ups

None — single-file workflow guard; if immediate fork-PR labeling is ever wanted, evaluate `pull_request_target` separately with its own security review.
