### PR TITLE
docs: CLI conventions for the openab command surface

### DIFF
--- a/docs/cli-conventions.md
+++ b/docs/cli-conventions.md
@@ -1,0 +1,56 @@
+# CLI Conventions (`openab`)
+
+One rule governs the `openab` command surface:
+
+> **Top-level verbs act on the bot itself; noun namespaces act on
+> subsystems.**
+
+## Top-level verbs — the bot's own lifecycle and control
+
+```
+openab run [-c config]    # run the bot (default command)
+openab setup              # interactive config wizard
+openab set <key> <value>  # ctl-socket write to the running bot (e.g. thread.name)
+openab get <key>          # ctl-socket read from the running bot
+```
+
+These are frozen. New top-level verbs require the same justification: the
+action must target the bot process itself, not a component of it.
+
+## Noun namespaces — subsystems and add-ons
+
+```
+openab mcp <addon> <action> [flags]
+# e.g.
+openab mcp gmail-native login
+openab mcp gmail-native serve --listen 127.0.0.1:8850
+```
+
+Everything that operates on a subsystem (MCP add-ons today; future
+subsystems follow the same shape) lives under a noun namespace. Namespace
+subcommands are for **interactive and operational actions** (logins,
+standalone/dev serving, diagnostics).
+
+## Long-running serving is config-driven, not CLI-driven
+
+Production serving belongs to `openab run` + `config.toml` — presence of a
+section enables the component (e.g. `[mcp]` starts the OAB MCP Facade
+listener). CLI `serve` actions under a namespace exist for development and
+standalone hosts, never as the production path (see #1451 for the
+facade-only run mode).
+
+## Precedent
+
+This mirrors how mature CLIs converged: `docker` keeps top-level lifecycle
+shortcuts (`docker run`) alongside management namespaces
+(`docker image ls`); `gh` scopes everything by noun (`gh pr create`,
+`gh auth login`). Mixed is fine — undocumented mixed is not.
+
+## Notes
+
+- `set`/`get` are semantically ctl-client operations; a purist rename
+  (`openab ctl set`) is deliberately not pursued — they are shipped and
+  scripted against. If purity is ever wanted, add aliases, never rename.
+- `openab-agent` is the coding agent + MCP *client* toolchain
+  (`openab-agent mcp list|status|doctor|connect|login`); serving surfaces
+  do not belong on it (#1451).


### PR DESCRIPTION
Docs-only. Records the CLI taxonomy rule settled in the #1449 review discussion: top-level verbs act on the bot itself (`run|setup|set|get`, frozen); subsystems and add-ons live under noun namespaces (`openab mcp <addon> <action>`); production serving is config-driven (`openab run` + config sections), with namespace `serve` actions reserved for dev/standalone use (#1451).

## Review Contract

### Goal

Add `docs/cli-conventions.md` so future CLI additions follow one documented taxonomy instead of case-by-case debate.

### Non-goals

- No code or CLI changes; no renames of shipped commands (`set`/`get` stay).
- Not a style guide for flag naming or output formatting — taxonomy only.

### Accepted Residual Risks

- Conventions can drift from code if unenforced; mitigated by keeping the doc to one falsifiable rule reviewers can apply mechanically.

### Acceptance Criteria

- The rule classifies every existing `openab` subcommand without exception (reviewer check against `src/main.rs` Commands enum).
- The doc reflects the #1451 direction (config-driven serving; no new top-level serve verbs).

### Follow-ups

- Update the namespace examples when #1451 lands (facade-only run mode) and when further `openab mcp` add-ons ship.
