### PR TITLE
docs(gmail-native): correct the Desktop OAuth client claim

### DIFF
--- a/docs/gmail-native.md
+++ b/docs/gmail-native.md
@@ -39,13 +39,15 @@ results state explicitly that nothing was sent.
    - `https://www.googleapis.com/auth/gmail.compose`
 3. Create an OAuth client (**Web application**) with redirect URI
    `http://localhost:53692/callback`. Note the client ID and secret.
-   (A secret-less **Desktop** client also works — omit the secret env var.)
+   (Google's **Desktop** client type also works with the same loopback
+   redirect, but note that Google still issues it a client secret and
+   requires it at the token endpoint — set both env vars either way.)
 
 ### 2. Log in (paste-back, once per account)
 
 ```sh
 export GMAIL_OAUTH_CLIENT_ID=<client-id>
-export GMAIL_OAUTH_CLIENT_SECRET=<client-secret>   # omit for Desktop clients
+export GMAIL_OAUTH_CLIENT_SECRET=<client-secret>
 openab mcp gmail-native login
 ```
 


### PR DESCRIPTION
Doc audit follow-up: the setup guide claimed a secret-less Desktop client works with the secret env var omitted. Google's Desktop (installed-app) client type still receives a client secret and requires it at the token endpoint — omitting it fails the exchange with `invalid_request`. Truly secret-less Google client types (iOS/Android/TV) don't apply to this loopback flow. Every other claim in the doc was cross-checked against the shipped code and the live b2/laptop validation runs and is accurate.

## Review Contract

### Goal
Remove the one unvalidated, likely-wrong claim from `docs/gmail-native.md` (Desktop client without a secret).

### Non-goals
No other doc or code changes.

### Accepted Residual Risks
None — strictly tightens the doc toward validated behavior.

### Acceptance Criteria
The doc no longer suggests omitting `GMAIL_OAUTH_CLIENT_SECRET`; the Desktop note reflects Google's actual token-endpoint requirement.

### Follow-ups
Optionally document the gmail.* restricted-scope verification requirement (>100 test users) if the adapter is ever positioned for public multi-user distribution — deferred until that's a real plan.