### PR TITLE
feat(mcp): facade-only run mode — adapter-less [mcp] config is valid

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -387,6 +387,9 @@ error_hold_ms = 2500
 # ~/.openab/agent/mcp.json. Any coding CLI on this host (Kiro, Claude Code,
 # Codex, ...) can connect to http://127.0.0.1:8848/mcp.
 # Presence of [mcp] enables the listener; omit the section to disable.
+# With no chat adapter configured, [mcp] alone is a valid config: openab
+# runs in facade-only mode (serves just the MCP listener) — for
+# coding-CLI-only hosts, dev loops, and CI runners (#1451).
 # NOTE: the endpoint has no authentication — it must stay on loopback
 # (non-loopback addresses are refused at startup).
 # [mcp]

--- a/openab-agent/src/main.rs
+++ b/openab-agent/src/main.rs
@@ -29,17 +29,6 @@ enum Commands {
         #[command(subcommand)]
         action: McpAction,
     },
-    /// Serve the OAB MCP Facade over loopback Streamable HTTP: an inbound
-    /// MCP server exposing `search_capabilities` / `execute_capability`
-    /// backed by the configured downstream MCP servers (global + project
-    /// mcp.json). The OAB broker hosts the same facade in-process when
-    /// `[mcp]` is set in config.toml; this subcommand is the standalone way
-    /// to run it.
-    McpFacade {
-        /// Loopback address to listen on (non-loopback addresses are refused).
-        #[arg(long, default_value = "127.0.0.1:8848")]
-        listen: String,
-    },
 }
 
 #[derive(Subcommand)]
@@ -171,12 +160,6 @@ async fn main() {
                 }
             }
         },
-        Some(Commands::McpFacade { listen }) => {
-            if let Err(e) = mcp::facade::serve_http(&listen).await {
-                eprintln!("mcp-facade: {e:#}");
-                std::process::exit(1);
-            }
-        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,8 +326,25 @@ async fn main() -> anyhow::Result<()> {
         && cfg.telegram.is_none()
         && !has_unified_platform(&cfg)
     {
+        // Facade-only run mode (#1451): an adapter-less config with `[mcp]`
+        // present is a valid deployment — the broker serves just the OAB MCP
+        // Facade listener. One entrypoint, config-driven: hosts that only
+        // need the capability surface (coding-CLI-only users, dev loops, CI
+        // runners, agent hosts with no chat platform) run the same
+        // `openab run` with a two-line config instead of a chat token.
+        if let Some(mcp_cfg) = cfg.mcp.clone() {
+            tracing::info!(
+                listen = %mcp_cfg.listen,
+                "no chat adapter configured — running in facade-only mode ([mcp] present)"
+            );
+            // Foreground, not spawned: the facade IS the workload. A bind
+            // failure or server exit terminates the process (fail fast).
+            return openab_mcp::mcp::facade::serve_http(&mcp_cfg.listen)
+                .await
+                .map_err(|e| anyhow::anyhow!("OAB MCP facade exited: {e:#}"));
+        }
         anyhow::bail!(
-            "no adapter configured — add [discord], [slack], [telegram], [wecom], [googlechat], or [gateway] to config, or set platform env vars (TELEGRAM_BOT_TOKEN, etc.)"
+            "no adapter configured — add [discord], [slack], [telegram], [wecom], [googlechat], or [gateway] to config (or [mcp] for facade-only mode), or set platform env vars (TELEGRAM_BOT_TOKEN, etc.)"
         );
     }
 


### PR DESCRIPTION
Closes #1451, per the #1449 review discussion: the standalone facade entrypoint existed only because `openab run` refused to start without a chat adapter. One entrypoint, config-driven.

## What changes

- `openab run` with **no chat adapter but `[mcp]` present** now serves just the OAB MCP Facade listener in the **foreground** (the facade is the workload; bind failure/server exit = process exit, fail fast). Log line announces `facade-only mode`.
- The `no adapter configured` bail message now mentions the `[mcp]` option.
- **Removes `openab-agent mcp-facade`** — serving surfaces don't belong on the coding-agent binary; shipped only hours ago in #1448, nothing depends on it.
- `config.toml.example` documents the mode.

## Who needs facade-only

Coding-CLI-only hosts (no bot anywhere), provider/dev iteration loops (validated tonight — the #1449 e2e had to detour to the agent binary), and CI/agent hosts where a chat token would be absurd. Normal bot deployments are unchanged: `[discord]+[mcp]` in one process remains the production path.

## Validation

- Root workspace: build release, 18 tests pass; openab-agent workspace builds; `cargo clippy --workspace --all-features -- -D warnings` clean.
- **Live functional check** (macOS arm64): `openab run -c` with a two-line `[mcp]`-only config → `facade-only mode` + `listening` logged, MCP `initialize` on the configured port returns HTTP 200; process killed cleanly.

## Review Contract

### Goal

Make an adapter-less config with `[mcp]` a valid `openab run` deployment (facade-only), and remove the misplaced `openab-agent mcp-facade` serving surface.

### Non-goals

- No new CLI subcommands (explicit maintainer direction — config-driven, not CLI-driven).
- No change to the production path (`[discord]+[mcp]` in-process facade).
- Native-adapter lifecycle management by the broker (config-driven adapter start) — tracked as the follow-up direction on #1451, separate PR.
- openab-agent's client-side `mcp` CLI (`list|status|doctor|connect|login`) is untouched.

### Accepted Residual Risks

- Anyone who adopted `openab-agent mcp-facade` in the hours since #1448 merged must switch to `openab run` with an `[mcp]`-only config (judged: nobody).
- Facade-only mode skips chat-adapter preflights by design; hooks/secrets behavior is identical to a normal run.

### Acceptance Criteria

- `openab run` with `[mcp]`-only config serves `/mcp` (initialize succeeds) and logs facade-only mode; with neither adapter nor `[mcp]`, the bail fires with the updated message.
- `openab-agent mcp-facade` no longer parses; `openab-agent mcp …` client commands unaffected.
- fmt/clippy/test green on both workspaces.

### Follow-ups

- #1450 doc updated in its own PR branch (same push series) to describe facade-only mode instead of the removed agent subcommand.
- Config-driven native-adapter lifecycle (broker starts `gmail-native` alongside the facade) — future PR per #1451.
