### PR TITLE
platform-schema: CI hardening, anti-drift hardening, owner-model docs, and trigger coverage

### DIFF
--- a/.github/workflows/platform-schema-conformance.yml
+++ b/.github/workflows/platform-schema-conformance.yml
@@ -2,9 +2,9 @@ name: platform-schema conformance
 
 # Verify docs/platforms/schema/*.toml stays in sync with the code: structural
 # schema validation + that every `source` code-ref still exists in the tree.
-# Runs on any change to the schema files, the checker itself, or the adapter/core
-# source trees that schema code-refs point into (so a rename/delete there is
-# caught immediately, not by the next unrelated schema PR).
+# Runs on any change to the schema files, the checker itself, this workflow, or
+# the adapter/core source trees that schema code-refs point into (so a
+# rename/delete there is caught immediately, not by the next unrelated schema PR).
 on:
   pull_request:
     paths:
@@ -14,6 +14,9 @@ on:
       - "crates/openab-gateway/src/**"
       - "crates/openab-core/src/**"
       - "src/main.rs"
+      # Self-trigger: a workflow-only edit (trigger coverage, cache, test
+      # command) must exercise the job it changes.
+      - ".github/workflows/platform-schema-conformance.yml"
   push:
     branches: [main]
     paths:
@@ -23,6 +26,7 @@ on:
       - "crates/openab-gateway/src/**"
       - "crates/openab-core/src/**"
       - "src/main.rs"
+      - ".github/workflows/platform-schema-conformance.yml"
   schedule:
     # Safety net: catch drift from renames/deletes even if a PR touching the
     # source tree somehow bypassed the path triggers above (e.g. merged via

--- a/.github/workflows/platform-schema-conformance.yml
+++ b/.github/workflows/platform-schema-conformance.yml
@@ -2,19 +2,32 @@ name: platform-schema conformance
 
 # Verify docs/platforms/schema/*.toml stays in sync with the code: structural
 # schema validation + that every `source` code-ref still exists in the tree.
-# Runs on any change to the schema files, the template, or the checker itself.
+# Runs on any change to the schema files, the checker itself, or the adapter/core
+# source trees that schema code-refs point into (so a rename/delete there is
+# caught immediately, not by the next unrelated schema PR).
 on:
   pull_request:
     paths:
       - "docs/platforms/schema/**"
       - "docs/platforms/_template.toml"
       - "crates/platform-schema/**"
+      - "crates/openab-gateway/src/**"
+      - "crates/openab-core/src/**"
+      - "src/main.rs"
   push:
     branches: [main]
     paths:
       - "docs/platforms/schema/**"
       - "docs/platforms/_template.toml"
       - "crates/platform-schema/**"
+      - "crates/openab-gateway/src/**"
+      - "crates/openab-core/src/**"
+      - "src/main.rs"
+  schedule:
+    # Safety net: catch drift from renames/deletes even if a PR touching the
+    # source tree somehow bypassed the path triggers above (e.g. merged via
+    # a workflow that skipped this check).
+    - cron: "0 6 * * 1"
 
 concurrency:
   group: platform-schema-${{ github.ref }}

--- a/.github/workflows/platform-schema-conformance.yml
+++ b/.github/workflows/platform-schema-conformance.yml
@@ -16,12 +16,19 @@ on:
       - "docs/platforms/_template.toml"
       - "crates/platform-schema/**"
 
+concurrency:
+  group: platform-schema-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   conformance:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-07-13)
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (2026-03-12)
+        with:
+          workspaces: "crates/platform-schema -> target"
       # Standalone crate (serde + toml only); excluded from the root workspace
       # so it builds without the heavy adapter crates.
       # --locked: build strictly from the committed Cargo.lock; fail if it is

--- a/.github/workflows/platform-schema-conformance.yml
+++ b/.github/workflows/platform-schema-conformance.yml
@@ -28,9 +28,13 @@ on:
     # source tree somehow bypassed the path triggers above (e.g. merged via
     # a workflow that skipped this check).
     - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 concurrency:
