### PR TITLE
docs: document maintainer take-over of fork PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,7 +295,9 @@ the PR:
 2. **Preserve attribution.** Cherry-pick the contributor's commits onto a new
    branch in this repository so the original commit author is preserved. If
    commits must be rewritten or squashed, add a
-   `Co-authored-by: Name <email>` trailer.
+   `Co-authored-by: username <username@users.noreply.github.com>` trailer
+   (GitHub requires the `Name <email>` form; the noreply address avoids
+   exposing a real email).
 3. **Credit in the PR description.** The replacement PR must mention the
    original contributor with `@username` and link the original PR
    (e.g. "Supersedes #123, carrying forward @contributor's work").

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,3 +279,33 @@ Every PR follows a label-driven lifecycle that keeps the review loop moving.
 - **Author comment always resets** — any comment by the PR author removes `pending-contributor` and `closing-soon`, flipping the PR back to `pending-maintainer`.
 - **Re-check may re-apply `closing-soon`** — after the flip, automated checks still run. If blockers remain (e.g., missing Discord URL, CI failure, `needs-rebase`), `closing-soon` will be re-applied immediately, keeping the ball on the contributor.
 - **Immediate `closing-soon`** — in some cases (e.g., missing Discord Discussion URL), `closing-soon` is applied immediately without waiting for the stale period. Auto-close follows in 24 hours.
+
+### Maintainer Take-Over of Fork PRs
+
+PRs from personal forks cannot always be finished on the contributor's branch:
+maintainer bots authenticate with GitHub App installation tokens, which GitHub
+does not allow to push to fork branches (the "Allow edits by maintainers"
+mechanism only applies to user credentials). Rather than blocking a good
+contribution on back-and-forth for small fixes, a maintainer may **take over**
+the PR:
+
+1. **Agree on direction first.** Take-over happens after a maintainer review,
+   when the approach is accepted and only nits or mechanical fixes remain —
+   or when the contributor is unresponsive and the change is worth landing.
+2. **Preserve attribution.** Cherry-pick the contributor's commits onto a new
+   branch in this repository so the original commit author is preserved. If
+   commits must be rewritten or squashed, add a
+   `Co-authored-by: Name <email>` trailer.
+3. **Credit in the PR description.** The replacement PR must mention the
+   original contributor with `@username` and link the original PR
+   (e.g. "Supersedes #1440, carrying forward @SunnyYYLin's contribution").
+4. **Finish the nits and merge.** The maintainer applies the remaining review
+   feedback on the new branch and merges once checks pass.
+5. **Close the original PR** with a comment linking the replacement, thanking
+   the contributor, and noting their authorship is preserved.
+
+Example: #1443 took over #1440.
+
+Contributors who prefer to finish the work themselves can say so on the PR —
+take-over is a convenience to get accepted work merged, not a way to bypass
+the contributor.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,7 +298,7 @@ the PR:
    `Co-authored-by: Name <email>` trailer.
 3. **Credit in the PR description.** The replacement PR must mention the
    original contributor with `@username` and link the original PR
-   (e.g. "Supersedes #1440, carrying forward @SunnyYYLin's contribution").
+   (e.g. "Supersedes #123, carrying forward @contributor's work").
 4. **Finish the nits and merge.** The maintainer applies the remaining review
    feedback on the new branch and merges once checks pass.
 5. **Close the original PR** with a comment linking the replacement, thanking


### PR DESCRIPTION
## Summary

Documents the maintainer take-over pattern for fork PRs in CONTRIBUTING.md (new section under PR Lifecycle).

Maintainer bots authenticate with GitHub App installation tokens, which cannot push to fork branches — "Allow edits by maintainers" only applies to user credentials. When a reviewed fork PR needs only nits/mechanical fixes, a maintainer may take it over: cherry-pick to preserve commit authorship (or `Co-authored-by` when rewriting), credit `@username` + link the original PR in the replacement description, finish the fixes, merge, and close the original with a link.

Pattern established in #1443 (took over #1440, carrying forward the original contributor's work).

## Review Contract

### Goal

Make the fork-PR take-over process an explicit, documented policy — attribution rules, when it applies, and the contributor's opt-out — so future take-overs follow one consistent pattern.

### Non-goals

- No workflow/CI changes and no change to the label lifecycle
- Not enabling App tokens to push to forks (GitHub platform limitation, out of our control)
- Not making take-over the default path — contributor-driven fixes remain preferred

### Accepted Residual Risks

- Docs-only: the policy relies on maintainers following it; no automation enforces attribution in replacement PRs
- Wording may need refinement as more take-overs happen

### Acceptance Criteria

- CONTRIBUTING.md renders correctly with the new "Maintainer Take-Over of Fork PRs" section under PR Lifecycle
- Section covers: why (App token limitation), attribution (cherry-pick / Co-authored-by), @username credit in PR description, closing the original PR, and contributor opt-out
- References #1443/#1440 as the worked example

### Follow-ups

None — docs-only. If take-over frequency grows, consider a PR-description template checkbox for "Supersedes #N" attribution.
