### PR TITLE
fix(gateway/feishu): enable CardKit typewriter streaming in card mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2192,7 +2192,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openab"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -832,9 +832,24 @@ impl AdapterRouter {
                         };
                         let msg = match streaming_strategy {
                             StreamingStrategy::EditablePlaceholder => {
-                                adapter
+                                match adapter
                                     .send_streaming_placeholder(&thread_channel, &initial)
-                                    .await?
+                                    .await
+                                {
+                                    Ok(msg) => msg,
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            error = ?e,
+                                            platform = %thread_channel.platform,
+                                            "streaming placeholder creation failed; \
+                                             falling back to draft sentinel",
+                                        );
+                                        MessageRef {
+                                            message_id: "draft".to_string(),
+                                            channel: thread_channel.clone(),
+                                        }
+                                    }
+                                }
                             }
                             StreamingStrategy::Draft => MessageRef {
                                 message_id: "draft".to_string(),

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -312,6 +312,22 @@ pub struct SenderContext {
 
 // --- ChatAdapter trait ---
 
+/// How the router should expose incremental output for a turn.
+///
+/// The legacy `use_streaming` and `show_streaming_placeholder` methods map to
+/// this enum through [`ChatAdapter::streaming_strategy`]. Shared adapters can
+/// override that method to choose a strategy from the concrete channel's
+/// platform without breaking existing trait implementations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StreamingStrategy {
+    /// Collect the turn and send it once at completion.
+    Disabled,
+    /// Edit a platform-native draft identified by the `draft` sentinel.
+    Draft,
+    /// Send a visible placeholder and edit it by its platform message ID.
+    EditablePlaceholder,
+}
+
 #[async_trait]
 pub trait ChatAdapter: Send + Sync + 'static {
     /// Platform name for logging and session key namespacing.
@@ -324,6 +340,19 @@ pub trait ChatAdapter: Send + Sync + 'static {
 
     /// Send a new message, returns a reference to the sent message.
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef>;
+
+    /// Send the initial message used by an editable-placeholder stream.
+    ///
+    /// Most adapters use the normal send lifecycle. Multiplexing adapters may
+    /// override this hook when starting a stream must return a platform-native
+    /// message ID while ordinary sends remain fire-and-forget.
+    async fn send_streaming_placeholder(
+        &self,
+        channel: &ChannelRef,
+        content: &str,
+    ) -> Result<MessageRef> {
+        self.send_message(channel, content).await
+    }
 
     /// Create a thread from a trigger message, returns the thread channel ref.
     async fn create_thread(
@@ -442,6 +471,26 @@ pub trait ChatAdapter: Send + Sync + 'static {
     /// return false to suppress the placeholder.
     fn show_streaming_placeholder(&self) -> bool {
         true
+    }
+
+    /// Select the streaming lifecycle for a concrete channel.
+    ///
+    /// The default preserves the pre-existing trait contract exactly. Unified
+    /// adapters may override it because one adapter instance can route several
+    /// platforms with different placeholder requirements.
+    fn streaming_strategy(
+        &self,
+        channel: &ChannelRef,
+        other_bot_present: bool,
+    ) -> StreamingStrategy {
+        let _ = channel;
+        if !self.use_streaming(other_bot_present) {
+            StreamingStrategy::Disabled
+        } else if self.show_streaming_placeholder() {
+            StreamingStrategy::EditablePlaceholder
+        } else {
+            StreamingStrategy::Draft
+        }
     }
 }
 
@@ -705,11 +754,12 @@ impl AdapterRouter {
         // coupling): it streams append-only `agent_message_chunk` deltas built from the
         // post+edit (`edit_message` snapshot) path, i.e. streaming=false. Decide it
         // explicitly by platform rather than by whatever Telegram happens to be set to.
-        let streaming = if thread_channel.platform == "acp" {
-            false
+        let streaming_strategy = if thread_channel.platform == "acp" {
+            StreamingStrategy::Disabled
         } else {
-            adapter.use_streaming(other_bot_present)
+            adapter.streaming_strategy(&thread_channel, other_bot_present)
         };
+        let streaming = streaming_strategy != StreamingStrategy::Disabled;
         // Keep the full turn text (incl. inter-tool narration) when streaming
         // (it was already shown live) OR when `[reactions] narration_display` is
         // set. Otherwise a send-once turn delivers only the final answer block.
@@ -780,14 +830,19 @@ impl AdapterRouter {
                         } else {
                             "…".to_string()
                         };
-                        let msg = if adapter.show_streaming_placeholder() {
-                            adapter.send_message(&thread_channel, &initial).await?
-                        } else {
-                            // Dummy ref for edit loop — gateway uses drafts, doesn't need real msg_id
-                            MessageRef {
+                        let msg = match streaming_strategy {
+                            StreamingStrategy::EditablePlaceholder => {
+                                adapter
+                                    .send_streaming_placeholder(&thread_channel, &initial)
+                                    .await?
+                            }
+                            StreamingStrategy::Draft => MessageRef {
                                 message_id: "draft".to_string(),
                                 channel: thread_channel.clone(),
-                            }
+                            },
+                            StreamingStrategy::Disabled => unreachable!(
+                                "disabled streaming cannot enter the placeholder branch"
+                            ),
                         };
                         let (tx, rx) = tokio::sync::watch::channel(initial);
                         let edit_adapter = adapter.clone();
@@ -1928,9 +1983,76 @@ mod tests {
         let adapter = TestAdapter;
         // Verify the method is callable and returns the declared value
         assert!(!adapter.use_streaming(false));
+        assert_eq!(
+            adapter.streaming_strategy(
+                &ChannelRef {
+                    platform: "test".into(),
+                    channel_id: "channel".into(),
+                    thread_id: None,
+                    parent_id: None,
+                    origin_event_id: None,
+                },
+                false,
+            ),
+            StreamingStrategy::Disabled,
+        );
         // renders_native_tables defaults to false: platforms that don't override
         // it keep the table→code/bullets conversion (e.g. Discord, Gateway).
         assert!(!adapter.renders_native_tables("discord"));
+    }
+
+    #[test]
+    fn streaming_strategy_preserves_legacy_placeholder_contract() {
+        struct StreamingAdapter(bool);
+
+        #[async_trait]
+        impl ChatAdapter for StreamingAdapter {
+            fn platform(&self) -> &'static str {
+                "test"
+            }
+            fn message_limit(&self) -> usize {
+                2000
+            }
+            async fn send_message(&self, _: &ChannelRef, _: &str) -> Result<MessageRef> {
+                unimplemented!()
+            }
+            async fn create_thread(
+                &self,
+                _: &ChannelRef,
+                _: &MessageRef,
+                _: &str,
+            ) -> Result<ChannelRef> {
+                unimplemented!()
+            }
+            async fn add_reaction(&self, _: &MessageRef, _: &str) -> Result<()> {
+                Ok(())
+            }
+            async fn remove_reaction(&self, _: &MessageRef, _: &str) -> Result<()> {
+                Ok(())
+            }
+            fn use_streaming(&self, _other_bot_present: bool) -> bool {
+                true
+            }
+            fn show_streaming_placeholder(&self) -> bool {
+                self.0
+            }
+        }
+
+        let channel = ChannelRef {
+            platform: "test".into(),
+            channel_id: "channel".into(),
+            thread_id: None,
+            parent_id: None,
+            origin_event_id: None,
+        };
+        assert_eq!(
+            StreamingAdapter(true).streaming_strategy(&channel, false),
+            StreamingStrategy::EditablePlaceholder,
+        );
+        assert_eq!(
+            StreamingAdapter(false).streaming_strategy(&channel, false),
+            StreamingStrategy::Draft,
+        );
     }
 
     #[test]

--- a/crates/openab-gateway/src/adapters/feishu.rs
+++ b/crates/openab-gateway/src/adapters/feishu.rs
@@ -2837,10 +2837,19 @@ async fn handle_card_edit(
     };
 
     match existing {
-        // Idle reaper already closed the stream; content is complete. Further
-        // cosmetic edits are no-ops that still "succeed" (core keeps om_post).
+        // Idle reaper already closed the stream. Report failure so core's
+        // delete-and-resend fallback can trigger (requires a working
+        // `delete_message` override on the adapter). Without this, the reply
+        // after the idle-finalize would be silently dropped - core sees Ok and
+        // never falls back to send-once. See issue #1464 / #1159.
         Existing::Finalized => {
-            emit_response(event_tx, &reply.request_id, true, Some(om_post), None);
+            emit_response(
+                event_tx,
+                &reply.request_id,
+                false,
+                None,
+                Some("session_finalized".into()),
+            );
         }
         Existing::Active { card_id, seq } => {
             let token = match adapter.token_cache.get_token(&adapter.client).await {
@@ -4923,6 +4932,33 @@ mod tests {
         let resp: crate::schema::GatewayResponse =
             serde_json::from_str(&rx.try_recv().unwrap()).unwrap();
         assert!(!resp.success, "failure must surface so core finalize takes over");
+    }
+
+    /// A finalized session (idle reaper closed it mid-turn) must report failure
+    /// so core's delete-and-resend fallback can trigger. Without this, the reply
+    /// after the idle-finalize would be silently dropped. See issue #1464.
+    #[tokio::test]
+    async fn s5_edit_finalized_session_reports_failure() {
+        let mut config = test_config();
+        config.streaming_mode = StreamingMode::Card;
+        let adapter = FeishuAdapter::new(config);
+        // Promote then mark finalized (simulates idle reaper mid-turn).
+        adapter
+            .stream_sessions
+            .lock()
+            .promote("om_ph5", "card_f".into(), "om_cardmsg_f".into(), "seed".into());
+        {
+            let mut reg = adapter.stream_sessions.lock();
+            reg.get_mut("om_ph5").unwrap().mark_finalized();
+        }
+        let (tx, mut rx) = tokio::sync::broadcast::channel(16);
+
+        handle_reply(&edit_reply("om_ph5", "text after idle", None, Some("r5")), &adapter, &tx).await;
+
+        let resp: crate::schema::GatewayResponse =
+            serde_json::from_str(&rx.try_recv().unwrap()).unwrap();
+        assert!(!resp.success, "finalized session must report failure so core falls back");
+        assert_eq!(resp.error.as_deref(), Some("session_finalized"));
     }
 
     /// Card mode: the FIRST reply (command=None) goes straight to a card with no

--- a/crates/openab-gateway/src/adapters/feishu.rs
+++ b/crates/openab-gateway/src/adapters/feishu.rs
@@ -2869,6 +2869,7 @@ async fn handle_card_edit(
             match outcome {
                 // Success: the post→card swap stays invisible — core keeps om_post.
                 feishu_card::CardOutcome::Updated => {
+                    tracing::info!(card_id = %card_id, msg_id = %om_post, seq, "feishu card stream updated");
                     emit_response(event_tx, &reply.request_id, true, Some(om_post), None);
                 }
                 // Rate limited: skip this frame. Every update sends the FULL text,

--- a/src/main.rs
+++ b/src/main.rs
@@ -907,14 +907,15 @@ async fn main() -> anyhow::Result<()> {
         None
     };
 
-    // Spawn cron scheduler (background task)
-    // Spawn embedded webhook server when gateway adapters are compiled in (unified mode).
-    // In unified mode, platform webhooks hit this axum server directly → Dispatcher.submit(),
-    // bypassing the WebSocket hop of the two-process model.
     #[cfg(feature = "feishu")]
     let mut unified_feishu_shutdown: Option<tokio::sync::watch::Sender<bool>> = None;
     #[cfg(feature = "feishu")]
     let mut unified_feishu_handle: Option<tokio::task::JoinHandle<()>> = None;
+
+    // Spawn cron scheduler (background task)
+    // Spawn embedded webhook server when gateway adapters are compiled in (unified mode).
+    // In unified mode, platform webhooks hit this axum server directly → Dispatcher.submit(),
+    // bypassing the WebSocket hop of the two-process model.
 
     #[cfg(any(
         feature = "telegram",
@@ -1248,6 +1249,16 @@ async fn main() -> anyhow::Result<()> {
                 loop {
                     match event_rx.recv().await {
                         Ok(event_json) => {
+                            // Gateway responses are consumed by unified adapter
+                            // request/response waits; they are not user events.
+                            if serde_json::from_str::<openab_gateway::schema::GatewayResponse>(
+                                &event_json,
+                            )
+                            .map(|response| response.schema == "openab.gateway.response.v1")
+                            .unwrap_or(false)
+                            {
+                                continue;
+                            }
                             let ctx = bridge_ctx.clone();
                             tokio::spawn(async move {
                                 if let Err(e) = process_gateway_event(&event_json, &ctx).await {

--- a/src/unified_adapter.rs
+++ b/src/unified_adapter.rs
@@ -369,6 +369,14 @@ impl ChatAdapter for UnifiedGatewayAdapter {
             "telegram" => StreamingStrategy::Disabled,
             #[cfg(feature = "feishu")]
             "feishu" => {
+                // Honor the streaming enablement decision before selecting a
+                // strategy. When streaming is explicitly disabled (e.g.
+                // TELEGRAM_STREAMING=false), Feishu must also be Disabled -
+                // otherwise Draft would set streaming=true, run a useless edit
+                // loop, and force keep_full_text=true (narration replay).
+                if !self.use_streaming(false) {
+                    return StreamingStrategy::Disabled;
+                }
                 match self
                     .gw_state
                     .feishu
@@ -444,6 +452,7 @@ mod tests {
     fn feishu_uses_real_editable_placeholder() {
         let (event_tx, _) = tokio::sync::broadcast::channel(16);
         let mut state = AppState::test_default(event_tx);
+        state.telegram_rich_messages = true;
         let mut pairs = std::collections::HashMap::new();
         pairs.insert("FEISHU_APP_ID".into(), "app".into());
         pairs.insert("FEISHU_APP_SECRET".into(), "secret".into());
@@ -466,6 +475,7 @@ mod tests {
     fn feishu_post_mode_keeps_draft_strategy() {
         let (event_tx, _) = tokio::sync::broadcast::channel(16);
         let mut state = AppState::test_default(event_tx);
+        state.telegram_rich_messages = true;
         let mut pairs = std::collections::HashMap::new();
         pairs.insert("FEISHU_APP_ID".into(), "app".into());
         pairs.insert("FEISHU_APP_SECRET".into(), "secret".into());
@@ -481,6 +491,26 @@ mod tests {
         );
         assert_eq!(
             adapter.streaming_strategy(&channel("feishu"), true),
+            StreamingStrategy::Disabled,
+        );
+    }
+
+    #[cfg(feature = "feishu")]
+    #[test]
+    fn feishu_disabled_when_streaming_off() {
+        let (event_tx, _) = tokio::sync::broadcast::channel(16);
+        let mut state = AppState::test_default(event_tx);
+        // telegram_rich_messages defaults to false -> use_streaming == false.
+        let mut pairs = std::collections::HashMap::new();
+        pairs.insert("FEISHU_APP_ID".into(), "app".into());
+        pairs.insert("FEISHU_APP_SECRET".into(), "secret".into());
+        pairs.insert("FEISHU_CARD_STREAMING_MODE".into(), "card".into());
+        state.apply_feishu_config(openab_gateway::GatewayFeishuConfig { pairs });
+        let adapter = UnifiedGatewayAdapter::new(Arc::new(state));
+
+        // Even in card mode, streaming must be Disabled when use_streaming is false.
+        assert_eq!(
+            adapter.streaming_strategy(&channel("feishu"), false),
             StreamingStrategy::Disabled,
         );
     }

--- a/src/unified_adapter.rs
+++ b/src/unified_adapter.rs
@@ -3,12 +3,28 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use openab_core::adapter::{ChannelRef, ChatAdapter, MessageRef};
-use openab_gateway::schema::{Content, GatewayReply, ReplyChannel};
+use openab_core::adapter::{ChannelRef, ChatAdapter, MessageRef, StreamingStrategy};
+use openab_gateway::schema::{Content, GatewayReply, GatewayResponse, ReplyChannel};
 use openab_gateway::AppState;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::Mutex;
+
+const GATEWAY_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+fn next_request_id() -> String {
+    format!(
+        "unified_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+            .saturating_mul(1_000_000)
+            .saturating_add(REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed) as u128)
+    )
+}
 
 pub struct UnifiedGatewayAdapter {
     pub gw_state: Arc<AppState>,
@@ -22,6 +38,23 @@ impl UnifiedGatewayAdapter {
             gw_state,
             telegram_reaction_state: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    fn uses_feishu_card_streaming(&self, channel: &ChannelRef) -> bool {
+        if channel.platform != "feishu" {
+            return false;
+        }
+
+        #[cfg(feature = "feishu")]
+        {
+            self.gw_state.feishu.as_ref().is_some_and(|feishu| {
+                feishu.config.streaming_mode
+                    == openab_gateway::adapters::feishu::StreamingMode::Card
+            })
+        }
+
+        #[cfg(not(feature = "feishu"))]
+        false
     }
 
     /// Dispatch a GatewayReply to the correct platform adapter.
@@ -96,8 +129,62 @@ impl UnifiedGatewayAdapter {
                 }
             }
             other => {
-                tracing::warn!(platform = other, "unified adapter: unknown platform, cannot route reply");
+                tracing::warn!(
+                    platform = other,
+                    "unified adapter: unknown platform, cannot route reply"
+                );
             }
+        }
+    }
+
+    /// Dispatch a reply and, when requested, wait for the platform response.
+    /// Feishu returns the native om_... message ID; unified mode must preserve
+    /// that ID because synthetic IDs cannot be edited by the Feishu API.
+    async fn dispatch_with_response(
+        &self,
+        reply: &GatewayReply,
+    ) -> Result<Option<GatewayResponse>> {
+        let Some(request_id) = reply.request_id.as_deref() else {
+            self.dispatch_reply(reply).await;
+            return Ok(None);
+        };
+        if reply.platform != "feishu" {
+            self.dispatch_reply(reply).await;
+            return Ok(None);
+        }
+
+        let mut rx = self.gw_state.event_tx.subscribe();
+        self.dispatch_reply(reply).await;
+        let request_id = request_id.to_string();
+        let wait = async {
+            loop {
+                match rx.recv().await {
+                    Ok(json) => {
+                        let Ok(response) = serde_json::from_str::<GatewayResponse>(&json) else {
+                            continue;
+                        };
+                        if response.schema == "openab.gateway.response.v1"
+                            && response.request_id == request_id
+                        {
+                            return Ok(response);
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        anyhow::bail!("gateway response channel closed")
+                    }
+                }
+            }
+        };
+        match tokio::time::timeout(GATEWAY_RESPONSE_TIMEOUT, wait).await {
+            Ok(Ok(response)) if response.success => Ok(Some(response)),
+            Ok(Ok(response)) => Err(anyhow::anyhow!(response
+                .error
+                .unwrap_or_else(|| "gateway reported failure".into()))),
+            Ok(Err(error)) => Err(error),
+            Err(_) => Err(anyhow::anyhow!(
+                "timed out waiting for gateway response to {request_id}"
+            )),
         }
     }
 
@@ -144,8 +231,29 @@ impl ChatAdapter for UnifiedGatewayAdapter {
         self.dispatch_reply(&reply).await;
         Ok(MessageRef {
             channel: channel.clone(),
-            message_id: format!("unified_{:x}", std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_nanos()),
+            message_id: next_request_id(),
+        })
+    }
+
+    async fn send_streaming_placeholder(
+        &self,
+        channel: &ChannelRef,
+        content: &str,
+    ) -> Result<MessageRef> {
+        if !self.uses_feishu_card_streaming(channel) {
+            return self.send_message(channel, content).await;
+        }
+
+        let mut reply = self.build_reply(channel, content, None, None);
+        reply.request_id = Some(next_request_id());
+        let message_id = self
+            .dispatch_with_response(&reply)
+            .await?
+            .and_then(|response| response.message_id)
+            .ok_or_else(|| anyhow::anyhow!("Feishu placeholder response omitted message_id"))?;
+        Ok(MessageRef {
+            channel: channel.clone(),
+            message_id,
         })
     }
 
@@ -187,7 +295,12 @@ impl ChatAdapter for UnifiedGatewayAdapter {
         let mut reply = self.build_reply(&msg.channel, content, Some("edit_message"), None);
         // Use the actual platform message_id (e.g. "draft" for streaming, or numeric for edits)
         reply.reply_to = msg.message_id.clone();
-        self.dispatch_reply(&reply).await;
+        if self.uses_feishu_card_streaming(&msg.channel) {
+            reply.request_id = Some(next_request_id());
+            self.dispatch_with_response(&reply).await?;
+        } else {
+            self.dispatch_reply(&reply).await;
+        }
         Ok(())
     }
 
@@ -201,8 +314,7 @@ impl ChatAdapter for UnifiedGatewayAdapter {
         self.dispatch_reply(&reply).await;
         Ok(MessageRef {
             channel: channel.clone(),
-            message_id: format!("unified_{:x}", std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_nanos()),
+            message_id: next_request_id(),
         })
     }
 
@@ -224,10 +336,154 @@ impl ChatAdapter for UnifiedGatewayAdapter {
         false
     }
 
+    fn streaming_strategy(
+        &self,
+        channel: &ChannelRef,
+        other_bot_present: bool,
+    ) -> StreamingStrategy {
+        if other_bot_present {
+            return StreamingStrategy::Disabled;
+        }
+
+        match channel.platform.as_str() {
+            "telegram" if self.use_streaming(false) => StreamingStrategy::Draft,
+            "telegram" => StreamingStrategy::Disabled,
+            #[cfg(feature = "feishu")]
+            "feishu" => {
+                match self
+                    .gw_state
+                    .feishu
+                    .as_ref()
+                    .map(|feishu| feishu.config.streaming_mode)
+                {
+                    // Card mode is an explicit operator opt-in. Keep the
+                    // existing unified send-once behavior for post/auto so the
+                    // bug fix does not change backward-compatible defaults.
+                    Some(openab_gateway::adapters::feishu::StreamingMode::Card) => {
+                        StreamingStrategy::EditablePlaceholder
+                    }
+                    _ => StreamingStrategy::Disabled,
+                }
+            }
+            _ if !self.use_streaming(false) => StreamingStrategy::Disabled,
+            _ => {
+                if self.show_streaming_placeholder() {
+                    StreamingStrategy::EditablePlaceholder
+                } else {
+                    StreamingStrategy::Draft
+                }
+            }
+        }
+    }
+
     fn renders_native_tables(&self, platform: &str) -> bool {
         // Telegram Rich Messages render markdown tables natively — skip the
         // table→code-block pre-pass so tables display with proper formatting.
         // Only applies to Telegram; other platforms in unified mode keep wrapping.
         platform == "telegram" && self.gw_state.telegram_rich_messages
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn channel(platform: &str) -> ChannelRef {
+        ChannelRef {
+            platform: platform.into(),
+            channel_id: "channel".into(),
+            thread_id: None,
+            parent_id: None,
+            origin_event_id: Some("event".into()),
+        }
+    }
+
+    #[test]
+    fn telegram_keeps_draft_strategy() {
+        let (event_tx, _) = tokio::sync::broadcast::channel(16);
+        let mut state = AppState::test_default(event_tx);
+        state.telegram_rich_messages = true;
+        let adapter = UnifiedGatewayAdapter::new(Arc::new(state));
+
+        assert_eq!(
+            adapter.streaming_strategy(&channel("telegram"), false),
+            StreamingStrategy::Draft,
+        );
+        assert_eq!(
+            adapter.streaming_strategy(&channel("telegram"), true),
+            StreamingStrategy::Disabled,
+        );
+    }
+
+    #[cfg(feature = "feishu")]
+    #[test]
+    fn feishu_uses_real_editable_placeholder() {
+        let (event_tx, _) = tokio::sync::broadcast::channel(16);
+        let mut state = AppState::test_default(event_tx);
+        let mut pairs = std::collections::HashMap::new();
+        pairs.insert("FEISHU_APP_ID".into(), "app".into());
+        pairs.insert("FEISHU_APP_SECRET".into(), "secret".into());
+        pairs.insert("FEISHU_CARD_STREAMING_MODE".into(), "card".into());
+        state.apply_feishu_config(openab_gateway::GatewayFeishuConfig { pairs });
+        let adapter = UnifiedGatewayAdapter::new(Arc::new(state));
+
+        assert_eq!(
+            adapter.streaming_strategy(&channel("feishu"), false),
+            StreamingStrategy::EditablePlaceholder,
+        );
+        assert_eq!(
+            adapter.streaming_strategy(&channel("feishu"), true),
+            StreamingStrategy::Disabled,
+        );
+    }
+
+    #[cfg(feature = "feishu")]
+    #[tokio::test]
+    async fn feishu_response_correlation_preserves_native_message_id() {
+        let (event_tx, _) = tokio::sync::broadcast::channel(16);
+        let state = Arc::new(AppState::test_default(event_tx.clone()));
+        let adapter = UnifiedGatewayAdapter::new(state);
+        let mut reply = adapter.build_reply(&channel("feishu"), "…", None, None);
+        reply.request_id = Some("request-1".into());
+
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            let response = GatewayResponse {
+                schema: "openab.gateway.response.v1".into(),
+                request_id: "request-1".into(),
+                success: true,
+                thread_id: None,
+                message_id: Some("om_native123".into()),
+                error: None,
+            };
+            event_tx
+                .send(serde_json::to_string(&response).unwrap())
+                .unwrap();
+        });
+
+        let response = adapter
+            .dispatch_with_response(&reply)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.message_id.as_deref(), Some("om_native123"));
+    }
+
+    #[cfg(feature = "feishu")]
+    #[tokio::test]
+    async fn feishu_send_once_remains_fire_and_forget() {
+        let (event_tx, _) = tokio::sync::broadcast::channel(16);
+        let state = Arc::new(AppState::test_default(event_tx));
+        let adapter = UnifiedGatewayAdapter::new(state);
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            adapter.send_message(&channel("feishu"), "complete response"),
+        )
+        .await
+        .expect("send-once delivery must not wait for a gateway response")
+        .unwrap();
+
+        assert!(result.message_id.starts_with("unified_"));
     }
 }

--- a/src/unified_adapter.rs
+++ b/src/unified_adapter.rs
@@ -304,6 +304,25 @@ impl ChatAdapter for UnifiedGatewayAdapter {
         Ok(())
     }
 
+    /// Override default `delete_message` (which falls back to edit-to-zero-width)
+    /// so platforms with native delete APIs (e.g. Feishu `DELETE /im/v1/messages/{id}`)
+    /// can perform real deletions. Critical for the streaming-edit-cap recovery
+    /// path: when Feishu's 20-edits-per-message cap is hit and we send full
+    /// content as a fresh message, we need to remove the half-edited placeholder
+    /// to avoid duplicated content. The default zero-width-edit fallback would
+    /// itself fail on a cap-reached message, leaving the placeholder visible.
+    ///
+    /// Fire-and-forget: Feishu's delete branch (`feishu.rs`) handles the command
+    /// and does not require a response. We do not wait on a response here: the
+    /// recovery path sends fresh content regardless of whether the delete landed,
+    /// so a response would only buy an extra log line at the cost of a per-finalize wait.
+    async fn delete_message(&self, msg: &MessageRef) -> Result<()> {
+        let mut reply = self.build_reply(&msg.channel, "", Some("delete_message"), None);
+        reply.reply_to = msg.message_id.clone();
+        self.dispatch_reply(&reply).await;
+        Ok(())
+    }
+
     async fn send_message_with_reply(
         &self,
         channel: &ChannelRef,
@@ -356,13 +375,18 @@ impl ChatAdapter for UnifiedGatewayAdapter {
                     .as_ref()
                     .map(|feishu| feishu.config.streaming_mode)
                 {
-                    // Card mode is an explicit operator opt-in. Keep the
-                    // existing unified send-once behavior for post/auto so the
-                    // bug fix does not change backward-compatible defaults.
+                    // Card mode is an explicit operator opt-in for CardKit
+                    // typewriter streaming via a real om_ placeholder.
                     Some(openab_gateway::adapters::feishu::StreamingMode::Card) => {
                         StreamingStrategy::EditablePlaceholder
                     }
-                    _ => StreamingStrategy::Disabled,
+                    // post/auto: keep Draft to preserve v0.9.0 behavior. The
+                    // edit loop's edits are rejected by is_valid_feishu_message_id
+                    // (synthetic "draft" sentinel), so streaming is effectively a
+                    // no-op and the turn is delivered send-once at turn end - but
+                    // `keep_full_text` stays true (streaming || narration_display),
+                    // so the send-once includes inter-tool narration as before.
+                    _ => StreamingStrategy::Draft,
                 }
             }
             _ if !self.use_streaming(false) => StreamingStrategy::Disabled,
@@ -430,6 +454,30 @@ mod tests {
         assert_eq!(
             adapter.streaming_strategy(&channel("feishu"), false),
             StreamingStrategy::EditablePlaceholder,
+        );
+        assert_eq!(
+            adapter.streaming_strategy(&channel("feishu"), true),
+            StreamingStrategy::Disabled,
+        );
+    }
+
+    #[cfg(feature = "feishu")]
+    #[test]
+    fn feishu_post_mode_keeps_draft_strategy() {
+        let (event_tx, _) = tokio::sync::broadcast::channel(16);
+        let mut state = AppState::test_default(event_tx);
+        let mut pairs = std::collections::HashMap::new();
+        pairs.insert("FEISHU_APP_ID".into(), "app".into());
+        pairs.insert("FEISHU_APP_SECRET".into(), "secret".into());
+        // No FEISHU_CARD_STREAMING_MODE -> defaults to Post.
+        state.apply_feishu_config(openab_gateway::GatewayFeishuConfig { pairs });
+        let adapter = UnifiedGatewayAdapter::new(Arc::new(state));
+
+        // post/auto keeps Draft to preserve v0.9.0 behavior: keep_full_text
+        // stays true so send-once includes inter-tool narration.
+        assert_eq!(
+            adapter.streaming_strategy(&channel("feishu"), false),
+            StreamingStrategy::Draft,
         );
         assert_eq!(
             adapter.streaming_strategy(&channel("feishu"), true),


### PR DESCRIPTION
## What problem does this solve?

When `FEISHU_CARD_STREAMING_MODE=card`, messages are delivered as CardKit cards but with **no visible typewriter effect** — the full reply appears all at once after the agent finishes. Root cause: the unified adapter's `show_streaming_placeholder()` returns false, so the core creates a draft placeholder (`message_id="draft"`), and all incremental `edit_message` commands are skipped by the `is_valid_feishu_message_id` seam.

This bug first appeared in v0.9.0, caused by the unified adapter replacing the legacy Feishu adapter's streaming path.

Closes #1367
Supersedes #1367 scope — see #1464 for the full v0.9.0 Feishu streaming regression analysis.

Discord Discussion URL: https://discordapp.com/channels/1491295327620169908/1530153804333449226

## Review Contract

### Goal
Restore CardKit typewriter streaming for Feishu in unified mode by giving the streaming placeholder a real `om_` message ID, so incremental edits flow through `handle_card_edit` → `update_card_stream` instead of being dropped at the draft seam.

### Non-goals
- No changes to Telegram streaming (retains Draft strategy).
- No changes to the default Feishu post-edit path (mode unset or `post`). Post/auto keeps `Draft` strategy to preserve v0.9.0 behavior (streaming is a no-op but `keep_full_text` stays true so send-once includes inter-tool narration).
- No multi-card splitting for very long responses (follow-up).
- No changes to the ACP platform streaming path (append-only deltas, unrelated).

### Accepted Residual Risks
- Feishu CardKit streaming mode has a server-side idle timeout. If the agent is idle longer than `FEISHU_CARD_IDLE_FINALIZE_MS`, the idle reaper finalizes the card. Late edits after finalize now report `success: false` (`session_finalized`) so core's delete-and-resend fallback triggers — this requires the `delete_message` override (added in this PR) to actually remove the stale card. Without the override, the fallback would leave a stale card plus a duplicate plain-text reply.
- Ordinary `send_message` remains fire-and-forget for non-streaming paths. Both `send_streaming_placeholder` and card-mode `edit_message` wait for the platform response (via `dispatch_with_response`), because they need the real `om_` ID and edit-cap/finalize signals respectively. This is the intended scope: the wait is isolated to the card streaming path.

### Acceptance Criteria
- [x] Without `FEISHU_CARD_STREAMING_MODE=card`, behavior is identical to before (post-edit path, Draft strategy).
- [x] With `FEISHU_CARD_STREAMING_MODE=card`, real CardKit updates stream during generation.
- [x] `card stream updated` with `seq=1` captured in production logs after model config fix.
- [x] `cargo test --features unified` passes.
- [x] `cargo clippy --workspace --features unified -- -D warnings` clean.
- [x] No trait-breaking changes for external/custom adapters.
- [x] `delete_message` override verified: stale card deleted after `streaming mode closed` (300309), fresh card sent via delete-and-resend recovery.
- [x] `Existing::Finalized` reports `success: false` — regression test `s5_edit_finalized_session_reports_failure`.

### Follow-ups
- Multi-card splitting for responses exceeding Feishu's per-card content limit.
- Configurable streaming flush interval (currently tied to dispatch batch cadence).
- F1 root cause: core→gateway card lifecycle lacks an explicit finish signal; the `stream_finish` trait seam (`adapter.rs:429`) is a candidate so the idle reaper does not finalize mid-turn. Tracked in #1464.

## At a Glance

```
Before (broken since v0.9.0):
  core → draft placeholder ("draft") → edit_message("draft", text)
       → is_valid_feishu_message_id("draft") == false → SKIPPED
       → try_send_initial_card at turn end → full text, no streaming

After (restores pre-v0.9.0 behavior):
  core → EditablePlaceholder → send_streaming_placeholder()
       → create Feishu post → dispatch_with_response() → real om_ ID
       → edit_message(om_xxx, text) → handle_card_edit
       → update_card_stream(card_id, seq++) → typewriter effect
       → idle > FEISHU_CARD_IDLE_FINALIZE_MS → finish_card_stream
       → late edit → Existing::Finalized → success: false
       → core delete-and-resend → delete_message override → DELETE /im/v1/messages/{id}
```

## Prior Art & Industry Research

**OpenClaw:**
Uses draft-message editing for Telegram streaming (edit_message every N tokens). Feishu path uses post-edit with a 20-edit cap before promoting to card.

**Hermes Agent:**
N/A — Hermes does not support Feishu.

**Other references:**
- Feishu CardKit streaming API: PUT /cardkit/v1/cards/:id/elements/:eid/content with strictly-increasing sequence numbers.
- Feishu errcode 300317: sequence must be strictly increasing.
- Feishu errcode 300309: streaming mode closed after server-side idle timeout.

## Proposed Solution

The fix restores the pre-v0.9.0 streaming path through the unified adapter architecture:

1. **`adapter.rs`**: Additive `StreamingStrategy` enum (Disabled / Draft / EditablePlaceholder) + `streaming_strategy()` method with default impl. Legacy `use_streaming()` / `show_streaming_placeholder()` retained — no trait break.

2. **`unified_adapter.rs`**: Selects `EditablePlaceholder` for Feishu when `FEISHU_CARD_STREAMING_MODE=card`. Post/auto keeps `Draft` to preserve v0.9.0 behavior. Adds `dispatch_with_response()` — a request-response channel that waits for the Feishu adapter to return the real `om_` message ID. The streaming placeholder path and card-mode edits both use this; normal `send_message` remains fire-and-forget. Adds `delete_message` override mirroring the standalone `GatewayAdapter` override so the edit-cap / session-finalized recovery path can perform a real `DELETE /im/v1/messages/{id}`.

3. **`main.rs`**: The `streaming_strategy` threading happens entirely inside `AdapterRouter`; no `main.rs` change was needed. The only `main.rs` change is filtering `GatewayResponse` events out of the unified inbound bridge (necessary companion to introducing `request_id` on this path).

4. **`feishu.rs`**: `Existing::Finalized` arm now reports `success: false` (`session_finalized`) so core's delete-and-resend fallback triggers. +1 line observability log on `CardOutcome::Updated` (card_id, msg_id, seq).

### Why a response channel instead of modifying `send_message`?

The unified adapter's `send_message` is fire-and-forget by design. Changing it to always wait for a platform response would:
- Add ~500ms latency to every message send (not just streaming)
- Require all platform adapters (Telegram, Discord, Line) to return message IDs
- Break the fire-and-forget contract that non-streaming paths rely on

The response channel isolates the wait to `send_streaming_placeholder` and card-mode `edit_message` only.

## Alternatives Considered

1. **Modify `send_message` to return real IDs**: Fewer lines (~50 vs ~140) but changes behavior for all platforms and all message paths. Rejected — too broad for an opt-in feature.
2. **One-line fix (`show_streaming_placeholder() → true`)**: Works but leaks Feishu-specific semantics into the generic adapter trait. No mechanism for adapters to customize placeholder behavior.
3. **Delta-based updates**: Rejected — Feishu CardKit requires full content on each PUT, not deltas.

## Validation

- [x] `cargo test --features unified` — all pass
- [x] `cargo clippy --workspace --features unified -- -D warnings` — clean
- [x] `cargo build --release --features unified` — success
- [x] Manual testing: deployed to local service, observed `card stream updated seq=1` on card_id after agent reply. `delete_message` override verified: 300309 → `feishu message deleted` → fresh card sent via recovery path.

## Review Findings Addressed

This commit addresses all four findings from the round-1 review by @wangyuyan-agent:

| Finding | Fix |
|---|---|
| **Blocking 1** (PR description inaccuracies) | Corrected: main.rs threading claim, send_message fire-and-forget scope, idle-finalize recovery path. |
| **Blocking 2** (missing `delete_message` override) | Added `delete_message` override on `UnifiedGatewayAdapter` mirroring standalone `gateway.rs:707`. |
| **F1** (idle reaper drops reply silently) | `Existing::Finalized` now reports `success: false`; combined with Blocking 2, core's delete-and-resend triggers correctly. Root cause (missing turn-finish signal) tracked as follow-up in #1464. |
| **F2** (post/auto default changed) | Reverted to `Draft` strategy for post/auto to preserve v0.9.0 `keep_full_text` behavior. |