-  group: platform-schema-${{ github.ref }}
+  # event_name is included because a scheduled run and a push-to-main run
+  # both resolve github.ref to refs/heads/main; without it they'd share a
+  # group and cancel-in-progress could cancel one in favor of the other.
+  group: platform-schema-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,8 @@ gh run view <run_id> --repo openabdev/openab --json conclusion -q .conclusion
 
 When modifying a platform adapter (`crates/openab-gateway/src/adapters/*.rs`), check whether the change affects the platform's documented capabilities or feature status. If it does, update the corresponding `docs/platforms/schema/<platform>.toml`.
 
+If you notice a platform's official API has changed (a new webhook event type, a deprecated field, etc.) or spot a platform-specific quirk while working on something else, feel free to update the corresponding `docs/platforms/schema/<platform>.toml` (`[capability.*]` or `[[quirks]]`) directly in your PR — no need to wait for a dedicated owner to notice.
+
 See [`docs/platforms/README.md`](docs/platforms/README.md) for:
 - The three-schema structure (capability, feature-support, quirks)
 - How to add a new feature to the closed set

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ gh run view <run_id> --repo openabdev/openab --json conclusion -q .conclusion
 
 When modifying a platform adapter (`crates/openab-gateway/src/adapters/*.rs`), check whether the change affects the platform's documented capabilities or feature status. If it does, update the corresponding `docs/platforms/schema/<platform>.toml`.
 
-If you notice a platform's official API has changed (a new webhook event type, a deprecated field, etc.) or spot a platform-specific quirk while working on something else, feel free to update the corresponding `docs/platforms/schema/<platform>.toml` (`[capability.*]` or `[[quirks]]`) directly in your PR — no need to wait for a dedicated owner to notice.
+If you notice a platform's official API has changed (a new webhook event type, a deprecated field, etc.) or spot a platform-specific quirk while working on something else, update the corresponding `docs/platforms/schema/<platform>.toml` (`[capability.*]` or `[[quirks]]`) in the same PR. Schema files have no dedicated owner — do not wait for one to notice.
 
 See [`docs/platforms/README.md`](docs/platforms/README.md) for:
 - The three-schema structure (capability, feature-support, quirks)

--- a/crates/platform-schema/tests/conformance.rs
+++ b/crates/platform-schema/tests/conformance.rs
@@ -207,6 +207,18 @@ fn check_code_ref_rejects_path_traversal() {
     );
 }
 
+#[test]
+fn check_code_ref_rejects_absolute_path() {
+    // Path::join replaces the base entirely when the joined path is absolute,
+    // so this exercises a different code path than the "../" traversal above.
+    let root = repo_root();
+    let err = check_code_ref(&root, "/etc/passwd").expect_err("absolute path must be rejected");
+    assert!(
+        err.contains("does not exist") || err.contains("escapes repo root"),
+        "unexpected error: {err}"
+    );
+}
+
 /// The template must keep enumerating every capability section + feature key, so
 /// a struct change can't silently leave the human-facing template behind.
 #[test]

--- a/crates/platform-schema/tests/conformance.rs
+++ b/crates/platform-schema/tests/conformance.rs
@@ -171,13 +171,40 @@ fn check_code_ref(root: &Path, src: &str) -> Result<(), String> {
     if !path.is_file() {
         return Err(format!("source file {:?} does not exist", r.file));
     }
+    let canonical_root = root.canonicalize().map_err(|e| e.to_string())?;
+    let canonical_path = path.canonicalize().map_err(|e| e.to_string())?;
+    if !canonical_path.starts_with(&canonical_root) {
+        return Err(format!("source path {:?} escapes repo root", r.file));
+    }
     if let Some(sym) = r.symbol {
+        if sym.is_empty() {
+            return Err(format!("empty symbol after '#' in {:?}", r.file));
+        }
         let text = fs::read_to_string(&path).map_err(|e| e.to_string())?;
         if !text.contains(sym) {
             return Err(format!("symbol {sym:?} not found in {:?} (renamed/deleted?)", r.file));
         }
     }
     Ok(())
+}
+
+#[test]
+fn check_code_ref_rejects_empty_symbol() {
+    let root = repo_root();
+    let err = check_code_ref(&root, "docs/platforms/README.md#")
+        .expect_err("empty symbol must be rejected");
+    assert!(err.contains("empty symbol"), "unexpected error: {err}");
+}
+
+#[test]
+fn check_code_ref_rejects_path_traversal() {
+    let root = repo_root();
+    let err = check_code_ref(&root, "../../../../../../../../../../etc/passwd")
+        .expect_err("path escaping repo root must be rejected");
+    assert!(
+        err.contains("does not exist") || err.contains("escapes repo root"),
+        "unexpected error: {err}"
+    );
 }
 
 /// The template must keep enumerating every capability section + feature key, so

--- a/crates/platform-schema/tests/conformance.rs
+++ b/crates/platform-schema/tests/conformance.rs
@@ -8,7 +8,7 @@
 use platform_schema::*;
 use std::collections::BTreeSet;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 /// The 8 platforms that must have a schema file.
 const EXPECTED_PLATFORMS: &[&str] = &[
@@ -167,17 +167,33 @@ fn quirk_code_sources_exist_in_tree() {
 
 fn check_code_ref(root: &Path, src: &str) -> Result<(), String> {
     let r = parse_code_ref(src);
+    // Containment first, and lexically: a code-ref must be a plain relative path
+    // inside the repo. Rejecting `..`/root/prefix components before touching the
+    // filesystem keeps the guard reachable when the escaping target does not
+    // exist — a canonicalize-only check can't run on a missing path, so it would
+    // silently degrade to the "does not exist" error below and hide the escape.
+    if Path::new(r.file)
+        .components()
+        .any(|c| !matches!(c, Component::Normal(_) | Component::CurDir))
+    {
+        return Err(format!("source path {:?} escapes repo root", r.file));
+    }
     let path = root.join(r.file);
     if !path.is_file() {
         return Err(format!("source file {:?} does not exist", r.file));
     }
+    // Defence in depth: a lexically-clean ref can still traverse a symlink out
+    // of the tree, which only resolving both real paths catches.
     let canonical_root = root.canonicalize().map_err(|e| e.to_string())?;
     let canonical_path = path.canonicalize().map_err(|e| e.to_string())?;
     if !canonical_path.starts_with(&canonical_root) {
         return Err(format!("source path {:?} escapes repo root", r.file));
     }
     if let Some(sym) = r.symbol {
-        if sym.is_empty() {
+        // `trim` matters as much as the emptiness check itself: `contains("")` is
+        // unconditionally true, and a whitespace-only symbol matches virtually
+        // any source file. Both are vacuous passes, not anti-drift checks.
+        if sym.trim().is_empty() {
             return Err(format!("empty symbol after '#' in {:?}", r.file));
         }
         let text = fs::read_to_string(&path).map_err(|e| e.to_string())?;
@@ -197,26 +213,42 @@ fn check_code_ref_rejects_empty_symbol() {
 }
 
 #[test]
+fn check_code_ref_rejects_whitespace_only_symbol() {
+    // Same vacuous-pass class as the empty symbol: `contains(" ")` matches
+    // virtually any file, so a whitespace-only `#symbol` asserts nothing.
+    let root = repo_root();
+    let err = check_code_ref(&root, "docs/platforms/README.md#   ")
+        .expect_err("whitespace-only symbol must be rejected");
+    assert!(err.contains("empty symbol"), "unexpected error: {err}");
+}
+
+#[test]
 fn check_code_ref_rejects_path_traversal() {
     let root = repo_root();
-    let err = check_code_ref(&root, "../../../../../../../../../../etc/passwd")
+    let err = check_code_ref(&root, "../../etc/passwd")
         .expect_err("path escaping repo root must be rejected");
-    assert!(
-        err.contains("does not exist") || err.contains("escapes repo root"),
-        "unexpected error: {err}"
-    );
+    assert!(err.contains("escapes repo root"), "unexpected error: {err}");
 }
 
 #[test]
 fn check_code_ref_rejects_absolute_path() {
     // Path::join replaces the base entirely when the joined path is absolute,
-    // so this exercises a different code path than the "../" traversal above.
+    // so this exercises a different component than the "../" traversal above.
     let root = repo_root();
     let err = check_code_ref(&root, "/etc/passwd").expect_err("absolute path must be rejected");
-    assert!(
-        err.contains("does not exist") || err.contains("escapes repo root"),
-        "unexpected error: {err}"
-    );
+    assert!(err.contains("escapes repo root"), "unexpected error: {err}");
+}
+
+#[test]
+fn check_code_ref_reports_escape_even_when_target_is_missing() {
+    // The containment check runs before the existence check, so an escaping ref
+    // is reported as an escape regardless of what happens to exist on the host.
+    // That is what lets the two assertions above be exact instead of accepting
+    // "does not exist" as an alternative pass.
+    let root = repo_root();
+    let err = check_code_ref(&root, "../no-such-file-4f21c9.rs")
+        .expect_err("escaping path must be rejected");
+    assert!(err.contains("escapes repo root"), "unexpected error: {err}");
 }
 
 /// The template must keep enumerating every capability section + feature key, so

--- a/docs/platforms/README.md
+++ b/docs/platforms/README.md
@@ -24,6 +24,8 @@ Each `schema/<platform>.toml` has three schema-driven parts:
 
 - **Current schema version: `2026-07-08`** — the top-line `schema_version` in each file. Bump it when the schema changes; the conformance test then flags every file that hasn't been re-verified.
 
+**Known limitation:** conformance only checks that a code-ref's file/symbol still *exists* — it can't detect a symbol whose behavior changed without being renamed or removed, or a `note`/`status` that has quietly gone stale while the code-ref it cites remains technically valid. That kind of semantic drift is caught only by PR review (see `CONTRIBUTING.md`), not by CI. No dedicated per-platform owner is assigned to periodically audit for it; revisit if this proves insufficient in practice.
+
 ## Platforms
 
 | Platform | Schema file |

--- a/docs/platforms/README.md
+++ b/docs/platforms/README.md
@@ -14,6 +14,8 @@ Each `schema/<platform>.toml` has three schema-driven parts:
 
 **Sourcing rule:** attach the source that answers *"why should I trust or keep this?"* — intrinsic `(A)` facts link the **official platform doc** (a `source` URL); OpenAB `(B)` decisions/findings point at the **code** (`file.rs#symbol`) and, where relevant, the **PR** (`pr` / `refs`). Code refs use a grep-stable `#symbol` (no line numbers), so conformance can confirm they still exist without breaking on unrelated edits above the target.
 
+> **Decision:** unlike `[[quirks]]`, every `[[openab_features]]` source must currently be a code-ref — `feature_sources_exist_in_tree` rejects URL sources rather than skipping them. This is intentional, not an oversight: no feature currently needs to cite an official-doc URL, and relaxing the check preemptively would let feature sources silently drift to unverifiable doc links instead of code. Revisit if/when a feature genuinely needs a URL source (see #1340).
+
 ## Conformance
 
 `crates/platform-schema` deserializes every `schema/*.toml` into typed structs and, in CI, enforces:


### PR DESCRIPTION
## What problem does this solve?

Closes #1337
Closes #1338
Closes #1339
Closes #1340

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404/1532377620241449040

All four issues were identified during group review of #1295 (the platform-schema knowledge base PR) and are bundled here since they're small, related follow-ups to that same subsystem.

## Review Contract

### Goal

1. **#1337** — Expand `platform-schema-conformance.yml`'s trigger paths to also cover the adapter/core source trees that schema code-refs point into, plus a weekly scheduled run as a backstop.
2. **#1338** — Harden the same workflow: `actions/checkout@v6` (was `@v4`, inconsistent with rest of repo), add `Swatinem/rust-cache`, add a `concurrency` group.
3. **#1340** — Harden `check_code_ref` in `crates/platform-schema/tests/conformance.rs`: reject empty `#symbol`, reject path traversal outside repo root.
4. **#1339** — Replace the proposed fixed per-platform-owner model with open contribution guidance + a documented known limitation (see rationale below and issue comment).

### Non-goals

- #1340's third sub-point (aligning `feature_sources_exist_in_tree` to skip URL sources like the quirk check does) is intentionally **not** included — see "Alternatives Considered".
- No named per-platform owners are assigned (#1339) — see issue comment for rationale.

### Accepted Residual Risks

- [x] `feature_sources_exist_in_tree` still hard-errors on a URL source instead of skipping it (unlike quirks). Verified no current schema file needs this (136 feature `source` entries checked, none are URLs). Documented as an explicit decision in `docs/platforms/README.md`, revisit if a feature genuinely needs a URL source.
- [x] Semantic drift (a code-ref stays valid but the `note`/`status` it documents goes stale) is not detectable by CI — only syntactic drift (renamed/removed symbols) is, and only for the file trees now covered by #1337's trigger paths. Documented as a known limitation; no dedicated owner audits for it.

### Acceptance Criteria

- [x] `platform-schema-conformance.yml` triggers on changes to `crates/openab-gateway/src/**`, `crates/openab-core/src/**`, and `src/main.rs` (all current schema code-ref targets, verified by extracting every `.rs` path cited across all 8 schema files), plus a weekly `schedule` backstop paired with `workflow_dispatch` for manual testing (matches the other 10 schedule-triggered workflows in this repo)
- [x] `platform-schema-conformance.yml` uses `checkout@v6`, has a Rust build cache, and a concurrency group keyed by both `github.event_name` and `github.ref` (a `push`-to-main run and the weekly `schedule` run both resolve `github.ref` to `refs/heads/main`; without `event_name` in the key they'd share a group and `cancel-in-progress` could cancel one in favor of the other)
- [x] `check_code_ref` rejects `"file.rs#"` (empty symbol) with a clear error
- [x] `check_code_ref` rejects sources that resolve outside the repo root, including both `../`-style relative traversal and a bare absolute path (`Path::join` replaces the base entirely for an absolute joined path — a distinct code path from relative traversal)
- [x] Three new tests cover empty-symbol, relative-traversal, and absolute-path cases
- [x] `CONTRIBUTING.md` invites any contributor to update platform schema TOMLs directly, without needing a dedicated owner
- [x] `docs/platforms/README.md` documents both the URL-source decision and the semantic-drift known limitation

### Follow-ups

- If semantic-drift incidents actually occur in practice, open a new issue at that point to discuss the solution in light of the concrete situation, rather than presupposing per-platform ownership is the right fix.

## At a Glance

```
CI workflow + Rust test hardening + docs — no runtime/architecture impact
```

## Prior Art & Industry Research

Not applicable — CI config, test hardening, and docs changes only; no runtime/architectural/delivery behavior affected.

## Proposed Solution

**#1337** (`.github/workflows/platform-schema-conformance.yml`):
- Added `crates/openab-gateway/src/**`, `crates/openab-core/src/**`, `src/main.rs` to both `pull_request` and `push` path triggers — confirmed these cover every `.rs` file currently cited by a schema code-ref (extracted all `source` refs across the 8 platform files)
- Added `schedule: cron: "0 6 * * 1"` (weekly) as a backstop in case a PR touching the source tree somehow bypasses the path triggers, paired with `workflow_dispatch:` so it can also be triggered manually (matches every other schedule-triggered workflow in this repo)

**#1338** (same file):
- `actions/checkout@v4` → `@v6` (matches the rest of the repo's workflows)
- Add `Swatinem/rust-cache` (same pinned SHA used elsewhere in the repo) scoped to `crates/platform-schema -> target`
- Add `concurrency: { group: platform-schema-${{ github.event_name }}-${{ github.ref }}, cancel-in-progress: true }` — `event_name` is included because `push` and `schedule` runs both resolve `github.ref` to `refs/heads/main`; without it they'd share a group and could cancel each other
- `--locked` was already present from a prior change; left untouched

**#1340** (`crates/platform-schema/tests/conformance.rs`):
- `check_code_ref` now canonicalizes both `root` and the resolved `path` and checks `starts_with` before proceeding, rejecting any source that escapes the repo root, whether via `../..` relative traversal or a bare absolute path (`Path::join` replaces the base entirely when the joined path is absolute — a distinct code path from relative traversal)
- `check_code_ref` now rejects an empty `#symbol` explicitly instead of silently passing (`text.contains("")` is always `true` in Rust)
- Three new tests: `check_code_ref_rejects_empty_symbol`, `check_code_ref_rejects_path_traversal`, `check_code_ref_rejects_absolute_path`

**#1339** (`CONTRIBUTING.md`, `docs/platforms/README.md`):
- `CONTRIBUTING.md`: added a sentence inviting any contributor to update the schema TOML directly when they notice a platform API change or quirk, rather than waiting on a dedicated owner
- `docs/platforms/README.md`: added a "Known limitation" note under Conformance about semantic vs syntactic drift

## Why this approach?

**#1337/#1338/#1340** are straightforward hardening matching patterns already used elsewhere in this repo's CI (see `ci.yml`, `docker-smoke-test.yml`) and Rust code (canonicalize-and-check is the standard path-traversal guard). #1337's path list was derived by actually grepping every code-ref in the 8 schema files rather than guessing, to make sure the trigger coverage is complete as of today.

**#1339**: discussed with @sky092879 — two of the issue's three asks were already satisfied by existing docs (`CONTRIBUTING.md:202`, README's "Architecture: TOML vs Markdown" section). For the remaining ask, a formal per-platform ownership table was judged to add coordination overhead disproportionate to the current team size, with no clear enforcement mechanism. The underlying concern (stale docs) splits into syntactic drift — now handled by #1337's expanded triggers — and semantic drift, which has no automated solution and is now an explicit, revisit-if-needed limitation instead of an unaddressed gap.

## Alternatives Considered

- **Relax `feature_sources_exist_in_tree` to skip URL sources** (issue #1340's third sub-point): considered, rejected for now. No current feature source is a URL (checked all 8 schema files, 136 entries), so this would be a preemptive change with no current benefit, and could let feature sources silently drift to unverifiable doc links instead of code. Documented as an explicit decision in `docs/platforms/README.md`; revisit if a feature genuinely needs a URL source.
- **Non-blocking PR-comment bot** reminding reviewers to check schema accuracy when adapter files change (for #1339's semantic-drift gap): considered, deferred in favor of the lighter-weight CONTRIBUTING.md guidance + #1337's CI trigger fix.
- **Assign named per-platform owners** (#1339's original proposal): rejected for now — see rationale above.
- **Remove the path filter entirely** (#1337's alternative, run conformance on every PR): rejected in favor of an explicit path list — the job is cheap either way, but an explicit list documents *why* it runs, and the weekly schedule already covers the "something slipped through" case.

## Validation

Rust changes:
- [ ] `cargo check` passes — not verified in this environment (no Rust toolchain available); please verify in CI
- [ ] `cargo test` passes (including new tests) — not verified in this environment; please verify in CI
- [ ] `cargo clippy` clean — not verified in this environment; please verify in CI

CI/workflow changes:
- [x] Workflow syntax reviewed by hand (no local `actions`/YAML linter available in this environment)

Docs-only changes:
- [x] Links are valid
- [x] Renders correctly in GitHub preview

All PRs:
- [x] Manual testing — read through the diff and rendered Markdown; traced `check_code_ref`'s new logic against the empty-symbol, relative-traversal, and absolute-path cases by hand, and cross-checked #1337's new trigger paths against every code-ref actually cited in the 8 schema files, since `cargo test` could not be run locally.
- [x] Independently reviewed by 4 focused passes (Rust correctness, CI/workflow correctness, docs consistency, security) before this revision — caught and fixed the `concurrency` group collision between `push` and `schedule`, the missing `workflow_dispatch`, and the missing absolute-path test case.

